### PR TITLE
워크아이템 런타임 반복 루프 추가

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -11,14 +11,15 @@ from harness_codex.runtime import (
     BasicStepRunner,
     ReportWriter,
     ResumeDisposition,
-    RunnerEngine,
     RunContext,
+    RunFailureKind,
     RunMode,
     RunReport,
     RunState,
     RunStateStore,
     RunStatus,
     UseCaseLoopState,
+    WorkItemLoopRunner,
     WorkItemLoopState,
     WorkItemReport,
     decide_resume_target,
@@ -417,7 +418,24 @@ def _apply_workflow(
             ],
         },
     )
-    result = RunnerEngine(BasicStepRunner()).run(workflow, context)
+    result = WorkItemLoopRunner(
+        step_runner=BasicStepRunner(),
+        workflow=workflow,
+    ).run(change_set=change_set, scopes=scopes, context=context)
+    item_results_by_id = {
+        item_result.scope.display_id: item_result
+        for item_result in result.item_results
+    }
+    completed_use_cases = tuple(
+        item_id
+        for item_id in result.completed_work_items
+        if any(scope.use_case is not None and scope.display_id == item_id for scope in scopes)
+    )
+    blocked_use_cases = tuple(
+        item_id
+        for item_id in result.blocked_work_items
+        if any(scope.use_case is not None and scope.display_id == item_id for scope in scopes)
+    )
     state = RunState(
         run_id=run_id,
         change_set_id=change_set.change_set_id,
@@ -428,15 +446,22 @@ def _apply_workflow(
         current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
         current_work_item_id=affected_work_items[0] if affected_work_items else None,
         status=result.status,
+        completed_use_cases=completed_use_cases,
+        completed_work_items=result.completed_work_items,
+        blocked_use_cases=blocked_use_cases,
+        blocked_work_items=result.blocked_work_items,
+        failure_kind=_first_failure_kind(result),
         work_item_states=tuple(
             WorkItemLoopState(
                 work_item_id=scope.display_id,
                 work_item_type=scope.work_item_type,
                 active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.display_id}/plan.md"),
-                status=result.status,
-                current_step_id=scope.current_stage,
-                verification_status=result.status.value,
-                blocker=result.blocker,
+                status=item_results_by_id.get(scope.display_id).status if scope.display_id in item_results_by_id else RunStatus.PENDING,
+                current_step_id=item_results_by_id.get(scope.display_id).current_stage if scope.display_id in item_results_by_id else scope.current_stage,
+                verification_status=item_results_by_id.get(scope.display_id).verification_status if scope.display_id in item_results_by_id else "",
+                retry_count=item_results_by_id.get(scope.display_id).retry_count if scope.display_id in item_results_by_id else 0,
+                failure_kind=_item_failure_kind(item_results_by_id.get(scope.display_id)),
+                blocker=item_results_by_id.get(scope.display_id).blocker if scope.display_id in item_results_by_id else None,
             )
             for scope in scopes
         ),
@@ -444,13 +469,17 @@ def _apply_workflow(
             UseCaseLoopState(
                 uc_id=scope.use_case.uc_id,
                 active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.use_case.uc_id}/plan.md"),
-                status=result.status,
-                blocker=result.blocker,
+                status=item_results_by_id.get(scope.display_id).status if scope.display_id in item_results_by_id else RunStatus.PENDING,
+                current_step_id=item_results_by_id.get(scope.display_id).current_stage if scope.display_id in item_results_by_id else scope.current_stage,
+                verification_status=item_results_by_id.get(scope.display_id).verification_status if scope.display_id in item_results_by_id else "",
+                retry_count=item_results_by_id.get(scope.display_id).retry_count if scope.display_id in item_results_by_id else 0,
+                failure_kind=_item_failure_kind(item_results_by_id.get(scope.display_id)),
+                blocker=item_results_by_id.get(scope.display_id).blocker if scope.display_id in item_results_by_id else None,
             )
             for scope in scopes
             if scope.use_case is not None
         ),
