### PR TITLE
[codex] Add workflow YAML schema validation

### DIFF
--- a/harness_codex/runtime/workflows/__init__.py
+++ b/harness_codex/runtime/workflows/__init__.py
@@ -1,13 +1,17 @@
 """Workflow YAML loading and validation."""
 
 from harness_codex.runtime.workflows.loader import (
+    DEFAULT_WORKFLOW_DIR,
     load_workflow_file,
+    load_named_workflow,
     load_workflow_text,
 )
 from harness_codex.runtime.workflows.schema import WorkflowSchemaError
 
 __all__ = [
+    "DEFAULT_WORKFLOW_DIR",
     "WorkflowSchemaError",
+    "load_named_workflow",
     "load_workflow_file",
     "load_workflow_text",
 ]

--- a/harness_codex/runtime/workflows/loader.py
+++ b/harness_codex/runtime/workflows/loader.py
@@ -19,6 +19,18 @@ from harness_codex.runtime.workflows.schema import (
 )
 
 
+DEFAULT_WORKFLOW_DIR = Path(".harness/workflows")
+
+
+def load_named_workflow(
+    name: str,
+    workflows_dir: Path | str = DEFAULT_WORKFLOW_DIR,
+) -> Workflow:
+    workflow_name = name.removesuffix(".yaml")
+    workflow_path = Path(workflows_dir) / f"{workflow_name}.yaml"
+    return load_workflow_file(workflow_path)
+
+
 def load_workflow_file(path: Path | str) -> Workflow:
     workflow_path = Path(path)
     return load_workflow_text(workflow_path.read_text(encoding="utf-8"))
@@ -65,10 +77,16 @@ def _to_workflow(document: Mapping[str, Any]) -> Workflow:
 
 
 def _to_step(raw_step: Mapping[str, Any]) -> Step:
+    metadata = dict(raw_step.get("metadata") or {})
+    provider = raw_step.get("provider")
+
+    if provider is not None:
+        metadata["provider"] = provider
+
     return Step(
         id=raw_step["id"],
         kind=parse_step_kind(raw_step["kind"], f"steps[{raw_step['id']}].kind"),
-        name=raw_step["name"],
+        name=raw_step.get("name") or raw_step["id"],
         needs=parse_needs(raw_step.get("needs"), f"steps[{raw_step['id']}].needs"),
         agent_id=raw_step.get("agent_id"),
         command=raw_step.get("command"),
@@ -85,7 +103,7 @@ def _to_step(raw_step: Mapping[str, Any]) -> Step:
             )
         ),
         timeout_sec=raw_step.get("timeout_sec"),
-        metadata=raw_step.get("metadata") or {},
+        metadata=metadata,
     )
 
 

--- a/harness_codex/runtime/workflows/schema.py
+++ b/harness_codex/runtime/workflows/schema.py
@@ -18,6 +18,9 @@ class WorkflowSchemaError(ValueError):
     """Raised when a workflow YAML document is invalid."""
 
 
