### PR TITLE
[P0] Add RunnerEngine and adapter boundary

### DIFF
--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -1,0 +1,139 @@
+"""Pure workflow execution engine.
+
+The engine owns ordering, dependency checks, status aggregation, and failure
+handling. It does not directly call Codex, shell, git, validators, or any other
+side-effecting tool.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+from harness_codex.runtime.models import (
+    RunContext,
+    RunResult,
+    RunStatus,
+    Step,
+    StepResult,
+    StepStatus,
+    Workflow,
+)
+from harness_codex.runtime.runner import StepRunner
+
+
+class WorkflowValidationError(ValueError):
+    """Raised when a workflow graph cannot be executed safely."""
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """Validated execution order for a workflow."""
+
+    steps: tuple[Step, ...]
+
+    def step_ids(self) -> tuple[str, ...]:
+        return tuple(step.id for step in self.steps)
+
+
+class RunnerEngine:
+    """Execute workflows through a side-effecting `StepRunner` boundary."""
+
+    def __init__(self, step_runner: StepRunner) -> None:
+        self._step_runner = step_runner
+
+    def plan(self, workflow: Workflow) -> ExecutionPlan:
+        """Validate the workflow and return dependency-safe execution order."""
+
+        steps_by_id = self._index_steps(workflow)
+        ordered_ids = self._topological_sort(workflow, steps_by_id)
+        return ExecutionPlan(steps=tuple(steps_by_id[step_id] for step_id in ordered_ids))
+
+    def run(self, workflow: Workflow, context: RunContext) -> RunResult:
+        """Run the workflow until all steps succeed or one step fails/blocks."""
+
+        execution_plan = self.plan(workflow)
+        results: list[StepResult] = []
+
+        for step in execution_plan.steps:
+            result = self._step_runner.run(step, context)
+            results.append(result)
+
+            if result.status == StepStatus.FAILED:
+                return RunResult(
+                    run_id=context.run_id,
+                    status=RunStatus.FAILED,
+                    step_results=tuple(results),
+                    failed_step_id=step.id,
+                    blocker=result.error,
+                )
+
+            if result.status == StepStatus.BLOCKED:
+                return RunResult(
+                    run_id=context.run_id,
+                    status=RunStatus.BLOCKED,
+                    step_results=tuple(results),
+                    failed_step_id=step.id,
+                    blocker=result.error,
+                )
+
+        return RunResult(
+            run_id=context.run_id,
+            status=RunStatus.SUCCEEDED,
+            step_results=tuple(results),
+        )
+
+    def _index_steps(self, workflow: Workflow) -> dict[str, Step]:
+        steps_by_id: dict[str, Step] = {}
+
+        for step in workflow.steps:
+            if step.id in steps_by_id:
+                raise WorkflowValidationError(f"Duplicate step id: {step.id}")
+            steps_by_id[step.id] = step
+
+        for step in workflow.steps:
+            for needed_step_id in step.needs:
+                if needed_step_id not in steps_by_id:
+                    raise WorkflowValidationError(
+                        f"Step {step.id} depends on unknown step: {needed_step_id}"
+                    )
+
+        return steps_by_id
+
+    def _topological_sort(
+        self,
+        workflow: Workflow,
+        steps_by_id: dict[str, Step],
+    ) -> tuple[str, ...]:
+        dependents_by_step_id: dict[str, list[str]] = {step.id: [] for step in workflow.steps}
+        remaining_needs_count: dict[str, int] = {
+            step.id: len(step.needs) for step in workflow.steps
+        }
+
+        for step in workflow.steps:
+            for needed_step_id in step.needs:
+                dependents_by_step_id[needed_step_id].append(step.id)
+
+        ready = deque(step.id for step in workflow.steps if remaining_needs_count[step.id] == 0)
+        ordered: list[str] = []
+
+        while ready:
+            step_id = ready.popleft()
+            ordered.append(step_id)
+
+            for dependent_step_id in dependents_by_step_id[step_id]:
+                remaining_needs_count[dependent_step_id] -= 1
+                if remaining_needs_count[dependent_step_id] == 0:
+                    ready.append(dependent_step_id)
+
+        if len(ordered) != len(steps_by_id):
+            unresolved = tuple(
+                step_id
+                for step_id, count in remaining_needs_count.items()
+                if count > 0
+            )
+            raise WorkflowValidationError(
+                "Workflow contains cyclic step dependencies: " + ", ".join(unresolved)
+            )
+
+        return tuple(ordered)

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -1,0 +1,23 @@
+"""Step runner boundary for runtime execution.
+
+`StepRunner` is the adapter boundary between the pure runtime engine and
+side-effecting implementations such as Codex, shell, git, and validators.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from harness_codex.runtime.models import RunContext, Step, StepResult
+
+
+class StepRunner(Protocol):
+    """Adapter interface used by `RunnerEngine` to execute one step.
+
+    Implementations may call Codex, shell, git, validators, or fake test doubles.
+    The engine depends only on this protocol and never performs those side
+    effects directly.
+    """
+
+    def run(self, step: Step, context: RunContext) -> StepResult:
+        """Execute one step and return a structured result."""


### PR DESCRIPTION
## 요약

`RunnerEngine`과 `StepRunner` 경계를 추가합니다.

이 PR은 실제 Codex 호출, shell 실행, git 작업, validator 실행을 구현하지 않습니다.
대신 런타임 엔진이 step 실행 순서, dependency 검증, 실패 중단을 담당하고,
실제 side effect는 `StepRunner` 뒤로 위임할 수 있도록 경계를 만듭니다.

## 변경 내용

- `StepRunner` protocol 추가
- `RunnerEngine` 추가
- `ExecutionPlan` 추가
- `WorkflowValidationError` 추가
- step dependency 기반 실행 순서 계산
- duplicate step id 검증
- unknown dependency 검증
- cyclic dependency 검증
- 실패/차단 step 발생 시 downstream step 실행 중단
- fake runner 기반 테스트 추가

## 배경

#6에서 `Workflow`, `Step`, `RunContext`, `StepResult`, `RunResult` 모델을 추가했습니다.

이번 PR은 그 모델을 실제 실행 엔진의 입력/출력으로 사용합니다.
다만 아직 외부 도구 실행은 붙이지 않습니다.

이렇게 분리해야 이후에 다음 작업을 안전하게 붙일 수 있습니다.

- workflow YAML
- plan / preview / apply mode
- command policy
- Codex adapter
- shell adapter
- validator adapter
- run state / checkpoint
- resume

## 설계 의도

`RunnerEngine`은 순수 orchestration만 담당합니다.

엔진이 담당하는 것:

- workflow graph 검증
- step 실행 순서 계산
- `StepRunner` 호출
- 실패/차단 시 실행 중단
- `RunResult` 생성

엔진이 담당하지 않는 것:

- Codex 호출
- shell 명령 실행
- git 명령 실행
- validator 실행
- 파일 수정
- policy 판단
- run state 저장

## 관련 이슈

Closes #7

## 검증

```bash
python -m pytest tests/runtime/test_models.py tests/runtime/test_engine.py -q