### PR TITLE
[codex] 수확 문서 기반 변경셋 생성 추가

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -27,8 +27,10 @@ from harness_codex.runtime.dashboard import dashboard_state_json
 from harness_codex.runtime.changes import (
     ChangeSet,
     ChangeSetResolver,
+    DesignBridgeError,
     NoActiveChangeSetsError,
     PlanningBlocked,
+    create_changeset_from_design,
 )
 from harness_codex.runtime.workflows import load_named_workflow
 
@@ -40,7 +42,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         output = args.func(args, repo_root)
-    except NoActiveChangeSetsError as exc:
+    except (NoActiveChangeSetsError, DesignBridgeError) as exc:
         print(str(exc), file=sys.stderr)
         return 2
 
@@ -62,6 +64,18 @@ def build_parser() -> argparse.ArgumentParser:
     changes_show = changes_subparsers.add_parser("show")
     changes_show.add_argument("change_set_id")
     changes_show.set_defaults(func=changes_show_command)
+    changes_create_from_design = changes_subparsers.add_parser("create-from-design")
+    changes_create_from_design.add_argument("--title", required=True)
+    changes_create_from_design.add_argument("--change-set-id")
+    changes_create_from_design.add_argument("--related-issue", default="")
+    changes_create_from_design.add_argument(
+        "--uc",
+        action="append",
+        default=[],
+        help="Limit generated slices to one canonical use case. May be passed more than once.",
+    )
+    changes_create_from_design.add_argument("--force", action="store_true")
+    changes_create_from_design.set_defaults(func=changes_create_from_design_command)
 
     run_change = subparsers.add_parser("run-change")
     run_change.add_argument("change_set_id")
@@ -144,6 +158,26 @@ def changes_show_command(args: argparse.Namespace, repo_root: Path) -> str:
             f"Work items: {work_items}",
         ]
     )
+
+
+def changes_create_from_design_command(args: argparse.Namespace, repo_root: Path) -> str:
+    result = create_changeset_from_design(
+        repo_root,
+        title=args.title,
+        change_set_id=args.change_set_id,
+        related_issue=args.related_issue,
+        selected_use_cases=tuple(args.uc),
+        force=args.force,
+    )
+    lines = [
+        f"CREATED: {result.change_set_id}",
+        f"ChangeSet: {result.change_set_path}",
+        "Affected use cases:",
+        *[f"- {use_case.uc_id}: {use_case.name}" for use_case in result.use_cases],
+        "Created documents:",
+        *[f"- {path}" for path in result.created_paths],
+    ]
+    return "\n".join(lines)
 
 
 def run_change_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/harness_codex/runtime/changes/__init__.py