+ALLOWED_SANDBOX_KINDS = frozenset({"worktree", "local"})
+
+
 def require_mapping(value: Any, path: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise WorkflowSchemaError(f"{path} must be a mapping")
@@ -46,6 +49,13 @@ def require_optional_string(value: Any, path: str) -> str | None:
     return require_string(value, path)
 
 
+def require_optional_mapping(value: Any, path: str) -> Mapping[str, Any] | None:
+    if value is None:
+        return None
+
+    return require_mapping(value, path)
+
+
 def require_optional_positive_int(value: Any, path: str) -> int | None:
     if value is None:
         return None
@@ -61,6 +71,18 @@ def validate_version(document: Mapping[str, Any]) -> None:
 
     if version != 1:
         raise WorkflowSchemaError("version must be 1")
+
+
+def validate_sandbox(value: Any) -> None:
+    if value is None:
+        return
+
+    sandbox = require_mapping(value, "sandbox")
+    kind = require_string(sandbox.get("kind"), "sandbox.kind")
+
+    if kind not in ALLOWED_SANDBOX_KINDS:
+        allowed = ", ".join(sorted(ALLOWED_SANDBOX_KINDS))
+        raise WorkflowSchemaError(f"sandbox.kind must be one of: {allowed}")
 
 
 def parse_run_mode(value: Any, path: str) -> RunMode:
@@ -116,6 +138,7 @@ def validate_workflow_document(document: Any) -> Mapping[str, Any]:
     workflow = require_mapping(root.get("workflow"), "workflow")
     require_string(workflow.get("name"), "workflow.name")
     parse_run_mode(workflow.get("mode"), "workflow.mode")
+    validate_sandbox(root.get("sandbox"))
 
     steps = require_sequence(root.get("steps"), "steps")
 
@@ -136,14 +159,16 @@ def validate_workflow_document(document: Any) -> Mapping[str, Any]:
         seen_step_ids.add(step_id)
 
         parse_step_kind(step.get("kind"), f"{step_path}.kind")
-        require_string(step.get("name"), f"{step_path}.name")
+        require_optional_string(step.get("name"), f"{step_path}.name")
         parse_needs(step.get("needs"), f"{step_path}.needs")
         require_optional_string(step.get("agent_id"), f"{step_path}.agent_id")
+        require_optional_string(step.get("provider"), f"{step_path}.provider")
         require_optional_string(step.get("command"), f"{step_path}.command")
         require_optional_positive_int(
             step.get("timeout_sec"), f"{step_path}.timeout_sec"
         )
         parse_string_paths(step.get("inputs"), f"{step_path}.inputs")
         parse_string_paths(step.get("outputs"), f"{step_path}.outputs")
+        require_optional_mapping(step.get("metadata"), f"{step_path}.metadata")
 
     return root

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import pytest
 
 from harness_codex.runtime import RunMode, StepKind
-from harness_codex.runtime.workflows import WorkflowSchemaError, load_workflow_text
+from harness_codex.runtime.workflows import (
+    WorkflowSchemaError,
+    load_named_workflow,
+    load_workflow_text,
+)
 
 
 VALID_WORKFLOW = """
@@ -36,6 +40,25 @@ steps:
 """
 
 
+MINIMAL_WORKFLOW = """
+version: 1
+workflow:
+  name: fix-issue
+  mode: plan
+sandbox:
+  kind: worktree
+steps:
+  - id: analyze
+    kind: agent
+    provider: codex
+  - id: validate
+    kind: validator
+    needs: [analyze]
+    command: ./gradlew test
+    timeout_sec: 300
+"""
+
+
 def test_load_workflow_text_converts_yaml_to_runtime_model() -> None:
     workflow = load_workflow_text(VALID_WORKFLOW)
 
@@ -58,6 +81,36 @@ def test_load_workflow_text_converts_yaml_to_runtime_model() -> None:
     assert validate.command == "./gradlew test"
     assert validate.timeout_sec == 300
     assert validate.outputs == (Path("reports/test-result.txt"),)
+
+
+def test_load_workflow_text_accepts_issue_minimal_schema() -> None:
+    workflow = load_workflow_text(MINIMAL_WORKFLOW)
+
+    assert workflow.name == "fix-issue"
+    assert workflow.metadata["sandbox"] == {"kind": "worktree"}
+    assert workflow.step_ids() == ("analyze", "validate")
+
+    analyze = workflow.step_by_id("analyze")
+    assert analyze.name == "analyze"
+    assert analyze.kind == StepKind.AGENT
+    assert analyze.metadata["provider"] == "codex"
+
+    validate = workflow.step_by_id("validate")
+    assert validate.name == "validate"
+    assert validate.command == "./gradlew test"
+
+
+def test_load_named_workflow_reads_from_harness_workflows_directory(
+    tmp_path: Path,
+) -> None:
+    workflows_dir = tmp_path / ".harness" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    (workflows_dir / "fix-issue.yaml").write_text(MINIMAL_WORKFLOW, encoding="utf-8")
+
+    workflow = load_named_workflow("fix-issue", workflows_dir=workflows_dir)
+
+    assert workflow.name == "fix-issue"
+    assert workflow.step_ids() == ("analyze", "validate")
 
 
 def test_load_workflow_rejects_empty_document() -> None:
@@ -93,6 +146,23 @@ steps:
 """
 
     with pytest.raises(WorkflowSchemaError, match="workflow.mode"):
+        load_workflow_text(text)
+
+
+def test_load_workflow_rejects_invalid_sandbox_kind() -> None:
+    text = """
+version: 1
+workflow:
+  name: fix-issue
+  mode: plan
+sandbox:
+  kind: root
+steps:
+  - id: analyze
+    kind: agent
+"""
+
+    with pytest.raises(WorkflowSchemaError, match="sandbox.kind"):
         load_workflow_text(text)
 
 


### PR DESCRIPTION
## Summary

Implements the remaining workflow YAML schema coverage for #8.

- Adds named workflow loading from `.harness/workflows/<name>.yaml`.
- Accepts the issue's minimal schema shape, including `provider: codex` and unnamed steps.
- Validates `sandbox.kind` and step metadata before compiling to the runtime model.
- Preserves provider data in step metadata for downstream execution adapters.

## Impact

Workflow files now fail earlier for invalid sandbox declarations and compile the documented v1 minimal schema into the existing runtime `Workflow` model.

## Validation

- `python -m pytest -q` passed locally: 27 tests.
- `python -m compileall harness_codex tests` passed locally.

## Notes

This environment did not have a local git checkout or `gh` installed, so the branch and commit were created through the GitHub connector against `main`.