### PR TITLE
[codex] 유스케이스 plan executor 회귀 테스트 추가

### DIFF
--- a/.codex/skills/harness-plan-executor/SKILL.md
+++ b/.codex/skills/harness-plan-executor/SKILL.md
@@ -181,6 +181,7 @@ Typical final commands are:
 ```bash
 ./gradlew build
 ./gradlew test
+./gradlew e2eTest
 ./gradlew architectureRules
 semgrep --config .semgrep/ddd-architecture.yml .
 ```

--- a/tests/test_plan_executor_use_case_loop.py
+++ b/tests/test_plan_executor_use_case_loop.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_plan_executor_skill() -> str:
+    return (REPO_ROOT / ".codex/skills/harness-plan-executor/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_plan_executor_targets_one_use_case_plan() -> None:
+    skill = read_plan_executor_skill()
+
+    assert "docs/plans/active/<UC-ID>/plan.md" in skill
+    assert "docs/plans/active/plan.md" not in skill
+    assert "Do not execute or complete other active UC plans" in skill
+
+
+def test_plan_executor_uses_e2e_goal_and_test_gate() -> None:
+    skill = read_plan_executor_skill()
+
+    assert "docs/use-cases/<UC-ID>/e2e-goal.md" in skill
+    assert ".codex/test-gate.yaml" in skill
+    assert "./gradlew test" in skill
+    assert "./gradlew e2eTest" in skill
+    assert "UC E2E goal" in skill
+
+
+def test_plan_executor_remediates_only_implementation_failures() -> None:
+    skill = read_plan_executor_skill()
+
+    assert "Only for `IMPLEMENTATION_FAILURE`" in skill
+    assert "UNCLEAR_E2E_GOAL" in skill
+    assert "DOCUMENT_DELTA_CONFLICT" in skill
+    assert "UPSTREAM_DESIGN_CONFLICT" in skill
+    assert "ENVIRONMENT_BLOCKER" in skill
+    assert "do not add remediation tasks" in skill
+
+
+def test_plan_executor_moves_only_completed_uc_plan() -> None:
+    skill = read_plan_executor_skill()
+
+    assert (
+        "docs/plans/active/<UC-ID>/plan.md -> docs/plans/completed/<UC-ID>/plan.md"
+        in skill
+    )
+    assert "all of these are true" in skill


### PR DESCRIPTION
## 구현 의도
- #22는 기존 PR #27에서 주요 지시가 이미 병합되어 있었지만, 이슈가 열린 상태라 UC scoped remediation loop 규칙을 테스트로 고정했습니다.
- 최종 검증 명령 목록에 UC E2E 기준인 `./gradlew e2eTest`를 명시했습니다.

## 구현 방법
- `harness-plan-executor` 스킬이 단일 `docs/plans/active/plan.md`가 아니라 `docs/plans/active/<UC-ID>/plan.md`만 대상으로 삼는지 검증하는 테스트를 추가했습니다.
- E2E goal, `.codex/test-gate.yaml`, `./gradlew test`, `./gradlew e2eTest` 기준을 회귀 테스트로 고정했습니다.
- remediation task는 `IMPLEMENTATION_FAILURE`에만 추가하고, 나머지 실패 유형은 상위 단계/blocker로 되돌리는 규칙을 검증했습니다.

## 검증 방법
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp venv/bin/python3 -m pytest tests/test_plan_executor_use_case_loop.py -q`

Closes #22