-        failed_step_id=result.failed_step_id,
+        failed_step_id=_first_failed_step_id(result),
     )
     RunStateStore(repo_root).save(state)
     ReportWriter(repo_root).write(
@@ -461,23 +490,53 @@ def _apply_workflow(
             mode=RunMode.APPLY,
             status=result.status,
             affected_use_cases=affected_use_cases,
+            completed_use_cases=completed_use_cases,
+            blocked_use_cases=blocked_use_cases,
             current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
             work_item_reports=tuple(
                 WorkItemReport(
                     work_item_id=scope.display_id,
                     work_item_type=scope.work_item_type,
                     active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.display_id}/plan.md"),
-                    status=result.status,
-                    current_stage=scope.current_stage,
+                    status=item_results_by_id.get(scope.display_id).status if scope.display_id in item_results_by_id else RunStatus.PENDING,
+                    current_stage=item_results_by_id.get(scope.display_id).current_stage if scope.display_id in item_results_by_id else scope.current_stage,
+                    completed_plan_path=item_results_by_id.get(scope.display_id).completed_plan_path if scope.display_id in item_results_by_id else None,
                     verification_goal_path=scope.verification_goal_path,
-                    blocker=result.blocker,
-                    verification_result=result.status.value,
+                    blocker=item_results_by_id.get(scope.display_id).blocker if scope.display_id in item_results_by_id else None,
+                    verification_result=item_results_by_id.get(scope.display_id).verification_status if scope.display_id in item_results_by_id else "",
                 )
                 for scope in scopes
             ),
         )
     )
     return state, result
+
+
+def _first_failed_step_id(result) -> str | None:
+    for item_result in result.item_results:
+        if item_result.failed_step_id:
+            return item_result.failed_step_id
+    return None
+
+
+def _first_failure_kind(result) -> RunFailureKind | None:
+    for item_result in result.item_results:
+        failure_kind = _item_failure_kind(item_result)
+        if failure_kind is not None:
+            return failure_kind
+    return None
+
+
+def _item_failure_kind(item_result) -> RunFailureKind | None:
+    if item_result is None or item_result.failure_kind is None:
+        return None
+    if item_result.failure_kind.value == "implementation":
+        return RunFailureKind.IMPLEMENTATION_FAILURE
+    if item_result.failure_kind.value == "upstream_design":
+        return RunFailureKind.UPSTREAM_DESIGN_CONFLICT
+    if item_result.failure_kind.value == "environment_blocker":
+        return RunFailureKind.ENVIRONMENT_BLOCKER
+    return None
 
 
 def _latest_run_id_for_change_set(repo_root: Path, change_set_id: str) -> str | None:

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -63,14 +63,20 @@ from harness_codex.runtime.verifier import (
     UseCaseVerifier,
     VerificationStatus,
 )
