### PR TITLE
[codex] ChangeSet workflow CLI 명령 추가

### DIFF
--- a/harness_codex/__main__.py
+++ b/harness_codex/__main__.py
@@ -1,0 +1,6 @@
+"""Run `python3 -m harness_codex` as the harness CLI."""
+
+from harness_codex.cli import main
+
+
+raise SystemExit(main())

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -1,0 +1,228 @@
+"""CLI entrypoint for ChangeSet and use-case workflow commands."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+from harness_codex.runtime import (
+    ReportWriter,
+    ResumeDisposition,
+    RunMode,
+    RunState,
+    RunStateStore,
+    RunStatus,
+    decide_resume_target,
+)
+from harness_codex.runtime.changes import (
+    ChangeSet,
+    ChangeSetResolver,
+    NoActiveChangeSetsError,
+    PlanningBlocked,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    repo_root = Path(args.repo_root)
+
+    try:
+        output = args.func(args, repo_root)
+    except NoActiveChangeSetsError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if output:
+        print(output)
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="harness")
+    parser.add_argument("--repo-root", default=".")
+    subparsers = parser.add_subparsers(required=True)
+
+    changes = subparsers.add_parser("changes")
+    changes_subparsers = changes.add_subparsers(required=True)
+    changes_list = changes_subparsers.add_parser("list")
+    changes_list.set_defaults(func=changes_list_command)
+    changes_show = changes_subparsers.add_parser("show")
+    changes_show.add_argument("change_set_id")
+    changes_show.set_defaults(func=changes_show_command)
+
+    run_change = subparsers.add_parser("run-change")
+    run_change.add_argument("change_set_id")
+    _add_mode_options(run_change)
+    run_change.set_defaults(func=run_change_command)
+
+    run_use_case = subparsers.add_parser("run-use-case")
+    run_use_case.add_argument("change_set_id")
+    run_use_case.add_argument("uc_id")
+    _add_mode_options(run_use_case)
+    run_use_case.set_defaults(func=run_use_case_command)
+
+    resume = subparsers.add_parser("resume")
+    resume.add_argument("run_id")
+    resume.set_defaults(func=resume_command)
+
+    report = subparsers.add_parser("report")
+    report.add_argument("run_id")
+    report.set_defaults(func=report_command)
+
+    return parser
+
+
+def changes_list_command(args: argparse.Namespace, repo_root: Path) -> str:
+    resolver = ChangeSetResolver(repo_root)
+    rows = [
+        f"{change_set.change_set_id}\t{change_set.status or '-'}\t{change_set.title}"
+        for change_set in resolver.list_active()
+    ]
+    return "\n".join(rows)
+
+
+def changes_show_command(args: argparse.Namespace, repo_root: Path) -> str:
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    affected = ", ".join(uc.uc_id for uc in change_set.affected_use_cases) or "-"
+    return "\n".join(
+        [
+            f"ChangeSet: {change_set.change_set_id}",
+            f"Status: {change_set.status or '-'}",
+            f"Title: {change_set.title}",
+            f"Before: {change_set.before_summary or '-'}",
+            f"After: {change_set.after_summary or '-'}",
+            f"Affected UC: {affected}",
+        ]
+    )
+
+
+def run_change_command(args: argparse.Namespace, repo_root: Path) -> str:
+    mode = _selected_mode(args)
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    resolver = ChangeSetResolver(repo_root)
+    scopes = resolver.resolve_planning_scopes(change_set)
+
+    if isinstance(scopes, PlanningBlocked):
+        return f"BLOCKED: {scopes.reason}"
+
+    if mode in (RunMode.PLAN, RunMode.PREVIEW):
+        return _format_scopes(change_set, scopes, mode)
+
+    run_id = _create_run_state(repo_root, change_set, tuple(scope.use_case.uc_id for scope in scopes))
+    return f"APPLY started: run_id={run_id}"
+
+
+def run_use_case_command(args: argparse.Namespace, repo_root: Path) -> str:
+    mode = _selected_mode(args)
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    resolver = ChangeSetResolver(repo_root)
+    scopes = resolver.resolve_planning_scopes(change_set)
+
+    if isinstance(scopes, PlanningBlocked):
+        return f"BLOCKED: {scopes.reason}"
+
+    selected = tuple(scope for scope in scopes if scope.use_case.uc_id == args.uc_id)
+    if not selected:
+        return f"BLOCKED: {args.uc_id} is not affected by {change_set.change_set_id}"
+
+    if mode in (RunMode.PLAN, RunMode.PREVIEW):
+        return _format_scopes(change_set, selected, mode)
+
+    run_id = _create_run_state(repo_root, change_set, (args.uc_id,))
+    return f"APPLY started: run_id={run_id} uc_id={args.uc_id}"
+
+
+def resume_command(args: argparse.Namespace, repo_root: Path) -> str:
+    state = RunStateStore(repo_root).load(args.run_id)
+    target = decide_resume_target(state)
+    if target.disposition == ResumeDisposition.COMPLETE:
+        return f"COMPLETE: {target.reason}"
+    return "\n".join(
+        [
+            f"Resume: {target.disposition.value}",
+            f"UC: {target.uc_id or '-'}",
+            f"Step: {target.step_id.value if target.step_id else '-'}",
+            f"Reason: {target.reason}",
+        ]
+    )
+
+
+def report_command(args: argparse.Namespace, repo_root: Path) -> str:
+    report_path = repo_root / ".harness/runs" / args.run_id / "report.md"
+    if not report_path.exists():
+        manifest = ReportWriter(repo_root).artifact_manifest(args.run_id, ())
+        return f"Report not found. Expected: {manifest.run_report_md}"
+    return report_path.read_text(encoding="utf-8").strip()
+
+
+def _load_change_set(repo_root: Path, change_set_id: str) -> ChangeSet:
+    return ChangeSetResolver(repo_root).load(
+        Path("docs/changes/active") / f"{change_set_id}.md"
+    )
+
+
+def _selected_mode(args: argparse.Namespace) -> RunMode:
+    if args.plan:
+        return RunMode.PLAN
+    if args.preview:
+        return RunMode.PREVIEW
+    return RunMode.APPLY
+
+
+def _add_mode_options(parser: argparse.ArgumentParser) -> None:
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--plan", action="store_true")
+    mode.add_argument("--preview", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+
+
+def _format_scopes(
+    change_set: ChangeSet,
+    scopes: tuple,
+    mode: RunMode,
+) -> str:
+    lines = [
+        f"Mode: {mode.value}",
+        f"ChangeSet: {change_set.change_set_id}",
+        "Side effects: false",
+    ]
+
+    for scope in scopes:
+        lines.extend(
+            [
+                f"UC: {scope.use_case.uc_id}",
+                "Planner inputs:",
+                *[f"- {path}" for path in scope.planner_inputs],
+                "Executor inputs:",
+                *[f"- {path}" for path in scope.executor_inputs],
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def _create_run_state(
+    repo_root: Path,
+    change_set: ChangeSet,
+    affected_use_cases: tuple[str, ...],
+) -> str:
+    run_id = f"run-{uuid4().hex[:12]}"
+    state = RunState(
+        run_id=run_id,
+        change_set_id=change_set.change_set_id,
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        affected_use_cases=affected_use_cases,
+        current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
+        status=RunStatus.PENDING,
+    )
+    RunStateStore(repo_root).save(state)
+    return run_id
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+
+from harness_codex.cli import main
+
+
+CHANGESET = """# ChangeSet CHG-001
+
+## 1. 메타데이터
+|항목|값|
+|---|---|
+|ChangeSet ID|`CHG-001`|
+|상태|active|
+
+## 3. Before / After
+|구분|내용|
+|---|---|
+|Before|old|
+|After|new|
+
+## 5. 영향 유스케이스
+|UC ID|유스케이스 이름|영향 유형|Slice 경로|상태|
+|---|---|---|---|---|
+|`UC-001`|결제 승인|update|`docs/use-cases/UC-001/`|planned|
+
+## 7. Planner 입력 범위
+- `docs/changes/active/<CHG-ID>.md`
+- `docs/use-cases/<UC-ID>/use-case.md`
+- `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/e2e-goal.md`
+- `.codex/repository-settings.md`
+"""
+
+
+def write_changeset(repo: Path) -> None:
+    active_dir = repo / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-001.md").write_text(CHANGESET, encoding="utf-8")
+
+
+def test_changes_list_outputs_active_changesets(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(["--repo-root", str(tmp_path), "changes", "list"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "CHG-001" in output
+    assert "active" in output
+
+
+def test_changes_show_outputs_affected_use_cases(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(["--repo-root", str(tmp_path), "changes", "show", "CHG-001"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Affected UC: UC-001" in output
+    assert "Before: old" in output
+
+
+def test_run_change_plan_has_no_side_effects(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(
+        ["--repo-root", str(tmp_path), "run-change", "CHG-001", "--plan"]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Mode: plan" in output
+    assert "Side effects: false" in output
+    assert not (tmp_path / ".harness/runs").exists()
+
+
+def test_run_use_case_preview_limits_to_selected_uc(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "run-use-case",
+            "CHG-001",
+            "UC-001",
+            "--preview",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Mode: preview" in output
+    assert "UC: UC-001" in output
+
+
+def test_run_change_apply_creates_resume_state(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(
+        ["--repo-root", str(tmp_path), "run-change", "CHG-001", "--apply"]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "APPLY started" in output
+    run_dirs = list((tmp_path / ".harness/runs").iterdir())
+    assert (run_dirs[0] / "state.json").is_file()
+
+
+def test_resume_reports_next_target(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+    main(["--repo-root", str(tmp_path), "run-change", "CHG-001", "--apply"])
+    capsys.readouterr()
+    run_id = next((tmp_path / ".harness/runs").iterdir()).name
+
+    exit_code = main(["--repo-root", str(tmp_path), "resume", run_id])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Resume: NEXT_USE_CASE" in output
+    assert "UC: UC-001" in output
+
+
+def test_report_command_reads_report_markdown(tmp_path: Path, capsys) -> None:
+    report_dir = tmp_path / ".harness/runs/run-001"
+    report_dir.mkdir(parents=True)
+    (report_dir / "report.md").write_text("# Run Report\n", encoding="utf-8")
+
+    exit_code = main(["--repo-root", str(tmp_path), "report", "run-001"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "# Run Report" in output


### PR DESCRIPTION
## 구현 의도
- #29 요구사항에 맞춰 ChangeSet workflow를 CLI에서 조회, 계획, 미리보기, 실행 시작, 재개, 보고서 조회 형태로 호출할 수 있는 command skeleton을 추가했습니다.
- 실제 Codex adapter/shell/test adapter 실행은 이슈 비범위라, `plan`/`preview`는 side effect 없이 범위만 출력하고 `apply`는 resume 가능한 run state 생성까지만 연결했습니다.

## 구현 방법
- `python3 -m harness_codex`로 실행 가능한 CLI entrypoint를 추가했습니다.
- `harness changes list`, `harness changes show <CHG-ID>`는 #23 ChangeSet resolver를 호출합니다.
- `harness run-change <CHG-ID> --plan/--preview/--apply`와 `harness run-use-case <CHG-ID> <UC-ID> --plan/--preview/--apply`는 resolver 결과를 기반으로 planner/executor 입력 범위를 출력하거나 run state를 생성합니다.
- `harness resume <run-id>`는 #24 resume 판단을 호출하고, `harness report <run-id>`는 #25 report 경로를 조회합니다.
- #25 report PR 위에 쌓은 스택 PR입니다.

## 검증 방법
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp venv/bin/python3 -m pytest tests/test_cli_commands.py tests/runtime/test_reports.py tests/runtime/test_run_state_resume.py tests/runtime/test_changeset_parser.py tests/runtime/test_affected_use_case_resolver.py -q`

Closes #29
