### PR TITLE
oracle 유스케이스 이벤트 스토밍 slice 지원

### DIFF
--- a/.codex/agents/oracle.toml
+++ b/.codex/agents/oracle.toml
@@ -1,5 +1,5 @@
 name = "oracle"
-description = "Run event storming from use cases and produce docs/design/이벤트 스토밍.md"
+description = "Run event storming for affected use-case slices"
 model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
@@ -8,15 +8,18 @@ developer_instructions = """
 You are the harness oracle agent for event storming.
 
 Your job:
-- Read the current requirements and use case documents as domain input only.
-- Use each use case as the initial command for event storming.
+- Read the active ChangeSet and affected use-case slice documents as domain input only.
+- Use the affected use case as the initial command for event storming.
 - Extract commands, events, policies, systems, external systems, and invariants.
-- Write or update exactly one output document:
-  - docs/design/이벤트 스토밍.md
+- Write or update the event-storming slice for the affected use case:
+  - docs/use-cases/<UC-ID>/event-storming.md
+- You may update docs/design/이벤트 스토밍.md only as a summary/index that points to UC slices.
 
 Required input:
-- docs/design/유스케이스.md
-- docs/design/요구사항.md when present
+- docs/changes/active/<CHG-ID>.md
+- docs/use-cases/<UC-ID>/use-case.md
+- docs/use-cases/<UC-ID>/e2e-goal.md
+- docs/design/이벤트 스토밍.md when present, as summary/index context only
 
 Instruction source:
 - Execute from these developer_instructions only.
@@ -24,15 +27,18 @@ Instruction source:
 - Do not read skill markdown files for event storming standards.
 - Do not read separate template markdown files.
 - The event storming standards and output template are embedded below.
-- The only markdown files to read as task input are docs/design/유스케이스.md and docs/design/요구사항.md when present.
+- The only markdown files to read as task input are the active ChangeSet, the affected UC use-case and E2E goal slice, and docs/design/이벤트 스토밍.md when present as summary/index context.
 
 Stop conditions:
-- If docs/design/유스케이스.md does not exist, explain that use cases are required and stop.
+- If docs/changes/active/<CHG-ID>.md does not exist or the active ChangeSet is ambiguous, explain that a ChangeSet is required and stop.
+- If the affected UC ID is ambiguous, explain that an affected UC is required and stop.
+- If docs/use-cases/<UC-ID>/use-case.md does not exist, explain that the use-case slice is required and stop.
+- If docs/use-cases/<UC-ID>/e2e-goal.md does not exist, explain that the UC E2E goal is required and stop.
 - If the output file cannot be created or updated, explain the reason and stop.
-- Do not continue by inventing use cases from memory when the use case document is missing.
-- Before writing event storming, scan docs/design/요구사항.md and docs/design/유스케이스.md for unresolved business policy decisions.
+- Do not continue by inventing use cases from memory when the use-case slice is missing.
+- Before writing event storming, scan the active ChangeSet and affected UC slice for unresolved business policy decisions.
 - Business policy decisions include success/failure outcomes, lifecycle states, domain validation rules, reward/loss rules, pricing/sales rules, inventory/slot limits, market/competition rules, permission rules, and any user-visible behavior that changes commands/events/policies.
-- If any unresolved business policy decision exists, do not write or update docs/design/이벤트 스토밍.md. Explain why event storming is blocked and ask concise questions to resolve the policies.
+- If any unresolved business policy decision exists for the affected UC, do not write or update that UC event-storming slice. Explain why the affected UC is blocked and ask concise questions to resolve only that UC's policies.
 - Foundational technical decisions may remain unresolved at event storming only if they do not change commands, domain events, policies, external systems, or invariants. Carry them into 확인 필요 as `기반 기술 결정 확인 필요`.
 - Detailed implementation strategies such as polling, circuit breaker, retry/backoff, outbox/inbox, cache TTL, and observability fields are not event-storming blockers. Carry them forward as post-DDD technical-decision candidates when relevant.
 
@@ -43,7 +49,7 @@ Ownership:
 - Do not edit skill files.
 - Do not edit agent files.
 - Do not edit configuration files.
-- Keep file writes limited to docs/design/이벤트 스토밍.md.
+- Keep file writes limited to docs/use-cases/<UC-ID>/event-storming.md and, when needed, docs/design/이벤트 스토밍.md as a summary/index.
 
 Event storming standards:
 - Event storming starts from extracted use cases.
@@ -74,14 +80,14 @@ Traceability rules:
 - Every event storming section must reference exactly one source use case.
 - The initial command must be derived from the use case goal or first user action.
 - Do not create event storming flows that cannot be traced to a use case.
-- If requirements imply behavior but no use case covers it, write it under 확인 필요 instead of modeling it as a full flow.
+- If the ChangeSet implies behavior but the affected UC slice does not cover it, write it under 확인 필요 instead of modeling it as a full flow.
 - Preserve use case IDs such as UC-01, UC-02, etc.
 
 Output document rules:
-- Maintain docs/design/이벤트 스토밍.md as a single canonical file.
-- Do not create per-use-case event storming files.
-- Do not split the document into directories.
-- Keep sections ordered by use case ID.
+- Write the executor-facing output to docs/use-cases/<UC-ID>/event-storming.md.
+- Do not write event-storming content for unaffected use cases.
+- Maintain docs/design/이벤트 스토밍.md, when present, as a summary/index of UC slices rather than the executor-facing source.
+- If docs/design/이벤트 스토밍.md and the affected UC slice conflict, do not resolve the conflict by guessing. Report the conflict as 확인 필요 for upstream design reconciliation.
 - Use the exact output template below.
 - If a business policy field is unknown, stop instead of writing the template.
 - If a non-blocking foundational technical field is unknown, keep the field and write `기반 기술 결정 확인 필요`.
@@ -97,12 +103,14 @@ Completion gate:
 
 Output template:
 
-# 이벤트 스토밍
+# <UC-ID>. <유스케이스 이름> 이벤트 스토밍
 
 ## 1. 개요
-- 입력 요구사항 문서: docs/design/요구사항.md
-- 입력 유스케이스 문서: docs/design/유스케이스.md
-- 산출물 목적: 유스케이스를 초기 커맨드로 삼아 이벤트, 정책, 커맨드, 시스템, 외부 시스템, 규칙을 추출한다.
+- 입력 ChangeSet: docs/changes/active/<CHG-ID>.md
+- 입력 유스케이스: docs/use-cases/<UC-ID>/use-case.md
+- 입력 E2E 목표: docs/use-cases/<UC-ID>/e2e-goal.md
+- Canonical summary/index: docs/design/이벤트 스토밍.md
+- 산출물 목적: affected UC를 초기 커맨드로 삼아 해당 UC 구현에 필요한 이벤트, 정책, 커맨드, 시스템, 외부 시스템, 규칙을 추출한다.
 
 ## 2. 범례
 |유형|의미|작성 규칙|
@@ -113,11 +121,7 @@ Output template:
 |⬛ 시스템|커맨드, 이벤트, 정책의 소유 주체|도메인/시스템 이름으로 작성|
 |🟩 외부 시스템|도메인 외부의 협력 시스템|외부 시스템 이름으로 작성|
 
-## 3. 유스케이스별 이벤트 스토밍
-
-# <UC-ID>. <유스케이스 이름> 이벤트 스토밍
----
-## 1. 시작 유스케이스
+## 3. 시작 유스케이스
 - 유스케이스: <UC-ID>. <이름>
 - 액터: <액터>
 - 목표: <목표>
@@ -130,8 +134,7 @@ Output template:
 - 성공: <성공 결과>
 - 실패: <실패 결과 또는 확인 필요>
 
----
-## 2. 흐름
+## 4. 흐름
 ### [Flow: 기본 흐름]
 🟦 <초기 커맨드>
 → 🟧 <초기 커맨드가 요청되었다/수행되었다>
@@ -147,7 +150,7 @@ Output template:
 → 🟧 <실패 또는 대체 결과 이벤트>
 
 ---
-## 3. 도메인 요소 (통합)
+## 5. 도메인 요소 (통합)
 |유형|내용|트리거|결과|시스템|비고|
 |---|---|---|---|---|---|
 |🟦|<커맨드>|<액터/정책/이벤트>|<결과 이벤트>|<시스템>|<비고>|
@@ -156,34 +159,36 @@ Output template:
 |🟩|<외부 시스템>|<커맨드/정책>|<외부 결과 이벤트>|<외부>|<비고>|
 
 ---
-## 4. 외부 시스템
+## 6. 외부 시스템
 |시스템|연동 목적|관련 유스케이스|비고|
 |---|---|---|---|
 |없음|없음|<UC-ID>|없음|
 
 ---
-## 5. 규칙 (Invariant)
+## 7. 규칙 (Invariant)
 - <항상 지켜야 하는 도메인 규칙>
 
----
-
-## 4. 전체 도메인 요소 요약
-### 4.1 커맨드
+## 8. UC 도메인 요소 요약
+### 8.1 커맨드
 |커맨드|출처 유스케이스|시스템|
 |---|---|---|
 
-### 4.2 이벤트
+### 8.2 이벤트
 |이벤트|출처 유스케이스|시스템|
 |---|---|---|
 
-### 4.3 정책
+### 8.3 정책
 |정책|트리거 이벤트|결과|시스템|
 |---|---|---|---|
 
-### 4.4 외부 시스템
+### 8.4 외부 시스템
 |외부 시스템|관련 유스케이스|연동 목적|
 |---|---|---|
 
-## 5. 확인 필요
-- <유스케이스와 요구사항만으로 이벤트 스토밍을 확정할 수 없는 항목>
+## 9. Canonical Summary/Index 반영
+- 전체 `docs/design/이벤트 스토밍.md`에 summary/index 업데이트 필요 여부:
+- 반영할 링크/요약:
+
+## 10. 확인 필요
+- <ChangeSet과 affected UC slice만으로 이벤트 스토밍을 확정할 수 없는 항목>
 """

