### PR TITLE
[codex] 완료 계획 경로를 문서 표준에 맞춤

### DIFF
--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -230,10 +230,10 @@ HARNESS_PLAN_EXECUTOR_WORKFLOW = Workflow(
         Step(
             id="complete-plan",
             kind=StepKind.GIT,
-            name="Move completed plan from active to complete after all checks pass",
+            name="Move completed plan from active to completed after all checks pass",
             needs=("run-final-verification",),
             inputs=(Path("docs/plans/active/plan.md"),),
-            outputs=(Path("docs/plans/complete/plan.md"),),
+            outputs=(Path("docs/plans/completed/plan.md"),),
         ),
     ),
 )
@@ -430,7 +430,7 @@ HARNESS_FULL_WORKFLOW = Workflow(
             name="Move active plan to completed plans after all checks pass",
             needs=("classify-verification-result",),
             inputs=(Path("docs/plans/active/plan.md"),),
-            outputs=(Path("docs/plans/complete/plan.md"),),
+            outputs=(Path("docs/plans/completed/plan.md"),),
             metadata={
                 "stage": "completion",
                 "condition": "all_tasks_checked_and_all_verification_passed",

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -234,4 +234,4 @@ def test_harness_full_workflow_records_completion_path() -> None:
         == "all_tasks_checked_and_all_verification_passed"
     )
     assert Path("docs/plans/active/plan.md") in complete.inputs
-    assert Path("docs/plans/complete/plan.md") in complete.outputs
+    assert Path("docs/plans/completed/plan.md") in complete.outputs


### PR DESCRIPTION
## 구현 의도

워크플로우 완료 단계가 문서 표준과 동일한 `docs/plans/completed` 경로를 사용하도록 맞췄습니다. 워크플로우 순서상 완료 처리에서 가장 먼저 드러나는 이슈는 런타임 모델이 `docs/plans/complete/plan.md`를 출력 대상으로 들고 있어, `docs/README.md`와 템플릿의 `docs/plans/completed/...` 규칙과 충돌하는 점이었습니다.

## 구현 방법

- `HARNESS_PLAN_EXECUTOR_WORKFLOW`의 `complete-plan` 출력 경로를 `docs/plans/completed/plan.md`로 변경했습니다.
- `HARNESS_FULL_WORKFLOW`의 `complete-plan` 출력 경로도 같은 표준 경로로 변경했습니다.
- 완료 경로를 검증하는 런타임 모델 테스트 기대값을 함께 갱신했습니다.

흐름은 실행/검증이 통과한 뒤 `complete-plan` 단계가 active plan을 completed plans 영역으로 이동하는 모델을 유지하되, 대상 디렉터리명만 문서 표준과 일치시키는 방식입니다.

## 검증 방법

- `venv/bin/python -m pytest -q -s`
- 결과: `41 passed in 0.23s`

참고로 시스템 `python3 -m pytest -q`는 시스템 환경에 `pytest`가 없어 실패했으며, 리포지토리 지침에 따라 루트의 `venv`로 재실행해 통과를 확인했습니다.