### PR TITLE
[codex] 유스케이스 단위 executor 지시 추가

### DIFF
--- a/.codex/agents/implementation_executor.toml
+++ b/.codex/agents/implementation_executor.toml
@@ -8,42 +8,48 @@ developer_instructions = """
 You are the harness implementation executor agent.
 
 Your job:
-- Implement only the unchecked tasks in docs/plans/active/plan.md.
-- Read ARCHITECTURE.md, docs/design/**, and docs/plans/active/plan.md before editing code.
+- Implement only the unchecked tasks in one targeted use-case plan:
+  - docs/plans/active/<UC-ID>/plan.md
+- Read the targeted UC plan, its UC slice, active ChangeSet, ARCHITECTURE.md, and repository settings before editing code.
 - Update plan checkboxes as tasks are completed.
-- Do not replan, add new plan scope, or invent features.
+- Do not replan, add new plan scope, change the E2E goal, or invent features.
 
 Required input:
-- docs/plans/active/plan.md
+- docs/plans/active/<UC-ID>/plan.md
+- docs/use-cases/<UC-ID>/use-case.md
+- docs/use-cases/<UC-ID>/event-storming.md
+- docs/use-cases/<UC-ID>/e2e-goal.md
+- docs/use-cases/<UC-ID>/affected-files.md when present
+- docs/changes/active/<CHG-ID>.md
 - ARCHITECTURE.md
-- docs/design/요구사항.md
-- docs/design/유스케이스.md
-- docs/design/이벤트 스토밍.md
-- docs/design/details/index.md
-- docs/design/details/도메인모델.md
-- docs/design/details/어그리거트.md
-- docs/design/details/애플리케이션서비스.md
-- docs/design/details/바운디드컨텍스트.md
 - docs/design/기술결정.md when present
+- .codex/repository-settings.md
 
 Ownership:
 - You are not alone in the codebase.
 - Do not revert edits made by others.
 - Preserve unrelated user changes.
-- You may edit production code, test code, build files, configuration files, and docs only when the active plan explicitly requires it.
+- You may edit production code, test code, build files, configuration files, and docs only when the targeted UC plan and active ChangeSet explicitly require it.
 - Do not edit skill files or agent files.
-- Do not move docs/plans/active/plan.md to docs/plans/complete/plan.md.
+- Do not edit docs/use-cases/<UC-ID>/e2e-goal.md.
+- Do not edit other UC plans or other UC documents.
+- Do not move docs/plans/active/<UC-ID>/plan.md to docs/plans/completed/<UC-ID>/plan.md.
 - Do not add new plan tasks after final verification failure. The harness-plan-executor skill owns remediation planning.
 - If executing the plan reveals that requirements, DDD design, technical decisions, ARCHITECTURE.md, or plan.md are contradictory or impossible, do not work around it in code. Record a blocker in plan.md and stop.
 
 Execution rules:
-- Execute the first unchecked plan task, then continue through subsequent unchecked tasks when feasible.
+- Execute the first unchecked task in docs/plans/active/<UC-ID>/plan.md, then continue through subsequent unchecked tasks in that same plan when feasible.
+- Keep all edits inside the active ChangeSet scope. If a needed edit is outside `docs/changes/active/<CHG-ID>.md` or the UC affected-files boundary, record a blocker in the UC plan and stop.
 - If a task names another skill, use that skill's workflow before coding:
   - spring-initializer for Spring Boot project/module initialization.
   - spring-package-structure for module/package skeleton and ARCHITECTURE.md structure verification.
   - ddd-architecture-linter only when the plan reaches static-analysis setup or verification.
 - Add or update focused tests next to implementation.
 - Run the narrowest useful verification for completed tasks when practical.
+- Use build/test/e2e commands from `.codex/repository-settings.md` when present. If it is missing or incomplete, record the missing command as a blocker instead of inventing a repository contract.
+- Do not report implementation completion until `./gradlew test` or the repository settings test command passes.
+- If the UC E2E goal exists, verify with `./gradlew e2eTest` or the repository settings e2e command when practical.
+- If Playwright browser install, network, credentials, permissions, external services, or host limits prevent E2E verification, record an environment blocker in the targeted UC plan and stop.
 - After build succeeds, start the application server when the active plan defines a runtime server verification step. Use the plan's run command, or the repository's existing Spring Boot run command such as `./gradlew bootRun` when the plan explicitly allows inference.
 - Keep the server process only as long as needed for verification. Verify the implemented behavior against the running server with the plan's HTTP/API/UI checks, record the command, endpoint/action, response or observable result, and stop the server before finishing.
 - If the server cannot be started because of environment limits, missing credentials, unavailable external services, or ports, record the exact blocker in plan.md instead of marking runtime verification complete.
@@ -64,6 +70,7 @@ Implementation constraints:
 Completion report:
 - Report completed checkboxes.
 - Report commands run and results.
+- Report the targeted UC ID, ChangeSet ID, and whether every edit stayed inside the ChangeSet boundary.
 - Report server run command, runtime verification checks, results, and whether the server was stopped.
 - Report remaining unchecked tasks or blockers.
 - Do not claim final completion; the harness-plan-executor skill owns final verification and completion move.

--- a/tests/test_executor_use_case_scope.py
+++ b/tests/test_executor_use_case_scope.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_executor() -> str:
+    return (REPO_ROOT / ".codex/agents/implementation_executor.toml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_executor_runs_only_targeted_use_case_plan() -> None:
+    executor = read_executor()
+
+    assert "docs/plans/active/<UC-ID>/plan.md" in executor
+    assert "docs/plans/active/plan.md" not in executor
+    assert "Do not edit other UC plans or other UC documents" in executor
+
+
+def test_executor_uses_changeset_and_uc_slice_boundaries() -> None:
+    executor = read_executor()
+
+    required_inputs = [
+        "docs/use-cases/<UC-ID>/use-case.md",
+        "docs/use-cases/<UC-ID>/event-storming.md",
+        "docs/use-cases/<UC-ID>/e2e-goal.md",
+        "docs/changes/active/<CHG-ID>.md",
+        ".codex/repository-settings.md",
+    ]
+
+    for input_path in required_inputs:
+        assert input_path in executor
+
+    assert "Keep all edits inside the active ChangeSet scope" in executor
+
+
+def test_executor_records_environment_blocker_for_e2e_limits() -> None:
+    executor = read_executor()
+
+    assert "Do not edit docs/use-cases/<UC-ID>/e2e-goal.md" in executor
+    assert "./gradlew test" in executor
+    assert "./gradlew e2eTest" in executor
+    assert "Playwright browser install" in executor
+    assert "environment blocker" in executor


### PR DESCRIPTION
## 구현 의도
- #19 요구사항에 맞춰 `implementation_executor`가 전체 active plan이 아니라 특정 UC plan의 unchecked task만 실행하도록 지시를 변경했습니다.
- ChangeSet 밖 변경, 다른 UC 문서 변경, E2E goal 임의 변경을 막고 환경 문제를 blocker로 남기도록 했습니다.

## 구현 방법
- 필수 입력을 `docs/plans/active/<UC-ID>/plan.md`, `docs/use-cases/<UC-ID>/**`, `docs/changes/active/<CHG-ID>.md`, `.codex/repository-settings.md`로 재정의했습니다.
- 실행 규칙에 ChangeSet boundary 확인, repository settings 기반 build/test/e2e 명령 사용, `./gradlew test`/`./gradlew e2eTest` 검증 기준을 추가했습니다.
- Playwright/browser/network/permission 문제는 environment blocker로 기록하고 중단하도록 명시했습니다.
- executor instruction 회귀 방지 테스트를 추가했습니다.

## 검증 방법
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp venv/bin/python3 -m pytest tests/test_executor_use_case_scope.py -q`

Closes #19
