### PR TITLE
런타임 스킬 호출 경계 추가

### DIFF
--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -23,6 +23,7 @@ steps:
     name: Create or update the work item implementation plan
     needs: [load-change-set]
     agent_id: implementation_planner
+    skill_id: harness-code-planner
     inputs:
       - docs/changes/active/<CHG-ID>.md
       - docs/use-cases/<UC-ID>
@@ -40,6 +41,7 @@ steps:
     name: Execute unchecked work item plan tasks
     needs: [plan-work-item]
     agent_id: implementation_executor
+    skill_id: harness-plan-executor
     inputs:
       - docs/plans/active/<WORK-ITEM-ID>/plan.md
       - docs/changes/active/<CHG-ID>.md

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -85,6 +85,7 @@ class Step:
     name: str
     needs: tuple[str, ...] = ()
     agent_id: str | None = None
+    skill_id: str | None = None
     command: str | None = None
     inputs: tuple[Path, ...] = ()
     outputs: tuple[Path, ...] = ()

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -33,6 +33,8 @@ class AgentRunRequest:
     step_dir: Path
     agent_config_path: Path
     agent_config: Mapping[str, Any]
+    skill_path: Path | None = None
+    skill_body: str | None = None
 
 
 @dataclass(frozen=True)
@@ -230,6 +232,35 @@ class BasicStepRunner:
             )
 
         agent_config = _load_agent_config(agent_config_path)
