### PR TITLE
명령 정책 엔진 추가

### DIFF
--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -19,12 +19,23 @@ from harness_codex.runtime.models import (
     StepStatus,
     Workflow,
 )
+from harness_codex.runtime.policy import (
+    CommandRequest,
+    PolicyDecision,
+    PolicyEffect,
+    PolicyEngine,
+)
+from harness_codex.runtime.runner import StepRunner
 
 __all__ = [
+    "CommandRequest",
     "ExecutionPlan",
     "FailureKind",
     "HARNESS_FULL_WORKFLOW",
     "HARNESS_PLAN_EXECUTOR_WORKFLOW",
+    "PolicyDecision",
+    "PolicyEffect",
+    "PolicyEngine",
     "RunContext",
     "RunMode",
     "RunResult",

--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -8,7 +8,7 @@ side-effecting tool.
 from __future__ import annotations
 
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from harness_codex.runtime.models import (
     RunContext,
@@ -16,10 +16,12 @@ from harness_codex.runtime.models import (
     RunStatus,
     RunMode,
     Step,
+    StepKind,
     StepResult,
     StepStatus,
     Workflow,
 )
+from harness_codex.runtime.policy import CommandRequest, PolicyDecision, PolicyEngine
 from harness_codex.runtime.runner import StepRunner
 
 
@@ -42,8 +44,13 @@ class ExecutionPlan:
 class RunnerEngine:
     """Execute workflows through a side-effecting `StepRunner` boundary."""
 
-    def __init__(self, step_runner: StepRunner) -> None:
+    def __init__(
+        self,
+        step_runner: StepRunner,
+        policy_engine: PolicyEngine | None = None,
+    ) -> None:
         self._step_runner = step_runner
+        self._policy_engine = policy_engine or PolicyEngine()
 
     def plan(self, workflow: Workflow) -> ExecutionPlan:
         """Validate the workflow and return dependency-safe execution order."""
@@ -66,7 +73,39 @@ class RunnerEngine:
         results: list[StepResult] = []
 
         for step in execution_plan.steps:
+            decision = self._evaluate_command_policy(step, context)
+            if decision is not None and not decision.allowed:
+                result = StepResult(
+                    step_id=step.id,
+                    status=StepStatus.BLOCKED,
+                    error=decision.reason,
+                    metadata={"policy_decision": decision.as_metadata()},
+                )
+                results.append(result)
+
+                return RunResult(
+                    run_id=context.run_id,
+                    status=RunStatus.BLOCKED,
+                    step_results=tuple(results),
+                    mode=context.mode,
+                    failed_step_id=step.id,
+                    blocker=decision.reason,
+                    metadata=self._result_metadata(
+                        execution_plan,
+                        context,
+                        tuple(results),
+                    ),
+                )
+
             result = self._step_runner.run(step, context)
+            if decision is not None:
+                result = replace(
+                    result,
+                    metadata={
+                        **dict(result.metadata),
+                        "policy_decision": decision.as_metadata(),
+                    },
+                )
             results.append(result)
 
             if result.status == StepStatus.FAILED:
@@ -77,7 +116,11 @@ class RunnerEngine:
                     mode=context.mode,
                     failed_step_id=step.id,
                     blocker=result.error,
-                    metadata=self._result_metadata(execution_plan, context),
+                    metadata=self._result_metadata(
+                        execution_plan,
+                        context,
+                        tuple(results),
+                    ),
                 )
 
             if result.status == StepStatus.BLOCKED:
@@ -88,7 +131,11 @@ class RunnerEngine:
                     mode=context.mode,
                     failed_step_id=step.id,
                     blocker=result.error,
-                    metadata=self._result_metadata(execution_plan, context),
+                    metadata=self._result_metadata(
+                        execution_plan,
+                        context,
+                        tuple(results),
+                    ),
                 )
 
         return RunResult(
@@ -96,7 +143,7 @@ class RunnerEngine:
             status=RunStatus.SUCCEEDED,
             step_results=tuple(results),
             mode=context.mode,
-            metadata=self._result_metadata(execution_plan, context),
+            metadata=self._result_metadata(execution_plan, context, tuple(results)),
         )
 
     def _dry_run_result(
@@ -104,38 +151,103 @@ class RunnerEngine:
         execution_plan: ExecutionPlan,
         context: RunContext,
     ) -> RunResult:
