### PR TITLE
[codex] 유스케이스 verifier 계약 추가

### DIFF
--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -19,6 +19,13 @@ from harness_codex.runtime.models import (
     StepStatus,
     Workflow,
 )
+from harness_codex.runtime.verifier import (
+    CommandCheck,
+    RequiredStageCheck,
+    UseCaseVerificationInput,
+    UseCaseVerificationResult,
+    VerificationStatus,
+)
 
 __all__ = [
     "ExecutionPlan",
@@ -35,6 +42,11 @@ __all__ = [
     "StepResult",
     "StepRunner",
     "StepStatus",
+    "CommandCheck",
+    "RequiredStageCheck",
+    "UseCaseVerificationInput",
+    "UseCaseVerificationResult",
+    "VerificationStatus",
     "Workflow",
     "WorkflowValidationError",
 ]

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -398,9 +398,11 @@ HARNESS_FULL_WORKFLOW = Workflow(
                 "typical_commands": (
                     "./gradlew build",
                     "./gradlew test",
+                    "./gradlew e2eTest",
                     "./gradlew architectureRules",
                     "semgrep --config .semgrep/ddd-architecture.yml .",
                 ),
+                "test_gate": ".codex/test-gate.yaml required stages must PASS",
                 "purpose": (
                     "Verify the implemented UC against its E2E goal and "
                     "repository quality gates."

--- a/harness_codex/runtime/verifier.py
+++ b/harness_codex/runtime/verifier.py
@@ -1,0 +1,81 @@
+"""Use-case scoped verification contract.
+
+This module defines the data passed between a use-case executor loop and a
+verifier/test-gate implementation. It does not run Gradle, Playwright, or shell
+commands directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Mapping
+
+
+class VerificationStatus(str, Enum):
+    """Outcome categories for one use-case verification pass."""
+
+    PASS = "PASS"
+    IMPLEMENTATION_FAILURE = "IMPLEMENTATION_FAILURE"
+    UNCLEAR_E2E_GOAL = "UNCLEAR_E2E_GOAL"
+    DOCUMENT_DELTA_CONFLICT = "DOCUMENT_DELTA_CONFLICT"
+    UPSTREAM_DESIGN_CONFLICT = "UPSTREAM_DESIGN_CONFLICT"
+    ENVIRONMENT_BLOCKER = "ENVIRONMENT_BLOCKER"
+
+
+@dataclass(frozen=True)
+class UseCaseVerificationInput:
+    """Inputs required to verify a single implemented use-case plan."""
+
+    change_set_path: Path
+    plan_path: Path
+    e2e_goal_path: Path
+    repository_settings_path: Path = Path(".codex/repository-settings.md")
+    test_gate_path: Path = Path(".codex/test-gate.yaml")
+    required_commands: tuple[str, ...] = (
+        "./gradlew test",
+        "./gradlew e2eTest",
+    )
+
+
+@dataclass(frozen=True)
+class CommandCheck:
+    """Recorded result for one build, test, e2e, or static-analysis command."""
+
+    name: str
+    command: str
+    passed: bool
+    evidence: str = ""
+
+
+@dataclass(frozen=True)
+class RequiredStageCheck:
+    """Required stage result read from `.codex/test-gate.yaml`."""
+
+    stage: str
+    passed: bool
+    evidence: str = ""
+
+
+@dataclass(frozen=True)
+class UseCaseVerificationResult:
+    """Structured verifier result for the orchestrator loop."""
+
+    status: VerificationStatus
+    command_checks: tuple[CommandCheck, ...] = ()
+    test_gate_checks: tuple[RequiredStageCheck, ...] = ()
+    blocker: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        """Whether all required use-case verification gates passed."""
+
+        return self.status == VerificationStatus.PASS
+
+    @property
+    def resumable_by_executor(self) -> bool:
+        """Whether the executor loop may add remediation and retry."""
+
+        return self.status == VerificationStatus.IMPLEMENTATION_FAILURE

--- a/tests/runtime/test_verifier_contract.py
+++ b/tests/runtime/test_verifier_contract.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from harness_codex.runtime import (
+    HARNESS_FULL_WORKFLOW,
+    CommandCheck,
+    RequiredStageCheck,
+    UseCaseVerificationInput,
+    UseCaseVerificationResult,
+    VerificationStatus,
+)
+
+
+def test_use_case_verification_input_targets_one_plan_and_e2e_goal() -> None:
+    verification_input = UseCaseVerificationInput(
+        change_set_path=Path("docs/changes/active/CHG-1.md"),
+        plan_path=Path("docs/plans/active/UC-1/plan.md"),
+        e2e_goal_path=Path("docs/use-cases/UC-1/e2e-goal.md"),
+    )
+
+    assert verification_input.plan_path == Path("docs/plans/active/UC-1/plan.md")
+    assert verification_input.e2e_goal_path == Path(
+        "docs/use-cases/UC-1/e2e-goal.md"
+    )
+    assert verification_input.repository_settings_path == Path(
+        ".codex/repository-settings.md"
+    )
+    assert verification_input.test_gate_path == Path(".codex/test-gate.yaml")
+    assert "./gradlew test" in verification_input.required_commands
+    assert "./gradlew e2eTest" in verification_input.required_commands
+
+
+def test_verification_result_distinguishes_retryable_failure() -> None:
+    implementation_failure = UseCaseVerificationResult(
+        status=VerificationStatus.IMPLEMENTATION_FAILURE,
+        command_checks=(
+            CommandCheck(
+                name="Tests",
+                command="./gradlew test",
+                passed=False,
+                evidence="failing application service test",
+            ),
+        ),
+    )
+    unclear_goal = UseCaseVerificationResult(
+        status=VerificationStatus.UNCLEAR_E2E_GOAL,
+        blocker="E2E goal has no observable success criteria",
+    )
+
+    assert implementation_failure.passed is False
+    assert implementation_failure.resumable_by_executor is True
+    assert unclear_goal.resumable_by_executor is False
+
+
+def test_verification_status_covers_orchestrator_failure_classification() -> None:
+    assert {status.value for status in VerificationStatus} == {
+        "PASS",
+        "IMPLEMENTATION_FAILURE",
+        "UNCLEAR_E2E_GOAL",
+        "DOCUMENT_DELTA_CONFLICT",
+        "UPSTREAM_DESIGN_CONFLICT",
+        "ENVIRONMENT_BLOCKER",
+    }
+
+
+def test_workflow_verifier_step_records_e2e_and_test_gate() -> None:
+    verification = HARNESS_FULL_WORKFLOW.step_by_id("verifier-run-use-case-e2e")
+
+    assert Path("docs/plans/active/<UC-ID>/plan.md") in verification.inputs
+    assert Path("docs/use-cases/<UC-ID>/e2e-goal.md") in verification.inputs
+    assert Path(".codex/test-gate.yaml") in verification.inputs
+    assert "./gradlew test" in verification.metadata["typical_commands"]
+    assert "./gradlew e2eTest" in verification.metadata["typical_commands"]
+    assert ".codex/test-gate.yaml" in verification.metadata["test_gate"]
+
+
+def test_test_gate_check_records_required_stage_result() -> None:
+    result = UseCaseVerificationResult(
+        status=VerificationStatus.PASS,
+        test_gate_checks=(
+            RequiredStageCheck(stage="unit", passed=True, evidence="./gradlew test"),
+            RequiredStageCheck(stage="e2e", passed=True, evidence="./gradlew e2eTest"),
+        ),
+    )
+
+    assert result.passed is True
+    assert all(check.passed for check in result.test_gate_checks)


### PR DESCRIPTION
## 구현 의도
- #20 요구사항에 맞춰 UC plan 실행 결과를 UC E2E 목표와 repository test gate 기준으로 검증하는 런타임 계약을 추가했습니다.
- 실제 Gradle/Playwright 실행 구현은 비범위로 두고, verifier와 orchestrator가 주고받을 입력/결과 모델을 명확히 했습니다.

## 구현 방법
- `UseCaseVerificationInput`으로 ChangeSet, UC plan, E2E goal, repository settings, `.codex/test-gate.yaml` 입력을 모델링했습니다.
- `VerificationStatus`에 PASS, IMPLEMENTATION_FAILURE, UNCLEAR_E2E_GOAL, DOCUMENT_DELTA_CONFLICT, UPSTREAM_DESIGN_CONFLICT, ENVIRONMENT_BLOCKER 분류를 추가했습니다.
- command check와 required stage check 결과를 구조화했습니다.
- 기존 full workflow verifier step metadata에 `./gradlew e2eTest`와 test gate required stage 기준을 추가했습니다.

## 검증 방법
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp venv/bin/python3 -m pytest tests/runtime/test_verifier_contract.py tests/runtime/test_models.py -q`

Closes #20
