### PR TITLE
Codex 사용량 제한 blocker 분류 추가

### DIFF
--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -141,10 +141,19 @@ class CodexCliAgentAdapter:
         )
 
         if completed.returncode != 0:
+            error = completed.stderr.strip() or completed.stdout.strip()
+            blocker = _agent_process_blocker_error(error)
+            if blocker is not None:
+                return AgentRunResult(
+                    status=StepStatus.BLOCKED,
+                    exit_code=completed.returncode,
+                    error=blocker,
+                    metadata=_agent_metadata(request, prompt_path, final_message_path),
+                )
             return AgentRunResult(
                 status=StepStatus.FAILED,
                 exit_code=completed.returncode,
-                error=completed.stderr.strip() or completed.stdout.strip(),
+                error=error,
                 metadata=_agent_metadata(request, prompt_path, final_message_path),
             )
 
@@ -461,6 +470,15 @@ def _decode_process_output(value: str | bytes | None) -> str:
     if isinstance(value, bytes):
         return value.decode(errors="replace")
     return value
+
+
+def _agent_process_blocker_error(output: str) -> str | None:
+    normalized = output.lower()
+    if "you've hit your usage limit" in normalized or "usage limit" in normalized:
+        return output
+    if "rate limit" in normalized:
+        return output
+    return None
 
 
 def _blocked_agent_result(

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -280,3 +280,41 @@ def test_codex_cli_agent_adapter_blocks_when_codex_binary_is_missing(
     assert (request.step_dir / "stderr.txt").read_text(encoding="utf-8") == (
         "codex binary not found: missing-codex"
     )
+
+
+def test_codex_cli_agent_adapter_blocks_on_usage_limit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    request = AgentRunRequest(
+        step=Step(
+            id="plan-work-item",
+            kind=StepKind.AGENT,
+            name="Create plan",
+            agent_id="implementation_planner",
+        ),
+        context=context(tmp_path),
+        step_dir=tmp_path / ".harness/runs/run-001/steps/plan-work-item",
+        agent_config_path=tmp_path / ".codex/agents/implementation_planner.toml",
+        agent_config={
+            "name": "implementation_planner",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=1,
+            stdout="",
+            stderr="ERROR: You've hit your usage limit. Try again later.",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = CodexCliAgentAdapter(codex_binary="codex-test").run(request)
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.exit_code == 1
+    assert "usage limit" in (result.error or "")


### PR DESCRIPTION
## 구현 의도
`codex exec` 사용량 제한이나 rate limit으로 AGENT 단계가 종료될 때 실제 구현 실패와 환경 blocker를 구분한다.

Closes #73

## 구현 방법
- `CodexCliAgentAdapter`가 non-zero 종료 결과를 처리할 때 stderr/stdout에서 사용량 제한 또는 rate limit 문구를 감지한다.
- 해당 문구가 있으면 `FAILED` 대신 `BLOCKED`로 반환한다.
- 기존 `_agent_failure_kind` 흐름에 따라 `BLOCKED`는 environment blocker로 기록된다.
- 사용량 제한 재현 테스트를 추가했다.

## 검증 방법
- `./venv/bin/python3 -m pytest tests/runtime/test_agent_runner.py -q -s`
- `./venv/bin/python3 -m pytest -q -s`
