### PR TITLE
[codex] Update plan executor for use-case scoped loops

### DIFF
--- a/.codex/skills/harness-plan-executor/SKILL.md
+++ b/.codex/skills/harness-plan-executor/SKILL.md
@@ -1,33 +1,37 @@
 ---
 name: harness-plan-executor
-description: Orchestrate execution of docs/plans/active/plan.md for harness engineering by delegating code implementation to the implementation_executor agent, running final verification including runtime server checks, adding remediation plan tasks after verification failures, and repeating until verification passes or a real blocker is documented.
+description: Orchestrate use-case scoped execution of docs/plans/active/<UC-ID>/plan.md for harness engineering by delegating implementation to the implementation_executor agent, verifying against the use-case E2E goal and test gate, adding remediation tasks only for implementation failures, and moving completed use-case plans to docs/plans/completed/<UC-ID>/plan.md.
 ---
 
 # Harness Plan Executor
 
 ## Purpose
 
-Orchestrate execution of the active plan in `docs/plans/active/plan.md`.
+Orchestrate execution of one use-case scoped active plan in `docs/plans/active/<UC-ID>/plan.md`.
 
 This skill does not implement product code directly. It delegates implementation to
-`.codex/agents/implementation_executor.toml`, runs final verification including runtime server checks, updates `plan.md`
-with remediation tasks after verification failures, and repeats the implementation/verification
-loop until verification passes or a real blocker is documented.
+`.codex/agents/implementation_executor.toml`, verifies the implemented behavior against
+`docs/use-cases/<UC-ID>/e2e-goal.md` and the repository test gate, updates only that UC plan
+with remediation tasks after implementation failures, and repeats the implementation/verification
+loop until the use case passes or a real blocker is documented.
 
 ## Required Inputs
 
-- `docs/plans/active/plan.md`
+- `docs/plans/active/<UC-ID>/plan.md`
+- `docs/use-cases/<UC-ID>/e2e-goal.md`
+- `docs/use-cases/<UC-ID>/**`
+- `docs/changes/active/<CHG-ID>.md`
 - `ARCHITECTURE.md`
-- `docs/design/요구사항.md`
-- `docs/design/유스케이스.md`
-- `docs/design/이벤트 스토밍.md`
-- `docs/design/details/index.md`
-- `docs/design/details/도메인모델.md`
-- `docs/design/details/어그리거트.md`
-- `docs/design/details/애플리케이션서비스.md`
-- `docs/design/details/바운디드컨텍스트.md`
+- `.codex/repository-settings.md`
+- `.codex/test-gate.yaml`
+- Relevant design or technical decision docs referenced by the UC plan, UC docs, or ChangeSet
 
-If `plan.md` or `ARCHITECTURE.md` is missing, stop. Do not invent a plan or architecture.
+If the UC ID or ChangeSet ID is not explicit in the user request, infer it from the active plan
+path, the plan front matter, or the ChangeSet. If more than one active UC plan is present and no
+target is clear, stop and ask which UC plan to execute.
+
+If the targeted UC plan, UC E2E goal, ChangeSet, `ARCHITECTURE.md`, repository settings, or test
+gate is missing, stop. Do not invent a plan, E2E goal, ChangeSet, architecture, or gate.
 
 ## Required Agent
 
@@ -41,12 +45,18 @@ from this skill as a fallback.
 
 Use sources in this order:
 
-1. `docs/plans/active/plan.md`
-2. `ARCHITECTURE.md`
-3. `docs/design/**`
-4. Existing repository code and build configuration
+1. `docs/plans/active/<UC-ID>/plan.md`
+2. `docs/use-cases/<UC-ID>/e2e-goal.md`
+3. `docs/changes/active/<CHG-ID>.md`
+4. `docs/use-cases/<UC-ID>/**`
+5. `.codex/test-gate.yaml`
+6. `ARCHITECTURE.md`
+7. Relevant `docs/design/**` and technical decision docs
+8. Existing repository code and build configuration
 