-        step_results = tuple(
-            StepResult(
-                step_id=step.id,
-                status=StepStatus.SKIPPED,
-                metadata={
-                    "mode": context.mode.value,
-                    "would_run": context.mode == RunMode.PREVIEW,
-                    "side_effects": False,
-                },
+        step_results: list[StepResult] = []
+
+        for step in execution_plan.steps:
+            decision = self._evaluate_command_policy(step, context)
+            if decision is not None and not decision.allowed:
+                result = StepResult(
+                    step_id=step.id,
+                    status=StepStatus.BLOCKED,
+                    error=decision.reason,
+                    metadata={"policy_decision": decision.as_metadata()},
+                )
+                step_results.append(result)
+
+                return RunResult(
+                    run_id=context.run_id,
+                    status=RunStatus.BLOCKED,
+                    step_results=tuple(step_results),
+                    mode=context.mode,
+                    failed_step_id=step.id,
+                    blocker=decision.reason,
+                    metadata=self._result_metadata(
+                        execution_plan,
+                        context,
+                        tuple(step_results),
+                    ),
+                )
+
+            metadata = {
+                "mode": context.mode.value,
+                "would_run": context.mode == RunMode.PREVIEW,
+                "side_effects": False,
+            }
+
+            if decision is not None:
+                metadata["policy_decision"] = decision.as_metadata()
+
+            step_results.append(
+                StepResult(
+                    step_id=step.id,
+                    status=StepStatus.SKIPPED,
+                    metadata=metadata,
+                )
             )
-            for step in execution_plan.steps
-        )
 
         return RunResult(
             run_id=context.run_id,
             status=RunStatus.SUCCEEDED,
-            step_results=step_results,
+            step_results=tuple(step_results),
             mode=context.mode,
-            metadata=self._result_metadata(execution_plan, context),
+            metadata=self._result_metadata(
+                execution_plan,
+                context,
+                tuple(step_results),
+            ),
         )
 
     def _result_metadata(
         self,
         execution_plan: ExecutionPlan,
         context: RunContext,
+        step_results: tuple[StepResult, ...] = (),
     ) -> dict[str, object]:
+        policy_decisions = tuple(
+            result.metadata["policy_decision"]
+            for result in step_results
+            if "policy_decision" in result.metadata
+        )
+
         return {
             "mode": context.mode.value,
             "workflow_name": context.workflow_name,
             "planned_steps": execution_plan.step_ids(),
             "side_effects": context.mode == RunMode.APPLY,
+            "policy_decisions": policy_decisions,
         }
+
+    def _evaluate_command_policy(
+        self,
+        step: Step,
+        context: RunContext,
+    ) -> PolicyDecision | None:
+        if step.command is None:
+            return None
+
+        if step.kind not in {StepKind.GIT, StepKind.SHELL, StepKind.VALIDATOR}:
+            return None
+
+        return self._policy_engine.evaluate(
+            CommandRequest(
+                step_id=step.id,
+                step_kind=step.kind,
+                command=step.command,
+                mode=context.mode,
+                repo_root=context.repo_root,
+                workdir=context.workdir,
+            )
+        )
 
     def _index_steps(self, workflow: Workflow) -> dict[str, Step]:
         steps_by_id: dict[str, Step] = {}

--- a/harness_codex/runtime/policy.py
+++ b/harness_codex/runtime/policy.py
@@ -1,0 +1,364 @@
+"""부작용이 있는 런타임 단계의 명령 정책 검사."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from harness_codex.runtime.models import RunMode, StepKind
+
+
+class PolicyEffect(str, Enum):
+    """명령 정책 평가 결과."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    REQUIRE_APPROVAL = "require_approval"
+
+
+@dataclass(frozen=True)
+class CommandRequest:
+    """정책 평가에 필요한 명령과 런타임 문맥."""
+
+    step_id: str
+    step_kind: StepKind
+    command: str
+    mode: RunMode
+    repo_root: Path
+    workdir: Path
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """명령 실행 결과에 기록되는 구조화된 정책 결과."""
+
+    effect: PolicyEffect
+    rule_id: str
+    reason: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def allowed(self) -> bool:
+        return self.effect == PolicyEffect.ALLOW
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "effect": self.effect.value,
+            "rule_id": self.rule_id,
+            "reason": self.reason,
+            **dict(self.metadata),
+        }
+
+
+class PolicyEngine:
+    """셸과 git 명령이 실행 경계를 넘기 전에 정책을 평가한다."""
+
+    _SECRET_FILENAMES = frozenset(
+        {
+            ".env",
+            "id_rsa",
+            "id_dsa",
+            "id_ecdsa",
+            "id_ed25519",
+            "credentials",
+            "credentials.json",
+            ".netrc",
+        }
+    )
+    _READ_COMMANDS = frozenset({"cat", "less", "more", "head", "tail", "sed", "awk"})
+    _MUTATION_COMMANDS = frozenset(
+        {
+            "chmod",
+            "chown",
+            "cp",
+            "install",
+            "mkdir",
+            "mv",
+            "rm",
+            "rmdir",
+            "sed",
+            "tee",
+            "touch",
+        }
+    )
+    _GIT_MUTATION_SUBCOMMANDS = frozenset(
+        {
+            "add",
+            "am",
+            "apply",
+            "checkout",
+            "cherry-pick",
+            "clean",
+            "commit",
+            "merge",
+            "mv",
+            "pull",
+            "push",
+            "rebase",
+            "reset",
+            "restore",
+            "revert",
+            "rm",
+            "stash",
+            "switch",
+        }
+    )
+
+    def evaluate(self, request: CommandRequest) -> PolicyDecision:
+        tokens = _split_command(request.command)
+        lowered_command = " ".join(request.command.lower().split())
+
+        if not tokens:
+            return PolicyDecision(
+                effect=PolicyEffect.DENY,
+                rule_id="empty-command",
+                reason="빈 명령은 실행할 수 없습니다.",
+            )
+
+        dangerous = self._deny_dangerous_command(tokens, lowered_command)
+        if dangerous is not None:
+            return dangerous
+
+        path_violation = self._deny_outside_worktree_write(tokens, request)
+        if path_violation is not None:
+            return path_violation
+
+        if self._is_plan_mode_mutation(tokens, request):
+            return PolicyDecision(
+                effect=PolicyEffect.DENY,
+                rule_id="plan-mode-mutation",
+                reason="plan 모드에서는 변경 명령을 실행할 수 없습니다.",
+                metadata={"mode": request.mode.value},
+            )
+
+        approval = self._require_approval(tokens)
+        if approval is not None:
+            return approval
+
+        return PolicyDecision(
+            effect=PolicyEffect.ALLOW,
+            rule_id="default-allow",
+            reason="명령이 기본 정책을 통과했습니다.",
+        )
+
+    def _deny_dangerous_command(
+        self,
+        tokens: tuple[str, ...],
+        lowered_command: str,
+    ) -> PolicyDecision | None:
+        command = Path(tokens[0]).name
+        lowered_tokens = tuple(token.lower() for token in tokens)
+
+        if command == "sudo":
+            return _deny("deny-sudo", "sudo 명령은 허용되지 않습니다.")
+
+        if command == "rm" and "-rf" in lowered_tokens and "/" in tokens[1:]:
+            return _deny("deny-rm-rf-root", "루트 디렉터리 삭제 명령은 허용되지 않습니다.")
+
+        if command == "chmod" and "-r" in lowered_tokens and "777" in lowered_tokens:
+            return _deny("deny-recursive-world-writable", "재귀적 777 권한 변경은 허용되지 않습니다.")
+
+        if command in {"curl", "wget"} and "| sh" in lowered_command:
+            return _deny("deny-pipe-to-shell", "다운로드한 스크립트를 셸로 바로 실행할 수 없습니다.")
+
+        if command == "git" and len(tokens) > 2:
+            subcommand = tokens[1].lower()
+            if subcommand == "push" and any(
+                token in {"--force", "-f", "--force-with-lease"}
+                for token in lowered_tokens[2:]
+            ):
+                return _deny("deny-force-push", "강제 push는 허용되지 않습니다.")
+
+        if command in self._READ_COMMANDS and any(
+            Path(token).name in self._SECRET_FILENAMES for token in tokens[1:]
+        ):
+            return _deny("deny-secret-read", "일반적인 시크릿 파일 출력은 허용되지 않습니다.")
+
+        return None
+
+    def _deny_outside_worktree_write(
+        self,
+        tokens: tuple[str, ...],
+        request: CommandRequest,
+    ) -> PolicyDecision | None:
+        if not _looks_like_write(tokens):
+            return None
+
+        for raw_path in _candidate_write_paths(tokens):
+            if raw_path.startswith("-"):
+                continue
+
+            resolved = _resolve_command_path(raw_path, request.workdir)
+            if not _is_relative_to(resolved, request.repo_root) and not _is_relative_to(
+                resolved, request.workdir
+            ):
+                return PolicyDecision(
+                    effect=PolicyEffect.DENY,
+                    rule_id="outside-worktree-write",
+                    reason="리포지토리 또는 worktree 밖에 쓰는 명령은 허용되지 않습니다.",
+                    metadata={"path": str(resolved)},
+                )
+
+        return None
+
+    def _is_plan_mode_mutation(
+        self,
+        tokens: tuple[str, ...],
+        request: CommandRequest,
+    ) -> bool:
+        if request.mode != RunMode.PLAN:
+            return False
+
+        command = Path(tokens[0]).name
+
+        if command in self._MUTATION_COMMANDS or _has_redirection(tokens):
+            return True
+
+        if command == "git" and len(tokens) > 1:
+            return tokens[1].lower() in self._GIT_MUTATION_SUBCOMMANDS
+
+        return False
+
+    def _require_approval(self, tokens: tuple[str, ...]) -> PolicyDecision | None:
+        command = Path(tokens[0]).name
+        lowered_tokens = tuple(token.lower() for token in tokens)
+
+        if command == "git" and len(tokens) > 1:
+            subcommand = tokens[1].lower()
+            if subcommand == "push":
+                return _approval("approval-git-push", "git push는 실행 전 승인이 필요합니다.")
+            if subcommand == "reset" and "--hard" in lowered_tokens[2:]:
+                return _approval(
+                    "approval-git-reset-hard",
+                    "git reset --hard는 실행 전 승인이 필요합니다.",
+                )
+
+        delete_targets = [token for token in tokens[1:] if not token.startswith("-")]
+        if command == "rm" and len(delete_targets) > 1:
+            return _approval("approval-mass-delete", "여러 경로 삭제는 실행 전 승인이 필요합니다.")
+
+        if command in {"curl", "wget"}:
+            return _approval("approval-network", "외부 네트워크 호출은 실행 전 승인이 필요합니다.")
+
+        if _looks_like_dependency_install(tokens):
+            return _approval("approval-dependency-install", "의존성 설치는 실행 전 승인이 필요합니다.")
+
+        return None
+
+
+def _deny(rule_id: str, reason: str) -> PolicyDecision:
+    return PolicyDecision(effect=PolicyEffect.DENY, rule_id=rule_id, reason=reason)
+
+
+def _approval(rule_id: str, reason: str) -> PolicyDecision:
+    return PolicyDecision(
+        effect=PolicyEffect.REQUIRE_APPROVAL,
+        rule_id=rule_id,
+        reason=reason,
+    )
+
+
+def _split_command(command: str) -> tuple[str, ...]:
+    try:
+        return tuple(shlex.split(command, posix=True))
+    except ValueError:
+        return tuple(command.split())
+
+
+def _looks_like_write(tokens: tuple[str, ...]) -> bool:
+    if _has_redirection(tokens):
+        return True
+
+    command = Path(tokens[0]).name
+    write_commands = {
+        "chmod",
+        "chown",
+        "cp",
+        "install",
+        "mkdir",
+        "mv",
+        "rm",
+        "rmdir",
+        "tee",
+        "touch",
+    }
+    if command in write_commands:
+        return True
+
+    return command == "git" and len(tokens) > 1 and tokens[1].lower() in {
+        "apply",
+        "checkout",
+        "clean",
+        "mv",
+        "reset",
+        "restore",
+        "rm",
+    }
+
+
+def _candidate_write_paths(tokens: tuple[str, ...]) -> tuple[str, ...]:
+    candidates: list[str] = []
+    skip_next = False
+
+    for index, token in enumerate(tokens[1:], start=1):
+        if skip_next:
+            skip_next = False
+            continue
+
+        if token in {">", ">>", "2>", "2>>"}:
+            if index + 1 < len(tokens):
+                candidates.append(tokens[index + 1])
+                skip_next = True
+            continue
+
+        if token.startswith((">", ">>")) and len(token.lstrip(">")) > 0:
+            candidates.append(token.lstrip(">"))
+            continue
+
+        if not token.startswith("-"):
+            candidates.append(token)
+
+    return tuple(candidates)
+
+
+def _has_redirection(tokens: tuple[str, ...]) -> bool:
+    return any(
+        token in {">", ">>", "2>", "2>>"} or token.startswith((">", ">>"))
+        for token in tokens
+    )
+
+
+def _resolve_command_path(raw_path: str, workdir: Path) -> Path:
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = workdir / path
+    return path.resolve(strict=False)
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def _looks_like_dependency_install(tokens: tuple[str, ...]) -> bool:
+    command = Path(tokens[0]).name
+    lowered = tuple(token.lower() for token in tokens)
+
+    if command in {"pip", "pip3"} and len(tokens) > 1 and lowered[1] == "install":
+        return True
+
+    if command in {"npm", "pnpm", "yarn"} and "install" in lowered[1:]:
+        return True
+
+    return command == "python3" and len(tokens) > 3 and lowered[1:4] == (
+        "-m",
+        "pip",
+        "install",
+    )