+        skill_id = _step_skill_id(step)
+        skill_path: Path | None = None
+        skill_body: str | None = None
+        if skill_id is not None:
+            skill_path = context.repo_root / ".codex/skills" / skill_id / "SKILL.md"
+            if not skill_path.exists():
+                return _blocked_agent_result(
+                    step,
+                    context,
+                    step_dir,
+                    f"missing skill config: {_relative_to_repo(skill_path, context)}",
+                )
+            skill_body = skill_path.read_text(encoding="utf-8")
+
+        invocation_path = step_dir / "invocation.json"
+        invocation_path.write_text(
+            json.dumps(
+                _agent_invocation_manifest(
+                    step,
+                    context,
+                    agent_config_path,
+                    skill_path,
+                ),
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         result = self._agent_adapter.run(
             AgentRunRequest(
                 step=step,
@@ -237,6 +268,8 @@ class BasicStepRunner:
                 step_dir=step_dir,
                 agent_config_path=agent_config_path,
                 agent_config=agent_config,
+                skill_path=skill_path,
+                skill_body=skill_body,
             )
         )
         result_path = step_dir / "result.json"
@@ -245,6 +278,7 @@ class BasicStepRunner:
                 {
                     "step_id": step.id,
                     "agent_id": step.agent_id,
+                    "skill_id": skill_id,
                     "status": result.status.value,
                     "exit_code": result.exit_code,
                     "error": result.error,
@@ -396,6 +430,15 @@ def _agent_metadata(
         "agent_config": str(
             _relative_to_repo(request.agent_config_path, request.context)
         ),
+        "skill_id": _step_skill_id(request.step),
+        "skill_path": (
+            str(_relative_to_repo(request.skill_path, request.context))
+            if request.skill_path is not None
+            else None
+        ),
+        "invocation_path": str(
+            _relative_to_repo(request.step_dir / "invocation.json", request.context)
+        ),
         "prompt_path": str(_relative_to_repo(prompt_path, request.context)),
         "stdout_path": str(
             _relative_to_repo(request.step_dir / "stdout.txt", request.context)
@@ -432,6 +475,7 @@ def _blocked_agent_result(
             {
                 "step_id": step.id,
                 "agent_id": step.agent_id,
+                "skill_id": _step_skill_id(step),
                 "status": StepStatus.BLOCKED.value,
                 "error": error,
             },
@@ -447,7 +491,7 @@ def _blocked_agent_result(
         output_path=_relative_to_repo(result_path, context),
         error=error,
         failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
-        metadata={"agent_id": step.agent_id},
+        metadata={"agent_id": step.agent_id, "skill_id": _step_skill_id(step)},
     )
 
 
@@ -466,6 +510,7 @@ def _agent_prompt(request: AgentRunRequest) -> str:
     )
     inputs = "\n".join(f"- `{path}`" for path in request.step.inputs) or "- 없음"
     outputs = "\n".join(f"- `{path}`" for path in request.step.outputs) or "- 없음"
+    skill_lines = _agent_prompt_skill_lines(request)
 
     return "\n".join(
         [
@@ -477,6 +522,8 @@ def _agent_prompt(request: AgentRunRequest) -> str:
             f"- ID: `{request.step.agent_id}`",
             f"- Name: `{config.get('name', request.step.agent_id)}`",
             f"- Description: {config.get('description', '')}",
+            "",
+            *skill_lines,
             "",
             "## Developer Instructions",
             str(instructions).strip(),
@@ -509,6 +556,61 @@ def _agent_prompt(request: AgentRunRequest) -> str:
             "완료 후 실제로 수행한 작업, 변경한 파일, 실행한 검증 명령, 남은 blocker를 간결하게 보고한다.",
         ]
     )
+
+
+def _step_skill_id(step: Step) -> str | None:
+    if step.skill_id:
+        return step.skill_id
+
+    skill_id = step.metadata.get("skill_id")
+    if isinstance(skill_id, str) and skill_id.strip():
+        return skill_id
+
+    return None
+
+
+def _agent_invocation_manifest(
+    step: Step,
+    context: RunContext,
+    agent_config_path: Path,
+    skill_path: Path | None,
+) -> dict[str, Any]:
+    return {
+        "step_id": step.id,
+        "agent_id": step.agent_id,
+        "agent_config": str(_relative_to_repo(agent_config_path, context)),
+        "skill_id": _step_skill_id(step),
+        "skill_path": (
+            str(_relative_to_repo(skill_path, context))
+            if skill_path is not None
+            else None
+        ),
+        "inputs": [str(path) for path in step.inputs],
+        "outputs": [str(path) for path in step.outputs],
+        "metadata": _jsonable(step.metadata),
+    }
+
+
+def _agent_prompt_skill_lines(request: AgentRunRequest) -> list[str]:
+    skill_id = _step_skill_id(request.step)
+    if skill_id is None:
+        return [
+            "## Skill",
+            "- ID: `-`",
+            "- Path: `-`",
+        ]
+
+    lines = [
+        "## Skill",
+        f"- ID: `{skill_id}`",
+        f"- Path: `{_relative_to_repo(request.skill_path, request.context)}`",
+        "",
+        "### Skill Instructions",
+        "```markdown",
+        (request.skill_body or "").strip(),
+        "```",
+    ]
+    return lines
 
 
 def _jsonable(value: Any) -> Any:

--- a/harness_codex/runtime/workflows/loader.py
+++ b/harness_codex/runtime/workflows/loader.py
@@ -89,6 +89,7 @@ def _to_step(raw_step: Mapping[str, Any]) -> Step:
         name=raw_step.get("name") or raw_step["id"],
         needs=parse_needs(raw_step.get("needs"), f"steps[{raw_step['id']}].needs"),
         agent_id=raw_step.get("agent_id"),
+        skill_id=raw_step.get("skill_id"),
         command=raw_step.get("command"),
         inputs=tuple(
             Path(path)

--- a/harness_codex/runtime/workflows/schema.py
+++ b/harness_codex/runtime/workflows/schema.py
@@ -162,6 +162,7 @@ def validate_workflow_document(document: Any) -> Mapping[str, Any]:
         require_optional_string(step.get("name"), f"{step_path}.name")
         parse_needs(step.get("needs"), f"{step_path}.needs")
         require_optional_string(step.get("agent_id"), f"{step_path}.agent_id")
+        require_optional_string(step.get("skill_id"), f"{step_path}.skill_id")
         require_optional_string(step.get("provider"), f"{step_path}.provider")
         require_optional_string(step.get("command"), f"{step_path}.command")
         require_optional_positive_int(

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -64,6 +64,25 @@ def write_agent_config(repo_root: Path, agent_id: str = "implementation_planner"
     )
 
 
+def write_skill(repo_root: Path, skill_id: str = "harness-code-planner") -> None:
+    skill_dir = repo_root / ".codex/skills" / skill_id
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {skill_id}",
+                "description: test skill",
+                "---",
+                "",
+                "# 테스트 스킬",
+                "스킬 호출 확인용 지시문",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_basic_step_runner_invokes_agent_adapter_and_writes_result(
     tmp_path: Path,
 ) -> None:
@@ -93,6 +112,41 @@ def test_basic_step_runner_invokes_agent_adapter_and_writes_result(
     assert result_json["metadata"] == {"fake": True}
 
 
+def test_basic_step_runner_records_skill_invocation_manifest(tmp_path: Path) -> None:
+    write_agent_config(tmp_path)
+    write_skill(tmp_path)
+    fake_adapter = FakeAgentAdapter()
+    runner = BasicStepRunner(agent_adapter=fake_adapter)
+    step = Step(
+        id="plan-work-item",
+        kind=StepKind.AGENT,
+        name="Create plan",
+        agent_id="implementation_planner",
+        skill_id="harness-code-planner",
+        inputs=(Path("docs/changes/active/CHG-001.md"),),
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    request = fake_adapter.requests[0]
+    assert request.skill_path == (
+        tmp_path / ".codex/skills/harness-code-planner/SKILL.md"
+    )
+    assert "스킬 호출 확인용 지시문" in (request.skill_body or "")
+
+    invocation = json.loads(
+        (
+            tmp_path / ".harness/runs/run-001/steps/plan-work-item/invocation.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert invocation["agent_id"] == "implementation_planner"
+    assert invocation["skill_id"] == "harness-code-planner"
+    assert invocation["skill_path"] == ".codex/skills/harness-code-planner/SKILL.md"
+    assert invocation["outputs"] == ["docs/plans/active/UC-001/plan.md"]
+
+
 def test_basic_step_runner_blocks_agent_without_config(tmp_path: Path) -> None:
     runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
     step = Step(
@@ -111,6 +165,23 @@ def test_basic_step_runner_blocks_agent_without_config(tmp_path: Path) -> None:
     )
 
 
+def test_basic_step_runner_blocks_agent_without_skill(tmp_path: Path) -> None:
+    write_agent_config(tmp_path)
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="plan-work-item",
+        kind=StepKind.AGENT,
+        name="Create plan",
+        agent_id="implementation_planner",
+        skill_id="harness-code-planner",
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "missing skill config" in (result.error or "")
+
+
 def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
     tmp_path: Path,
     monkeypatch,
@@ -122,6 +193,7 @@ def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
             kind=StepKind.AGENT,
             name="Execute plan",
             agent_id="implementation_executor",
+            skill_id="harness-plan-executor",
             timeout_sec=30,
         ),
         context=context(tmp_path),
@@ -135,6 +207,8 @@ def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
             "sandbox_mode": "workspace-write",
             "developer_instructions": "테스트 지시문",
         },
+        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
+        skill_body="# Harness Plan Executor\n스킬 본문",
     )
     request.step_dir.mkdir(parents=True)
     calls = []
@@ -165,6 +239,8 @@ def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
     )
     prompt = (request.step_dir / "prompt.md").read_text(encoding="utf-8")
     assert "implementation_executor" in prompt
+    assert "harness-plan-executor" in prompt
+    assert "스킬 본문" in prompt
     assert "테스트 지시문" in prompt
     assert calls[0][1]["timeout"] == 30
 

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -26,6 +26,7 @@ steps:
     kind: agent
     name: Analyze active plan
     agent_id: implementation_executor
+    skill_id: harness-plan-executor
     inputs:
       - docs/plans/active/plan.md
 
@@ -73,6 +74,7 @@ def test_load_workflow_text_converts_yaml_to_runtime_model() -> None:
     analyze = workflow.step_by_id("analyze")
     assert analyze.kind == StepKind.AGENT
     assert analyze.agent_id == "implementation_executor"
+    assert analyze.skill_id == "harness-plan-executor"
     assert analyze.inputs == (Path("docs/plans/active/plan.md"),)
 
     validate = workflow.step_by_id("validate")
@@ -118,6 +120,10 @@ def test_default_changeset_work_item_workflow_loads() -> None:
 
     assert workflow.name == "changeset-use-case-workflow"
     assert workflow.step_by_id("plan-work-item").agent_id == "implementation_planner"
+    assert workflow.step_by_id("plan-work-item").skill_id == "harness-code-planner"
+    assert workflow.step_by_id("execute-work-item").skill_id == (
+        "harness-plan-executor"
+    )
     assert workflow.step_by_id("verify-work-item").command
 
 


### PR DESCRIPTION
## 구현 의도

런타임의 AGENT 단계가 에이전트뿐 아니라 어떤 스킬 지시문을 함께 호출해야 하는지 명시하고, 실행 디렉터리에 호출 증적을 남기도록 구현했습니다. 이 PR은 #63 범위만 다루며, work-item 전체 반복 루프와 CLI 상태 전환은 후속 이슈 #64, #65에서 처리합니다.

Closes #63

## 구현 방법

- `Step` 모델과 workflow YAML 스키마에 `skill_id`를 추가했습니다.
- `changeset-use-case-workflow`의 planner 단계는 `harness-code-planner`, executor 단계는 `harness-plan-executor`를 참조하게 했습니다.
- `BasicStepRunner`가 AGENT 단계 실행 전에 `.codex/skills/<skill_id>/SKILL.md`를 확인하고, 누락 시 BLOCKED 결과를 반환합니다.
- agent 호출 전에 `invocation.json`을 기록해 step, agent, skill, 입력, 출력, metadata 흐름을 확인할 수 있게 했습니다.
- `CodexCliAgentAdapter` prompt에 스킬 ID, 경로, 본문을 포함해 실제 agent 호출 컨텍스트로 전달합니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/runtime/test_workflow_loader.py`
- `./venv/bin/python3 -m pytest -q -s`

전체 테스트 결과: 108 passed.