-If sources conflict, follow `plan.md` for task order and scope, then `ARCHITECTURE.md` for structural constraints. Record the conflict in `plan.md` under `검증 실패` or a short executor note before continuing.
+If sources conflict, follow the UC plan for task order, the ChangeSet for scope boundary, the UC
+E2E goal for completion criteria, and `ARCHITECTURE.md` for structural constraints. Record the
+conflict in the UC plan under `검증 실패` and classify it before continuing.
 
 Do not read `ticketon-ddd블로그` at runtime.
 
@@ -54,47 +64,54 @@ Do not read `ticketon-ddd블로그` at runtime.
 
 - Do not implement code directly from this skill.
 - Delegate product code, tests, build/config edits, and focused task verification to `implementation_executor`.
-- Do not add features, domain rules, integrations, UI flows, infrastructure, or dependencies outside `plan.md`.
-- Do not change requirements or architecture documents unless the active plan explicitly requires it.
+- Do not add features, domain rules, integrations, UI flows, infrastructure, or dependencies outside the targeted UC plan and ChangeSet.
+- Do not change requirements, UC docs, ChangeSet, architecture, or technical decision documents unless the targeted UC plan explicitly requires it.
 - Do not mark implementation checkboxes complete yourself unless you are recording results already completed by `implementation_executor`.
-- Do not move `docs/plans/active/plan.md` to `docs/plans/complete/plan.md` until every checkbox is checked and build, tests, runtime server verification, and static analysis are recorded as successful, unless runtime server verification is explicitly marked not applicable with a reason.
+- Do not move `docs/plans/active/<UC-ID>/plan.md` to `docs/plans/completed/<UC-ID>/plan.md` until every checkbox is checked, the UC E2E goal is satisfied, and build, tests, runtime server verification, and static analysis are recorded as successful, unless runtime server verification is explicitly marked not applicable with a reason.
+- Do not execute or complete other active UC plans while handling the targeted UC.
 - Preserve user changes. Never revert unrelated work.
 
 ## Execution Workflow
 
-1. Read `plan.md`, `ARCHITECTURE.md`, and the relevant design docs.
-2. Identify unchecked implementation/test/setup tasks in `plan.md`.
-3. Invoke `implementation_executor` to execute the unchecked tasks. The executor owns code edits, test edits, build/config edits required by the plan, focused verification, and checkbox updates.
-4. When `implementation_executor` stops, inspect `plan.md` and the executor report.
-5. If unchecked tasks remain because of a blocker, report the blocker and stop.
-6. If all tasks are checked, run final verification from `plan.md` section `8. 검증 방법`, including runtime server verification after a successful build when the plan defines it.
-7. Record final verification results in section `10. 검증 결과`.
-8. If final verification passes, move `docs/plans/active/plan.md` to `docs/plans/complete/plan.md`.
-9. If final verification fails, classify the failure before adding remediation tasks. Add remediation only for implementation-level failures. Stop and report to the user for design/requirements/architecture/technical-decision failures.
+1. Resolve the targeted UC ID and ChangeSet ID.
+2. Read `docs/plans/active/<UC-ID>/plan.md`, `docs/use-cases/<UC-ID>/e2e-goal.md`, the related `docs/use-cases/<UC-ID>/**` files, `docs/changes/active/<CHG-ID>.md`, `ARCHITECTURE.md`, repository settings, and `.codex/test-gate.yaml`.
+3. Confirm the UC plan is inside the ChangeSet scope and names the UC E2E goal as its completion target. If it does not, classify the mismatch before execution.
+4. Identify unchecked implementation/test/setup tasks in the targeted UC plan only.
+5. Invoke `implementation_executor` to execute the unchecked tasks. The executor owns code edits, test edits, build/config edits required by the UC plan, focused verification, and checkbox updates.
+6. When `implementation_executor` stops, inspect the targeted UC plan and the executor report.
+7. If unchecked tasks remain because of a blocker, report the blocker and stop.
+8. If all tasks are checked, run final verification from the UC plan section `8. 검증 방법`, the UC E2E goal, and `.codex/test-gate.yaml`, including runtime server verification after a successful build when the plan defines it.
+9. Record final verification results in the UC plan section `10. 검증 결과`.
+10. If final verification passes, move `docs/plans/active/<UC-ID>/plan.md` to `docs/plans/completed/<UC-ID>/plan.md`.
+11. If final verification fails, classify the failure before adding remediation tasks. Add remediation only for implementation-level failures. Stop and report to the user for unclear E2E goals, document deltas, upstream design/architecture/technical-decision failures, and environment blockers.
 
 ## Verification Failure Loop
 
