### PR TITLE
[P0] Add runtime execution model skeleton

### DIFF
--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime support package for harness-codex."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -1,0 +1,27 @@
+"""Core runtime model and execution abstractions."""
+
+from harness_codex.runtime.models import (
+    FailureKind,
+    RunContext,
+    RunMode,
+    RunResult,
+    RunStatus,
+    Step,
+    StepKind,
+    StepResult,
+    StepStatus,
+    Workflow,
+)
+
+__all__ = [
+    "FailureKind",
+    "RunContext",
+    "RunMode",
+    "RunResult",
+    "RunStatus",
+    "Step",
+    "StepKind",
+    "StepResult",
+    "StepStatus",
+    "Workflow",
+]

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -2,6 +2,7 @@
 
 from harness_codex.runtime.models import (
     FailureKind,
+    HARNESS_PLAN_EXECUTOR_WORKFLOW,
     RunContext,
     RunMode,
     RunResult,
@@ -15,6 +16,7 @@ from harness_codex.runtime.models import (
 
 __all__ = [
     "FailureKind",
+    "HARNESS_PLAN_EXECUTOR_WORKFLOW",
     "RunContext",
     "RunMode",
     "RunResult",

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -1,0 +1,238 @@
+"""Runtime data model for harness-codex.
+
+This module models the current harness execution flow as structured data.
+
+It does not call Codex, shell, git, or test tools directly. Later runtime work can
+build RunnerEngine, workflow YAML, policy checks, state persistence, and resume
+support on top of these objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class RunMode(str, Enum):
+    """How much side effect the runtime may perform."""
+
+    PLAN = "plan"
+    PREVIEW = "preview"
+    APPLY = "apply"
+
+
+class StepKind(str, Enum):
+    """Runtime step categories.
+
+    The current harness-plan-executor flow is not just "agent + shell".
+
+    It also:
+    - records plan/verification evidence,
+    - classifies verification failures,
+    - decides whether to remediate, block, or complete the plan.
+
+    So this first model includes `decision` and `record` in addition to the
+    obvious execution step kinds.
+    """
+
+    AGENT = "agent"
+    SHELL = "shell"
+    VALIDATOR = "validator"
+    GIT = "git"
+    DECISION = "decision"
+    RECORD = "record"
+
+
+class StepStatus(str, Enum):
+    """Lifecycle state for a single step."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    BLOCKED = "blocked"
+
+
+class RunStatus(str, Enum):
+    """Lifecycle state for a whole run."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    BLOCKED = "blocked"
+    CANCELLED = "cancelled"
+
+
+class FailureKind(str, Enum):
+    """Failure classification used by the current plan executor loop."""
+
+    IMPLEMENTATION = "implementation"
+    UPSTREAM_DESIGN = "upstream_design"
+    ENVIRONMENT_BLOCKER = "environment_blocker"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Step:
+    """A side-effect-free description of one runtime action."""
+
+    id: str
+    kind: StepKind
+    name: str
+    needs: tuple[str, ...] = ()
+    agent_id: str | None = None
+    command: str | None = None
+    inputs: tuple[Path, ...] = ()
+    outputs: tuple[Path, ...] = ()
+    timeout_sec: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Workflow:
+    """A reusable ordered graph of harness runtime steps."""
+
+    name: str
+    mode: RunMode
+    steps: tuple[Step, ...]
+    description: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def step_ids(self) -> tuple[str, ...]:
+        """Return step IDs in declared order."""
+
+        return tuple(step.id for step in self.steps)
+
+    def step_by_id(self, step_id: str) -> Step:
+        """Return a step by ID.
+
+        Raises:
+            KeyError: if the workflow does not contain the requested step.
+        """
+
+        for step in self.steps:
+            if step.id == step_id:
+                return step
+
+        raise KeyError(f"Unknown step id: {step_id}")
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Context shared by adapters during one run."""
+
+    run_id: str
+    workflow_name: str
+    mode: RunMode
+    repo_root: Path
+    workdir: Path
+    run_dir: Path
+    active_plan_path: Path = Path("docs/plans/active/plan.md")
+    architecture_path: Path = Path("ARCHITECTURE.md")
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Structured result for one executed step."""
+
+    step_id: str
+    status: StepStatus
+    exit_code: int | None = None
+    output_path: Path | None = None
+    error: str | None = None
+    failure_kind: FailureKind | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def successful(self) -> bool:
+        """Whether the step completed successfully."""
+
+        return self.status == StepStatus.SUCCEEDED
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Structured result for a whole workflow run."""
+
+    run_id: str
+    status: RunStatus
+    step_results: tuple[StepResult, ...]
+    failed_step_id: str | None = None
+    blocker: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+HARNESS_PLAN_EXECUTOR_WORKFLOW = Workflow(
+    name="harness-plan-executor",
+    mode=RunMode.APPLY,
+    description="Structured model of the existing harness-plan-executor skill flow.",
+    steps=(
+        Step(
+            id="load-active-plan",
+            kind=StepKind.RECORD,
+            name="Read active plan, architecture, and design sources",
+            inputs=(
+                Path("docs/plans/active/plan.md"),
+                Path("ARCHITECTURE.md"),
+                Path("docs/design"),
+            ),
+        ),
+        Step(
+            id="delegate-implementation",
+            kind=StepKind.AGENT,
+            name="Delegate unchecked plan tasks to implementation_executor",
+            needs=("load-active-plan",),
+            agent_id="implementation_executor",
+            inputs=(Path(".codex/agents/implementation_executor.toml"),),
+        ),
+        Step(
+            id="inspect-executor-result",
+            kind=StepKind.RECORD,
+            name="Inspect updated plan and executor report",
+            needs=("delegate-implementation",),
+            inputs=(Path("docs/plans/active/plan.md"),),
+        ),
+        Step(
+            id="run-final-verification",
+            kind=StepKind.VALIDATOR,
+            name="Run build, tests, static analysis, and runtime server verification when defined",
+            needs=("inspect-executor-result",),
+            metadata={
+                "typical_commands": (
+                    "./gradlew build",
+                    "./gradlew test",
+                    "./gradlew architectureRules",
+                    "semgrep --config .semgrep/ddd-architecture.yml .",
+                )
+            },
+        ),
+        Step(
+            id="classify-verification-failure",
+            kind=StepKind.DECISION,
+            name="Classify verification failure as implementation, upstream design, or environment blocker",
+            needs=("run-final-verification",),
+            metadata={
+                "failure_kinds": tuple(kind.value for kind in FailureKind),
+            },
+        ),
+        Step(
+            id="record-remediation-or-blocker",
+            kind=StepKind.RECORD,
+            name="Record remediation tasks or blocker evidence in the active plan",
+            needs=("classify-verification-failure",),
+            outputs=(Path("docs/plans/active/plan.md"),),
+        ),
+        Step(
+            id="complete-plan",
+            kind=StepKind.GIT,
+            name="Move completed plan from active to complete after all checks pass",
+            needs=("run-final-verification",),
+            inputs=(Path("docs/plans/active/plan.md"),),
+            outputs=(Path("docs/plans/complete/plan.md"),),
+        ),
+    ),
+)

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+
+import pytest
+
+from harness_codex.runtime import (
+    FailureKind,
+    HARNESS_PLAN_EXECUTOR_WORKFLOW,
+    RunContext,
+    RunMode,
+    RunResult,
+    RunStatus,
+    Step,
+    StepKind,
+    StepResult,
+    StepStatus,
+    Workflow,
+)
+
+
+def test_harness_plan_executor_workflow_models_current_skill_flow() -> None:
+    workflow = HARNESS_PLAN_EXECUTOR_WORKFLOW
+
+    assert workflow.name == "harness-plan-executor"
+    assert workflow.mode == RunMode.APPLY
+
+    assert workflow.step_ids() == (
+        "load-active-plan",
+        "delegate-implementation",
+        "inspect-executor-result",
+        "run-final-verification",
+        "classify-verification-failure",
+        "record-remediation-or-blocker",
+        "complete-plan",
+    )
+
+
+def test_delegate_implementation_step_targets_implementation_executor() -> None:
+    step = HARNESS_PLAN_EXECUTOR_WORKFLOW.step_by_id("delegate-implementation")
+
+    assert step.kind == StepKind.AGENT
+    assert step.agent_id == "implementation_executor"
+    assert step.needs == ("load-active-plan",)
+    assert Path(".codex/agents/implementation_executor.toml") in step.inputs
+
+
+def test_final_verification_step_keeps_typical_commands_as_metadata() -> None:
+    step = HARNESS_PLAN_EXECUTOR_WORKFLOW.step_by_id("run-final-verification")
+
+    assert step.kind == StepKind.VALIDATOR
+    assert "./gradlew build" in step.metadata["typical_commands"]
+    assert "./gradlew test" in step.metadata["typical_commands"]
+
+
+def test_workflow_step_by_id_raises_for_unknown_step() -> None:
+    with pytest.raises(KeyError):
+        HARNESS_PLAN_EXECUTOR_WORKFLOW.step_by_id("unknown-step")
+
+
+def test_run_context_carries_runtime_paths() -> None:
+    context = RunContext(
+        run_id="run-001",
+        workflow_name="harness-plan-executor",
+        mode=RunMode.APPLY,
+        repo_root=Path("/repo"),
+        workdir=Path("/repo"),
+        run_dir=Path("/repo/.harness/runs/run-001"),
+    )
+
+    assert context.run_id == "run-001"
+    assert context.active_plan_path == Path("docs/plans/active/plan.md")
+    assert context.architecture_path == Path("ARCHITECTURE.md")
+
+
+def test_step_result_successful_property() -> None:
+    success = StepResult(
+        step_id="run-final-verification",
+        status=StepStatus.SUCCEEDED,
+        exit_code=0,
+    )
+    failure = StepResult(
+        step_id="run-final-verification",
+        status=StepStatus.FAILED,
+        exit_code=1,
+        error="build failed",
+        failure_kind=FailureKind.IMPLEMENTATION,
+    )
+
+    assert success.successful is True
+    assert failure.successful is False
+
+
+def test_run_result_can_represent_blocker_without_losing_step_results() -> None:
+    result = RunResult(
+        run_id="run-001",
+        status=RunStatus.BLOCKED,
+        failed_step_id="run-final-verification",
+        blocker="missing external service",
+        step_results=(
+            StepResult(
+                step_id="load-active-plan",
+                status=StepStatus.SUCCEEDED,
+            ),
+            StepResult(
+                step_id="run-final-verification",
+                status=StepStatus.BLOCKED,
+                failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
+            ),
+        ),
+    )
+
+    assert result.status == RunStatus.BLOCKED
+    assert result.failed_step_id == "run-final-verification"
+    assert len(result.step_results) == 2
+
+
+def test_custom_workflow_can_represent_multiple_steps_without_side_effects() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.PLAN,
+        steps=(
+            Step(
+                id="analyze",
+                kind=StepKind.AGENT,
+                name="Analyze repository",
+                agent_id="implementation_executor",
+            ),
+            Step(
+                id="validate",
+                kind=StepKind.VALIDATOR,
+                name="Run tests",
+                needs=("analyze",),
+                command="./gradlew test",
+            ),
+        ),
+    )
+
+    assert workflow.step_ids() == ("analyze", "validate")
+    assert workflow.step_by_id("validate").needs == ("analyze",)


### PR DESCRIPTION
## 요약

`harness-codex`의 첫 번째 런타임 모델 뼈대를 추가합니다.

이 PR은 Codex 호출, shell 실행, git 작업, validator 실행을 직접 구현하지 않습니다.  
현재 `harness-plan-executor`의 실행 흐름을 구조화된 런타임 객체로 표현하는 것까지만 다룹니다.

## 변경 내용

- `RunMode`, `StepKind`, `StepStatus`, `RunStatus`, `FailureKind` 추가
- `Step`, `Workflow`, `RunContext`, `StepResult`, `RunResult` 추가
- 현재 `harness-plan-executor` 흐름을 표현하는 `HARNESS_PLAN_EXECUTOR_WORKFLOW` 추가
- 런타임 모델 동작을 확인하는 테스트 추가

## 배경

현재 harness 흐름은 skill/agent 지시문 중심으로 동작합니다.

앞으로 다음 기능을 안정적으로 추가하려면 먼저 공통 실행 모델이 필요합니다.

- `RunnerEngine`
- workflow YAML
- `plan / preview / apply` 실행 모드
- command policy
- run state / checkpoint
- resume
- report 생성

이 PR은 그 기반이 되는 모델만 먼저 고정합니다.

## 현재 실행 흐름 반영

`HARNESS_PLAN_EXECUTOR_WORKFLOW`는 현재 흐름을 다음 단계로 표현합니다.

1. active plan, architecture, design source 읽기
2. `implementation_executor`에게 미완료 plan task 위임
3. executor 결과와 갱신된 plan 확인
4. 최종 검증 실행
5. 검증 실패 유형 분류
6. remediation task 또는 blocker 기록
7. 모든 검증 통과 시 plan 완료 처리

## 관련 이슈

Closes #6

## 제외 범위

이 PR에서는 다음 항목을 구현하지 않습니다.

- Codex 실제 호출
- shell 명령 실행
- git 명령 실행
- workflow YAML 파싱
- command policy engine
- worktree sandbox
- resume 기능
- report 생성

## 검증

- 런타임 모델 테스트 추가
- `HARNESS_PLAN_EXECUTOR_WORKFLOW`가 현재 skill 흐름을 표현하는지 확인
- `StepResult`, `RunResult`가 실패와 blocker를 구조화해서 표현할 수 있는지 확인