### PR TITLE
런타임 apply 출력 정합성 정리

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -160,7 +160,7 @@ def run_change_command(args: argparse.Namespace, repo_root: Path) -> str:
         return _format_scopes(change_set, scopes, mode)
 
     state, result = _apply_workflow(repo_root, change_set, scopes)
-    return f"APPLY started: run_id={state.run_id} status={result.status.value}"
+    return _format_apply_result(state, result)
 
 
 def run_use_case_command(args: argparse.Namespace, repo_root: Path) -> str:
@@ -184,7 +184,7 @@ def run_use_case_command(args: argparse.Namespace, repo_root: Path) -> str:
         return _format_scopes(change_set, selected, mode)
 
     state, result = _apply_workflow(repo_root, change_set, selected)
-    return f"APPLY started: run_id={state.run_id} uc_id={args.uc_id} status={result.status.value}"
+    return _format_apply_result(state, result, selected_id=args.uc_id)
 
 
 def run_work_item_command(args: argparse.Namespace, repo_root: Path) -> str:
@@ -204,7 +204,7 @@ def run_work_item_command(args: argparse.Namespace, repo_root: Path) -> str:
         return _format_scopes(change_set, selected, mode)
 
     state, result = _apply_workflow(repo_root, change_set, selected)
-    return f"APPLY started: run_id={state.run_id} work_item_id={args.work_item_id} status={result.status.value}"
+    return _format_apply_result(state, result, selected_id=args.work_item_id)
 
 
 def stages_list_command(args: argparse.Namespace, repo_root: Path) -> str:
@@ -341,6 +341,35 @@ def _format_scopes(
             ]
         )
 
+    return "\n".join(lines)
+
+
+def _format_apply_result(
+    state: RunState,
+    result,
+    *,
+    selected_id: str | None = None,
+) -> str:
+    lines = [
+        f"APPLY started: run_id={state.run_id} status={result.status.value}",
+        f"Report: .harness/runs/{state.run_id}/report.md",
+        f"State: .harness/runs/{state.run_id}/state.json",
+    ]
+    if selected_id:
+        lines.append(f"Selected: {selected_id}")
+    lines.extend(
+        [
+            f"Completed work items: {', '.join(state.completed_work_items) or '-'}",
+            f"Blocked work items: {', '.join(state.blocked_work_items) or '-'}",
+        ]
+    )
+    if state.failed_step_id:
+        lines.append(f"Failed step: {state.failed_step_id}")
+    if state.failure_kind:
+        lines.append(f"Failure kind: {state.failure_kind.value}")
+    blocker = _first_blocker(result)
+    if blocker:
+        lines.append(f"Blocker: {blocker}")
     return "\n".join(lines)
 
 