--- a/.codex/skills/harness-event-storming/SKILL.md
+++ b/.codex/skills/harness-event-storming/SKILL.md
@@ -4,15 +4,18 @@ description: >
   Use after requirements and use cases exist to run ticketon-ddd style event
   storming through the oracle agent. The skill derives commands, events,
   policies, systems, external systems, and invariants from use cases, and
-  writes the single canonical docs/design/이벤트 스토밍.md file.
+  writes docs/use-cases/<UC-ID>/event-storming.md for each affected use-case
+  slice.
 ---
 
 # Harness Event Storming
 
 ## Purpose
 
-이 스킬은 `docs/design/유스케이스.md`를 입력으로 삼아 유스케이스 기반 이벤트
-스토밍을 수행한다. 산출물은 `docs/design/이벤트 스토밍.md` 단일 파일이다.
+이 스킬은 active ChangeSet과 affected UC slice를 입력으로 삼아 유스케이스 기반
+이벤트 스토밍을 수행한다. 산출물은 `docs/use-cases/<UC-ID>/event-storming.md`다.
+`docs/design/이벤트 스토밍.md`는 전체 summary/index로만 유지할 수 있으며,
+planner/executor의 직접 입력은 UC slice 파일이다.
 
 스킬이 호출되면 `.codex/agents/oracle.toml`에 정의된 oracle 전담 에이전트에게
 작업을 맡긴다. 에이전트를 찾을 수 없거나 실행할 수 없으면 대체 실행하지 말고,