+from harness_codex.runtime.work_items import (
+    ChangeSetLoopResult,
+    WorkItemLoopResult,
+    WorkItemLoopRunner,
+)
 
 __all__ = [
     "ArtifactDirtyState",
     "AgentAdapter",
     "AgentRunRequest",
     "AgentRunResult",
-    "CommandRequest",
     "BasicStepRunner",
+    "ChangeSetLoopResult",
+    "CommandRequest",
     "CodexCliAgentAdapter",
     "ExecutionPlan",
     "FailureKind",
@@ -102,6 +108,8 @@ __all__ = [
     "UseCaseLoopState",
     "UseCaseReport",
     "WorkItemLoopState",
+    "WorkItemLoopResult",
+    "WorkItemLoopRunner",
     "WorkItemReport",
     "UseCaseStep",
     "CommandCheck",

--- a/harness_codex/runtime/work_items.py
+++ b/harness_codex/runtime/work_items.py
@@ -1,0 +1,405 @@
+"""ChangeSet work item 단위 plan/execute/verify loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from harness_codex.runtime.changes.models import ChangeSet, PlanningInputScope
+from harness_codex.runtime.models import (
+    FailureKind,
+    RunContext,
+    RunStatus,
+    Step,
+    StepResult,
+    StepStatus,
+    Workflow,
+)
+from harness_codex.runtime.runner import StepRunner
+
+
+@dataclass(frozen=True)
+class WorkItemLoopResult:
+    """하나의 work item loop 결과."""
+
+    scope: PlanningInputScope
+    status: RunStatus
+    step_results: tuple[StepResult, ...]
+    retry_count: int = 0
+    current_stage: str = "plan"
+    verification_status: str = ""
+    completed_plan_path: Path | None = None
+    failed_step_id: str | None = None
+    blocker: str | None = None
+    failure_kind: FailureKind | None = None
+
+
+@dataclass(frozen=True)
+class ChangeSetLoopResult:
+    """ChangeSet work item loop 전체 결과."""
+
+    run_id: str
+    status: RunStatus
+    item_results: tuple[WorkItemLoopResult, ...]
+
+    @property
+    def completed_work_items(self) -> tuple[str, ...]:
+        return tuple(
+            result.scope.display_id
+            for result in self.item_results
+            if result.status == RunStatus.SUCCEEDED
+        )
+
+    @property
+    def blocked_work_items(self) -> tuple[str, ...]:
+        return tuple(
+            result.scope.display_id
+            for result in self.item_results
+            if result.status == RunStatus.BLOCKED
+        )
+
+    @property
+    def failed_work_items(self) -> tuple[str, ...]:
+        return tuple(
+            result.scope.display_id
+            for result in self.item_results
+            if result.status == RunStatus.FAILED
+        )
+
+
+class WorkItemLoopRunner:
+    """planner -> executor -> verifier를 work item별로 반복 실행한다."""
+
+    def __init__(
+        self,
+        *,
+        step_runner: StepRunner,
+        workflow: Workflow,
+        max_retries: int = 1,
+    ) -> None:
+        self._step_runner = step_runner
+        self._workflow = workflow
+        self._max_retries = max_retries
+
+    def run(
+        self,
+        *,
+        change_set: ChangeSet,
+        scopes: tuple[PlanningInputScope, ...],
+        context: RunContext,
+    ) -> ChangeSetLoopResult:
+        results: list[WorkItemLoopResult] = []
+
+        for scope in scopes:
+            item_result = self._run_one(change_set, scope, context)
+            results.append(item_result)
+            if item_result.status != RunStatus.SUCCEEDED:
+                break
+
+        return ChangeSetLoopResult(
+            run_id=context.run_id,
+            status=_aggregate_status(tuple(results), expected_count=len(scopes)),
+            item_results=tuple(results),
+        )
+
+    def _run_one(
+        self,
+        change_set: ChangeSet,
+        scope: PlanningInputScope,
+        context: RunContext,
+    ) -> WorkItemLoopResult:
+        item_context = replace(
+            context,
+            active_plan_path=_plan_path(scope),
+            metadata={
+                **dict(context.metadata),
+                "current_work_item": _scope_metadata(scope),
+            },
+        )
+        step_results: list[StepResult] = []
+
+        load_result = self._run_step("load-change-set", change_set, scope, item_context)
+        step_results.append(load_result)
+        if not load_result.successful:
+            return _stopped_result(scope, step_results, "plan", load_result)
+
+        plan_result = self._run_step("plan-work-item", change_set, scope, item_context)
+        step_results.append(plan_result)
+        if not plan_result.successful:
+            return _stopped_result(scope, step_results, "plan", plan_result)
+
+        retry_count = 0
+        while True:
+            execute_result = self._run_step(
+                "execute-work-item",
+                change_set,
+                scope,
+                item_context,
+            )
+            step_results.append(execute_result)
+            if not execute_result.successful:
+                return _stopped_result(
+                    scope,
+                    step_results,
+                    "execute",
+                    execute_result,
+                    retry_count=retry_count,
+                )
+
+            verify_result = self._run_step(
+                "verify-work-item",
+                change_set,
+                scope,
+                item_context,
+            )
+            step_results.append(verify_result)
+            if verify_result.successful:
+                break
+
+            if verify_result.failure_kind != FailureKind.IMPLEMENTATION:
+                return _stopped_result(
+                    scope,
+                    step_results,
+                    "verify",
+                    verify_result,
+                    retry_count=retry_count,
+                )
+
+            if retry_count >= self._max_retries:
+                return _stopped_result(
+                    scope,
+                    step_results,
+                    "verify",
+                    verify_result,
+                    retry_count=retry_count,
+                )
+
+            retry_count += 1
+            self._record_remediation(scope, item_context, retry_count, verify_result)
+
+        classify_result = self._run_step(
+            "classify-verification-result",
+            change_set,
+            scope,
+            item_context,
+        )
+        step_results.append(classify_result)
+        if not classify_result.successful:
+            return _stopped_result(
+                scope,
+                step_results,
+                "verify",
+                classify_result,
+                retry_count=retry_count,
+            )
+
+        complete_result = self._run_step(
+            "complete-work-item-plan",
+            change_set,
+            scope,
+            item_context,
+        )
+        step_results.append(complete_result)
+        if not complete_result.successful:
+            return _stopped_result(
+                scope,
+                step_results,
+                "complete",
+                complete_result,
+                retry_count=retry_count,
+            )
+
+        return WorkItemLoopResult(
+            scope=scope,
+            status=RunStatus.SUCCEEDED,
+            step_results=tuple(step_results),
+            retry_count=retry_count,
+            current_stage="complete",
+            verification_status=StepStatus.SUCCEEDED.value,
+            completed_plan_path=_completed_plan_path(scope),
+        )
+
+    def _run_step(
+        self,
+        step_id: str,
+        change_set: ChangeSet,
+        scope: PlanningInputScope,
+        context: RunContext,
+    ) -> StepResult:
+        step = _materialize_step(
+            self._workflow.step_by_id(step_id),
+            change_set,
+            scope,
+        )
+        return self._step_runner.run(step, context)
+
+    def _record_remediation(
+        self,
+        scope: PlanningInputScope,
+        context: RunContext,
+        retry_count: int,
+        failed_result: StepResult,
+    ) -> None:
+        item_dir = (
+            context.run_dir
+            / "work-items"
+            / scope.display_id
+            / "remediation"
+        )
+        item_dir.mkdir(parents=True, exist_ok=True)
+        evidence = failed_result.error or failed_result.status.value
+        text = "\n".join(
+            [
+                f"# 재실행 계획 {retry_count}",
+                "",
+                f"- Work item: `{scope.display_id}`",
+                f"- 실패 단계: `{failed_result.step_id}`",
+                f"- 실패 유형: `{FailureKind.IMPLEMENTATION.value}`",
+                f"- 실패 증거: {evidence}",
+                "",
+            ]
+        )
+        (item_dir / f"{retry_count}.md").write_text(text, encoding="utf-8")
+
+        plan_path = context.repo_root / _plan_path(scope)
+        if plan_path.exists():
+            with plan_path.open("a", encoding="utf-8") as file:
+                file.write("\n" + text)
+
+
+def _materialize_step(
+    step: Step,
+    change_set: ChangeSet,
+    scope: PlanningInputScope,
+) -> Step:
+    if step.id == "plan-work-item":
+        return replace(
+            step,
+            inputs=scope.planner_inputs,
+            outputs=(_plan_path(scope),),
+            metadata=_step_metadata(step, scope),
+        )
+    if step.id == "execute-work-item":
+        return replace(
+            step,
+            inputs=scope.executor_inputs,
+            outputs=(_plan_path(scope),),
+            metadata=_step_metadata(step, scope),
+        )
+    if step.id == "verify-work-item":
+        inputs = tuple(
+            path
+            for path in (
+                _plan_path(scope),
+                scope.verification_goal_path,
+                Path(".codex/test-gate.yaml"),
+            )
+            if path is not None
+        )
+        return replace(step, inputs=inputs, metadata=_step_metadata(step, scope))
+    if step.id == "complete-work-item-plan":
+        return replace(
+            step,
+            inputs=(_plan_path(scope),),
+            outputs=(_completed_plan_path(scope),),
+            metadata=_step_metadata(step, scope),
+        )
+
+    return replace(
+        step,
+        inputs=_replace_placeholders(step.inputs, change_set, scope),
+        outputs=_replace_placeholders(step.outputs, change_set, scope),
+        metadata=_step_metadata(step, scope),
+    )
+
+
+def _replace_placeholders(
+    paths: tuple[Path, ...],
+    change_set: ChangeSet,
+    scope: PlanningInputScope,
+) -> tuple[Path, ...]:
+    return tuple(
+        Path(
+            str(path)
+            .replace("<CHG-ID>", change_set.change_set_id)
+            .replace("<WORK-ITEM-ID>", scope.display_id)
+            .replace("<UC-ID>", scope.use_case.uc_id if scope.use_case else "")
+            .replace("<MAINT-ID>", scope.display_id)
+        )
+        for path in paths
+    )
+
+
+def _step_metadata(step: Step, scope: PlanningInputScope) -> dict[str, object]:
+    return {
+        **dict(step.metadata),
+        "work_item_id": scope.display_id,
+        "work_item_type": scope.work_item_type.value,
+        "plan_path": str(_plan_path(scope)),
+        "verification_goal_path": (
+            str(scope.verification_goal_path) if scope.verification_goal_path else None
+        ),
+    }
+
+
+def _scope_metadata(scope: PlanningInputScope) -> dict[str, object]:
+    return {
+        "id": scope.display_id,
+        "type": scope.work_item_type.value,
+        "plan_path": str(_plan_path(scope)),
+        "planner_inputs": [str(path) for path in scope.planner_inputs],
+        "executor_inputs": [str(path) for path in scope.executor_inputs],
+        "verification_goal_path": (
+            str(scope.verification_goal_path) if scope.verification_goal_path else None
+        ),
+    }
+
+
+def _plan_path(scope: PlanningInputScope) -> Path:
+    return scope.plan_path or Path(f"docs/plans/active/{scope.display_id}/plan.md")
+
+
+def _completed_plan_path(scope: PlanningInputScope) -> Path:
+    return Path(f"docs/plans/completed/{scope.display_id}/plan.md")
+
+
+def _stopped_result(
+    scope: PlanningInputScope,
+    step_results: list[StepResult],
+    current_stage: str,
+    result: StepResult,
+    *,
+    retry_count: int = 0,
+) -> WorkItemLoopResult:
+    status = (
+        RunStatus.BLOCKED
+        if result.status == StepStatus.BLOCKED
+        else RunStatus.FAILED
+    )
+    return WorkItemLoopResult(
+        scope=scope,
+        status=status,
+        step_results=tuple(step_results),
+        retry_count=retry_count,
+        current_stage=current_stage,
+        verification_status=result.status.value,
+        failed_step_id=result.step_id,
+        blocker=result.error,
+        failure_kind=result.failure_kind,
+    )
+
+
+def _aggregate_status(
+    results: tuple[WorkItemLoopResult, ...],
+    *,
+    expected_count: int,
+) -> RunStatus:
+    if not results:
+        return RunStatus.PENDING
+    if any(result.status == RunStatus.BLOCKED for result in results):
+        return RunStatus.BLOCKED
+    if any(result.status == RunStatus.FAILED for result in results):
+        return RunStatus.FAILED
+    if len(results) == expected_count:
+        return RunStatus.SUCCEEDED
+    return RunStatus.RUNNING

--- a/tests/runtime/test_work_item_loop_runner.py
+++ b/tests/runtime/test_work_item_loop_runner.py
@@ -1,0 +1,186 @@
+from pathlib import Path
+
+from harness_codex.runtime import (
+    FailureKind,
+    RunContext,
+    RunMode,
+    RunStatus,
+    Step,
+    StepResult,
+    StepStatus,
+    WorkItemLoopRunner,
+)
+from harness_codex.runtime.changes.models import (
+    AffectedUseCase,
+    ChangeSet,
+    PlanningInputScope,
+    WorkItemType,
+)
+from harness_codex.runtime.workflows import load_named_workflow
+
+
+class FakeStepRunner:
+    def __init__(self, results: dict[str, list[StepResult]] | None = None) -> None:
+        self.results = results or {}
+        self.steps: list[Step] = []
+
+    def run(self, step: Step, context: RunContext) -> StepResult:
+        self.steps.append(step)
+        if step.id in self.results and self.results[step.id]:
+            return self.results[step.id].pop(0)
+        return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
+
+
+def context(repo_root: Path) -> RunContext:
+    return RunContext(
+        run_id="run-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=repo_root / ".harness/runs/run-001",
+    )
+
+
+def change_set() -> ChangeSet:
+    return ChangeSet(
+        change_set_id="CHG-001",
+        title="테스트 변경",
+        path=Path("docs/changes/active/CHG-001.md"),
+    )
+
+
+def scope() -> PlanningInputScope:
+    use_case = AffectedUseCase(
+        uc_id="UC-001",
+        name="결제 승인",
+        impact_type="update",
+        slice_path=Path("docs/use-cases/UC-001"),
+    )
+    return PlanningInputScope(
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        use_case=use_case,
+        planner_inputs=(
+            Path("docs/changes/active/CHG-001.md"),
+            Path("docs/use-cases/UC-001/e2e-goal.md"),
+        ),
+        executor_inputs=(
+            Path("docs/plans/active/UC-001/plan.md"),
+            Path("docs/changes/active/CHG-001.md"),
+        ),
+        e2e_goal_path=Path("docs/use-cases/UC-001/e2e-goal.md"),
+        work_item_id="UC-001",
+        work_item_type=WorkItemType.USE_CASE,
+        plan_path=Path("docs/plans/active/UC-001/plan.md"),
+        verification_goal_path=Path("docs/use-cases/UC-001/e2e-goal.md"),
+    )
+
+
+def workflow():
+    return load_named_workflow("changeset-use-case-workflow")
+
+
+def test_work_item_loop_materializes_inputs_and_outputs(tmp_path: Path) -> None:
+    fake_runner = FakeStepRunner()
+    runner = WorkItemLoopRunner(step_runner=fake_runner, workflow=workflow())
+
+    result = runner.run(
+        change_set=change_set(),
+        scopes=(scope(),),
+        context=context(tmp_path),
+    )
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.completed_work_items == ("UC-001",)
+    assert [step.id for step in fake_runner.steps] == [
+        "load-change-set",
+        "plan-work-item",
+        "execute-work-item",
+        "verify-work-item",
+        "classify-verification-result",
+        "complete-work-item-plan",
+    ]
+
+    plan_step = fake_runner.steps[1]
+    assert plan_step.inputs == (
+        Path("docs/changes/active/CHG-001.md"),
+        Path("docs/use-cases/UC-001/e2e-goal.md"),
+    )
+    assert plan_step.outputs == (Path("docs/plans/active/UC-001/plan.md"),)
+
+    execute_step = fake_runner.steps[2]
+    assert execute_step.inputs == (
+        Path("docs/plans/active/UC-001/plan.md"),
+        Path("docs/changes/active/CHG-001.md"),
+    )
+
+    complete_step = fake_runner.steps[-1]
+    assert complete_step.outputs == (Path("docs/plans/completed/UC-001/plan.md"),)
+
+
+def test_work_item_loop_retries_implementation_failure(tmp_path: Path) -> None:
+    plan_path = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan_path.parent.mkdir(parents=True)
+    plan_path.write_text("# Plan\n", encoding="utf-8")
+    fake_runner = FakeStepRunner(
+        {
+            "verify-work-item": [
+                StepResult(
+                    step_id="verify-work-item",
+                    status=StepStatus.FAILED,
+                    error="unit test failed",
+                    failure_kind=FailureKind.IMPLEMENTATION,
+                ),
+                StepResult(
+                    step_id="verify-work-item",
+                    status=StepStatus.SUCCEEDED,
+                ),
+            ]
+        }
+    )
+    runner = WorkItemLoopRunner(step_runner=fake_runner, workflow=workflow())
+
+    result = runner.run(
+        change_set=change_set(),
+        scopes=(scope(),),
+        context=context(tmp_path),
+    )
+
+    item_result = result.item_results[0]
+    assert item_result.status == RunStatus.SUCCEEDED
+    assert item_result.retry_count == 1
+    assert [step.id for step in fake_runner.steps].count("execute-work-item") == 2
+    assert [step.id for step in fake_runner.steps].count("verify-work-item") == 2
+
+    remediation = (
+        tmp_path / ".harness/runs/run-001/work-items/UC-001/remediation/1.md"
+    ).read_text(encoding="utf-8")
+    assert "unit test failed" in remediation
+    assert "재실행 계획 1" in plan_path.read_text(encoding="utf-8")
+
+
+def test_work_item_loop_stops_on_environment_blocker(tmp_path: Path) -> None:
+    fake_runner = FakeStepRunner(
+        {
+            "verify-work-item": [
+                StepResult(
+                    step_id="verify-work-item",
+                    status=StepStatus.BLOCKED,
+                    error="missing service",
+                    failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
+                ),
+            ]
+        }
+    )
+    runner = WorkItemLoopRunner(step_runner=fake_runner, workflow=workflow())
+
+    result = runner.run(
+        change_set=change_set(),
+        scopes=(scope(),),
+        context=context(tmp_path),
+    )
+
+    assert result.status == RunStatus.BLOCKED
+    assert result.blocked_work_items == ("UC-001",)
+    assert [step.id for step in fake_runner.steps].count("execute-work-item") == 1
+    assert result.item_results[0].blocker == "missing service"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -141,7 +141,7 @@ def test_resume_reports_next_target(tmp_path: Path, capsys) -> None:
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Resume: NEXT_USE_CASE" in output
+    assert "Resume: WAIT_FOR_ENVIRONMENT" in output
     assert "UC: UC-001" in output
 
 


### PR DESCRIPTION
## 구현 의도

ChangeSet의 work item별 입력과 출력을 이어서 `planner -> executor -> verifier` 흐름을 실행하고, 구현 실패일 때만 remediation을 기록한 뒤 executor/verifier 루프를 재시도하도록 만들었습니다. 이 PR은 #64 범위를 다루며 #66 위에 쌓인 stacked PR입니다. UI는 포함하지 않았습니다.

Closes #64

## 구현 방법

- `WorkItemLoopRunner`를 추가해 ChangeSet scope별로 `load-change-set -> plan-work-item -> execute-work-item -> verify-work-item -> classify-verification-result -> complete-work-item-plan` 순서로 실행합니다.
- workflow step의 `<CHG-ID>`, `<WORK-ITEM-ID>`, `<UC-ID>`, `<MAINT-ID>` placeholder를 현재 work item scope의 실제 입력/출력 경로로 구체화합니다.
- verifier가 `IMPLEMENTATION` 실패를 반환하면 `.harness/runs/<run-id>/work-items/<id>/remediation/<n>.md`에 재실행 계획을 기록하고, active plan이 있으면 같은 내용을 append한 뒤 executor/verifier를 다시 실행합니다.
- 환경 blocker나 설계/상위 단계 blocker는 재시도하지 않고 상태, report, resume 판단에 blocker로 연결합니다.
- CLI `run-change/run-use-case/run-work-item --apply`는 기존 선형 `RunnerEngine` 대신 work item loop runner를 사용해 run state와 report를 작성합니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_work_item_loop_runner.py tests/test_cli_commands.py`
- `./venv/bin/python3 -m pytest -q -s`

전체 테스트 결과: 111 passed.