--- a/tests/runtime/test_engine.py
+++ b/tests/runtime/test_engine.py
@@ -317,6 +317,32 @@ def test_run_in_plan_mode_records_plan_without_running_steps() -> None:
     )
 
 
+def test_run_in_plan_mode_blocks_mutating_command_before_dry_run() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="mutate",
+                kind=StepKind.SHELL,
+                name="Mutate file",
+                command="touch changed.txt",
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner()
+    engine = RunnerEngine(fake_runner)
+
+    result = engine.run(workflow, context_with_mode(RunMode.PLAN))
+
+    assert result.status == RunStatus.BLOCKED
+    assert result.failed_step_id == "mutate"
+    assert result.metadata["policy_decisions"][0]["rule_id"] == (
+        "plan-mode-mutation"
+    )
+    assert fake_runner.executed_step_ids == []
+
+
 def test_run_in_preview_mode_records_preview_without_running_steps() -> None:
     workflow = Workflow(
         name="example",
@@ -365,3 +391,52 @@ def test_run_in_apply_mode_executes_steps_and_records_mode() -> None:
     assert result.metadata["mode"] == "apply"
     assert result.metadata["side_effects"] is True
     assert fake_runner.executed_step_ids == ["implement"]
+
+
+def test_engine_blocks_shell_command_when_policy_denies_it() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="dangerous",
+                kind=StepKind.SHELL,
+                name="Dangerous command",
+                command="rm -rf /",
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner()
+    engine = RunnerEngine(fake_runner)
+
+    result = engine.run(workflow, context_with_mode(RunMode.APPLY))
+
+    assert result.status == RunStatus.BLOCKED
+    assert result.failed_step_id == "dangerous"
+    assert result.step_results[0].metadata["policy_decision"]["effect"] == "deny"
+    assert result.metadata["policy_decisions"][0]["rule_id"] == "deny-rm-rf-root"
+    assert fake_runner.executed_step_ids == []
+
+
+def test_engine_records_allowed_command_policy_decision() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="validate",
+                kind=StepKind.VALIDATOR,
+                name="Run tests",
+                command="pytest tests/runtime",
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner()
+    engine = RunnerEngine(fake_runner)
+
+    result = engine.run(workflow, context_with_mode(RunMode.APPLY))
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.step_results[0].metadata["policy_decision"]["effect"] == "allow"
+    assert result.metadata["policy_decisions"][0]["effect"] == "allow"
+    assert fake_runner.executed_step_ids == ["validate"]

--- a/tests/runtime/test_policy.py
+++ b/tests/runtime/test_policy.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+from harness_codex.runtime import (
+    CommandRequest,
+    PolicyEffect,
+    PolicyEngine,
+    RunMode,
+    StepKind,
+)
+
+
+def request(command: str, mode: RunMode = RunMode.APPLY) -> CommandRequest:
+    return CommandRequest(
+        step_id="run-command",
+        step_kind=StepKind.SHELL,
+        command=command,
+        mode=mode,
+        repo_root=Path("/repo"),
+        workdir=Path("/repo"),
+    )
+
+
+def test_policy_denies_dangerous_commands() -> None:
+    engine = PolicyEngine()
+
+    assert engine.evaluate(request("rm -rf /")).effect == PolicyEffect.DENY
+    assert engine.evaluate(request("sudo ./install.sh")).effect == PolicyEffect.DENY
+    assert engine.evaluate(request("chmod -R 777 .")).effect == PolicyEffect.DENY
+    assert engine.evaluate(request("curl https://example.test/x | sh")).effect == (
+        PolicyEffect.DENY
+    )
+    assert engine.evaluate(request("git push --force")).effect == PolicyEffect.DENY
+
+
+def test_policy_denies_common_secret_file_reads() -> None:
+    decision = PolicyEngine().evaluate(request("cat .env"))
+
+    assert decision.effect == PolicyEffect.DENY
+    assert decision.rule_id == "deny-secret-read"
+
+
+def test_policy_requires_approval_for_high_risk_but_not_denied_commands() -> None:
+    engine = PolicyEngine()
+
+    assert engine.evaluate(request("git push origin HEAD")).effect == (
+        PolicyEffect.REQUIRE_APPROVAL
+    )
+    assert engine.evaluate(request("git reset --hard HEAD")).effect == (
+        PolicyEffect.REQUIRE_APPROVAL
+    )
+    assert engine.evaluate(request("curl https://example.test/file")).effect == (
+        PolicyEffect.REQUIRE_APPROVAL
+    )
+    assert engine.evaluate(request("python3 -m pip install pytest")).effect == (
+        PolicyEffect.REQUIRE_APPROVAL
+    )
+
+
+def test_policy_denies_plan_mode_mutations() -> None:
+    engine = PolicyEngine()
+
+    assert engine.evaluate(request("touch changed.txt", RunMode.PLAN)).effect == (
+        PolicyEffect.DENY
+    )
+    assert engine.evaluate(request("git commit -m test", RunMode.PLAN)).effect == (
+        PolicyEffect.DENY
+    )
+
+
+def test_policy_allows_read_only_plan_mode_commands() -> None:
+    decision = PolicyEngine().evaluate(request("pytest tests/runtime", RunMode.PLAN))
+
+    assert decision.effect == PolicyEffect.ALLOW
+
+
+def test_policy_denies_writes_outside_repository_or_worktree() -> None:
+    decision = PolicyEngine().evaluate(request("touch /tmp/outside.txt"))
+
+    assert decision.effect == PolicyEffect.DENY
+    assert decision.rule_id == "outside-worktree-write"
+
+
+def test_policy_allows_read_only_commands() -> None:
+    decision = PolicyEngine().evaluate(request("pytest tests/runtime"))
+
+    assert decision.effect == PolicyEffect.ALLOW
+    assert decision.allowed is True


### PR DESCRIPTION
## 구현 의도
- 워크플로우 순서상 이미 구현된 #8 다음 미구현 P0인 #10을 대상으로, shell/git 실행을 raw command가 아닌 정책 평가 경계 뒤에서만 실행하도록 했습니다.
- 위험 명령 deny, 승인 필요 명령 분류, plan 모드 변경 명령 차단, worktree 외부 쓰기 차단을 런타임 모델에 추가했습니다.

## 구현 방법
- CommandRequest, PolicyDecision, PolicyEffect, PolicyEngine을 추가해 명령 평가 결과를 구조화했습니다.
- RunnerEngine이 SHELL, GIT, VALIDATOR 단계의 command를 StepRunner로 넘기기 전에 정책을 평가합니다.
- 정책이 deny 또는 require_approval이면 실행하지 않고 BLOCKED 결과를 반환하며, 허용/차단 결정은 StepResult.metadata와 RunResult.metadata에 기록합니다.
- dry-run 경로에서도 정책을 평가해 plan 모드 변경 명령은 실행 전 차단되도록 했습니다.

## 검증 방법
- venv/bin/python3 -m pytest -s 실행: 54개 테스트 통과.
- git diff --check 실행: 공백 오류 없음.
- 참고: 캡처를 켠 venv/bin/python3 -m pytest는 이 환경에서 pytest 캡처 임시파일 FileNotFoundError로 수집 전 종료되어, 캡처를 끈 -s로 전체 테스트를 검증했습니다.

Closes #10