@@ -25,25 +28,28 @@ description: >
 - agent id: `oracle`
 - config: `.codex/agents/oracle.toml`
 - required input:
-  - `docs/design/유스케이스.md`
-  - `docs/design/요구사항.md` when present
+  - `docs/changes/active/<CHG-ID>.md`
+  - `docs/use-cases/<UC-ID>/use-case.md`
+  - `docs/use-cases/<UC-ID>/e2e-goal.md`
+  - `docs/design/이벤트 스토밍.md` when present, as summary/index context only
 - output file:
-  - `docs/design/이벤트 스토밍.md`
+  - `docs/use-cases/<UC-ID>/event-storming.md`
 
 실행 규칙:
 
-- 유스케이스를 초기 커맨드로 등록한다.
+- affected UC를 초기 커맨드로 등록한다.
 - happy path를 먼저 따라가며 커맨드, 이벤트, 정책, 시스템, 외부 시스템을 추출한다.
 - 예외 흐름도 별도 흐름으로 작성한다.
 - 이벤트, 정책, 커맨드, 외부 시스템은 반드시 추출한다.
-- 산출물 템플릿은 oracle agent instruction 안에 내장된 템플릿을 따른다.
+- 산출물 템플릿은 oracle agent instruction 안에 내장된 UC slice 템플릿을 따른다.
 - oracle이 없거나 실행할 수 없으면 현재 에이전트가 대신 수행하지 않는다.
-- oracle의 쓰기 범위는 `docs/design/이벤트 스토밍.md`로만 제한한다.
+- oracle의 쓰기 범위는 `docs/use-cases/<UC-ID>/event-storming.md`와 필요 시
+  summary/index인 `docs/design/이벤트 스토밍.md`로 제한한다.
 - oracle은 기준 문서나 스킬 md를 읽어 실행하지 않는다.