-When final verification fails after all planned tasks were executed:
+When final verification fails after all planned tasks for the targeted UC were executed:
 
 1. Record the failed command, exit result, and concise failure evidence under `11. 검증 실패`.
 2. Classify the failure:
-   - **Implementation-level failure**: code does not match the approved plan, tests expose a missing branch, mapping/configuration is incomplete, static analysis finds a fixable package/dependency violation, or a verification command fails because of an implementation mistake inside the approved scope.
-   - **Upstream design failure**: requirements, use cases, event storming, DDD design, technical decisions, or ARCHITECTURE.md are inconsistent, incomplete, impossible to implement safely, or contradicted by tests/static analysis in a way that requires changing approved design artifacts.
-   - **Environment blocker**: permissions, unavailable external services, missing local tools that cannot be installed in this run, network, credentials, or host constraints prevent verification.
-3. For upstream design failures, do not add remediation tasks. Add a blocker section to `plan.md` and stop:
+   - **IMPLEMENTATION_FAILURE**: code does not match the approved UC plan, tests expose a missing branch, mapping/configuration is incomplete, static analysis finds a fixable package/dependency violation, or a verification command fails because of an implementation mistake inside the UC plan and ChangeSet scope.
+   - **UNCLEAR_E2E_GOAL**: `docs/use-cases/<UC-ID>/e2e-goal.md` is missing, ambiguous, untestable, or lacks enough observable success criteria to verify completion.
+   - **DOCUMENT_DELTA_CONFLICT**: the UC plan, UC docs, E2E goal, and active ChangeSet disagree about the intended document delta or implementation scope.
+   - **UPSTREAM_DESIGN_CONFLICT**: requirements, use cases, event storming, DDD design, technical decisions, or `ARCHITECTURE.md` are inconsistent, incomplete, impossible to implement safely, or contradicted by tests/static analysis in a way that requires changing approved design artifacts.
+   - **ENVIRONMENT_BLOCKER**: permissions, unavailable external services, missing local tools that cannot be installed in this run, network, credentials, or host constraints prevent verification.
+3. For `UNCLEAR_E2E_GOAL`, do not add remediation tasks. Record the blocker and return to the harvester/user goal gate.
+4. For `DOCUMENT_DELTA_CONFLICT`, do not add remediation tasks. Record the blocker and return to ChangeSet revision.
+5. For `UPSTREAM_DESIGN_CONFLICT`, do not add remediation tasks. Add a blocker section to the targeted UC plan and stop:
 
 ```markdown
-## 12. 상위 설계 재검토 필요
-- 실패 유형: 요구사항/설계/아키텍처/기술결정 불일치
+## 12. 상위 단계 재검토 필요
+- 실패 유형: UNCLEAR_E2E_GOAL | DOCUMENT_DELTA_CONFLICT | UPSTREAM_DESIGN_CONFLICT
 - 실패 증거:
-- 왜 plan executor에서 고칠 수 없는가:
+- 왜 UC plan executor에서 고칠 수 없는가:
 - 되돌아갈 단계:
 - 사용자 확인 필요:
 ```
 