@@ -492,6 +521,9 @@ def _apply_workflow(
             affected_use_cases=affected_use_cases,
             completed_use_cases=completed_use_cases,
             blocked_use_cases=blocked_use_cases,
+            completed_work_items=result.completed_work_items,
+            failed_work_items=result.failed_work_items,
+            blocked_work_items=result.blocked_work_items,
             current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
             work_item_reports=tuple(
                 WorkItemReport(
@@ -516,6 +548,13 @@ def _first_failed_step_id(result) -> str | None:
     for item_result in result.item_results:
         if item_result.failed_step_id:
             return item_result.failed_step_id
+    return None
+
+
+def _first_blocker(result) -> str | None:
+    for item_result in result.item_results:
+        if item_result.blocker:
+            return item_result.blocker
     return None
 
 

--- a/harness_codex/runtime/dashboard.py
+++ b/harness_codex/runtime/dashboard.py
@@ -31,6 +31,9 @@ class DashboardRun:
     run_id: str
     change_set_id: str
     status: RunStatus
+    completed_work_items: tuple[str, ...]
+    failed_work_items: tuple[str, ...]
+    blocked_work_items: tuple[str, ...]
     work_items: tuple[DashboardWorkItem, ...]
     report_path: Path
 
@@ -78,6 +81,13 @@ def load_dashboard_runs(repo_root: Path | str) -> tuple[DashboardRun, ...]:
                 run_id=state.run_id,
                 change_set_id=state.change_set_id,
                 status=state.status,
+                completed_work_items=state.completed_work_items,
+                failed_work_items=tuple(
+                    item.work_item_id
+                    for item in state.work_item_states
+                    if item.status == RunStatus.FAILED
+                ),
+                blocked_work_items=state.blocked_work_items,
                 work_items=tuple(work_items),
                 report_path=Path(".harness/runs") / state.run_id / "report.md",
             )
@@ -94,6 +104,9 @@ def dashboard_state_json(repo_root: Path | str) -> str:
             "run_id": run.run_id,
             "change_set_id": run.change_set_id,
             "status": run.status.value,
+            "completed_work_items": list(run.completed_work_items),
+            "failed_work_items": list(run.failed_work_items),
+            "blocked_work_items": list(run.blocked_work_items),
             "report_path": str(run.report_path),
             "work_items": [
                 {

--- a/harness_codex/runtime/reports.py
+++ b/harness_codex/runtime/reports.py
@@ -73,6 +73,9 @@ class RunReport:
     completed_use_cases: tuple[str, ...] = ()
     failed_use_cases: tuple[str, ...] = ()
     blocked_use_cases: tuple[str, ...] = ()
+    completed_work_items: tuple[str, ...] = ()
+    failed_work_items: tuple[str, ...] = ()
+    blocked_work_items: tuple[str, ...] = ()
     current_use_case_id: str | None = None
     started_at: str | None = None
     completed_at: str | None = None
@@ -183,6 +186,9 @@ class ReportWriter:
                 f"- Failed UC: {', '.join(report.failed_use_cases) or '-'}",
                 f"- Blocked UC: {', '.join(report.blocked_use_cases) or '-'}",
                 f"- Work items: {work_items or '-'}",
+                f"- Completed work items: {', '.join(report.completed_work_items) or '-'}",
+                f"- Failed work items: {', '.join(report.failed_work_items) or '-'}",
+                f"- Blocked work items: {', '.join(report.blocked_work_items) or '-'}",
                 "",
             ]
         )

--- a/tests/runtime/test_reports.py
+++ b/tests/runtime/test_reports.py
@@ -7,7 +7,9 @@ from harness_codex.runtime import (
     RunReport,
     RunStatus,
     UseCaseReport,
+    WorkItemReport,
 )
+from harness_codex.runtime.changes.models import WorkItemType
 
 
 def use_case_report(uc_id: str, status: RunStatus, blocker: str | None = None) -> UseCaseReport:
@@ -56,7 +58,17 @@ def test_report_writer_generates_run_json_and_markdown(tmp_path: Path) -> None:
         status=RunStatus.SUCCEEDED,
         affected_use_cases=("UC-001",),
         completed_use_cases=("UC-001",),
+        completed_work_items=("UC-001",),
         use_case_reports=(use_case_report("UC-001", RunStatus.SUCCEEDED),),
+        work_item_reports=(
+            WorkItemReport(
+                work_item_id="UC-001",
+                work_item_type=WorkItemType.USE_CASE,
+                active_plan_path=Path("docs/plans/active/UC-001/plan.md"),
+                status=RunStatus.SUCCEEDED,
+                completed_plan_path=Path("docs/plans/completed/UC-001/plan.md"),
+            ),
+        ),
     )
     writer = ReportWriter(tmp_path)
 
@@ -73,7 +85,9 @@ def test_report_writer_generates_run_json_and_markdown(tmp_path: Path) -> None:
 
     assert run_json["run_id"] == "run-001"
     assert run_json["completed_use_cases"] == ["UC-001"]
+    assert run_json["completed_work_items"] == ["UC-001"]
     assert "Status: succeeded" in run_md
+    assert "Completed work items: UC-001" in run_md
 
 
 def test_report_writer_generates_failed_and_blocked_uc_reports(tmp_path: Path) -> None:
@@ -86,6 +100,8 @@ def test_report_writer_generates_failed_and_blocked_uc_reports(tmp_path: Path) -
         affected_use_cases=("UC-001", "UC-002"),
         failed_use_cases=("UC-001",),
         blocked_use_cases=("UC-002",),
+        failed_work_items=("UC-001",),
+        blocked_work_items=("UC-002",),
         use_case_reports=(
             use_case_report("UC-001", RunStatus.FAILED),
             use_case_report("UC-002", RunStatus.BLOCKED, blocker="E2E goal unclear"),

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from harness_codex.cli import main
@@ -127,8 +128,15 @@ def test_run_change_apply_creates_resume_state(tmp_path: Path, capsys) -> None:
     output = capsys.readouterr().out
     assert exit_code == 0
     assert "APPLY started" in output
+    assert "Report: .harness/runs/" in output
+    assert "State: .harness/runs/" in output
     run_dirs = list((tmp_path / ".harness/runs").iterdir())
     assert (run_dirs[0] / "state.json").is_file()
+    assert (run_dirs[0] / "report.json").is_file()
+    assert (run_dirs[0] / "report.md").is_file()
+
+    report = json.loads((run_dirs[0] / "report.json").read_text(encoding="utf-8"))
+    assert report["blocked_work_items"] == ["UC-001"]
 
 
 def test_resume_reports_next_target(tmp_path: Path, capsys) -> None:
@@ -189,3 +197,5 @@ def test_dashboard_outputs_work_item_state(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     assert '"id": "MAINT-001"' in output
     assert '"type": "maintenance"' in output
+    dashboard = json.loads(output)
+    assert dashboard[0]["blocked_work_items"] == ["MAINT-001"]


### PR DESCRIPTION
## 구현 의도

사용자가 `harness run-change/run-use-case/run-work-item --apply`를 실행했을 때 CLI 출력, run report, dashboard가 실제 work item loop 결과와 같은 상태를 보여주도록 정리했습니다. 이 PR은 #65 범위를 다루며 #67 위에 쌓인 stacked PR입니다. UI 구현은 포함하지 않았습니다.

Closes #65

## 구현 방법

- apply 명령 출력에 report/state 경로, 완료/차단 work item, 실패 단계, 실패 유형, blocker를 포함했습니다.
- `RunReport`에 completed/failed/blocked work item 목록을 추가하고 JSON/Markdown report에 기록했습니다.
- dashboard JSON에도 completed/failed/blocked work item 목록을 추가해 report/state와 같은 loop 결과를 노출합니다.
- CLI apply 테스트에서 생성된 `state.json`, `report.json`, `report.md`와 blocked work item 값을 확인하도록 보강했습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py tests/runtime/test_reports.py`
- `./venv/bin/python3 -m pytest -q -s`

전체 테스트 결과: 111 passed.
