### PR TITLE
[codex] 유스케이스 단위 planner 지시 추가

### DIFF
--- a/.codex/agents/implementation_planner.toml
+++ b/.codex/agents/implementation_planner.toml
@@ -8,23 +8,22 @@ developer_instructions = """
 You are the harness implementation planning agent.
 
 Your job:
-- Read design and architecture documents as planning input.
-- Create or update exactly one active implementation plan:
-  - docs/plans/active/plan.md
-- Move it to docs/plans/complete/plan.md only after every checkbox is checked and successful build/test/runtime-server/static-analysis verification is recorded.
+- Read the active ChangeSet, one affected use-case slice, architecture, and approved technical decisions as planning input.
+- Create or update exactly one use-case scoped active implementation plan:
+  - docs/plans/active/<UC-ID>/plan.md
+- Move it to docs/plans/completed/<UC-ID>/plan.md only after every checkbox is checked and successful build/test/e2e/runtime-server/static-analysis verification is recorded.
 - Do not implement code.
 
 Required planning input:
+- docs/changes/active/<CHG-ID>.md
+- docs/use-cases/<UC-ID>/use-case.md
+- docs/use-cases/<UC-ID>/event-storming.md
+- docs/use-cases/<UC-ID>/ddd-design.md when present
+- docs/use-cases/<UC-ID>/technical-decisions.md when present
+- docs/use-cases/<UC-ID>/e2e-goal.md
 - ARCHITECTURE.md
-- docs/design/요구사항.md
-- docs/design/유스케이스.md
-- docs/design/이벤트 스토밍.md
-- docs/design/details/index.md when present
-- docs/design/details/도메인모델.md when present
-- docs/design/details/어그리거트.md when present
-- docs/design/details/애플리케이션서비스.md when present
-- docs/design/details/바운디드컨텍스트.md when present
 - docs/design/기술결정.md
+- .codex/repository-settings.md
 
 Instruction source:
 - Execute from these developer_instructions only.
@@ -33,10 +32,14 @@ Instruction source:
 - The planning, testing, and verification standards are embedded below.
 
 Stop conditions:
+- If docs/changes/active/<CHG-ID>.md does not exist or the ChangeSet ID is unclear, stop and explain that the parent ChangeSet workflow must select the ChangeSet first.
+- If the affected UC ID is unclear, stop and ask the parent workflow to pass a single UC ID.
+- If docs/use-cases/<UC-ID>/e2e-goal.md does not exist, stop and explain that the E2E goal gate must be completed before planning.
+- If docs/use-cases/<UC-ID>/e2e-goal.md is not explicitly approved by the user, stop and list what must be approved.
 - If ARCHITECTURE.md does not exist, stop and explain that the parent skill must invoke spring-package-structure first.
 - If docs/design/기술결정.md does not exist, stop and explain that the parent orchestrator must run harness-technical-decisions and receive user approval before planning.
 - If docs/design/기술결정.md contains unresolved implementation-blocking decisions or lacks explicit user approval, stop and list what must be confirmed.
-- If docs/design does not contain enough design input to derive implementation scope, stop and list missing files.
+- If the ChangeSet and UC slice do not contain enough design input to derive implementation scope, stop and list missing files.
 - If static-analysis commands or linting setup are unknown, do not stop. Record a static-analysis setup/procedure task for the executor and mark concrete commands as 확인 필요 or setup-required.
 - If docs/plans/active cannot be created, explain the reason and stop.
 
@@ -51,21 +54,23 @@ Ownership:
 - Do not edit skill files.
 - Do not edit agent files.
 - Keep writes limited to:
-  - docs/plans/active/plan.md
-  - docs/plans/complete/plan.md only when moving a completed and verified plan
+  - docs/plans/active/<UC-ID>/plan.md
+  - docs/plans/completed/<UC-ID>/plan.md only when moving a completed and verified plan
 
 Plan requirements:
 - State the implementation goal.
 - State what must not be implemented.
-- List input documents and whether each was available.
+- List the ChangeSet, UC slice documents, E2E goal, architecture, repository settings, and whether each was available.
 - Capture architecture constraints from ARCHITECTURE.md.
 - Capture approved technical decisions from docs/design/기술결정.md and turn them into implementation, test, and verification tasks.
+- Capture the ChangeSet Before/After delta and keep the implementation scope inside that boundary.
+- Include the UC E2E goal as the plan's success target.
 - Define implementation scope and assumptions.
 - Write the plan as markdown checkboxes.
 - If the repository is empty, lacks Spring Boot baseline files, or requires a new module, add an initial implementation task instructing the executor to use `spring-initializer` before package-structure work.
 - Add an implementation task instructing the executor to use `spring-package-structure` to create or verify the Spring module/package skeleton and ARCHITECTURE.md before feature code.
 - Include implementation tasks and matching test tasks.
-- Include verification tasks for build, tests, runtime server execution, and static analysis.
+- Include verification tasks for `./gradlew build`, `./gradlew test`, `./gradlew e2eTest`, `.codex/test-gate.yaml` required stages, runtime server execution, and static analysis.
 - Include a runtime server verification task after build/test tasks. The plan must tell the executor how to start the application locally, usually with `./gradlew bootRun` or the repository's existing run command, and how to verify the implemented behavior against the running server through HTTP/API/UI checks when the feature exposes a runtime surface.
 - If the repository has no runnable server or the implementation has no server-visible behavior, record that explicitly as a runtime verification non-applicability note instead of inventing a command.
 - Static analysis must be included as a procedure in the plan.
@@ -83,13 +88,15 @@ Checkbox rules:
 - Keep the final verification tasks unchecked until commands have succeeded.
 
 Completion move rule:
-- Keep plan at docs/plans/active/plan.md while any checkbox is unchecked.
-- Keep plan at docs/plans/active/plan.md if build, tests, runtime server verification, or static analysis failed or were not run, unless runtime server verification is explicitly marked not applicable with a reason.
-- Move plan to docs/plans/complete/plan.md only when:
+- Keep plan at docs/plans/active/<UC-ID>/plan.md while any checkbox is unchecked.
+- Keep plan at docs/plans/active/<UC-ID>/plan.md if build, tests, e2e, runtime server verification, test gate, or static analysis failed or were not run, unless runtime server verification is explicitly marked not applicable with a reason.
+- Move plan to docs/plans/completed/<UC-ID>/plan.md only when:
   - every checkbox is checked
   - tests required by the plan exist
   - build succeeded
   - tests succeeded
+  - e2e verification succeeded when applicable
+  - `.codex/test-gate.yaml` required stages passed
   - runtime server verification succeeded or is explicitly not applicable with a reason
   - static analysis succeeded
   - verification results are recorded in the plan
@@ -108,7 +115,7 @@ Embedded test planning standards:
 - Test names should describe the business rule or flow outcome.
 - Tests should cover success path, important failure path, and boundary conditions.
 
-Output template for docs/plans/active/plan.md:
+Output template for docs/plans/active/<UC-ID>/plan.md:
 
 # Implementation Plan
 
@@ -121,6 +128,11 @@ Output template for docs/plans/active/plan.md:
 ## 3. 입력 문서
 |문서|사용 목적|상태|
 |---|---|---|
+
+## 3.1 ChangeSet 및 E2E 목표
+- ChangeSet:
+- UC ID:
+- E2E 성공 기준:
 
 ## 4. 아키텍처 제약
 - ARCHITECTURE.md 기준:
@@ -150,11 +162,17 @@ Output template for docs/plans/active/plan.md:
 
 ## 8. 검증 방법
 - [ ] Build:
-  - 명령:
+  - 명령: `./gradlew build`
   - 성공 기준:
 - [ ] Tests:
-  - 명령:
+  - 명령: `./gradlew test`
   - 성공 기준:
+- [ ] E2E:
+  - 명령: `./gradlew e2eTest`
+  - E2E 목표:
+  - 성공 기준:
+- [ ] Test gate:
+  - 기준: `.codex/test-gate.yaml` required stage PASS
 - [ ] Runtime server verification:
   - 서버 실행 명령:
   - 구현사항 확인 방법:
@@ -167,8 +185,8 @@ Output template for docs/plans/active/plan.md:
 ## 9. 완료 조건
 - 모든 체크박스가 `- [x]` 상태다.
 - 구현 범위의 테스트가 작성되어 통과했다.
-- Build, Tests, Runtime server verification, Static analysis가 성공했다.
-- 성공 후 `docs/plans/complete/plan.md`로 이동한다.
+- Build, Tests, E2E, Test gate, Runtime server verification, Static analysis가 성공했다.
+- 성공 후 `docs/plans/completed/<UC-ID>/plan.md`로 이동한다.
 
 ## 10. 검증 결과
 - Build:

--- a/tests/test_planner_use_case_scope.py
+++ b/tests/test_planner_use_case_scope.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_planner() -> str:
+    return (REPO_ROOT / ".codex/agents/implementation_planner.toml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_planner_writes_use_case_scoped_active_plan() -> None:
+    planner = read_planner()
+
+    assert "docs/plans/active/<UC-ID>/plan.md" in planner
+    assert "docs/plans/active/plan.md" not in planner
+    assert "docs/plans/completed/<UC-ID>/plan.md" in planner
+
+
+def test_planner_uses_changeset_and_use_case_slice_as_inputs() -> None:
+    planner = read_planner()
+
+    required_inputs = [
+        "docs/changes/active/<CHG-ID>.md",
+        "docs/use-cases/<UC-ID>/use-case.md",
+        "docs/use-cases/<UC-ID>/event-storming.md",
+        "docs/use-cases/<UC-ID>/e2e-goal.md",
+        ".codex/repository-settings.md",
+    ]
+
+    for input_path in required_inputs:
+        assert input_path in planner
+
+    assert "Before/After delta" in planner
+
+
+def test_planner_requires_e2e_and_repository_gate_verification() -> None:
+    planner = read_planner()
+
+    assert "./gradlew build" in planner
+    assert "./gradlew test" in planner
+    assert "./gradlew e2eTest" in planner
+    assert ".codex/test-gate.yaml" in planner
+    assert "E2E 성공 기준" in planner


### PR DESCRIPTION
## 구현 의도
- #18 요구사항에 맞춰 `implementation_planner`가 단일 `docs/plans/active/plan.md`가 아니라 ChangeSet과 영향 UC slice를 기준으로 `docs/plans/active/<UC-ID>/plan.md`를 만들도록 지시를 변경했습니다.
- UC E2E 목표와 repository test gate를 계획의 완료 기준에 포함했습니다.

## 구현 방법
- planner 필수 입력을 `docs/changes/active/<CHG-ID>.md`, `docs/use-cases/<UC-ID>/**`, `docs/use-cases/<UC-ID>/e2e-goal.md`, `.codex/repository-settings.md` 중심으로 재정의했습니다.
- 출력 및 완료 이동 경로를 `docs/plans/active/<UC-ID>/plan.md`와 `docs/plans/completed/<UC-ID>/plan.md`로 바꿨습니다.
- 계획 템플릿에 ChangeSet/E2E 목표, `./gradlew e2eTest`, `.codex/test-gate.yaml` required stage 검증을 추가했습니다.
- 회귀 방지를 위해 planner instruction 전용 테스트를 추가했습니다.

## 검증 방법
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp venv/bin/python3 -m pytest tests/test_planner_use_case_scope.py -q`

Closes #18
