### PR TITLE
Codex CLI 옵션 호환성 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+.harness/runs/
 .venv/
 venv/

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -165,8 +165,8 @@ class CodexCliAgentAdapter:
             "exec",
             "--cd",
             str(request.context.workdir),
-            "--ask-for-approval",
-            "never",
+            "-c",
+            'approval_policy="never"',
             "--output-last-message",
             str(final_message_path),
         ]

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -229,6 +229,8 @@ def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
     assert result.status == StepStatus.SUCCEEDED
     command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
     assert command[:2] == ["codex-test", "exec"]
+    assert "--ask-for-approval" not in command
+    assert 'approval_policy="never"' in command
     assert "--output-last-message" in command
     assert "--model" in command
     assert (request.step_dir / "stdout.txt").read_text(encoding="utf-8") == (


### PR DESCRIPTION
## 구현 의도
런타임 AGENT 단계가 현재 설치된 `codex exec` 옵션과 맞지 않아 harvester 실행 전에 실패하는 문제를 해결한다.

Closes #71

## 구현 방법
- `CodexCliAgentAdapter` 명령 생성에서 더 이상 지원되지 않는 `--ask-for-approval never`를 제거했다.
- 현재 CLI가 지원하는 `-c approval_policy="never"` 설정으로 비대화 실행 정책을 전달한다.
- `.harness/runs/`를 ignore해 런타임 실행 산출물이 작업트리에 남아 PR 범위에 섞이지 않게 했다.
- agent runner 테스트가 새 명령 형식을 검증하도록 보강했다.

## 검증 방법
- `./venv/bin/python3 -m pytest tests/runtime/test_agent_runner.py -q -s`
- `./venv/bin/python3 -m pytest -q -s`
- 초기 프롬프트 `간단한 사칙연산과 되돌리기 기능이 있는 계산기 만들어줘`로 harvester AGENT 런타임 단계를 재실행해 `codex exec` 옵션 파싱 실패가 해소되고 단계가 성공하는 것을 확인했다.
