### PR TITLE
[codex] 실행 모드별 런타임 동작 분리

### DIFF
--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -14,6 +14,7 @@ from harness_codex.runtime.models import (
     RunContext,
     RunResult,
     RunStatus,
+    RunMode,
     Step,
     StepResult,
     StepStatus,
@@ -58,6 +59,10 @@ class RunnerEngine:
         """Run the workflow until all steps succeed or one step fails/blocks."""
 
         execution_plan = self.plan(workflow)
+
+        if context.mode in (RunMode.PLAN, RunMode.PREVIEW):
+            return self._dry_run_result(execution_plan, context)
+
         results: list[StepResult] = []
 
         for step in execution_plan.steps:
@@ -69,8 +74,10 @@ class RunnerEngine:
                     run_id=context.run_id,
                     status=RunStatus.FAILED,
                     step_results=tuple(results),
+                    mode=context.mode,
                     failed_step_id=step.id,
                     blocker=result.error,
+                    metadata=self._result_metadata(execution_plan, context),
                 )
 
             if result.status == StepStatus.BLOCKED:
@@ -78,15 +85,57 @@ class RunnerEngine:
                     run_id=context.run_id,
                     status=RunStatus.BLOCKED,
                     step_results=tuple(results),
+                    mode=context.mode,
                     failed_step_id=step.id,
                     blocker=result.error,
+                    metadata=self._result_metadata(execution_plan, context),
                 )
 
         return RunResult(
             run_id=context.run_id,
             status=RunStatus.SUCCEEDED,
             step_results=tuple(results),
+            mode=context.mode,
+            metadata=self._result_metadata(execution_plan, context),
         )
+
+    def _dry_run_result(
+        self,
+        execution_plan: ExecutionPlan,
+        context: RunContext,
+    ) -> RunResult:
+        step_results = tuple(
+            StepResult(
+                step_id=step.id,
+                status=StepStatus.SKIPPED,
+                metadata={
+                    "mode": context.mode.value,
+                    "would_run": context.mode == RunMode.PREVIEW,
+                    "side_effects": False,
+                },
+            )
+            for step in execution_plan.steps
+        )
+
+        return RunResult(
+            run_id=context.run_id,
+            status=RunStatus.SUCCEEDED,
+            step_results=step_results,
+            mode=context.mode,
+            metadata=self._result_metadata(execution_plan, context),
+        )
+
+    def _result_metadata(
+        self,
+        execution_plan: ExecutionPlan,
+        context: RunContext,
+    ) -> dict[str, object]:
+        return {
+            "mode": context.mode.value,
+            "workflow_name": context.workflow_name,
+            "planned_steps": execution_plan.step_ids(),
+            "side_effects": context.mode == RunMode.APPLY,
+        }
 
     def _index_steps(self, workflow: Workflow) -> dict[str, Step]:
         steps_by_id: dict[str, Step] = {}

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -161,6 +161,7 @@ class RunResult:
     run_id: str
     status: RunStatus
     step_results: tuple[StepResult, ...]
+    mode: RunMode | None = None
     failed_step_id: str | None = None
     blocker: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)

--- a/tests/runtime/test_engine.py
+++ b/tests/runtime/test_engine.py
@@ -38,10 +38,14 @@ class FakeStepRunner:
 
 
 def context() -> RunContext:
+    return context_with_mode(RunMode.APPLY)
+
+
+def context_with_mode(mode: RunMode) -> RunContext:
     return RunContext(
         run_id="run-001",
         workflow_name="example",
-        mode=RunMode.APPLY,
+        mode=mode,
         repo_root=Path("/repo"),
         workdir=Path("/repo"),
         run_dir=Path("/repo/.harness/runs/run-001"),
@@ -276,3 +280,88 @@ def test_plan_returns_execution_plan_without_running_steps() -> None:
 
     assert plan.step_ids() == ("analyze", "validate")
     assert fake_runner.executed_step_ids == []
+
+
+def test_run_in_plan_mode_records_plan_without_running_steps() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="analyze",
+                kind=StepKind.AGENT,
+                name="Analyze",
+            ),
+            Step(
+                id="validate",
+                kind=StepKind.VALIDATOR,
+                name="Validate",
+                needs=("analyze",),
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner()
+    engine = RunnerEngine(fake_runner)
+
+    result = engine.run(workflow, context_with_mode(RunMode.PLAN))
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.mode == RunMode.PLAN
+    assert result.metadata["mode"] == "plan"
+    assert result.metadata["planned_steps"] == ("analyze", "validate")
+    assert result.metadata["side_effects"] is False
+    assert fake_runner.executed_step_ids == []
+    assert tuple(step_result.status for step_result in result.step_results) == (
+        StepStatus.SKIPPED,
+        StepStatus.SKIPPED,
+    )
+
+
+def test_run_in_preview_mode_records_preview_without_running_steps() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="implement",
+                kind=StepKind.AGENT,
+                name="Implement",
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner()
+    engine = RunnerEngine(fake_runner)
+
+    result = engine.run(workflow, context_with_mode(RunMode.PREVIEW))
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.mode == RunMode.PREVIEW
+    assert result.metadata["mode"] == "preview"
+    assert result.metadata["planned_steps"] == ("implement",)
+    assert result.metadata["side_effects"] is False
+    assert fake_runner.executed_step_ids == []
+    assert result.step_results[0].metadata["would_run"] is True
+
+
+def test_run_in_apply_mode_executes_steps_and_records_mode() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="implement",
+                kind=StepKind.AGENT,
+                name="Implement",
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner()
+    engine = RunnerEngine(fake_runner)
+
+    result = engine.run(workflow, context_with_mode(RunMode.APPLY))
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.mode == RunMode.APPLY
+    assert result.metadata["mode"] == "apply"
+    assert result.metadata["side_effects"] is True
+    assert fake_runner.executed_step_ids == ["implement"]


### PR DESCRIPTION
## 구현 의도

워크플로우 런타임에서 `plan`, `preview`, `apply` 모드를 명시적으로 분리해 `plan`/`preview` 실행이 `StepRunner` 경계의 부수효과를 만들지 않도록 했습니다. 의존성 순서상 `#8`의 schema/loader 구현은 이미 코드에 반영되어 있어, 다음 실제 구현 대상인 #9를 처리했습니다.

## 구현 방법

`RunnerEngine.run()`은 먼저 기존처럼 workflow graph를 검증하고 실행 순서를 계산합니다. 이후 `RunContext.mode`가 `plan` 또는 `preview`이면 모든 step을 `SKIPPED` 결과로 기록하고 `StepRunner`를 호출하지 않습니다. `apply` 모드에서는 기존 실행 흐름을 유지하되 `RunResult.mode`와 결과 메타데이터에 mode, workflow 이름, 계획된 step 목록, side effect 여부를 남깁니다.

## 검증 방법

- `venv/bin/python -m pytest -s`
- 41개 테스트 통과
- 일반 `pytest` 캡처 모드는 로컬 환경에서 임시 캡처 파일 오류가 발생해 `-s`로 캡처를 끄고 검증했습니다.

Closes #9