-4. Report the blocker to the user and name the stage to revisit, such as `$harness-requirements-usecases`, `$harness-event-storming`, `$harness-ddd-design`, `$harness-technical-decisions`, or `$harness-code-planner`.
-5. For environment blockers, do not add code-remediation tasks. Record the blocker and ask the user for the missing permission/tool/service.
-6. Only for implementation-level failures, add a new unchecked remediation section to `plan.md`, for example:
+6. Report the blocker to the user and name the stage to revisit, such as the harvester/user goal gate, ChangeSet revision, `$harness-event-storming`, `$harness-ddd-design`, `$harness-technical-decisions`, or `$harness-code-planner`.
+7. For `ENVIRONMENT_BLOCKER`, do not add code-remediation tasks. Record the blocker and ask the user for the missing permission/tool/service.
+8. Only for `IMPLEMENTATION_FAILURE`, add a new unchecked remediation section to the targeted UC plan, for example:
 
 ```markdown
 ## 12. 재실행 계획 N
@@ -103,15 +120,19 @@ When final verification fails after all planned tasks were executed:
 - [ ] 실패했던 최종 검증 명령을 다시 실행한다.
 ```
 
-7. Keep the plan in `docs/plans/active/plan.md`.
-8. Invoke `implementation_executor` again to execute only the newly added unchecked remediation tasks.
-9. Re-run final verification.
-10. Repeat until build, tests, runtime server verification, and static analysis all pass or a non-implementation blocker is found.
+9. Keep the plan in `docs/plans/active/<UC-ID>/plan.md`.
+10. Invoke `implementation_executor` again to execute only the newly added unchecked remediation tasks for the targeted UC.
+11. Re-run final verification for the targeted UC.
+12. Repeat until the UC E2E goal, build, tests, runtime server verification, and static analysis all pass or a non-implementation blocker is found.
 
-## Upstream Failure Signals
+## Non-Implementation Failure Signals
 
-Treat a final verification failure as upstream design failure, not an implementation remediation, when any of these are true:
+Treat a final verification failure as non-implementation failure, not implementation remediation,
+when any of these are true:
 
+- The UC E2E goal is absent, ambiguous, or not testable.
+- The active ChangeSet does not include this UC or contradicts the UC plan.
+- The UC docs and ChangeSet describe different intended behavior or document deltas.
 - The approved requirements or use cases contradict the DDD design.
 - Event storming lacks a command/event/policy needed to implement or test the behavior.
 - Aggregate boundaries make required consistency impossible without changing DDD design.
@@ -124,8 +145,8 @@ Treat a final verification failure as upstream design failure, not an implementa
 
 Stop the loop only when:
 
-- final verification passes, or
-- the failure is an upstream design/requirements/architecture/technical-decision issue that must return to the user, or
+- final verification passes for the targeted UC, or
+- the failure is an unclear E2E goal, document delta conflict, upstream design/requirements/architecture/technical-decision issue that must return to the user, or
 - the failure is an environment/permission/external-service blocker that cannot be fixed in the repository, or
 - the same failure repeats with no new plausible repository change; document it as a blocker instead of looping blindly.
 
@@ -141,7 +162,7 @@ Stop the loop only when:
 
 ## Test Expectations
 
-Use the test scope in `plan.md`.
+Use the test scope in the targeted UC plan, the UC E2E goal, and `.codex/test-gate.yaml`.
 
 - Domain/Aggregate/VO tests verify invariants, state transitions, invalid values, and boundary conditions.
 - Domain service tests verify domain calculations and decisions.
@@ -153,7 +174,7 @@ Do not use application service tests to re-test aggregate internals.
 
 ## Verification
 
-Follow `plan.md` section `8. 검증 방법`.
+Follow the targeted UC plan section `8. 검증 방법`, the UC E2E goal, and `.codex/test-gate.yaml`.
 
 Typical final commands are:
 
