### PR TITLE
Codex blocker 메시지 정리

### DIFF
--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -473,11 +473,12 @@ def _decode_process_output(value: str | bytes | None) -> str:
 
 
 def _agent_process_blocker_error(output: str) -> str | None:
-    normalized = output.lower()
-    if "you've hit your usage limit" in normalized or "usage limit" in normalized:
-        return output
-    if "rate limit" in normalized:
-        return output
+    for line in output.splitlines():
+        normalized = line.lower()
+        if "you've hit your usage limit" in normalized or "usage limit" in normalized:
+            return line
+        if "rate limit" in normalized:
+            return line
     return None
 
 

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -318,3 +318,43 @@ def test_codex_cli_agent_adapter_blocks_on_usage_limit(
     assert result.status == StepStatus.BLOCKED
     assert result.exit_code == 1
     assert "usage limit" in (result.error or "")
+
+
+def test_codex_cli_agent_adapter_reports_usage_limit_before_warnings(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    request = AgentRunRequest(
+        step=Step(
+            id="plan-work-item",
+            kind=StepKind.AGENT,
+            name="Create plan",
+            agent_id="implementation_planner",
+        ),
+        context=context(tmp_path),
+        step_dir=tmp_path / ".harness/runs/run-001/steps/plan-work-item",
+        agent_config_path=tmp_path / ".codex/agents/implementation_planner.toml",
+        agent_config={
+            "name": "implementation_planner",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=1,
+            stdout="",
+            stderr=(
+                "WARN plugin sync failed\n"
+                "ERROR: You've hit your usage limit. Try again later.\n"
+            ),
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = CodexCliAgentAdapter(codex_binary="codex-test").run(request)
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.error == "ERROR: You've hit your usage limit. Try again later."


### PR DESCRIPTION
## 구현 의도
`codex exec` stderr에 warning 로그가 먼저 있어도 런타임 blocker가 실제 조치 대상 에러를 보여주도록 한다.

Closes #75

## 구현 방법
- AGENT process blocker 감지 시 전체 stderr를 반환하지 않고 사용량 제한/rate limit과 매칭된 라인만 반환한다.
- warning 뒤에 사용량 제한 에러가 오는 케이스를 테스트로 추가했다.

## 검증 방법
- `./venv/bin/python3 -m pytest tests/runtime/test_agent_runner.py -q -s`
- `./venv/bin/python3 -m pytest -q -s`
