### PR TITLE
[codex] ChangeSet 유스케이스 워크플로우 모델 반영

### DIFF
--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -241,112 +241,160 @@ HARNESS_FULL_WORKFLOW = Workflow(
     name="harness-full-workflow",
     mode=RunMode.APPLY,
     description=(
-        "Full harness lifecycle: harvester prepares approved use-case input, "
-        "then orchestrator runs oracle, planner, executor, verification, and "
-        "repeat/remediation flow until completion or blocker."
+        "Full harness lifecycle: capture implementation intent, create a "
+        "ChangeSet, identify affected use cases, and run use-case scoped "
+        "planning, execution, E2E verification, remediation, and completion."
     ),
     steps=(
         Step(
-            id="harvest-use-cases",
-            kind=StepKind.AGENT,
-            name="Harvest and refine use cases until the user confirms OK",
-            agent_id="use_case_harvester",
+            id="capture-implementation-intent",
+            kind=StepKind.RECORD,
+            name="Capture implementation prompt or change request",
             outputs=(
-                Path("docs/design/요구사항.md"),
-                Path("docs/design/유스케이스.md"),
+                Path("docs/changes/active"),
             ),
             metadata={
-                "stage": "harvester",
-                "gate": "user_ok_required",
+                "stage": "intake",
+                "scope": "change_set",
                 "purpose": (
-                    "Prepare approved problem framing and use cases before "
-                    "post-harvest orchestration starts."
+                    "Record the implementation intent that will be tracked as "
+                    "a ChangeSet instead of a repository-wide active plan."
                 ),
             },
         ),
         Step(
-            id="orchestrator-start",
+            id="create-change-set",
             kind=StepKind.RECORD,
-            name="Start post-harvest orchestration after harvester gate passes",
-            needs=("harvest-use-cases",),
+            name="Create active ChangeSet from captured implementation intent",
+            needs=("capture-implementation-intent",),
             inputs=(
-                Path("AGENTS.md"),
-                Path("ARCHITECTURE.md"),
-                Path("docs/design"),
+                Path("docs/templates/changes/change-set.md"),
             ),
+            outputs=(Path("docs/changes/active/<CHG-ID>.md"),),
             metadata={
-                "stage": "orchestrator",
-                "purpose": "Load source-of-truth documents for orchestration.",
+                "stage": "change-set",
+                "scope": "change_set",
+                "purpose": (
+                    "Create the source-of-truth ChangeSet that bounds the "
+                    "subsequent use-case scoped workflow."
+                ),
             },
         ),
         Step(
-            id="oracle-generate-plan",
+            id="identify-affected-use-cases",
+            kind=StepKind.DECISION,
+            name="Identify use cases affected by the active ChangeSet",
+            needs=("create-change-set",),
+            inputs=(
+                Path("docs/changes/active/<CHG-ID>.md"),
+                Path("docs/use-cases"),
+            ),
+            metadata={
+                "stage": "change-set",
+                "scope": "affected_use_cases",
+                "purpose": (
+                    "Resolve the affected UC list before any UC-specific "
+                    "event storming, design, planning, or execution starts."
+                ),
+            },
+        ),
+        Step(
+            id="storm-affected-use-case",
             kind=StepKind.AGENT,
-            name="Generate execution checklist from source-of-truth docs",
-            needs=("orchestrator-start",),
+            name="Run event storming for one affected use-case slice",
+            needs=("identify-affected-use-cases",),
             agent_id="oracle",
             inputs=(
-                Path("AGENTS.md"),
-                Path("ARCHITECTURE.md"),
-                Path("docs/design"),
+                Path("docs/changes/active/<CHG-ID>.md"),
+                Path("docs/use-cases/<UC-ID>/use-case.md"),
             ),
-            outputs=(Path("docs/plans/active/plan.md"),),
+            outputs=(Path("docs/use-cases/<UC-ID>/event-storming.md"),),
             metadata={
-                "stage": "oracle",
+                "stage": "event-storming",
+                "scope": "use_case",
                 "purpose": (
-                    "Turn approved requirements, use cases, event storming, "
-                    "DDD design, and architecture rules into an execution plan."
+                    "Update only the affected use-case event storming slice "
+                    "within the active ChangeSet boundary."
                 ),
             },
         ),
         Step(
-            id="planner-refine-active-plan",
+            id="design-affected-use-case",
             kind=StepKind.AGENT,
-            name="Refine active execution plan into implementable tasks",
-            needs=("oracle-generate-plan",),
-            agent_id="planner",
+            name="Derive DDD design for one affected use-case slice",
+            needs=("storm-affected-use-case",),
+            agent_id="ddd_architect",
             inputs=(
-                Path("docs/plans/active/plan.md"),
-                Path("ARCHITECTURE.md"),
-                Path("docs/design"),
+                Path("docs/changes/active/<CHG-ID>.md"),
+                Path("docs/use-cases/<UC-ID>/event-storming.md"),
             ),
-            outputs=(Path("docs/plans/active/plan.md"),),
+            outputs=(Path("docs/use-cases/<UC-ID>/ddd-design.md"),),
+            metadata={
+                "stage": "ddd-design",
+                "scope": "use_case",
+                "purpose": (
+                    "Keep design updates scoped to the affected use case "
+                    "instead of rewriting repository-wide design artifacts."
+                ),
+            },
+        ),
+        Step(
+            id="planner-create-use-case-plan",
+            kind=StepKind.AGENT,
+            name="Create an implementation plan for one affected use case",
+            needs=("design-affected-use-case",),
+            agent_id="implementation_planner",
+            inputs=(
+                Path("docs/changes/active/<CHG-ID>.md"),
+                Path("docs/use-cases/<UC-ID>"),
+                Path("ARCHITECTURE.md"),
+            ),
+            outputs=(Path("docs/plans/active/<UC-ID>/plan.md"),),
             metadata={
                 "stage": "planner",
+                "scope": "use_case",
                 "purpose": (
-                    "Make the active plan executable without changing approved "
-                    "requirements or architecture scope."
+                    "Create a plan whose completion target is the affected "
+                    "use-case E2E goal."
                 ),
             },
         ),
         Step(
-            id="executor-implement-plan",
+            id="executor-implement-use-case-plan",
             kind=StepKind.AGENT,
-            name="Implement unchecked tasks in the active plan",
-            needs=("planner-refine-active-plan",),
+            name="Implement unchecked tasks in one use-case scoped plan",
+            needs=("planner-create-use-case-plan",),
             agent_id="implementation_executor",
             inputs=(
-                Path("docs/plans/active/plan.md"),
+                Path("docs/plans/active/<UC-ID>/plan.md"),
+                Path("docs/use-cases/<UC-ID>"),
+                Path("docs/changes/active/<CHG-ID>.md"),
                 Path("ARCHITECTURE.md"),
-                Path("docs/design"),
                 Path(".codex/agents/implementation_executor.toml"),
             ),
-            outputs=(Path("docs/plans/active/plan.md"),),
+            outputs=(Path("docs/plans/active/<UC-ID>/plan.md"),),
             metadata={
                 "stage": "executor",
+                "scope": "use_case",
                 "purpose": (
-                    "Implement only unchecked tasks in the active plan and "
-                    "update checkboxes after focused verification."
+                    "Implement only the current UC plan and update that plan "
+                    "after focused verification."
                 ),
             },
         ),
         Step(
-            id="run-verification",
+            id="verifier-run-use-case-e2e",
             kind=StepKind.VALIDATOR,
-            name="Run tests, build, static analysis, and runtime verification",
-            needs=("executor-implement-plan",),
+            name="Run E2E goal and quality gates for one affected use case",
+            needs=("executor-implement-use-case-plan",),
+            inputs=(
+                Path("docs/plans/active/<UC-ID>/plan.md"),
+                Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
+                Path(".codex/test-gate.yaml"),
+            ),
             metadata={
-                "stage": "test",
+                "stage": "verifier",
+                "scope": "use_case",
                 "typical_commands": (
                     "./gradlew build",
                     "./gradlew test",
@@ -354,89 +402,95 @@ HARNESS_FULL_WORKFLOW = Workflow(
                     "semgrep --config .semgrep/ddd-architecture.yml .",
                 ),
                 "purpose": (
-                    "Verify completed implementation against the active plan "
-                    "and repository quality gates."
+                    "Verify the implemented UC against its E2E goal and "
+                    "repository quality gates."
                 ),
             },
         ),
         Step(
-            id="classify-verification-result",
+            id="classify-use-case-verification-result",
             kind=StepKind.DECISION,
-            name="Decide whether to complete, remediate, or stop as blocker",
-            needs=("run-verification",),
+            name="Decide whether to complete, remediate, or stop the use case",
+            needs=("verifier-run-use-case-e2e",),
             metadata={
-                "stage": "orchestrator",
-                "on_success": "complete-plan",
-                "on_implementation_failure": "record-remediation-and-repeat",
-                "on_upstream_design_failure": "record-upstream-blocker",
-                "on_environment_blocker": "record-environment-blocker",
+                "stage": "verifier",
+                "scope": "use_case",
+                "on_success": "complete-use-case-plan",
+                "on_implementation_failure": "revise-use-case-plan-and-repeat",
+                "on_upstream_design_failure": "record-use-case-blocker",
+                "on_environment_blocker": "record-use-case-blocker",
                 "purpose": (
-                    "Classify verification result before deciding whether "
-                    "the executor loop should repeat or stop."
+                    "Classify verification result before repeating only the "
+                    "affected UC plan loop or stopping with blocker evidence."
                 ),
             },
         ),
         Step(
-            id="record-remediation-and-repeat",
+            id="revise-use-case-plan-and-repeat",
             kind=StepKind.RECORD,
-            name="Record remediation tasks and repeat executor/verification loop",
-            needs=("classify-verification-result",),
-            outputs=(Path("docs/plans/active/plan.md"),),
+            name="Record remediation tasks and repeat the UC executor loop",
+            needs=("classify-use-case-verification-result",),
+            outputs=(Path("docs/plans/active/<UC-ID>/plan.md"),),
             metadata={
                 "stage": "orchestrator",
-                "loop_target": "executor-implement-plan",
-                "loop_until": "verification_passes_or_blocker",
+                "scope": "use_case",
+                "loop_target": "executor-implement-use-case-plan",
+                "loop_until": "use_case_e2e_passes_or_blocker",
                 "purpose": (
-                    "For implementation-level failures, append remediation "
-                    "tasks to the active plan and repeat executor verification."
+                    "Append remediation only to the failing UC plan and repeat "
+                    "that UC's executor/E2E verification loop."
                 ),
             },
         ),
         Step(
-            id="record-upstream-blocker",
+            id="record-use-case-blocker",
             kind=StepKind.RECORD,
-            name="Record upstream design, requirements, or architecture blocker",
-            needs=("classify-verification-result",),
-            outputs=(Path("docs/plans/active/plan.md"),),
+            name="Record blocker evidence for one affected use case",
+            needs=("classify-use-case-verification-result",),
+            outputs=(Path("docs/plans/active/<UC-ID>/plan.md"),),
             metadata={
                 "stage": "orchestrator",
-                "stop_reason": "upstream_design_blocker",
+                "scope": "use_case",
+                "stop_reasons": (
+                    "upstream_design_blocker",
+                    "environment_blocker",
+                ),
                 "purpose": (
-                    "Stop execution when the failure requires revisiting "
-                    "requirements, event storming, DDD design, technical "
-                    "decisions, or architecture."
+                    "Stop the UC loop when failure cannot be remediated inside "
+                    "the current UC plan and ChangeSet boundary."
                 ),
             },
         ),
         Step(
-            id="record-environment-blocker",
-            kind=StepKind.RECORD,
-            name="Record environment, permission, tool, credential, or service blocker",
-            needs=("classify-verification-result",),
-            outputs=(Path("docs/plans/active/plan.md"),),
-            metadata={
-                "stage": "orchestrator",
-                "stop_reason": "environment_blocker",
-                "purpose": (
-                    "Stop execution when verification cannot continue because "
-                    "of host, permission, credential, network, or external "
-                    "service limitations."
-                ),
-            },
-        ),
-        Step(
-            id="complete-plan",
+            id="complete-use-case-plan",
             kind=StepKind.GIT,
-            name="Move active plan to completed plans after all checks pass",
-            needs=("classify-verification-result",),
-            inputs=(Path("docs/plans/active/plan.md"),),
-            outputs=(Path("docs/plans/complete/plan.md"),),
+            name="Move the completed UC plan out of active plans",
+            needs=("classify-use-case-verification-result",),
+            inputs=(Path("docs/plans/active/<UC-ID>/plan.md"),),
+            outputs=(Path("docs/plans/completed/<UC-ID>/plan.md"),),
             metadata={
                 "stage": "completion",
-                "condition": "all_tasks_checked_and_all_verification_passed",
+                "scope": "use_case",
+                "condition": "use_case_e2e_goal_and_quality_gates_passed",
                 "purpose": (
-                    "Complete the active plan only after implementation, tests, "
-                    "build, runtime verification, and static analysis pass."
+                    "Complete only the UC plan whose tasks and E2E gate passed."
+                ),
+            },
+        ),
+        Step(
+            id="complete-change-set",
+            kind=StepKind.GIT,
+            name="Complete the active ChangeSet after all affected UCs complete",
+            needs=("complete-use-case-plan",),
+            inputs=(Path("docs/changes/active/<CHG-ID>.md"),),
+            outputs=(Path("docs/changes/completed/<CHG-ID>.md"),),
+            metadata={
+                "stage": "completion",
+                "scope": "change_set",
+                "condition": "all_affected_use_case_plans_completed",
+                "purpose": (
+                    "Complete the ChangeSet only after every affected UC plan "
+                    "has passed and moved to completed plans."
                 ),
             },
         ),

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -146,92 +146,125 @@ def test_harness_full_workflow_models_top_level_harness_lifecycle() -> None:
     assert workflow.mode == RunMode.APPLY
 
     assert workflow.step_ids() == (
-        "harvest-use-cases",
-        "orchestrator-start",
-        "oracle-generate-plan",
-        "planner-refine-active-plan",
-        "executor-implement-plan",
-        "run-verification",
-        "classify-verification-result",
-        "record-remediation-and-repeat",
-        "record-upstream-blocker",
-        "record-environment-blocker",
-        "complete-plan",
+        "capture-implementation-intent",
+        "create-change-set",
+        "identify-affected-use-cases",
+        "storm-affected-use-case",
+        "design-affected-use-case",
+        "planner-create-use-case-plan",
+        "executor-implement-use-case-plan",
+        "verifier-run-use-case-e2e",
+        "classify-use-case-verification-result",
+        "revise-use-case-plan-and-repeat",
+        "record-use-case-blocker",
+        "complete-use-case-plan",
+        "complete-change-set",
     )
 
 
-def test_harness_full_workflow_starts_with_harvester_gate() -> None:
-    step = HARNESS_FULL_WORKFLOW.step_by_id("harvest-use-cases")
+def test_harness_full_workflow_starts_with_change_set_intake() -> None:
+    capture = HARNESS_FULL_WORKFLOW.step_by_id("capture-implementation-intent")
+    change_set = HARNESS_FULL_WORKFLOW.step_by_id("create-change-set")
+    affected = HARNESS_FULL_WORKFLOW.step_by_id("identify-affected-use-cases")
 
-    assert step.kind == StepKind.AGENT
-    assert step.agent_id == "use_case_harvester"
-    assert step.needs == ()
-    assert step.metadata["stage"] == "harvester"
-    assert step.metadata["gate"] == "user_ok_required"
+    assert capture.kind == StepKind.RECORD
+    assert capture.needs == ()
+    assert capture.metadata["scope"] == "change_set"
+
+    assert change_set.kind == StepKind.RECORD
+    assert change_set.needs == ("capture-implementation-intent",)
+    assert Path("docs/changes/active/<CHG-ID>.md") in change_set.outputs
+
+    assert affected.kind == StepKind.DECISION
+    assert affected.needs == ("create-change-set",)
+    assert affected.metadata["scope"] == "affected_use_cases"
 
 
-def test_harness_full_workflow_orchestrates_oracle_planner_executor_verification() -> (
+def test_harness_full_workflow_orchestrates_use_case_scoped_loop() -> (
     None
 ):
-    oracle = HARNESS_FULL_WORKFLOW.step_by_id("oracle-generate-plan")
-    planner = HARNESS_FULL_WORKFLOW.step_by_id("planner-refine-active-plan")
-    executor = HARNESS_FULL_WORKFLOW.step_by_id("executor-implement-plan")
-    verification = HARNESS_FULL_WORKFLOW.step_by_id("run-verification")
+    storming = HARNESS_FULL_WORKFLOW.step_by_id("storm-affected-use-case")
+    design = HARNESS_FULL_WORKFLOW.step_by_id("design-affected-use-case")
+    planner = HARNESS_FULL_WORKFLOW.step_by_id("planner-create-use-case-plan")
+    executor = HARNESS_FULL_WORKFLOW.step_by_id("executor-implement-use-case-plan")
+    verification = HARNESS_FULL_WORKFLOW.step_by_id("verifier-run-use-case-e2e")
 
-    assert oracle.kind == StepKind.AGENT
-    assert oracle.agent_id == "oracle"
-    assert oracle.needs == ("orchestrator-start",)
+    assert storming.kind == StepKind.AGENT
+    assert storming.agent_id == "oracle"
+    assert storming.needs == ("identify-affected-use-cases",)
+    assert Path("docs/use-cases/<UC-ID>/event-storming.md") in storming.outputs
+
+    assert design.kind == StepKind.AGENT
+    assert design.agent_id == "ddd_architect"
+    assert design.needs == ("storm-affected-use-case",)
+    assert Path("docs/use-cases/<UC-ID>/ddd-design.md") in design.outputs
 
     assert planner.kind == StepKind.AGENT
-    assert planner.agent_id == "planner"
-    assert planner.needs == ("oracle-generate-plan",)
+    assert planner.agent_id == "implementation_planner"
+    assert planner.needs == ("design-affected-use-case",)
+    assert Path("docs/plans/active/<UC-ID>/plan.md") in planner.outputs
 
     assert executor.kind == StepKind.AGENT
     assert executor.agent_id == "implementation_executor"
-    assert executor.needs == ("planner-refine-active-plan",)
+    assert executor.needs == ("planner-create-use-case-plan",)
+    assert Path("docs/plans/active/<UC-ID>/plan.md") in executor.inputs
 
     assert verification.kind == StepKind.VALIDATOR
-    assert verification.needs == ("executor-implement-plan",)
+    assert verification.needs == ("executor-implement-use-case-plan",)
+    assert Path("docs/use-cases/<UC-ID>/e2e-goal.md") in verification.inputs
     assert "./gradlew build" in verification.metadata["typical_commands"]
     assert "./gradlew test" in verification.metadata["typical_commands"]
 
 
-def test_harness_full_workflow_records_repeat_loop_intent() -> None:
-    decision = HARNESS_FULL_WORKFLOW.step_by_id("classify-verification-result")
-    remediation = HARNESS_FULL_WORKFLOW.step_by_id("record-remediation-and-repeat")
+def test_harness_full_workflow_records_use_case_repeat_loop_intent() -> None:
+    decision = HARNESS_FULL_WORKFLOW.step_by_id(
+        "classify-use-case-verification-result"
+    )
+    remediation = HARNESS_FULL_WORKFLOW.step_by_id("revise-use-case-plan-and-repeat")
 
     assert decision.kind == StepKind.DECISION
-    assert decision.needs == ("run-verification",)
+    assert decision.needs == ("verifier-run-use-case-e2e",)
     assert (
         decision.metadata["on_implementation_failure"]
-        == "record-remediation-and-repeat"
+        == "revise-use-case-plan-and-repeat"
     )
+    assert decision.metadata["on_success"] == "complete-use-case-plan"
 
     assert remediation.kind == StepKind.RECORD
-    assert remediation.needs == ("classify-verification-result",)
-    assert remediation.metadata["loop_target"] == "executor-implement-plan"
-    assert remediation.metadata["loop_until"] == "verification_passes_or_blocker"
+    assert remediation.needs == ("classify-use-case-verification-result",)
+    assert remediation.metadata["loop_target"] == "executor-implement-use-case-plan"
+    assert remediation.metadata["loop_until"] == "use_case_e2e_passes_or_blocker"
+    assert Path("docs/plans/active/<UC-ID>/plan.md") in remediation.outputs
 
 
-def test_harness_full_workflow_records_blocker_paths() -> None:
-    upstream = HARNESS_FULL_WORKFLOW.step_by_id("record-upstream-blocker")
-    environment = HARNESS_FULL_WORKFLOW.step_by_id("record-environment-blocker")
+def test_harness_full_workflow_records_use_case_blocker_path() -> None:
+    blocker = HARNESS_FULL_WORKFLOW.step_by_id("record-use-case-blocker")
 
-    assert upstream.kind == StepKind.RECORD
-    assert upstream.metadata["stop_reason"] == "upstream_design_blocker"
+    assert blocker.kind == StepKind.RECORD
+    assert blocker.needs == ("classify-use-case-verification-result",)
+    assert "upstream_design_blocker" in blocker.metadata["stop_reasons"]
+    assert "environment_blocker" in blocker.metadata["stop_reasons"]
+    assert Path("docs/plans/active/<UC-ID>/plan.md") in blocker.outputs
 
-    assert environment.kind == StepKind.RECORD
-    assert environment.metadata["stop_reason"] == "environment_blocker"
 
+def test_harness_full_workflow_records_use_case_and_change_set_completion() -> None:
+    complete_uc = HARNESS_FULL_WORKFLOW.step_by_id("complete-use-case-plan")
+    complete_change_set = HARNESS_FULL_WORKFLOW.step_by_id("complete-change-set")
 
-def test_harness_full_workflow_records_completion_path() -> None:
-    complete = HARNESS_FULL_WORKFLOW.step_by_id("complete-plan")
-
-    assert complete.kind == StepKind.GIT
-    assert complete.needs == ("classify-verification-result",)
+    assert complete_uc.kind == StepKind.GIT
+    assert complete_uc.needs == ("classify-use-case-verification-result",)
     assert (
-        complete.metadata["condition"]
-        == "all_tasks_checked_and_all_verification_passed"
+        complete_uc.metadata["condition"]
+        == "use_case_e2e_goal_and_quality_gates_passed"
     )
-    assert Path("docs/plans/active/plan.md") in complete.inputs
-    assert Path("docs/plans/complete/plan.md") in complete.outputs
+    assert Path("docs/plans/active/<UC-ID>/plan.md") in complete_uc.inputs
+    assert Path("docs/plans/completed/<UC-ID>/plan.md") in complete_uc.outputs
+
+    assert complete_change_set.kind == StepKind.GIT
+    assert complete_change_set.needs == ("complete-use-case-plan",)
+    assert (
+        complete_change_set.metadata["condition"]
+        == "all_affected_use_case_plans_completed"
+    )
+    assert Path("docs/changes/active/<CHG-ID>.md") in complete_change_set.inputs
+    assert Path("docs/changes/completed/<CHG-ID>.md") in complete_change_set.outputs


### PR DESCRIPTION
## 구현 의도

- 워크플로우 순서상 먼저 구현해야 하는 열린 P0 이슈인 #15 범위를 반영했습니다.
- 기존 전체 문서 기반 단일 active plan 흐름을 ChangeSet 생성, 영향 유스케이스 식별, 유스케이스별 plan/executor/E2E loop 흐름으로 표현하려고 했습니다.

## 구현 방법

- `HARNESS_FULL_WORKFLOW` 단계 목록을 `capture-implementation-intent` → `create-change-set` → `identify-affected-use-cases` → 유스케이스별 event storming/design/plan/executor/verifier → UC plan 완료 → ChangeSet 완료 순서로 재정의했습니다.
- 각 단계의 `inputs`, `outputs`, `needs`, `metadata.scope`를 ChangeSet 또는 use-case 단위로 기록해 런타임 모델에서 데이터 흐름과 루프 단위를 확인할 수 있게 했습니다.
- 모델 테스트를 새 워크플로우 순서, UC별 반복 루프, blocker 경로, ChangeSet 완료 조건을 검증하도록 갱신했습니다.

## 검증 방법

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. venv/bin/python3 -m pytest -q -s`
- 결과: 41 passed

Closes #15