@@ -164,18 +185,26 @@ Typical final commands are:
 semgrep --config .semgrep/ddd-architecture.yml .
 ```
 
-If static-analysis tooling is not installed yet, implement the setup task described in `plan.md` before final verification.
+If static-analysis tooling is not installed yet, implement the setup task described in the targeted
+UC plan before final verification.
 
-After build succeeds, start the application server if `plan.md` defines runtime server verification. Use the command recorded in the plan, such as `./gradlew bootRun`, wait until the server is ready, run the plan's HTTP/API/UI checks for the implemented behavior, record the observed result in section `10. 검증 결과`, and stop the server before continuing. If the server cannot start because of environment limits, credentials, external services, or a port conflict, record the exact blocker under `11. 검증 실패` and treat it as an environment blocker unless a repository fix inside the approved scope is clear.
+After build succeeds, start the application server if the targeted UC plan defines runtime server
+verification. Use the command recorded in the UC plan, such as `./gradlew bootRun`, wait until the
+server is ready, run the UC plan's HTTP/API/UI checks for the implemented behavior, record the
+observed result in section `10. 검증 결과`, and stop the server before continuing. If the server
+cannot start because of environment limits, credentials, external services, or a port conflict,
+record the exact blocker under `11. 검증 실패` and treat it as an environment blocker unless a
+repository fix inside the approved scope is clear.
 
-If a command cannot run because of environment limits, record the exact failure in `plan.md`
+If a command cannot run because of environment limits, record the exact failure in the targeted UC plan
 under `11. 검증 실패` and report it as BLOCKED instead of adding code-remediation tasks.
 
 ## Completion
 
 Keep the plan active until all of these are true:
 
-- Every checkbox in `plan.md` is `- [x]`.
+- Every checkbox in `docs/plans/active/<UC-ID>/plan.md` is `- [x]`.
+- The implemented behavior satisfies `docs/use-cases/<UC-ID>/e2e-goal.md`.
 - Required tests exist and pass.
 - Build passes.
 - Runtime server verification passes, or is explicitly marked not applicable with a reason.
@@ -185,8 +214,8 @@ Keep the plan active until all of these are true:
 Only then move:
 
 ```text
-docs/plans/active/plan.md -> docs/plans/complete/plan.md
+docs/plans/active/<UC-ID>/plan.md -> docs/plans/completed/<UC-ID>/plan.md
 ```
 
 If final verification fails, do not move the plan. Add remediation tasks and delegate back to
-`implementation_executor`.
+`implementation_executor` only when the failure is `IMPLEMENTATION_FAILURE`.


### PR DESCRIPTION
## Summary

Implements #22 by updating the `harness-plan-executor` skill instructions for use-case scoped execution.

- Replaces the single `docs/plans/active/plan.md` model with `docs/plans/active/<UC-ID>/plan.md`.
- Adds required UC E2E goal, UC docs, active ChangeSet, repository settings, and test-gate inputs.
- Defines UC-scoped execution, verification, remediation, and completion behavior.
- Classifies failures into `IMPLEMENTATION_FAILURE`, `UNCLEAR_E2E_GOAL`, `DOCUMENT_DELTA_CONFLICT`, `UPSTREAM_DESIGN_CONFLICT`, and `ENVIRONMENT_BLOCKER`.
- Moves successful UC plans to `docs/plans/completed/<UC-ID>/plan.md`.

## Validation

- `git diff --check`
- `TMPDIR=/tmp PYTHONPATH=. /home/jiwoo/workspace/harness/.venv/bin/python -m pytest -q -s` passed: 30 tests.

## Notes

`python` was unavailable in the new worktree, and `python3` did not have `pytest` installed, so validation used the existing workspace virtualenv with `TMPDIR=/tmp` and capture disabled after pytest hit an environment-specific capture temp-file error.