### PR TITLE
[codex] run state와 resume 판단 추가

### DIFF
--- a/harness_codex/__main__.py
+++ b/harness_codex/__main__.py
@@ -1,0 +1,6 @@
+"""Run `python3 -m harness_codex` as the harness CLI."""
+
+from harness_codex.cli import main
+
+
+raise SystemExit(main())

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -1,0 +1,228 @@
+"""CLI entrypoint for ChangeSet and use-case workflow commands."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+from harness_codex.runtime import (
+    ReportWriter,
+    ResumeDisposition,
+    RunMode,
+    RunState,
+    RunStateStore,
+    RunStatus,
+    decide_resume_target,
+)
+from harness_codex.runtime.changes import (
+    ChangeSet,
+    ChangeSetResolver,
+    NoActiveChangeSetsError,
+    PlanningBlocked,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root = Path(args.repo_root)
+
+    try:
+        output = args.func(args, repo_root)
+    except NoActiveChangeSetsError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if output:
+        print(output)
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="harness")
+    parser.add_argument("--repo-root", default=".")
+    subparsers = parser.add_subparsers(required=True)
+
+    changes = subparsers.add_parser("changes")
+    changes_subparsers = changes.add_subparsers(required=True)
+    changes_list = changes_subparsers.add_parser("list")
+    changes_list.set_defaults(func=changes_list_command)
+    changes_show = changes_subparsers.add_parser("show")
+    changes_show.add_argument("change_set_id")
+    changes_show.set_defaults(func=changes_show_command)
+
+    run_change = subparsers.add_parser("run-change")
+    run_change.add_argument("change_set_id")
+    _add_mode_options(run_change)
+    run_change.set_defaults(func=run_change_command)
+
+    run_use_case = subparsers.add_parser("run-use-case")
+    run_use_case.add_argument("change_set_id")
+    run_use_case.add_argument("uc_id")
+    _add_mode_options(run_use_case)
+    run_use_case.set_defaults(func=run_use_case_command)
+
+    resume = subparsers.add_parser("resume")
+    resume.add_argument("run_id")
+    resume.set_defaults(func=resume_command)
+
+    report = subparsers.add_parser("report")
+    report.add_argument("run_id")
+    report.set_defaults(func=report_command)
+
+    return parser
+
+
+def changes_list_command(args: argparse.Namespace, repo_root: Path) -> str:
+    resolver = ChangeSetResolver(repo_root)
+    rows = [
+        f"{change_set.change_set_id}\t{change_set.status or '-'}\t{change_set.title}"
+        for change_set in resolver.list_active()
+    ]
+    return "\n".join(rows)
+
+
+def changes_show_command(args: argparse.Namespace, repo_root: Path) -> str:
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    affected = ", ".join(uc.uc_id for uc in change_set.affected_use_cases) or "-"
+    return "\n".join(
+        [
+            f"ChangeSet: {change_set.change_set_id}",
+            f"Status: {change_set.status or '-'}",
+            f"Title: {change_set.title}",
+            f"Before: {change_set.before_summary or '-'}",
+            f"After: {change_set.after_summary or '-'}",
+            f"Affected UC: {affected}",
+        ]
+    )
+
+
+def run_change_command(args: argparse.Namespace, repo_root: Path) -> str:
+    mode = _selected_mode(args)
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    resolver = ChangeSetResolver(repo_root)
+    scopes = resolver.resolve_planning_scopes(change_set)
+
+    if isinstance(scopes, PlanningBlocked):
+        return f"BLOCKED: {scopes.reason}"
+
+    if mode in (RunMode.PLAN, RunMode.PREVIEW):
+        return _format_scopes(change_set, scopes, mode)
+
+    run_id = _create_run_state(repo_root, change_set, tuple(scope.use_case.uc_id for scope in scopes))
+    return f"APPLY started: run_id={run_id}"
+
+
+def run_use_case_command(args: argparse.Namespace, repo_root: Path) -> str:
+    mode = _selected_mode(args)
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    resolver = ChangeSetResolver(repo_root)
+    scopes = resolver.resolve_planning_scopes(change_set)
+
+    if isinstance(scopes, PlanningBlocked):
+        return f"BLOCKED: {scopes.reason}"
+
+    selected = tuple(scope for scope in scopes if scope.use_case.uc_id == args.uc_id)
+    if not selected:
+        return f"BLOCKED: {args.uc_id} is not affected by {change_set.change_set_id}"
+
+    if mode in (RunMode.PLAN, RunMode.PREVIEW):
+        return _format_scopes(change_set, selected, mode)
+
+    run_id = _create_run_state(repo_root, change_set, (args.uc_id,))
+    return f"APPLY started: run_id={run_id} uc_id={args.uc_id}"
+
+
+def resume_command(args: argparse.Namespace, repo_root: Path) -> str:
+    state = RunStateStore(repo_root).load(args.run_id)
+    target = decide_resume_target(state)
+    if target.disposition == ResumeDisposition.COMPLETE:
+        return f"COMPLETE: {target.reason}"
+    return "\n".join(
+        [
+            f"Resume: {target.disposition.value}",
+            f"UC: {target.uc_id or '-'}",
+            f"Step: {target.step_id.value if target.step_id else '-'}",
+            f"Reason: {target.reason}",
+        ]
+    )
+
+
+def report_command(args: argparse.Namespace, repo_root: Path) -> str:
+    report_path = repo_root / ".harness/runs" / args.run_id / "report.md"
+    if not report_path.exists():
+        manifest = ReportWriter(repo_root).artifact_manifest(args.run_id, ())
+        return f"Report not found. Expected: {manifest.run_report_md}"
+    return report_path.read_text(encoding="utf-8").strip()
+
+
+def _load_change_set(repo_root: Path, change_set_id: str) -> ChangeSet:
+    return ChangeSetResolver(repo_root).load(
+        Path("docs/changes/active") / f"{change_set_id}.md"
+    )
+
+
+def _selected_mode(args: argparse.Namespace) -> RunMode:
+    if args.plan:
+        return RunMode.PLAN
+    if args.preview:
+        return RunMode.PREVIEW
+    return RunMode.APPLY
+
+
+def _add_mode_options(parser: argparse.ArgumentParser) -> None:
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--plan", action="store_true")
+    mode.add_argument("--preview", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+
+
+def _format_scopes(
+    change_set: ChangeSet,
+    scopes: tuple,
+    mode: RunMode,
+) -> str:
+    lines = [
+        f"Mode: {mode.value}",
+        f"ChangeSet: {change_set.change_set_id}",
+        "Side effects: false",
+    ]
+
+    for scope in scopes:
+        lines.extend(
+            [
+                f"UC: {scope.use_case.uc_id}",
+                "Planner inputs:",
+                *[f"- {path}" for path in scope.planner_inputs],
+                "Executor inputs:",
+                *[f"- {path}" for path in scope.executor_inputs],
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def _create_run_state(
+    repo_root: Path,
+    change_set: ChangeSet,
+    affected_use_cases: tuple[str, ...],
+) -> str:
+    run_id = f"run-{uuid4().hex[:12]}"
+    state = RunState(
+        run_id=run_id,
+        change_set_id=change_set.change_set_id,
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        affected_use_cases=affected_use_cases,
+        current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
+        status=RunStatus.PENDING,
+    )
+    RunStateStore(repo_root).save(state)
+    return run_id
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -19,6 +19,12 @@ from harness_codex.runtime.models import (
     StepStatus,
     Workflow,
 )
+from harness_codex.runtime.reports import (
+    ArtifactManifest,
+    ReportWriter,
+    RunReport,
+    UseCaseReport,
+)
 from harness_codex.runtime.state import (
     ResumeDisposition,
     ResumeTarget,
@@ -35,9 +41,12 @@ __all__ = [
     "FailureKind",
     "HARNESS_FULL_WORKFLOW",
     "HARNESS_PLAN_EXECUTOR_WORKFLOW",
+    "ArtifactManifest",
+    "ReportWriter",
     "RunContext",
     "RunMode",
     "RunResult",
+    "RunReport",
     "RunFailureKind",
     "RunStatus",
     "RunState",
@@ -51,6 +60,7 @@ __all__ = [
     "StepRunner",
     "StepStatus",
     "UseCaseLoopState",
+    "UseCaseReport",
     "UseCaseStep",
     "Workflow",
     "WorkflowValidationError",

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -19,6 +19,16 @@ from harness_codex.runtime.models import (
     StepStatus,
     Workflow,
 )
+from harness_codex.runtime.state import (
+    ResumeDisposition,
+    ResumeTarget,
+    RunFailureKind,
+    RunState,
+    RunStateStore,
+    UseCaseLoopState,
+    UseCaseStep,
+    decide_resume_target,
+)
 
 __all__ = [
     "ExecutionPlan",
@@ -28,13 +38,21 @@ __all__ = [
     "RunContext",
     "RunMode",
     "RunResult",
+    "RunFailureKind",
     "RunStatus",
+    "RunState",
+    "RunStateStore",
     "RunnerEngine",
+    "ResumeDisposition",
+    "ResumeTarget",
     "Step",
     "StepKind",
     "StepResult",
     "StepRunner",
     "StepStatus",
+    "UseCaseLoopState",
+    "UseCaseStep",
     "Workflow",
     "WorkflowValidationError",
+    "decide_resume_target",
 ]

--- a/harness_codex/runtime/reports.py
+++ b/harness_codex/runtime/reports.py
@@ -1,0 +1,192 @@
+"""Artifact manifest and report writer for workflow runs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from harness_codex.runtime.models import RunMode, RunStatus
+
+
+@dataclass(frozen=True)
+class ArtifactManifest:
+    """Paths for generated run and per-use-case artifacts."""
+
+    run_id: str
+    run_dir: Path
+    run_report_json: Path
+    run_report_md: Path
+    events_path: Path
+    use_case_artifacts: Mapping[str, Mapping[str, Path]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class UseCaseReport:
+    """Report for one affected use case."""
+
+    uc_id: str
+    active_plan_path: Path
+    e2e_goal_path: Path
+    change_set_path: Path
+    status: RunStatus
+    completed_plan_path: Path | None = None
+    executor_status: str = ""
+    verifier_status: str = ""
+    commands_run: tuple[str, ...] = ()
+    test_gate_result: str = ""
+    remediation_count: int = 0
+    blocker: str | None = None
+    artifact_paths: Mapping[str, Path] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RunReport:
+    """Top-level report for one ChangeSet workflow run."""
+
+    run_id: str
+    change_set_id: str
+    workflow_name: str
+    mode: RunMode
+    status: RunStatus
+    affected_use_cases: tuple[str, ...]
+    completed_use_cases: tuple[str, ...] = ()
+    failed_use_cases: tuple[str, ...] = ()
+    blocked_use_cases: tuple[str, ...] = ()
+    current_use_case_id: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    report_paths: Mapping[str, Path] = field(default_factory=dict)
+    artifact_paths: Mapping[str, Path] = field(default_factory=dict)
+    use_case_reports: tuple[UseCaseReport, ...] = ()
+
+
+class ReportWriter:
+    """Write JSON and Markdown reports without running agents or shell."""
+
+    def __init__(self, repo_root: Path | str) -> None:
+        self.repo_root = Path(repo_root)
+
+    def artifact_manifest(
+        self,
+        run_id: str,
+        use_case_ids: tuple[str, ...],
+    ) -> ArtifactManifest:
+        run_dir = Path(".harness/runs") / run_id
+        use_case_artifacts = {
+            uc_id: {
+                "report_json": run_dir / "use-cases" / uc_id / "report.json",
+                "report_md": run_dir / "use-cases" / uc_id / "report.md",
+                "executor_result": run_dir
+                / "use-cases"
+                / uc_id
+                / "executor-result.json",
+                "verifier_result": run_dir
+                / "use-cases"
+                / uc_id
+                / "verifier-result.json",
+                "remediation_history": run_dir
+                / "use-cases"
+                / uc_id
+                / "remediation-history.md",
+                "blocker": run_dir / "use-cases" / uc_id / "blocker.md",
+                "executor_log": run_dir / "use-cases" / uc_id / "logs/executor.log",
+                "verifier_log": run_dir / "use-cases" / uc_id / "logs/verifier.log",
+            }
+            for uc_id in use_case_ids
+        }
+        return ArtifactManifest(
+            run_id=run_id,
+            run_dir=run_dir,
+            run_report_json=run_dir / "report.json",
+            run_report_md=run_dir / "report.md",
+            events_path=run_dir / "events.ndjson",
+            use_case_artifacts=use_case_artifacts,
+        )
+
+    def write(self, report: RunReport) -> ArtifactManifest:
+        manifest = self.artifact_manifest(report.run_id, report.affected_use_cases)
+
+        self._write_json(manifest.run_report_json, _to_json(report))
+        self._write_text(manifest.run_report_md, self._run_markdown(report))
+        self._write_json(Path(".harness/runs") / report.run_id / "artifacts.json", _to_json(manifest))
+
+        for use_case_report in report.use_case_reports:
+            artifacts = manifest.use_case_artifacts[use_case_report.uc_id]
+            self._write_json(artifacts["report_json"], _to_json(use_case_report))
+            self._write_text(
+                artifacts["report_md"],
+                self._use_case_markdown(use_case_report),
+            )
+            if use_case_report.blocker:
+                self._write_text(
+                    artifacts["blocker"],
+                    f"# Blocker {use_case_report.uc_id}\n\n{use_case_report.blocker}\n",
+                )
+
+        return manifest
+
+    def _write_json(self, relative_path: Path, value: Mapping[str, Any]) -> None:
+        path = self.repo_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def _write_text(self, relative_path: Path, text: str) -> None:
+        path = self.repo_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def _run_markdown(self, report: RunReport) -> str:
+        return "\n".join(
+            [
+                f"# Run Report {report.run_id}",
+                "",
+                f"- ChangeSet: {report.change_set_id}",
+                f"- Workflow: {report.workflow_name}",
+                f"- Mode: {report.mode.value}",
+                f"- Status: {report.status.value}",
+                f"- Affected UC: {', '.join(report.affected_use_cases)}",
+                f"- Completed UC: {', '.join(report.completed_use_cases) or '-'}",
+                f"- Failed UC: {', '.join(report.failed_use_cases) or '-'}",
+                f"- Blocked UC: {', '.join(report.blocked_use_cases) or '-'}",
+                "",
+            ]
+        )
+
+    def _use_case_markdown(self, report: UseCaseReport) -> str:
+        return "\n".join(
+            [
+                f"# Use Case Report {report.uc_id}",
+                "",
+                f"- Status: {report.status.value}",
+                f"- Active plan: `{report.active_plan_path}`",
+                f"- Completed plan: `{report.completed_plan_path or '-'}`",
+                f"- E2E goal: `{report.e2e_goal_path}`",
+                f"- ChangeSet: `{report.change_set_path}`",
+                f"- Executor: {report.executor_status or '-'}",
+                f"- Verifier: {report.verifier_status or '-'}",
+                f"- Commands: {', '.join(report.commands_run) or '-'}",
+                f"- Test gate: {report.test_gate_result or '-'}",
+                f"- Remediation count: {report.remediation_count}",
+                f"- Blocker: {report.blocker or '-'}",
+                "",
+            ]
+        )
+
+
+def _to_json(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, RunMode | RunStatus):
+        return value.value
+    if isinstance(value, tuple):
+        return [_to_json(item) for item in value]
+    if hasattr(value, "__dataclass_fields__"):
+        return {key: _to_json(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {key: _to_json(item) for key, item in value.items()}
+    return value

--- a/harness_codex/runtime/state.py
+++ b/harness_codex/runtime/state.py
@@ -1,0 +1,242 @@
+"""Run state and resume support for use-case scoped workflows."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from harness_codex.runtime.models import RunMode, RunStatus
+
+
+class UseCaseStep(str, Enum):
+    """Coarse-grained steps in one use-case workflow loop."""
+
+    PLAN = "plan"
+    EXECUTE = "execute"
+    VERIFY = "verify"
+    REMEDIATE = "remediate"
+    COMPLETE = "complete"
+
+
+class ResumeDisposition(str, Enum):
+    """Whether and where a run may resume."""
+
+    NEXT_USE_CASE = "NEXT_USE_CASE"
+    RETRY_REMEDIATION = "RETRY_REMEDIATION"
+    WAIT_FOR_GOAL_CLARIFICATION = "WAIT_FOR_GOAL_CLARIFICATION"
+    WAIT_FOR_CHANGESET_REVISION = "WAIT_FOR_CHANGESET_REVISION"
+    WAIT_FOR_UPSTREAM_DESIGN = "WAIT_FOR_UPSTREAM_DESIGN"
+    WAIT_FOR_ENVIRONMENT = "WAIT_FOR_ENVIRONMENT"
+    COMPLETE = "COMPLETE"
+
+
+class RunFailureKind(str, Enum):
+    """Failure categories that decide resume behavior."""
+
+    IMPLEMENTATION_FAILURE = "IMPLEMENTATION_FAILURE"
+    UNCLEAR_E2E_GOAL = "UNCLEAR_E2E_GOAL"
+    DOCUMENT_DELTA_CONFLICT = "DOCUMENT_DELTA_CONFLICT"
+    UPSTREAM_DESIGN_CONFLICT = "UPSTREAM_DESIGN_CONFLICT"
+    ENVIRONMENT_BLOCKER = "ENVIRONMENT_BLOCKER"
+
+
+@dataclass(frozen=True)
+class UseCaseLoopState:
+    """Persisted state for one affected use-case loop."""
+
+    uc_id: str
+    active_plan_path: Path
+    status: RunStatus = RunStatus.PENDING
+    current_step_id: UseCaseStep = UseCaseStep.PLAN
+    verification_status: str = ""
+    retry_count: int = 0
+    last_executor_result: Mapping[str, Any] = field(default_factory=dict)
+    last_verifier_result: Mapping[str, Any] = field(default_factory=dict)
+    failure_kind: RunFailureKind | None = None
+    blocker: str | None = None
+
+
+@dataclass(frozen=True)
+class RunState:
+    """Persisted state for a ChangeSet workflow run."""
+
+    run_id: str
+    change_set_id: str
+    workflow_name: str
+    mode: RunMode
+    affected_use_cases: tuple[str, ...]
+    current_use_case_id: str | None = None
+    current_step_id: UseCaseStep | None = None
+    completed_use_cases: tuple[str, ...] = ()
+    blocked_use_cases: tuple[str, ...] = ()
+    failed_step_id: str | None = None
+    failure_kind: RunFailureKind | None = None
+    status: RunStatus = RunStatus.PENDING
+    use_case_states: tuple[UseCaseLoopState, ...] = ()
+
+
+@dataclass(frozen=True)
+class ResumeTarget:
+    """Calculated next resume target for a stored run state."""
+
+    disposition: ResumeDisposition
+    uc_id: str | None = None
+    step_id: UseCaseStep | None = None
+    reason: str = ""
+
+
+class RunStateStore:
+    """JSON file store under `.harness/runs/<run-id>/state.json`."""
+
+    def __init__(self, repo_root: Path | str) -> None:
+        self.repo_root = Path(repo_root)
+
+    def state_path(self, run_id: str) -> Path:
+        return self.repo_root / ".harness/runs" / run_id / "state.json"
+
+    def save(self, state: RunState) -> Path:
+        path = self.state_path(state.run_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(_to_json(state), ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def load(self, run_id: str) -> RunState:
+        data = json.loads(self.state_path(run_id).read_text(encoding="utf-8"))
+        return _run_state_from_json(data)
+
+
+def decide_resume_target(state: RunState) -> ResumeTarget:
+    """Decide where the workflow can resume from stored state."""
+
+    if state.status == RunStatus.SUCCEEDED:
+        return ResumeTarget(
+            disposition=ResumeDisposition.COMPLETE,
+            reason="run already succeeded",
+        )
+
+    if state.failure_kind == RunFailureKind.IMPLEMENTATION_FAILURE:
+        return ResumeTarget(
+            disposition=ResumeDisposition.RETRY_REMEDIATION,
+            uc_id=state.current_use_case_id,
+            step_id=UseCaseStep.REMEDIATE,
+            reason="implementation failure can resume from remediation loop",
+        )
+
+    if state.failure_kind == RunFailureKind.UNCLEAR_E2E_GOAL:
+        return ResumeTarget(
+            disposition=ResumeDisposition.WAIT_FOR_GOAL_CLARIFICATION,
+            uc_id=state.current_use_case_id,
+            reason="E2E goal must be clarified before resume",
+        )
+
+    if state.failure_kind == RunFailureKind.DOCUMENT_DELTA_CONFLICT:
+        return ResumeTarget(
+            disposition=ResumeDisposition.WAIT_FOR_CHANGESET_REVISION,
+            uc_id=state.current_use_case_id,
+            reason="ChangeSet and UC documents conflict",
+        )
+
+    if state.failure_kind == RunFailureKind.UPSTREAM_DESIGN_CONFLICT:
+        return ResumeTarget(
+            disposition=ResumeDisposition.WAIT_FOR_UPSTREAM_DESIGN,
+            uc_id=state.current_use_case_id,
+            reason="upstream design or technical decision must change",
+        )
+
+    if state.failure_kind == RunFailureKind.ENVIRONMENT_BLOCKER:
+        return ResumeTarget(
+            disposition=ResumeDisposition.WAIT_FOR_ENVIRONMENT,
+            uc_id=state.current_use_case_id,
+            reason="environment blocker must be resolved before resume",
+        )
+
+    next_uc = _first_incomplete_use_case(state)
+    if next_uc is not None:
+        return ResumeTarget(
+            disposition=ResumeDisposition.NEXT_USE_CASE,
+            uc_id=next_uc,
+            step_id=UseCaseStep.PLAN,
+            reason="completed use cases are skipped",
+        )
+
+    return ResumeTarget(
+        disposition=ResumeDisposition.COMPLETE,
+        reason="all affected use cases are completed",
+    )
+
+
+def _first_incomplete_use_case(state: RunState) -> str | None:
+    completed = set(state.completed_use_cases)
+    blocked = set(state.blocked_use_cases)
+
+    for uc_id in state.affected_use_cases:
+        if uc_id not in completed and uc_id not in blocked:
+            return uc_id
+
+    return None
+
+
+def _to_json(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, tuple):
+        return [_to_json(item) for item in value]
+    if hasattr(value, "__dataclass_fields__"):
+        return {key: _to_json(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {key: _to_json(item) for key, item in value.items()}
+    return value
+
+
+def _run_state_from_json(data: Mapping[str, Any]) -> RunState:
+    use_case_states = tuple(
+        UseCaseLoopState(
+            uc_id=item["uc_id"],
+            active_plan_path=Path(item["active_plan_path"]),
+            status=RunStatus(item["status"]),
+            current_step_id=UseCaseStep(item["current_step_id"]),
+            verification_status=item.get("verification_status", ""),
+            retry_count=item.get("retry_count", 0),
+            last_executor_result=item.get("last_executor_result", {}),
+            last_verifier_result=item.get("last_verifier_result", {}),
+            failure_kind=(
+                RunFailureKind(item["failure_kind"])
+                if item.get("failure_kind") is not None
+                else None
+            ),
+            blocker=item.get("blocker"),
+        )
+        for item in data.get("use_case_states", [])
+    )
+
+    return RunState(
+        run_id=data["run_id"],
+        change_set_id=data["change_set_id"],
+        workflow_name=data["workflow_name"],
+        mode=RunMode(data["mode"]),
+        affected_use_cases=tuple(data["affected_use_cases"]),
+        current_use_case_id=data.get("current_use_case_id"),
+        current_step_id=(
+            UseCaseStep(data["current_step_id"])
+            if data.get("current_step_id") is not None
+            else None
+        ),
+        completed_use_cases=tuple(data.get("completed_use_cases", [])),
+        blocked_use_cases=tuple(data.get("blocked_use_cases", [])),
+        failed_step_id=data.get("failed_step_id"),
+        failure_kind=(
+            RunFailureKind(data["failure_kind"])
+            if data.get("failure_kind") is not None
+            else None
+        ),
+        status=RunStatus(data["status"]),
+        use_case_states=use_case_states,
+    )

--- a/tests/runtime/test_reports.py
+++ b/tests/runtime/test_reports.py
@@ -1,0 +1,109 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime import (
+    ReportWriter,
+    RunMode,
+    RunReport,
+    RunStatus,
+    UseCaseReport,
+)
+
+
+def use_case_report(uc_id: str, status: RunStatus, blocker: str | None = None) -> UseCaseReport:
+    return UseCaseReport(
+        uc_id=uc_id,
+        active_plan_path=Path(f"docs/plans/active/{uc_id}/plan.md"),
+        completed_plan_path=(
+            Path(f"docs/plans/completed/{uc_id}/plan.md")
+            if status == RunStatus.SUCCEEDED
+            else None
+        ),
+        e2e_goal_path=Path(f"docs/use-cases/{uc_id}/e2e-goal.md"),
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        status=status,
+        executor_status="succeeded" if status == RunStatus.SUCCEEDED else "stopped",
+        verifier_status=status.value,
+        commands_run=("./gradlew test", "./gradlew e2eTest"),
+        test_gate_result="PASS" if status == RunStatus.SUCCEEDED else "FAIL",
+        remediation_count=1 if status == RunStatus.FAILED else 0,
+        blocker=blocker,
+    )
+
+
+def test_artifact_manifest_contains_run_and_use_case_paths(tmp_path: Path) -> None:
+    writer = ReportWriter(tmp_path)
+
+    manifest = writer.artifact_manifest("run-001", ("UC-001",))
+
+    assert manifest.run_report_json == Path(".harness/runs/run-001/report.json")
+    assert manifest.run_report_md == Path(".harness/runs/run-001/report.md")
+    assert manifest.events_path == Path(".harness/runs/run-001/events.ndjson")
+    assert manifest.use_case_artifacts["UC-001"]["executor_result"] == Path(
+        ".harness/runs/run-001/use-cases/UC-001/executor-result.json"
+    )
+    assert manifest.use_case_artifacts["UC-001"]["blocker"] == Path(
+        ".harness/runs/run-001/use-cases/UC-001/blocker.md"
+    )
+
+
+def test_report_writer_generates_run_json_and_markdown(tmp_path: Path) -> None:
+    report = RunReport(
+        run_id="run-001",
+        change_set_id="CHG-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        status=RunStatus.SUCCEEDED,
+        affected_use_cases=("UC-001",),
+        completed_use_cases=("UC-001",),
+        use_case_reports=(use_case_report("UC-001", RunStatus.SUCCEEDED),),
+    )
+    writer = ReportWriter(tmp_path)
+
+    writer.write(report)
+
+    run_json = json.loads(
+        (tmp_path / ".harness/runs/run-001/report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    run_md = (tmp_path / ".harness/runs/run-001/report.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert run_json["run_id"] == "run-001"
+    assert run_json["completed_use_cases"] == ["UC-001"]
+    assert "Status: succeeded" in run_md
+
+
+def test_report_writer_generates_failed_and_blocked_uc_reports(tmp_path: Path) -> None:
+    report = RunReport(
+        run_id="run-002",
+        change_set_id="CHG-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        status=RunStatus.BLOCKED,
+        affected_use_cases=("UC-001", "UC-002"),
+        failed_use_cases=("UC-001",),
+        blocked_use_cases=("UC-002",),
+        use_case_reports=(
+            use_case_report("UC-001", RunStatus.FAILED),
+            use_case_report("UC-002", RunStatus.BLOCKED, blocker="E2E goal unclear"),
+        ),
+    )
+    writer = ReportWriter(tmp_path)
+
+    writer.write(report)
+
+    failed = json.loads(
+        (
+            tmp_path / ".harness/runs/run-002/use-cases/UC-001/report.json"
+        ).read_text(encoding="utf-8")
+    )
+    blocker = (
+        tmp_path / ".harness/runs/run-002/use-cases/UC-002/blocker.md"
+    ).read_text(encoding="utf-8")
+
+    assert failed["status"] == "failed"
+    assert failed["remediation_count"] == 1
+    assert "E2E goal unclear" in blocker

--- a/tests/runtime/test_run_state_resume.py
+++ b/tests/runtime/test_run_state_resume.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+from harness_codex.runtime import (
+    ResumeDisposition,
+    RunFailureKind,
+    RunMode,
+    RunState,
+    RunStateStore,
+    RunStatus,
+    UseCaseLoopState,
+    UseCaseStep,
+    decide_resume_target,
+)
+
+
+def test_run_state_store_round_trips_json(tmp_path: Path) -> None:
+    state = RunState(
+        run_id="run-001",
+        change_set_id="CHG-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        affected_use_cases=("UC-001", "UC-002"),
+        current_use_case_id="UC-001",
+        current_step_id=UseCaseStep.VERIFY,
+        status=RunStatus.RUNNING,
+        use_case_states=(
+            UseCaseLoopState(
+                uc_id="UC-001",
+                active_plan_path=Path("docs/plans/active/UC-001/plan.md"),
+                status=RunStatus.RUNNING,
+                current_step_id=UseCaseStep.VERIFY,
+            ),
+        ),
+    )
+    store = RunStateStore(tmp_path)
+
+    path = store.save(state)
+    loaded = store.load("run-001")
+
+    assert path == tmp_path / ".harness/runs/run-001/state.json"
+    assert loaded == state
+
+
+def test_resume_skips_completed_use_cases() -> None:
+    state = RunState(
+        run_id="run-001",
+        change_set_id="CHG-001",
+        workflow_name="workflow",
+        mode=RunMode.APPLY,
+        affected_use_cases=("UC-001", "UC-002"),
+        completed_use_cases=("UC-001",),
+        status=RunStatus.RUNNING,
+    )
+
+    target = decide_resume_target(state)
+
+    assert target.disposition == ResumeDisposition.NEXT_USE_CASE
+    assert target.uc_id == "UC-002"
+    assert target.step_id == UseCaseStep.PLAN
+
+
+def test_implementation_failure_resumes_from_remediation_loop() -> None:
+    state = RunState(
+        run_id="run-001",
+        change_set_id="CHG-001",
+        workflow_name="workflow",
+        mode=RunMode.APPLY,
+        affected_use_cases=("UC-001",),
+        current_use_case_id="UC-001",
+        failed_step_id="verifier-run-use-case-e2e",
+        failure_kind=RunFailureKind.IMPLEMENTATION_FAILURE,
+        status=RunStatus.FAILED,
+    )
+
+    target = decide_resume_target(state)
+
+    assert target.disposition == ResumeDisposition.RETRY_REMEDIATION
+    assert target.uc_id == "UC-001"
+    assert target.step_id == UseCaseStep.REMEDIATE
+
+
+def test_non_implementation_failures_wait_for_upstream_resolution() -> None:
+    cases = {
+        RunFailureKind.UNCLEAR_E2E_GOAL: ResumeDisposition.WAIT_FOR_GOAL_CLARIFICATION,
+        RunFailureKind.DOCUMENT_DELTA_CONFLICT: ResumeDisposition.WAIT_FOR_CHANGESET_REVISION,
+        RunFailureKind.UPSTREAM_DESIGN_CONFLICT: ResumeDisposition.WAIT_FOR_UPSTREAM_DESIGN,
+        RunFailureKind.ENVIRONMENT_BLOCKER: ResumeDisposition.WAIT_FOR_ENVIRONMENT,
+    }
+
+    for failure_kind, expected in cases.items():
+        state = RunState(
+            run_id="run-001",
+            change_set_id="CHG-001",
+            workflow_name="workflow",
+            mode=RunMode.APPLY,
+            affected_use_cases=("UC-001",),
+            current_use_case_id="UC-001",
+            failure_kind=failure_kind,
+            status=RunStatus.BLOCKED,
+        )
+
+        assert decide_resume_target(state).disposition == expected
+
+
+def test_completed_run_has_no_resume_target() -> None:
+    state = RunState(
+        run_id="run-001",
+        change_set_id="CHG-001",
+        workflow_name="workflow",
+        mode=RunMode.APPLY,
+        affected_use_cases=("UC-001",),
+        completed_use_cases=("UC-001",),
+        status=RunStatus.SUCCEEDED,
+    )
+
+    target = decide_resume_target(state)
+
+    assert target.disposition == ResumeDisposition.COMPLETE
+    assert target.uc_id is None

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+
+from harness_codex.cli import main
+
+
+CHANGESET = """# ChangeSet CHG-001
+
+## 1. 메타데이터
+|항목|값|
+|---|---|
+|ChangeSet ID|`CHG-001`|
+|상태|active|
+
+## 3. Before / After
+|구분|내용|
+|---|---|
+|Before|old|
+|After|new|
+
+## 5. 영향 유스케이스
+|UC ID|유스케이스 이름|영향 유형|Slice 경로|상태|
+|---|---|---|---|---|
+|`UC-001`|결제 승인|update|`docs/use-cases/UC-001/`|planned|
+
+## 7. Planner 입력 범위
+- `docs/changes/active/<CHG-ID>.md`
+- `docs/use-cases/<UC-ID>/use-case.md`
+- `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/e2e-goal.md`
+- `.codex/repository-settings.md`
+"""
+
+
+def write_changeset(repo: Path) -> None:
+    active_dir = repo / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-001.md").write_text(CHANGESET, encoding="utf-8")
+
+
+def test_changes_list_outputs_active_changesets(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(["--repo-root", str(tmp_path), "changes", "list"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "CHG-001" in output
+    assert "active" in output
+
+
+def test_changes_show_outputs_affected_use_cases(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(["--repo-root", str(tmp_path), "changes", "show", "CHG-001"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Affected UC: UC-001" in output
+    assert "Before: old" in output
+
+
+def test_run_change_plan_has_no_side_effects(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(
+        ["--repo-root", str(tmp_path), "run-change", "CHG-001", "--plan"]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Mode: plan" in output
+    assert "Side effects: false" in output
+    assert not (tmp_path / ".harness/runs").exists()
+
+
+def test_run_use_case_preview_limits_to_selected_uc(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "run-use-case",
+            "CHG-001",
+            "UC-001",
+            "--preview",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Mode: preview" in output
+    assert "UC: UC-001" in output
+
+
+def test_run_change_apply_creates_resume_state(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(
+        ["--repo-root", str(tmp_path), "run-change", "CHG-001", "--apply"]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "APPLY started" in output
+    run_dirs = list((tmp_path / ".harness/runs").iterdir())
+    assert (run_dirs[0] / "state.json").is_file()
+
+
+def test_resume_reports_next_target(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+    main(["--repo-root", str(tmp_path), "run-change", "CHG-001", "--apply"])
+    capsys.readouterr()
+    run_id = next((tmp_path / ".harness/runs").iterdir()).name
+
+    exit_code = main(["--repo-root", str(tmp_path), "resume", run_id])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Resume: NEXT_USE_CASE" in output
+    assert "UC: UC-001" in output
+
+
+def test_report_command_reads_report_markdown(tmp_path: Path, capsys) -> None:
+    report_dir = tmp_path / ".harness/runs/run-001"
+    report_dir.mkdir(parents=True)
+    (report_dir / "report.md").write_text("# Run Report\n", encoding="utf-8")
+
+    exit_code = main(["--repo-root", str(tmp_path), "report", "run-001"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "# Run Report" in output


### PR DESCRIPTION
## 구현 의도
- #24 요구사항에 맞춰 ChangeSet/UC workflow의 중간 상태를 `.harness/runs/<run-id>/state.json`에 저장하고, 실패/중단 이후 어디서 재개할지 판단하는 모델을 추가했습니다.

## 구현 방법
- `RunState`, `UseCaseLoopState`, `RunFailureKind`, `UseCaseStep` 모델을 추가했습니다.
- `RunStateStore`가 run state를 JSON으로 저장/로드합니다.
- `decide_resume_target`이 완료 UC를 건너뛰고, implementation failure는 remediation loop로, E2E goal/ChangeSet/design/environment 문제는 각각 상위 대기 상태로 분류합니다.
- #23 ChangeSet parser PR 위에 쌓은 스택 PR입니다.

## 검증 방법
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp venv/bin/python3 -m pytest tests/runtime/test_run_state_resume.py tests/runtime/test_changeset_parser.py tests/runtime/test_affected_use_case_resolver.py -q`

Closes #24