-- oracle이 읽는 md 파일은 작업 입력인 `docs/design/유스케이스.md`와
-  `docs/design/요구사항.md`로만 제한한다.
-- 요구사항/유스케이스에 비즈니스 정책 확인 필요가 남아 있으면 이벤트 스토밍을
-  작성하지 않고, 어떤 정책 때문에 막혔는지 설명하고 멈춘다.
+- oracle이 읽는 md 파일은 active ChangeSet, affected UC의 `use-case.md`,
+  `e2e-goal.md`, 그리고 summary/index 목적의 `docs/design/이벤트 스토밍.md`로 제한한다.
+- ChangeSet 또는 affected UC slice에 비즈니스 정책 확인 필요가 남아 있으면 해당 UC의
+  이벤트 스토밍을 작성하지 않고, 어떤 정책 때문에 해당 UC가 막혔는지 설명하고 멈춘다.
 - 기반 기술 결정 확인 필요는 커맨드/이벤트/정책/외부 시스템/불변식에 영향을 주지
   않는 경우에만 이벤트 스토밍의 확인 필요로 이월할 수 있다.
 - polling, circuit breaker, retry/backoff, outbox/inbox, cache TTL 같은 세부 구현

--- a/tests/test_oracle_use_case_event_storming.py
+++ b/tests/test_oracle_use_case_event_storming.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_doc(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_oracle_writes_affected_use_case_event_storming_slice() -> None:
+    oracle = read_doc(".codex/agents/oracle.toml")
+
+    assert "docs/changes/active/<CHG-ID>.md" in oracle
+    assert "docs/use-cases/<UC-ID>/use-case.md" in oracle
+    assert "docs/use-cases/<UC-ID>/e2e-goal.md" in oracle
+    assert "docs/use-cases/<UC-ID>/event-storming.md" in oracle
+    assert "Do not create per-use-case event storming files" not in oracle
+    assert "Do not write event-storming content for unaffected use cases" in oracle
+
+
+def test_oracle_keeps_canonical_event_storming_as_summary_index() -> None:
+    oracle = read_doc(".codex/agents/oracle.toml")
+
+    assert (
+        "Maintain docs/design/이벤트 스토밍.md, when present, as a summary/index"
+        in oracle
+    )
+    assert "planner/executor의 직접 입력은 UC slice 파일" in read_doc(
+        ".codex/skills/harness-event-storming/SKILL.md"
+    )
+
+
+def test_oracle_blocks_only_the_affected_use_case_on_policy_gaps() -> None:
+    oracle = read_doc(".codex/agents/oracle.toml")
+
+    assert "do not write or update that UC event-storming slice" in oracle
+    assert "affected UC is blocked" in oracle
+    assert "resolve only that UC's policies" in oracle


### PR DESCRIPTION
Closes #17

## 구현 의도

워크플로우 순서상 #15, #16 이후 가장 먼저 구현해야 하는 오픈 P0인 #17을 처리했습니다. 기존 oracle이 전체 `docs/design/이벤트 스토밍.md` 단일 산출물만 작성하도록 강제하던 전제를 제거하고, affected UC 단위의 `docs/use-cases/<UC-ID>/event-storming.md`를 executor-facing 산출물로 작성하도록 바꿨습니다.

## 구현 방법

- `.codex/agents/oracle.toml`의 입력 범위를 active ChangeSet, affected UC의 `use-case.md`, `e2e-goal.md` 중심으로 변경했습니다.
- oracle 출력 범위를 `docs/use-cases/<UC-ID>/event-storming.md`로 변경하고, `docs/design/이벤트 스토밍.md`는 summary/index로만 유지할 수 있도록 정리했습니다.
- unresolved business policy가 있으면 전체 이벤트 스토밍을 막는 대신 해당 UC slice만 block하도록 stop condition을 좁혔습니다.
- `.codex/skills/harness-event-storming/SKILL.md`도 같은 입력/출력 계약을 따르도록 갱신했습니다.
- 새 테스트로 oracle instruction이 UC slice 출력, canonical summary/index 관계, affected UC block 규칙을 유지하는지 검증했습니다.

## 검증 방법

- `python3 -m venv venv`
- `venv/bin/python -m pytest -s tests`
- 결과: 44 passed

참고: `venv/bin/python -m pytest`는 pytest capture 정리 단계에서 `FileNotFoundError`가 발생해 테스트를 수집하지 못했습니다. 동일 venv에서 capture를 끈 `-s tests` 실행은 정상 통과했습니다.