### PR TITLE
런타임 apply 스모크 검증 추가

### DIFF
--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -38,6 +38,7 @@ from harness_codex.runtime.runner import (
     AgentRunResult,
     BasicStepRunner,
     CodexCliAgentAdapter,
+    RecordingAgentAdapter,
     StepRunner,
 )
 from harness_codex.runtime.state import (
@@ -88,6 +89,7 @@ __all__ = [
     "PolicyDecision",
     "PolicyEffect",
     "PolicyEngine",
+    "RecordingAgentAdapter",
     "RunContext",
     "RunMode",
     "RunResult",

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -7,6 +7,7 @@ side-effecting implementations such as Codex, shell, git, and validators.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tomllib
@@ -187,11 +188,75 @@ class CodexCliAgentAdapter:
         return command
 
 
+class RecordingAgentAdapter:
+    """테스트용 AGENT adapter. 외부 Codex 호출 없이 invocation 산출물만 만든다."""
+
+    def run(self, request: AgentRunRequest) -> AgentRunResult:
+        prompt_path = request.step_dir / "prompt.md"
+        final_message_path = request.step_dir / "final-message.md"
+        recording_path = request.step_dir / "agent-recording.json"
+
+        prompt_path.write_text(_agent_prompt(request), encoding="utf-8")
+        final_message_path.write_text(
+            f"recorded agent step: {request.step.id}\n",
+            encoding="utf-8",
+        )
+        (request.step_dir / "stdout.txt").write_text(
+            "recording agent adapter\n",
+            encoding="utf-8",
+        )
+        (request.step_dir / "stderr.txt").write_text("", encoding="utf-8")
+
+        for output in request.step.outputs:
+            output_path = request.context.repo_root / output
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            if not output_path.exists():
+                output_path.write_text(
+                    "\n".join(
+                        [
+                            f"# Recorded output for {request.step.id}",
+                            "",
+                            f"- Agent: `{request.step.agent_id}`",
+                            f"- Skill: `{_step_skill_id(request.step) or '-'}`",
+                            "",
+                        ]
+                    ),
+                    encoding="utf-8",
+                )
+
+        recording_path.write_text(
+            json.dumps(
+                {
+                    "step_id": request.step.id,
+                    "agent_id": request.step.agent_id,
+                    "skill_id": _step_skill_id(request.step),
+                    "outputs": [str(path) for path in request.step.outputs],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        return AgentRunResult(
+            status=StepStatus.SUCCEEDED,
+            exit_code=0,
+            metadata={
+                **_agent_metadata(request, prompt_path, final_message_path),
+                "adapter": "recording",
+                "recording_path": str(
+                    _relative_to_repo(recording_path, request.context)
+                ),
+            },
+        )
+
+
 class BasicStepRunner:
     """Local MVP adapter for record/shell/validator/git steps."""
 
     def __init__(self, agent_adapter: AgentAdapter | None = None) -> None:
-        self._agent_adapter = agent_adapter or CodexCliAgentAdapter()
+        self._agent_adapter = agent_adapter or _default_agent_adapter()
 
     def run(self, step: Step, context: RunContext) -> StepResult:
         step_dir = context.run_dir / "steps" / step.id
@@ -416,6 +481,12 @@ def _relative_to_repo(path: Path, context: RunContext) -> Path:
 def _load_agent_config(path: Path) -> Mapping[str, Any]:
     with path.open("rb") as file:
         return tomllib.load(file)
+
+
+def _default_agent_adapter() -> AgentAdapter:
+    if os.environ.get("HARNESS_CODEX_AGENT_ADAPTER") == "recording":
+        return RecordingAgentAdapter()
+    return CodexCliAgentAdapter()
 
 
 def _agent_metadata(

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -14,6 +14,7 @@ from harness_codex.runtime.runner import (
     AgentRunResult,
     BasicStepRunner,
     CodexCliAgentAdapter,
+    RecordingAgentAdapter,
 )
 
 
@@ -278,3 +279,35 @@ def test_codex_cli_agent_adapter_blocks_when_codex_binary_is_missing(
     assert (request.step_dir / "stderr.txt").read_text(encoding="utf-8") == (
         "codex binary not found: missing-codex"
     )
+
+
+def test_recording_agent_adapter_materializes_outputs(tmp_path: Path) -> None:
+    write_agent_config(tmp_path)
+    write_skill(tmp_path)
+    request = AgentRunRequest(
+        step=Step(
+            id="plan-work-item",
+            kind=StepKind.AGENT,
+            name="Create plan",
+            agent_id="implementation_planner",
+            skill_id="harness-code-planner",
+            outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        ),
+        context=context(tmp_path),
+        step_dir=tmp_path / ".harness/runs/run-001/steps/plan-work-item",
+        agent_config_path=tmp_path / ".codex/agents/implementation_planner.toml",
+        agent_config={"name": "implementation_planner"},
+        skill_path=tmp_path / ".codex/skills/harness-code-planner/SKILL.md",
+        skill_body="# 테스트 스킬",
+    )
+    request.step_dir.mkdir(parents=True)
+
+    result = RecordingAgentAdapter().run(request)
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert (tmp_path / "docs/plans/active/UC-001/plan.md").is_file()
+    recording = json.loads(
+        (request.step_dir / "agent-recording.json").read_text(encoding="utf-8")
+    )
+    assert recording["agent_id"] == "implementation_planner"
+    assert recording["skill_id"] == "harness-code-planner"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -62,6 +62,83 @@ def write_maintenance_changeset(repo: Path) -> None:
         (maint_dir / name).write_text(name, encoding="utf-8")
 
 
+def write_apply_smoke_fixture(repo: Path) -> None:
+    write_changeset(repo)
+    use_case_dir = repo / "docs/use-cases/UC-001"
+    use_case_dir.mkdir(parents=True)
+    for name in ("use-case.md", "event-storming.md", "e2e-goal.md"):
+        (use_case_dir / name).write_text(name, encoding="utf-8")
+    (repo / "ARCHITECTURE.md").write_text("architecture", encoding="utf-8")
+
+    codex_dir = repo / ".codex"
+    (codex_dir / "agents").mkdir(parents=True)
+    (codex_dir / "skills").mkdir(parents=True)
+    (codex_dir / "repository-settings.md").write_text("settings", encoding="utf-8")
+    (codex_dir / "test-gate.yaml").write_text(
+        "required:\n"
+        "  - stage: unit\n"
+        "    command: python3 -c 'print(\"ok\")'\n",
+        encoding="utf-8",
+    )
+    for agent_id in ("implementation_planner", "implementation_executor"):
+        (codex_dir / "agents" / f"{agent_id}.toml").write_text(
+            "\n".join(
+                [
+                    f'name = "{agent_id}"',
+                    'description = "smoke agent"',
+                    'developer_instructions = """스모크 테스트"""',
+                ]
+            ),
+            encoding="utf-8",
+        )
+    for skill_id in ("harness-code-planner", "harness-plan-executor"):
+        skill_dir = codex_dir / "skills" / skill_id
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {skill_id}\n---\n\n# {skill_id}\n",
+            encoding="utf-8",
+        )
+
+    workflow_dir = repo / ".harness/workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "changeset-use-case-workflow.yaml").write_text(
+        """
+version: 1
+workflow:
+  name: changeset-use-case-workflow
+  mode: apply
+sandbox:
+  kind: worktree
+steps:
+  - id: load-change-set
+    kind: record
+    inputs:
+      - docs/changes/active
+  - id: plan-work-item
+    kind: agent
+    needs: [load-change-set]
+    agent_id: implementation_planner
+    skill_id: harness-code-planner
+  - id: execute-work-item
+    kind: agent
+    needs: [plan-work-item]
+    agent_id: implementation_executor
+    skill_id: harness-plan-executor
+  - id: verify-work-item
+    kind: validator
+    needs: [execute-work-item]
+    command: python3 -c 'print("ok")'
+  - id: classify-verification-result
+    kind: decision
+    needs: [verify-work-item]
+  - id: complete-work-item-plan
+    kind: git
+    needs: [classify-verification-result]
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
 def test_changes_list_outputs_active_changesets(tmp_path: Path, capsys) -> None:
     write_changeset(tmp_path)
 
@@ -137,6 +214,51 @@ def test_run_change_apply_creates_resume_state(tmp_path: Path, capsys) -> None:
 
     report = json.loads((run_dirs[0] / "report.json").read_text(encoding="utf-8"))
     assert report["blocked_work_items"] == ["UC-001"]
+
+
+def test_run_change_apply_smoke_records_agent_skill_invocations(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_apply_smoke_fixture(tmp_path)
+    monkeypatch.setenv("HARNESS_CODEX_AGENT_ADAPTER", "recording")
+
+    exit_code = main(
+        ["--repo-root", str(tmp_path), "run-change", "CHG-001", "--apply"]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "status=succeeded" in output
+    run_dir = next((tmp_path / ".harness/runs").iterdir())
+    assert (tmp_path / "docs/plans/completed/UC-001/plan.md").is_file()
+
+    planner_invocation = json.loads(
+        (run_dir / "steps/plan-work-item/invocation.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    executor_invocation = json.loads(
+        (run_dir / "steps/execute-work-item/invocation.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert planner_invocation["agent_id"] == "implementation_planner"
+    assert planner_invocation["skill_id"] == "harness-code-planner"
+    assert executor_invocation["agent_id"] == "implementation_executor"
+    assert executor_invocation["skill_id"] == "harness-plan-executor"
+
+    report = json.loads((run_dir / "report.json").read_text(encoding="utf-8"))
+    assert report["completed_work_items"] == ["UC-001"]
+    assert report["blocked_work_items"] == []
+
+    main(["--repo-root", str(tmp_path), "dashboard"])
+    dashboard = json.loads(capsys.readouterr().out)
+    assert dashboard[0]["completed_work_items"] == ["UC-001"]
+
+    main(["--repo-root", str(tmp_path), "resume", run_dir.name])
+    assert "COMPLETE:" in capsys.readouterr().out
 
 
 def test_resume_reports_next_target(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## 구현 의도

CLI `--apply` 경로에서 planner/executor agent와 skill invocation이 실제 run artifact로 남고, verifier/complete/report/dashboard/resume까지 이어지는지 통합 smoke로 확인합니다. 이 PR은 #69 범위를 다루며 #68 위에 쌓인 stacked PR입니다. 실제 Codex 네트워크 실행과 UI 구현은 포함하지 않습니다.

Closes #69

## 구현 방법

- 테스트 전용 `RecordingAgentAdapter`를 추가했습니다. `HARNESS_CODEX_AGENT_ADAPTER=recording`일 때만 사용하며 기본 동작은 기존 `CodexCliAgentAdapter` 그대로입니다.
- recording adapter는 prompt/final-message/stdout/stderr/agent-recording을 남기고, step output 파일을 생성해 planner output이 executor/verifier/complete 단계로 이어지게 합니다.
- CLI smoke fixture는 agent config, skill, ChangeSet, UC 문서, test gate, workflow를 임시 repo에 구성한 뒤 `run-change --apply`를 실행합니다.
- smoke 테스트에서 planner/executor invocation의 agent_id/skill_id, completed plan 이동, report/dashboard completed work item, resume COMPLETE를 검증합니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/test_cli_commands.py`
- `./venv/bin/python3 -m pytest -q -s`

전체 테스트 결과: 113 passed.