+++ b/harness_codex/runtime/changes/__init__.py
@@ -11,6 +11,12 @@ from harness_codex.runtime.changes.models import (
     WorkItemType,
 )
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.changes.design_bridge import (
+    DesignBridgeError,
+    DesignBridgeResult,
+    DesignUseCase,
+    create_changeset_from_design,
+)
 from harness_codex.runtime.changes.resolver import (
     ChangeSetResolver,
     NoActiveChangeSetsError,
@@ -23,9 +29,13 @@ __all__ = [
     "ChangeSet",
     "ChangeSetDocument",
     "ChangeSetResolver",
+    "DesignBridgeError",
+    "DesignBridgeResult",
+    "DesignUseCase",
     "NoActiveChangeSetsError",
     "PlanningBlocked",
     "PlanningInputScope",
     "WorkItemType",
+    "create_changeset_from_design",
     "parse_changeset_markdown",
 ]

--- a/harness_codex/runtime/changes/design_bridge.py
+++ b/harness_codex/runtime/changes/design_bridge.py
@@ -1,0 +1,600 @@
+"""Create ChangeSet execution inputs from harvested design documents."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+USE_CASE_RE = re.compile(
+    r"^(?:##\s+|-\s+)?(?P<id>UC[- ]?\d+)\.?\s*(?P<name>.+?)\s*$",
+    re.MULTILINE,
+)
+SECTION_RE = re.compile(r"^##\s+.+?\s*$", re.MULTILINE)
+
+
+class DesignBridgeError(RuntimeError):
+    """Raised when harvested design documents cannot become execution inputs."""
+
+
+@dataclass(frozen=True)
+class DesignUseCase:
+    uc_id: str
+    source_id: str
+    name: str
+    source_block: str
+
+    @property
+    def slice_path(self) -> Path:
+        return Path("docs/use-cases") / self.uc_id
+
+
+@dataclass(frozen=True)
+class DesignBridgeResult:
+    change_set_id: str
+    change_set_path: Path
+    use_cases: tuple[DesignUseCase, ...]
+    created_paths: tuple[Path, ...]
+
+
+def create_changeset_from_design(
+    repo_root: Path | str,
+    *,
+    title: str,
+    change_set_id: str | None = None,
+    related_issue: str = "",
+    selected_use_cases: tuple[str, ...] = (),
+    force: bool = False,
+) -> DesignBridgeResult:
+    repo = Path(repo_root)
+    requirements_path = Path("docs/design/요구사항.md")
+    use_cases_path = Path("docs/design/유스케이스.md")
+    requirements = _read_required(repo, requirements_path)
+    use_cases_text = _read_required(repo, use_cases_path)
+    use_cases = _parse_design_use_cases(use_cases_text)
+
+    if selected_use_cases:
+        selected = {_normalize_uc_id(uc_id) for uc_id in selected_use_cases}
+        use_cases = tuple(uc for uc in use_cases if uc.uc_id in selected)
+
+    if not use_cases:
+        raise DesignBridgeError(
+            f"No use cases found in {use_cases_path}. Expected entries like 'UC-01. User performs a goal'."
+        )
+
+    if change_set_id is None:
+        change_set_id = _next_change_set_id(repo)
+
+    change_set_path = Path("docs/changes/active") / f"{change_set_id}.md"
+    created_paths = [change_set_path]
+    documents: dict[Path, str] = {}
+    documents[change_set_path] = _render_change_set(
+        change_set_id=change_set_id,
+        title=title,
+        related_issue=related_issue,
+        requirements_path=requirements_path,
+        use_cases_path=use_cases_path,
+        requirements=requirements,
+        use_cases=use_cases,
+    )
+
+    for use_case in use_cases:
+        documents.update(
+            _render_use_case_slice(
+                change_set_id=change_set_id,
+                use_case=use_case,
+            )
+        )
+        created_paths.extend(
+            use_case.slice_path / name
+            for name in (
+                "index.md",
+                "use-case.md",
+                "event-storming.md",
+                "e2e-goal.md",
+                "affected-files.md",
+            )
+        )
+
+    _write_documents(repo, documents, force=force)
+    return DesignBridgeResult(
+        change_set_id=change_set_id,
+        change_set_path=change_set_path,
+        use_cases=use_cases,
+        created_paths=tuple(dict.fromkeys(created_paths)),
+    )
+
+
+def _read_required(repo: Path, relative_path: Path) -> str:
+    path = repo / relative_path
+    if not path.exists():
+        raise DesignBridgeError(f"Required design document not found: {relative_path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _parse_design_use_cases(text: str) -> tuple[DesignUseCase, ...]:
+    sections = list(SECTION_RE.finditer(text))
+    by_id: dict[str, DesignUseCase] = {}
+
+    for match in USE_CASE_RE.finditer(text):
+        raw_id = match.group("id")
+        uc_id = _normalize_uc_id(raw_id)
+        if uc_id in by_id and not match.group(0).startswith("##"):
+            continue
+        name = match.group("name").strip()
+        block = _source_block(text, match.start(), sections)
+        by_id[uc_id] = DesignUseCase(
+            uc_id=uc_id,
+            source_id=raw_id,
+            name=name,
+            source_block=block,
+        )
+
+    return tuple(by_id.values())
+
+
+def _source_block(text: str, start: int, sections: list[re.Match[str]]) -> str:
+    end = len(text)
+    for section in sections:
+        if section.start() > start:
+            end = section.start()
+            break
+    return text[start:end].strip()
+
+
+def _normalize_uc_id(raw_id: str) -> str:
+    number = int(re.search(r"\d+", raw_id).group(0))
+    return f"UC-{number:03d}"
+
+
+def _next_change_set_id(repo: Path) -> str:
+    date = datetime.now().strftime("%Y%m%d")
+    active = repo / "docs/changes/active"
+    completed = repo / "docs/changes/completed"
+    existing = [
+        path.stem
+        for directory in (active, completed)
+        for path in directory.glob(f"CHG-{date}-*.md")
+        if directory.exists()
+    ]
+    sequence = 1
+    for value in existing:
+        try:
+            sequence = max(sequence, int(value.rsplit("-", maxsplit=1)[1]) + 1)
+        except (IndexError, ValueError):
+            continue
+    return f"CHG-{date}-{sequence:03d}"
+
+
+def _render_change_set(
+    *,
+    change_set_id: str,
+    title: str,
+    related_issue: str,
+    requirements_path: Path,
+    use_cases_path: Path,
+    requirements: str,
+    use_cases: tuple[DesignUseCase, ...],
+) -> str:
+    changed_rows = "\n".join(
+        [
+            f"|`{requirements_path}`|read|Canonical requirements source|ready|",
+            f"|`{use_cases_path}`|read|Canonical use-case source|ready|",
+            *[
+                f"|`{use_case.slice_path}/`|create|Execution slice for {use_case.uc_id}|planned|"
+                for use_case in use_cases
+            ],
+        ]
+    )
+    affected_rows = "\n".join(
+        f"|`{use_case.uc_id}`|{_escape_table(use_case.name)}|new|`{use_case.slice_path}/`|planned|"
+        for use_case in use_cases
+    )
+    work_item_rows = "\n".join(
+        f"|`{use_case.uc_id}`|use_case|{_escape_table(use_case.name)}|new|`{use_case.slice_path}/`|planned|"
+        for use_case in use_cases
+    )
+    goal_rows = "\n".join(
+        f"|`{use_case.uc_id}`|`{use_case.slice_path}/e2e-goal.md`|new|pending|Generated from design intake|"
+        for use_case in use_cases
+    )
+    summary = _first_non_empty_line(requirements) or title
+
+    return f"""# ChangeSet {change_set_id}
+
+## 1. Metadata
+
+|Item|Value|
+|---|---|
+|ChangeSet ID|`{change_set_id}`|
+|Status|active|
+|Created date|{datetime.now().strftime("%Y-%m-%d")}|
+|Author|Codex|
+|Related issue/request|{_escape_table(related_issue) or "-"}|
+
+## 2. Implementation Intent
+
+- Request summary: {_escape_text(title)}
+- Expected user result: The harvested design docs become runnable ChangeSet workflow inputs.
+- Reason for change: The runtime pipeline starts from ChangeSet and use-case slice docs, but harvested design docs are upstream canonical inputs.
+
+## 3. Before / After
+
+|Item|Content|
+|---|---|
+|Before|{_escape_table(summary)}|
+|After|An active ChangeSet and affected use-case slices exist for runtime planning.|
+
+## 4. Changed Documents
+
+|Document|Change Type|Reason|Status|
+|---|---|---|---|
+{changed_rows}
+
+## 5. Affected Use Cases
+
+|Use Case ID|Use Case Name|Impact Type|Slice Path|Status|
+|---|---|---|---|---|
+{affected_rows}
+
+## 6. Affected Work Items
+
+|Work Item ID|Type|Name|Impact Type|Slice Path|Status|
+|---|---|---|---|---|---|
+{work_item_rows}
+
+## 7. Verification Goal Changes
+
+|Work Item ID|Verification Goal Path|Change Status|Approval Status|Notes|
+|---|---|---|---|---|
+{goal_rows}
+
+## 8. Planner Input Scope
+
+- `docs/changes/active/<CHG-ID>.md`
+- `docs/use-cases/<UC-ID>/use-case.md`
+- `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/ddd-design.md` when present
+- `docs/use-cases/<UC-ID>/technical-decisions.md` when present
+- `docs/use-cases/<UC-ID>/e2e-goal.md`
+- `docs/use-cases/<UC-ID>/affected-files.md`
+- `ARCHITECTURE.md`
+- `.codex/repository-settings.md`
+
+## 9. Scope Boundary
+
+### Included
+
+- Create runtime execution inputs from `{requirements_path}` and `{use_cases_path}`.
+- Plan and implement only the affected use-case slices listed in this ChangeSet.
+
+### Excluded
+
+- Redesigning canonical requirements or canonical use cases during execution.
+- Creating maintenance work items unless a later ChangeSet explicitly adds them.
+
+### Forbidden Changes
+
+- Do not edit use-case slice docs outside this ChangeSet.
+- Do not edit `docs/design/**` unless a ChangeSet explicitly approves canonical design changes.
+- Do not make unlisted code, test, or configuration changes.
+
+## 10. Completion Conditions
+
+- Every affected use-case slice exists.
+- Every affected use-case E2E goal is approved before implementation planning.
+- Every affected use-case plan completes and moves to `docs/plans/completed/<UC-ID>/plan.md`.
+- Required repository test gates pass.
+- This ChangeSet moves to `docs/changes/completed/{change_set_id}.md`.
+
+## 11. Verification Record
+
+|Command/Check|Result|Evidence|
+|---|---|---|
+|`python3 -m harness_codex changes list`|pending||
+|`python3 -m harness_codex run-use-case {change_set_id} <UC-ID> --preview`|pending||
+
+## 12. Blockers / Conflicts
+
+- None.
+"""
+
+
+def _render_use_case_slice(
+    *,
+    change_set_id: str,
+    use_case: DesignUseCase,
+) -> dict[Path, str]:
+    change_set_path = Path("docs/changes/active") / f"{change_set_id}.md"
+    return {
+        use_case.slice_path / "index.md": _render_index(change_set_path, use_case),
+        use_case.slice_path / "use-case.md": _render_use_case(change_set_path, use_case),
+        use_case.slice_path / "event-storming.md": _render_event_storming(
+            change_set_path,
+            use_case,
+        ),
+        use_case.slice_path / "e2e-goal.md": _render_e2e_goal(change_set_path, use_case),
+        use_case.slice_path / "affected-files.md": _render_affected_files(
+            change_set_path,
+            use_case,
+        ),
+    }
+
+
+def _render_index(change_set_path: Path, use_case: DesignUseCase) -> str:
+    return f"""# {use_case.uc_id}. {_escape_text(use_case.name)}
+
+## 1. Metadata
+
+|Item|Value|
+|---|---|
+|UC ID|`{use_case.uc_id}`|
+|Status|draft|
+|Related ChangeSet|`{change_set_path}`|
+|Canonical source|`docs/design/유스케이스.md`|
+
+## 2. Slice Documents
+
+|Document|Purpose|Status|
+|---|---|---|
+|`use-case.md`|Use-case execution scope|draft|
+|`event-storming.md`|Event-storming route and generated storming output|draft|
+|`e2e-goal.md`|Given/When/Then verification target|pending approval|
+|`affected-files.md`|Expected files and forbidden paths|draft|
+
+## 3. Runtime Paths
+
+- Active plan: `docs/plans/active/{use_case.uc_id}/plan.md`
+- Verification: `docs/plans/active/{use_case.uc_id}/verification.md`
+- Completed plan: `docs/plans/completed/{use_case.uc_id}/plan.md`
+"""
+
+
+def _render_use_case(change_set_path: Path, use_case: DesignUseCase) -> str:
+    source = _escape_fence(use_case.source_block)
+    return f"""# {use_case.uc_id}. {_escape_text(use_case.name)}
+
+## 1. Overview
+
+- Actor: See canonical source.
+- Supporting actor: See canonical source.
+- Goal: {_escape_text(use_case.name)}
+- Related ChangeSet: `{change_set_path}`
+- Canonical source: `docs/design/유스케이스.md`
+
+## 2. Preconditions
+
+- See canonical source.
+
+## 3. Basic Flow
+
+1. Follow the canonical use-case flow for `{use_case.source_id}`.
+
+## 4. Exception Flow
+
+|Condition|System Response|User / External Observation|
+|---|---|---|
+|Invalid or unsupported input|Reject the operation and keep the user in a recoverable state.|The user sees an actionable failure result.|
+
+## 5. Outcomes
+
+### Success Outcomes
+
+- The user achieves the goal described by `{use_case.source_id}`.
+
+### Failure Outcomes
+
+- Invalid, unsupported, or incomplete input is rejected without corrupting state.
+
+## 6. Non-Functional Requirements
+
+|Area|Requirement|Decision Status|
+|---|---|---|
+|Performance|Use the canonical non-functional requirements when present.|pending|
+|Consistency|Keep operation results deterministic for the same input.|pending|
+|Security / Authorization|Use the canonical security requirements when present.|pending|
+|Operations|Expose failures clearly enough for verification.|pending|
+
+## 7. Scope
+
+### Included
+
+- Implement behavior needed for `{use_case.source_id}`.
+
+### Excluded
+
+- Behavior from use cases not listed in the active ChangeSet.
+
+## 8. Canonical Excerpt
+
+```markdown
+{source}
+```
+
+## 9. Confirmation Needed
+
+- Approve the E2E goal before implementation planning.
+"""
+
+
+def _render_event_storming(change_set_path: Path, use_case: DesignUseCase) -> str:
+    return f"""# {use_case.uc_id}. {_escape_text(use_case.name)} Event Storming
+
+## 1. Inputs
+
+- ChangeSet: `{change_set_path}`
+- Use case: `docs/use-cases/{use_case.uc_id}/use-case.md`
+- E2E goal: `docs/use-cases/{use_case.uc_id}/e2e-goal.md`
+- Canonical source: `docs/design/유스케이스.md`
+
+## 2. Status
+
+- Event storming has not been derived yet.
+- Run the event-storming step for this affected use-case slice before DDD design.
+
+## 3. Draft Elements
+
+|Type|Name|Source|Status|
+|---|---|---|---|
+|Command|To be derived|`{use_case.source_id}`|pending|
+|Event|To be derived|`{use_case.source_id}`|pending|
+|Policy|To be derived|`{use_case.source_id}`|pending|
+
+## 4. Scope Boundary
+
+### Included
+
+- Derive commands, events, policies, external systems, and invariants for `{use_case.source_id}` only.
+
+### Excluded
+
+- Event-storming content for unaffected use cases.
+"""
+
+
+def _render_e2e_goal(change_set_path: Path, use_case: DesignUseCase) -> str:
+    return f"""# {use_case.uc_id}. {_escape_text(use_case.name)} E2E Goal
+
+## 1. Metadata
+
+|Item|Value|
+|---|---|
+|UC ID|`{use_case.uc_id}`|
+|Related ChangeSet|`{change_set_path}`|
+|Approval Status|pending|
+|Verification Command|Repository-specific test command|
+
+## 2. Goal
+
+- User-observable result: The user completes `{use_case.source_id}` successfully.
+- System completion condition: The implementation satisfies the canonical use-case flow and rejects invalid input safely.
+
+## 3. Given / When / Then
+
+### Given
+
+- The application is available to the user.
+- Inputs required by `{use_case.source_id}` are available.
+
+### When
+
+- The user performs `{use_case.source_id}`.
+
+### Then
+
+- The system returns the expected successful result.
+- Invalid or unsupported input returns an actionable failure result.
+
+## 4. Success Criteria
+
+- The use-case happy path passes through the user-visible interface.
+- Invalid input handling is covered by tests.
+
+## 5. Failure Criteria
+
+- The implementation produces an incorrect result for valid input.
+- The implementation accepts invalid input silently.
+
+## 6. Verification Method
+
+|Step|Command|Success Criteria|Required|
+|---|---|---|---|
+|Repository test gate|Project-specific command from the implementation plan|Exit code 0|required|
+|Use-case E2E|Project-specific E2E command when available|Given/When/Then is satisfied|required when E2E exists|
+
+## 7. Observation Evidence
+
+|Evidence|Record Location|
+|---|---|
+|Test log|`docs/plans/active/{use_case.uc_id}/verification.md`|
+|Application observation|`docs/plans/active/{use_case.uc_id}/verification.md`|
+|Blocker reason|`docs/plans/active/{use_case.uc_id}/plan.md` or `verification.md`|
+
+## 8. Confirmation Needed
+
+- Approve or refine this E2E goal before implementation planning.
+"""
+
+
+def _render_affected_files(change_set_path: Path, use_case: DesignUseCase) -> str:
+    return f"""# {use_case.uc_id}. {_escape_text(use_case.name)} Affected Files
+
+## 1. Inputs
+
+- ChangeSet: `{change_set_path}`
+- Use case: `docs/use-cases/{use_case.uc_id}/use-case.md`
+- E2E goal: `docs/use-cases/{use_case.uc_id}/e2e-goal.md`
+
+## 2. Expected Changed Files
+
+|Path|Change Type|Reason|Verification Method|
+|---|---|---|---|
+|Application source paths|create/update|Implement `{use_case.source_id}`|Repository test gate|
+
+## 3. Expected Test Files
+
+|Path|Test Target|Verification Rule|
+|---|---|---|
+|Application test paths|`{use_case.source_id}` behavior|Happy path and invalid input behavior pass|
+
+## 4. Documentation Files
+
+|Path|Reason|Approval Required|
+|---|---|---|
+|`docs/use-cases/{use_case.uc_id}/...`|Use-case execution slice|yes|
+
+## 5. Forbidden Files / Paths
+
+|Path|Reason|
+|---|---|
+|`docs/use-cases/<other-UC-ID>/`|Outside the active ChangeSet scope|
+|`docs/design/**`|Canonical changes require explicit ChangeSet approval|
+
+## 6. Scope Boundary
+
+### Included
+
+- Files needed to implement and verify `{use_case.source_id}`.
+
+### Excluded
+
+- Unaffected use-case docs and unrelated application behavior.
+
+## 7. Confirmation Needed
+
+- Replace broad application source and test path placeholders during implementation planning.
+"""
+
+
+def _write_documents(repo: Path, documents: dict[Path, str], *, force: bool) -> None:
+    conflicts = tuple(path for path in documents if (repo / path).exists())
+    if conflicts and not force:
+        joined = ", ".join(str(path) for path in conflicts)
+        raise DesignBridgeError(f"Refusing to overwrite existing generated documents: {joined}")
+
+    for relative_path, text in documents.items():
+        path = repo / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
+def _first_non_empty_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip().lstrip("#").strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _escape_table(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _escape_text(value: str) -> str:
+    return value.replace("\n", " ").strip()
+
+
+def _escape_fence(value: str) -> str:
+    return value.replace("```", "` ` `").strip()

--- a/harness_codex/runtime/changes/parser.py
+++ b/harness_codex/runtime/changes/parser.py
@@ -27,7 +27,7 @@ def parse_changeset_markdown(
 
     title = _first_heading(text)
     sections = _sections(text)
-    metadata = _parse_table(sections.get("1. 메타데이터", ""))
+    metadata = _parse_table(_section(sections, "1. 메타데이터", "1. Metadata"))
     before_after = _parse_table(sections.get("3. Before / After", ""))
 
     change_set_id = _strip_code(metadata.get("ChangeSet ID", ""))
@@ -35,18 +35,38 @@ def parse_changeset_markdown(
         change_set_id = path.stem
 
     affected_use_cases = _parse_affected_use_cases(
-        sections.get("5. 영향 유스케이스", "")
+        _section(
+            sections,
+            "5. 영향 유스케이스",
+            "5. Affected Use Cases",
+            "5. Affected use cases",
+        )
     )
     affected_maintenance_items = _parse_affected_maintenance_items(
-        sections.get("6. 영향 maintenance", "")
-        or sections.get("6. 영향 Maintenance", "")
-        or sections.get("6. 영향 유지보수", "")
-        or sections.get("5. 영향 maintenance", "")
+        _section(
+            sections,
+            "6. 영향 maintenance",
+            "6. 영향 Maintenance",
+            "6. 영향 유지보수",
+            "5. 영향 maintenance",
+            "6. Affected Maintenance",
+            "6. Affected maintenance",
+            "5. Affected Maintenance",
+            "5. Affected maintenance",
+        )
     )
     affected_work_items = _parse_affected_work_items(
-        sections.get("5. 영향 work items", "")
-        or sections.get("5. 영향 작업", "")
-        or sections.get("6. 영향 작업", "")
+        _section(
+            sections,
+            "5. 영향 Work Item",
+            "5. 영향 work items",
+            "5. 영향 작업",
+            "6. 영향 작업",
+            "6. Affected Work Items",
+            "6. Affected work items",
+            "5. Affected Work Items",
+            "5. Affected work items",
+        )
     )
 
     if not affected_work_items:
@@ -59,31 +79,43 @@ def parse_changeset_markdown(
         change_set_id=change_set_id,
         title=title,
         path=path,
-        status=metadata.get("상태", ""),
-        related_issue=metadata.get("관련 이슈/요청", ""),
-        intent_summary=_bullet_value(sections.get("2. 구현 의도", ""), "요청 요약"),
+        status=_first_value(metadata, "상태", "Status"),
+        related_issue=_first_value(metadata, "관련 이슈/요청", "Related issue/request"),
+        intent_summary=_bullet_value(
+            _section(sections, "2. 구현 의도", "2. Implementation Intent"),
+            "요청 요약",
+            "Request summary",
+        ),
         before_summary=before_after.get("Before", ""),
         after_summary=before_after.get("After", ""),
         changed_documents=_parse_changed_documents(
-            sections.get("4. 변경 문서", "")
+            _section(sections, "4. 변경 문서", "4. Changed Documents")
         ),
         affected_use_cases=affected_use_cases,
         affected_maintenance_items=affected_maintenance_items,
         affected_work_items=affected_work_items,
         planner_inputs=_parse_bulleted_paths(
-            sections.get("7. Planner 입력 범위", "")
+            _section(
+                sections,
+                "7. Planner 입력 범위",
+                "7. Planner Input Scope",
+                "8. Planner Input Scope",
+            )
         ),
         included_scope=_parse_bullets_after_heading(
-            sections.get("8. Scope Boundary", ""),
+            _section(sections, "8. Scope Boundary", "9. Scope Boundary"),
             "### 포함",
+            "### Included",
         ),
         excluded_scope=_parse_bullets_after_heading(
-            sections.get("8. Scope Boundary", ""),
+            _section(sections, "8. Scope Boundary", "9. Scope Boundary"),
             "### 제외",
+            "### Excluded",
         ),
         forbidden_changes=_parse_bullets_after_heading(
-            sections.get("8. Scope Boundary", ""),
+            _section(sections, "8. Scope Boundary", "9. Scope Boundary"),
             "### 금지 변경",
+            "### Forbidden Changes",
         ),
     )
 
@@ -107,6 +139,21 @@ def _sections(text: str) -> dict[str, str]:
     return sections
 
 
+def _section(sections: dict[str, str], *names: str) -> str:
+    for name in names:
+        if name in sections:
+            return sections[name]
+    return ""
+
+
+def _first_value(rows: dict[str, str], *names: str) -> str:
+    for name in names:
+        value = rows.get(name)
+        if value:
+            return value
+    return ""
+
+
 def _parse_table(section: str) -> dict[str, str]:
     rows: dict[str, str] = {}
 
@@ -128,8 +175,11 @@ def _table_rows(section: str) -> list[list[str]]:
         cells = [cell.strip() for cell in stripped.strip("|").split("|")]
         if cells and cells[0] not in {
             "항목",
+            "Item",
             "문서",
+            "Document",
             "UC ID",
+            "Use Case ID",
             "Maintenance ID",
             "MAINT ID",
             "Work Item ID",
@@ -252,8 +302,9 @@ def _parse_bulleted_paths(section: str) -> tuple[Path, ...]:
     return tuple(paths)
 
 
-def _parse_bullets_after_heading(section: str, heading: str) -> tuple[str, ...]:
-    if heading not in section:
+def _parse_bullets_after_heading(section: str, *headings: str) -> tuple[str, ...]:
+    heading = next((candidate for candidate in headings if candidate in section), "")
+    if not heading:
         return ()
 
     after_heading = section.split(heading, maxsplit=1)[1]
@@ -272,12 +323,13 @@ def _parse_bullets(section: str) -> list[str]:
     ]
 
 
-def _bullet_value(section: str, label: str) -> str:
-    prefix = f"- {label}:"
+def _bullet_value(section: str, *labels: str) -> str:
+    prefixes = tuple(f"- {label}:" for label in labels)
     for line in section.splitlines():
         stripped = line.strip()
-        if stripped.startswith(prefix):
-            return stripped.removeprefix(prefix).strip()
+        for prefix in prefixes:
+            if stripped.startswith(prefix):
+                return stripped.removeprefix(prefix).strip()
     return ""
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -61,6 +61,56 @@ def write_maintenance_changeset(repo: Path) -> None:
         (maint_dir / name).write_text(name, encoding="utf-8")
 
 
+def write_design_docs(repo: Path) -> None:
+    design_dir = repo / "docs/design"
+    design_dir.mkdir(parents=True)
+    (design_dir / "요구사항.md").write_text(
+        """# Requirements Specification
+
+## 1. Overview
+- Initial idea: simple calculator app
+- Goal: Let a user calculate arithmetic results.
+
+## 3. Functional Requirements
+### 3.1 Calculator Operations
+- FR-001. The system shall add, subtract, multiply, and divide numbers.
+- FR-002. The system shall reject invalid numeric input.
+- FR-003. The system shall reject division by zero.
+""",
+        encoding="utf-8",
+    )
+    (design_dir / "유스케이스.md").write_text(
+        """# Use Case Document
+
+## 1. Actor Definition
+### Primary Actor
+- User
+
+## 2. High-Level Use Case List
+### User
+- UC-01. User performs calculator operations
+
+## 3. Use Case Details
+## UC-01. User performs calculator operations
+**Actor**
+- User
+
+**Goal**
+- Calculate addition, subtraction, multiplication, and division results.
+
+**Basic Flow**
+1. The user enters two numbers and selects an operation.
+2. The system validates the inputs.
+3. The system displays the result.
+
+**Exception Flow**
+- Invalid numeric input is rejected.
+- Division by zero is rejected.
+""",
+        encoding="utf-8",
+    )
+
+
 def test_changes_list_outputs_active_changesets(tmp_path: Path, capsys) -> None:
     write_changeset(tmp_path)
 
@@ -81,6 +131,75 @@ def test_changes_show_outputs_affected_use_cases(tmp_path: Path, capsys) -> None
     assert exit_code == 0
     assert "Affected UC: UC-001" in output
     assert "Before: old" in output
+
+
+def test_changes_create_from_design_generates_runnable_slice(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    write_design_docs(tmp_path)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "create-from-design",
+            "--title",
+            "simple calculator app",
+            "--change-set-id",
+            "CHG-20260507-001",
+            "--related-issue",
+            "#77",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "CREATED: CHG-20260507-001" in output
+    assert "UC-001: User performs calculator operations" in output
+    assert (tmp_path / "docs/changes/active/CHG-20260507-001.md").is_file()
+    assert (tmp_path / "docs/use-cases/UC-001/use-case.md").is_file()
+    assert (tmp_path / "docs/use-cases/UC-001/event-storming.md").is_file()
+    assert (tmp_path / "docs/use-cases/UC-001/e2e-goal.md").is_file()
+    assert (tmp_path / "docs/use-cases/UC-001/affected-files.md").is_file()
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "run-use-case",
+            "CHG-20260507-001",
+            "UC-001",
+            "--preview",
+        ]
+    )
+
+    preview = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Mode: preview" in preview
+    assert "UC: UC-001" in preview
+    assert "docs/use-cases/UC-001/use-case.md" in preview
+
+
+def test_changes_create_from_design_reports_missing_design_doc(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "create-from-design",
+            "--title",
+            "simple calculator app",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Required design document not found" in captured.err
 
 
 def test_run_change_plan_has_no_side_effects(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## 구현 의도

Issue #77의 수확 문서와 런타임 실행 문서 사이의 수동 연결 단계를 제거합니다. `docs/design/요구사항.md`와 `docs/design/유스케이스.md`를 읽어 active ChangeSet과 affected use-case slice 문서를 생성하고, 생성된 ChangeSet을 기존 `run-use-case --preview` 흐름에서 바로 해석할 수 있게 합니다.

## 구현 방법

- `harness changes create-from-design` 명령을 추가했습니다.
- 새 런타임 브리지 모듈이 canonical design docs를 읽고 UC 항목을 `UC-001` 형태로 정규화한 뒤 `docs/changes/active/<CHG-ID>.md`와 `docs/use-cases/<UC-ID>/` 하위 slice 문서를 생성합니다.
- 기존 parser가 영어 ChangeSet 섹션도 읽도록 확장해서 `docs/` 영어 작성 규칙과 런타임 해석을 같이 만족시켰습니다.
- 기존 문서가 있으면 기본적으로 덮어쓰지 않고, 필요한 경우 `--force`로 명시적으로 재생성할 수 있게 했습니다.

## 검증 방법

- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py tests/runtime/test_changeset_parser.py tests/runtime/test_affected_use_case_resolver.py`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime tests/test_cli_commands.py`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s`

Closes #77
