### PR TITLE
[codex] ChangeSet-first runtime interface 및 쉘 자동완성 도입

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -38,7 +38,12 @@ from harness_codex.runtime.changes import (
     PlanningBlocked,
     create_changeset_from_design,
 )
-from harness_codex.runtime.workflows import load_named_workflow
+from harness_codex.runtime.workflows import (
+    WorkflowMaterializationError,
+    load_named_workflow,
+    materialize_workflow_for_scope,
+    write_materialized_workflow_manifest,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -48,7 +53,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         output = args.func(args, repo_root)
-    except (NoActiveChangeSetsError, DesignBridgeError) as exc:
+    except (NoActiveChangeSetsError, DesignBridgeError, WorkflowMaterializationError) as exc:
         print(str(exc), file=sys.stderr)
         return 2
 
@@ -83,6 +88,8 @@ def build_parser() -> argparse.ArgumentParser:
     changes_subparsers = changes.add_subparsers(required=True)
     changes_list = changes_subparsers.add_parser("list")
     changes_list.set_defaults(func=changes_list_command)
+    changes_active = changes_subparsers.add_parser("active")
+    changes_active.set_defaults(func=changes_active_command)
     changes_show = changes_subparsers.add_parser("show")
     changes_show.add_argument("change_set_id")
     changes_show.set_defaults(func=changes_show_command)
@@ -196,6 +203,14 @@ def changes_list_command(args: argparse.Namespace, repo_root: Path) -> str:
         f"{change_set.change_set_id}\t{change_set.status or '-'}\t{change_set.title}"
         for change_set in resolver.list_active()
     ]
+    return "\n".join(rows)
+
+
+def changes_active_command(args: argparse.Namespace, repo_root: Path) -> str:
+    resolver = ChangeSetResolver(repo_root)
+    rows: list[str] = []
+    for change_set in resolver.list_active():
+        rows.extend(_format_active_change_set(repo_root, resolver, change_set))
     return "\n".join(rows)
 
 
@@ -437,10 +452,44 @@ def _format_scopes(
                 *[f"- {path}" for path in scope.planner_inputs],
                 "Executor inputs:",
                 *[f"- {path}" for path in scope.executor_inputs],
+                f"Verification goal: {scope.verification_goal_path or '-'}",
             ]
         )
 
     return "\n".join(lines)
+
+
+def _format_active_change_set(
+    repo_root: Path,
+    resolver: ChangeSetResolver,
+    change_set: ChangeSet,
+) -> list[str]:
+    latest_run_id = _latest_run_id_for_change_set(repo_root, change_set.change_set_id)
+    blocked = resolver.validate_active_change_set(change_set)
+    scopes = resolver.resolve_work_item_scopes(change_set) if blocked is None else blocked
+    lines = [
+        f"ChangeSet: {change_set.change_set_id}",
+        f"Title: {change_set.title}",
+        f"Status: {change_set.status or 'active'}",
+        f"Path: {change_set.path or Path('docs/changes/active') / f'{change_set.change_set_id}.md'}",
+        f"Latest run: {latest_run_id or '-'}",
+    ]
+    if isinstance(scopes, PlanningBlocked):
+        lines.append(f"Runtime status: BLOCKED - {scopes.reason}")
+        return lines
+
+    lines.append("Runtime status: READY")
+    lines.append("Work items:")
+    for scope in scopes:
+        lines.extend(
+            [
+                f"- {scope.display_id} ({scope.work_item_type.value})",
+                f"  stage: {scope.current_stage}",
+                f"  plan: {scope.plan_path or '-'}",
+                f"  verification goal: {scope.verification_goal_path or '-'}",
+            ]
+        )
+    return lines
 
 
 def _format_harvest_plan(workflow, mode: RunMode, idea: str) -> str:
@@ -593,44 +642,68 @@ def _apply_workflow(
         "changeset-use-case-workflow",
         workflows_dir=workflow_dir,
     )
-    context = RunContext(
-        run_id=run_id,
-        workflow_name=workflow.name,
-        mode=RunMode.APPLY,
-        repo_root=repo_root,
-        workdir=repo_root,
-        run_dir=run_dir,
-        metadata={
-            "change_set_id": change_set.change_set_id,
-            "change_set_path": str(
-                change_set.path
-                or Path(f"docs/changes/active/{change_set.change_set_id}.md")
-            ),
-            "affected_work_items": [
-                {
-                    "id": scope.display_id,
-                    "type": scope.work_item_type.value,
-                    "plan_path": str(
-                        scope.plan_path
-                        or Path(f"docs/plans/active/{scope.display_id}/plan.md")
-                    ),
-                    "planner_inputs": [
-                        str(path) for path in scope.planner_inputs
-                    ],
-                    "executor_inputs": [
-                        str(path) for path in scope.executor_inputs
-                    ],
-                    "verification_goal_path": (
-                        str(scope.verification_goal_path)
-                        if scope.verification_goal_path
-                        else None
-                    ),
-                }
-                for scope in scopes
-            ],
-        },
-    )
-    result = RunnerEngine(BasicStepRunner()).run(workflow, context)
+
+    result_by_work_item = {}
+    final_result = None
+    for scope in scopes:
+        materialized_workflow = materialize_workflow_for_scope(workflow, change_set, scope)
+        write_materialized_workflow_manifest(
+            materialized_workflow,
+            run_dir / f"materialized-workflow-{scope.display_id}.json",
+        )
+        context = RunContext(
+            run_id=run_id,
+            workflow_name=materialized_workflow.name,
+            mode=RunMode.APPLY,
+            repo_root=repo_root,
+            workdir=repo_root,
+            run_dir=run_dir / scope.display_id,
+            metadata={
+                "change_set_id": change_set.change_set_id,
+                "change_set_path": str(
+                    change_set.path
+                    or Path(f"docs/changes/active/{change_set.change_set_id}.md")
+                ),
+                "active_work_item_id": scope.display_id,
+                "active_work_item_type": scope.work_item_type.value,
+                "active_plan_path": str(
+                    scope.plan_path
+                    or Path(f"docs/plans/active/{scope.display_id}/plan.md")
+                ),
+                "verification_goal_path": (
+                    str(scope.verification_goal_path)
+                    if scope.verification_goal_path
+                    else None
+                ),
+                "affected_work_items": [
+                    {
+                        "id": item.display_id,
+                        "type": item.work_item_type.value,
+                        "plan_path": str(
+                            item.plan_path
+                            or Path(f"docs/plans/active/{item.display_id}/plan.md")
+                        ),
+                        "planner_inputs": [str(path) for path in item.planner_inputs],
+                        "executor_inputs": [str(path) for path in item.executor_inputs],
+                        "verification_goal_path": (
+                            str(item.verification_goal_path)
+                            if item.verification_goal_path
+                            else None
+                        ),
+                    }
+                    for item in scopes
+                ],
+            },
+        )
+        scope_result = RunnerEngine(BasicStepRunner()).run(materialized_workflow, context)
+        result_by_work_item[scope.display_id] = scope_result
+        final_result = scope_result
+        if scope_result.status != RunStatus.SUCCEEDED:
+            break
+
+    if final_result is None:
+        raise RuntimeError("workflow execution requires at least one ChangeSet work item")
+
     state = RunState(
         run_id=run_id,
         change_set_id=change_set.change_set_id,
@@ -640,16 +713,16 @@ def _apply_workflow(
         affected_work_items=affected_work_items,
         current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
         current_work_item_id=affected_work_items[0] if affected_work_items else None,
-        status=result.status,
+        status=final_result.status,
         work_item_states=tuple(
             WorkItemLoopState(
                 work_item_id=scope.display_id,
                 work_item_type=scope.work_item_type,
                 active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.display_id}/plan.md"),
-                status=result.status,
+                status=result_by_work_item.get(scope.display_id, final_result).status,
                 current_step_id=scope.current_stage,
-                verification_status=result.status.value,
-                blocker=result.blocker,
+                verification_status=result_by_work_item.get(scope.display_id, final_result).status.value,
+                blocker=result_by_work_item.get(scope.display_id, final_result).blocker,
             )
             for scope in scopes
         ),
@@ -657,13 +730,13 @@ def _apply_workflow(
             UseCaseLoopState(
                 uc_id=scope.use_case.uc_id,
                 active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.use_case.uc_id}/plan.md"),
-                status=result.status,
-                blocker=result.blocker,
+                status=result_by_work_item.get(scope.display_id, final_result).status,
+                blocker=result_by_work_item.get(scope.display_id, final_result).blocker,
             )
             for scope in scopes
             if scope.use_case is not None
         ),
-        failed_step_id=result.failed_step_id,
+        failed_step_id=final_result.failed_step_id,
     )
     RunStateStore(repo_root).save(state)
     ReportWriter(repo_root).write(
@@ -672,7 +745,7 @@ def _apply_workflow(
             change_set_id=change_set.change_set_id,
             workflow_name=workflow.name,
             mode=RunMode.APPLY,
-            status=result.status,
+            status=final_result.status,
             affected_use_cases=affected_use_cases,
             current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
             work_item_reports=tuple(
@@ -680,17 +753,17 @@ def _apply_workflow(
                     work_item_id=scope.display_id,
                     work_item_type=scope.work_item_type,
                     active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.display_id}/plan.md"),
-                    status=result.status,
+                    status=result_by_work_item.get(scope.display_id, final_result).status,
                     current_stage=scope.current_stage,
                     verification_goal_path=scope.verification_goal_path,
-                    blocker=result.blocker,
-                    verification_result=result.status.value,
+                    blocker=result_by_work_item.get(scope.display_id, final_result).blocker,
+                    verification_result=result_by_work_item.get(scope.display_id, final_result).status.value,
                 )
                 for scope in scopes
             ),
         )
     )
-    return state, result
+    return state, final_result
 
 
 def _latest_run_id_for_change_set(repo_root: Path, change_set_id: str) -> str | None:

--- a/harness_codex/runtime/changes/resolver.py
+++ b/harness_codex/runtime/changes/resolver.py
@@ -44,17 +44,94 @@ class ChangeSetResolver:
         relative_path = change_set_path.relative_to(self.repo_root)
         return parse_changeset_markdown(text, path=relative_path)
 
-    def resolve_planning_scopes(
+    def validate_active_change_set(
         self,
         change_set: ChangeSet,
-    ) -> tuple[PlanningInputScope, ...] | PlanningBlocked:
+    ) -> PlanningBlocked | None:
+        """Validate the ChangeSet-first runtime contract before execution."""
+
+        change_set_path = change_set.path or Path(
+            f"docs/changes/active/{change_set.change_set_id}.md"
+        )
+        expected_path = Path("docs/changes/active") / f"{change_set.change_set_id}.md"
+        if not (self.repo_root / change_set_path).exists():
+            return PlanningBlocked(
+                change_set_id=change_set.change_set_id,
+                reason=f"Active ChangeSet file does not exist: {change_set_path}",
+            )
+        if change_set_path != expected_path:
+            return PlanningBlocked(
+                change_set_id=change_set.change_set_id,
+                reason=(
+                    "ChangeSet ID and active path do not match: "
+                    f"id={change_set.change_set_id} path={change_set_path}"
+                ),
+            )
+
         work_items = change_set.ordered_work_items()
         if not work_items:
             return PlanningBlocked(
                 change_set_id=change_set.change_set_id,
-                reason="ChangeSet has no affected use cases",
+                reason="ChangeSet has no affected work items",
             )
 
+        for work_item in work_items:
+            if not (self.repo_root / work_item.slice_path).exists():
+                return PlanningBlocked(
+                    change_set_id=change_set.change_set_id,
+                    reason=(
+                        f"Work item {work_item.work_item_id} slice path does not exist: "
+                        f"{work_item.slice_path}"
+                    ),
+                )
+
+            if work_item.work_item_type == WorkItemType.USE_CASE:
+                use_case = _find_use_case(change_set, work_item.work_item_id)
+                if use_case is None:
+                    return PlanningBlocked(
+                        change_set_id=change_set.change_set_id,
+                        reason=(
+                            f"Use case work item {work_item.work_item_id} "
+                            "has no affected use-case row"
+                        ),
+                    )
+                missing = _missing_use_case_documents(
+                    self.repo_root,
+                    use_case.slice_path,
+                )
+                if missing:
+                    return PlanningBlocked(
+                        change_set_id=change_set.change_set_id,
+                        reason=(
+                            f"Use case work item {work_item.work_item_id} "
+                            "is missing required documents: "
+                            + ", ".join(str(path) for path in missing)
+                        ),
+                    )
+                continue
+
+            missing = _missing_maintenance_documents(self.repo_root, work_item.slice_path)
+            if missing:
+                return PlanningBlocked(
+                    change_set_id=change_set.change_set_id,
+                    reason=(
+                        f"Maintenance work item {work_item.work_item_id} "
+                        "is missing required documents: "
+                        + ", ".join(str(path) for path in missing)
+                    ),
+                )
+
+        return None
+
+    def resolve_planning_scopes(
+        self,
+        change_set: ChangeSet,
+    ) -> tuple[PlanningInputScope, ...] | PlanningBlocked:
+        blocked = self.validate_active_change_set(change_set)
+        if blocked is not None:
+            return blocked
+
+        work_items = change_set.ordered_work_items()
         change_set_path = change_set.path or Path(
             f"docs/changes/active/{change_set.change_set_id}.md"
         )
@@ -76,16 +153,6 @@ class ChangeSetResolver:
                 )
                 continue
 
-            blocked = _missing_maintenance_documents(self.repo_root, work_item.slice_path)
-            if blocked:
-                return PlanningBlocked(
-                    change_set_id=change_set.change_set_id,
-                    reason=(
-                        f"Maintenance work item {work_item.work_item_id} "
-                        f"is missing required documents: {', '.join(str(path) for path in blocked)}"
-                    ),
-                )
-
             scopes.append(
                 _maintenance_scope(
                     repo_root=self.repo_root,
@@ -96,7 +163,6 @@ class ChangeSetResolver:
             )
 
         return tuple(scopes)
-
 
     def resolve_work_item_scopes(
         self,
@@ -196,6 +262,17 @@ def _maintenance_scope(
         plan_path=plan_path,
         verification_goal_path=slice_path / "verification-goal.md",
     )
+
+
+def _missing_use_case_documents(
+    repo_root: Path,
+    slice_path: Path,
+) -> tuple[Path, ...]:
+    required = (
+        slice_path / "use-case.md",
+        slice_path / "e2e-goal.md",
+    )
+    return tuple(path for path in required if not (repo_root / path).exists())
 
 
 def _missing_maintenance_documents(

--- a/harness_codex/runtime/workflows/__init__.py
+++ b/harness_codex/runtime/workflows/__init__.py
@@ -1,4 +1,4 @@
-"""Workflow YAML loading and validation."""
+"""Workflow YAML loading, validation, and materialization."""
 
 from harness_codex.runtime.workflows.loader import (
     DEFAULT_WORKFLOW_DIR,
@@ -6,12 +6,24 @@ from harness_codex.runtime.workflows.loader import (
     load_named_workflow,
     load_workflow_text,
 )
+from harness_codex.runtime.workflows.materializer import (
+    WorkflowMaterializationError,
+    materialization_replacements,
+    materialize_workflow_for_scope,
+    unresolved_placeholders,
+    write_materialized_workflow_manifest,
+)
 from harness_codex.runtime.workflows.schema import WorkflowSchemaError
 
 __all__ = [
     "DEFAULT_WORKFLOW_DIR",
+    "WorkflowMaterializationError",
     "WorkflowSchemaError",
     "load_named_workflow",
     "load_workflow_file",
     "load_workflow_text",
+    "materialization_replacements",
+    "materialize_workflow_for_scope",
+    "unresolved_placeholders",
+    "write_materialized_workflow_manifest",
 ]

--- a/harness_codex/runtime/workflows/materializer.py
+++ b/harness_codex/runtime/workflows/materializer.py
@@ -1,0 +1,197 @@
+"""Materialize workflow placeholders from ChangeSet work item scope."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from harness_codex.runtime.changes.models import (
+    ChangeSet,
+    PlanningInputScope,
+    WorkItemType,
+)
+from harness_codex.runtime.models import Step, Workflow
+
+_PLACEHOLDER_PATTERN = re.compile(r"<[A-Z][A-Z0-9_-]*>")
+
+
+class WorkflowMaterializationError(ValueError):
+    """Raised when a workflow still contains unresolved placeholders."""
+
+
+def materialize_workflow_for_scope(
+    workflow: Workflow,
+    change_set: ChangeSet,
+    scope: PlanningInputScope,
+) -> Workflow:
+    """Return a workflow whose placeholders are bound to one ChangeSet work item."""
+
+    replacements = materialization_replacements(change_set, scope)
+    steps = tuple(_materialize_step(step, replacements) for step in workflow.steps)
+    materialized = replace(
+        workflow,
+        steps=steps,
+        metadata={
+            **dict(workflow.metadata),
+            "materialized": True,
+            "change_set_id": change_set.change_set_id,
+            "work_item_id": scope.display_id,
+            "work_item_type": scope.work_item_type.value,
+            "replacements": replacements,
+        },
+    )
+    unresolved = unresolved_placeholders(materialized)
+    if unresolved:
+        raise WorkflowMaterializationError(
+            "unresolved workflow placeholders: " + ", ".join(sorted(unresolved))
+        )
+    return materialized
+
+
+def materialization_replacements(
+    change_set: ChangeSet,
+    scope: PlanningInputScope,
+) -> dict[str, str]:
+    """Return placeholder replacement values for a ChangeSet work item scope."""
+
+    uc_id = scope.use_case.uc_id if scope.use_case is not None else ""
+    maint_id = scope.display_id if scope.work_item_type == WorkItemType.MAINTENANCE else ""
+    return {
+        "<CHG-ID>": change_set.change_set_id,
+        "<UC-ID>": uc_id,
+        "<MAINT-ID>": maint_id,
+        "<WORK-ITEM-ID>": scope.display_id,
+    }
+
+
+def unresolved_placeholders(workflow: Workflow) -> frozenset[str]:
+    """Return placeholders still present in materialized workflow fields."""
+
+    values: list[str] = [workflow.name]
+    if workflow.description:
+        values.append(workflow.description)
+    for step in workflow.steps:
+        values.extend(
+            value
+            for value in (
+                step.id,
+                step.name,
+                step.agent_id or "",
+                step.skill_id or "",
+                step.command or "",
+            )
+            if value
+        )
+        values.extend(str(path) for path in step.inputs)
+        values.extend(str(path) for path in step.outputs)
+        values.extend(_metadata_strings(step.metadata))
+    return frozenset(
+        placeholder
+        for value in values
+        for placeholder in _PLACEHOLDER_PATTERN.findall(value)
+    )
+
+
+def write_materialized_workflow_manifest(
+    workflow: Workflow,
+    path: Path,
+) -> None:
+    """Write a compact materialized workflow manifest for run auditing."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_workflow_manifest(workflow), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _materialize_step(step: Step, replacements: dict[str, str]) -> Step:
+    return replace(
+        step,
+        id=_replace_text(step.id, replacements),
+        name=_replace_text(step.name, replacements),
+        needs=tuple(_replace_text(need, replacements) for need in step.needs),
+        agent_id=_replace_optional_text(step.agent_id, replacements),
+        skill_id=_replace_optional_text(step.skill_id, replacements),
+        command=_replace_optional_text(step.command, replacements),
+        inputs=tuple(_replace_path(path, replacements) for path in step.inputs),
+        outputs=tuple(_replace_path(path, replacements) for path in step.outputs),
+        metadata=_replace_metadata(step.metadata, replacements),
+    )
+
+
+def _replace_optional_text(value: str | None, replacements: dict[str, str]) -> str | None:
+    if value is None:
+        return None
+    return _replace_text(value, replacements)
+
+
+def _replace_path(path: Path, replacements: dict[str, str]) -> Path:
+    return Path(_replace_text(str(path), replacements))
+
+
+def _replace_text(value: str, replacements: dict[str, str]) -> str:
+    result = value
+    for placeholder, replacement in replacements.items():
+        result = result.replace(placeholder, replacement)
+    return result
+
+
+def _replace_metadata(value: Any, replacements: dict[str, str]) -> Any:
+    if isinstance(value, str):
+        return _replace_text(value, replacements)
+    if isinstance(value, Path):
+        return _replace_path(value, replacements)
+    if isinstance(value, tuple):
+        return tuple(_replace_metadata(item, replacements) for item in value)
+    if isinstance(value, list):
+        return [_replace_metadata(item, replacements) for item in value]
+    if isinstance(value, dict):
+        return {
+            _replace_text(str(key), replacements): _replace_metadata(item, replacements)
+            for key, item in value.items()
+        }
+    return value
+
+
+def _metadata_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Path):
+        return [str(value)]
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for key, item in value.items():
+            strings.append(str(key))
+            strings.extend(_metadata_strings(item))
+        return strings
+    if isinstance(value, (list, tuple)):
+        strings: list[str] = []
+        for item in value:
+            strings.extend(_metadata_strings(item))
+        return strings
+    return []
+
+
+def _workflow_manifest(workflow: Workflow) -> dict[str, Any]:
+    return {
+        "name": workflow.name,
+        "mode": workflow.mode.value,
+        "metadata": dict(workflow.metadata),
+        "steps": [
+            {
+                "id": step.id,
+                "kind": step.kind.value,
+                "agent_id": step.agent_id,
+                "skill_id": step.skill_id,
+                "command": step.command,
+                "needs": list(step.needs),
+                "inputs": [str(path) for path in step.inputs],
+                "outputs": [str(path) for path in step.outputs],
+            }
+            for step in workflow.steps
+        ],
+    }

--- a/tests/runtime/test_affected_use_case_resolver.py
+++ b/tests/runtime/test_affected_use_case_resolver.py
@@ -19,6 +19,13 @@ def write_changeset(tmp_path: Path, body: str) -> Path:
     return path
 
 
+def write_use_case_slice(tmp_path: Path, uc_id: str = "UC-001") -> None:
+    slice_dir = tmp_path / "docs/use-cases" / uc_id
+    slice_dir.mkdir(parents=True)
+    (slice_dir / "use-case.md").write_text("# use case\n", encoding="utf-8")
+    (slice_dir / "e2e-goal.md").write_text("# e2e goal\n", encoding="utf-8")
+
+
 CHANGESET = """# ChangeSet CHG-001
 
 ## 1. 메타데이터
@@ -62,6 +69,7 @@ def test_resolver_raises_when_no_active_changeset(tmp_path: Path) -> None:
 
 def test_resolver_builds_per_use_case_planning_scope(tmp_path: Path) -> None:
     path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(tmp_path)
     resolver = ChangeSetResolver(tmp_path)
     change_set = resolver.load(path)
 
@@ -77,15 +85,34 @@ def test_resolver_builds_per_use_case_planning_scope(tmp_path: Path) -> None:
     assert scope.e2e_goal_path == Path("docs/use-cases/UC-001/e2e-goal.md")
 
 
-def test_resolver_blocks_when_no_affected_use_cases() -> None:
-    resolver = ChangeSetResolver(Path("/repo"))
+def test_resolver_blocks_when_no_affected_work_items(tmp_path: Path) -> None:
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    change_set_path = active_dir / "CHG-EMPTY.md"
+    change_set_path.write_text("# ChangeSet CHG-EMPTY\n", encoding="utf-8")
+    resolver = ChangeSetResolver(tmp_path)
 
     result = resolver.resolve_planning_scopes(
-        ChangeSet(change_set_id="CHG-EMPTY", title="empty")
+        ChangeSet(
+            change_set_id="CHG-EMPTY",
+            title="empty",
+            path=Path("docs/changes/active/CHG-EMPTY.md"),
+        )
     )
 
     assert isinstance(result, PlanningBlocked)
-    assert result.reason == "ChangeSet has no affected use cases"
+    assert result.reason == "ChangeSet has no affected work items"
+
+
+def test_resolver_blocks_missing_use_case_documents(tmp_path: Path) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    (tmp_path / "docs/use-cases/UC-001").mkdir(parents=True)
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "Use case work item UC-001 is missing required documents" in result.reason
 
 
 def test_resolver_builds_maintenance_planning_scope(tmp_path: Path) -> None:

--- a/tests/runtime/test_workflow_materializer.py
+++ b/tests/runtime/test_workflow_materializer.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import pytest
+
+from harness_codex.runtime.changes.models import (
+    AffectedUseCase,
+    ChangeSet,
+    PlanningInputScope,
+    WorkItemType,
+)
+from harness_codex.runtime.models import RunMode, Step, StepKind, Workflow
+from harness_codex.runtime.workflows import (
+    WorkflowMaterializationError,
+    materialize_workflow_for_scope,
+    unresolved_placeholders,
+)
+
+
+def test_materialize_workflow_for_use_case_scope_replaces_paths_and_metadata() -> None:
+    workflow = Workflow(
+        name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="plan-<WORK-ITEM-ID>",
+                kind=StepKind.AGENT,
+                name="Plan <UC-ID>",
+                agent_id="implementation_planner",
+                inputs=(Path("docs/changes/active/<CHG-ID>.md"),),
+                outputs=(Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),),
+                metadata={"uc": "<UC-ID>", "items": ["<WORK-ITEM-ID>"]},
+            ),
+        ),
+    )
+    change_set = ChangeSet(
+        change_set_id="CHG-001",
+        title="ChangeSet-first runtime",
+        path=Path("docs/changes/active/CHG-001.md"),
+    )
+    use_case = AffectedUseCase(
+        uc_id="UC-001",
+        name="결제 승인",
+        impact_type="update",
+        slice_path=Path("docs/use-cases/UC-001"),
+    )
+    scope = PlanningInputScope(
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        use_case=use_case,
+        planner_inputs=(),
+        executor_inputs=(),
+        e2e_goal_path=Path("docs/use-cases/UC-001/e2e-goal.md"),
+        work_item_id="UC-001",
+        work_item_type=WorkItemType.USE_CASE,
+        plan_path=Path("docs/plans/active/UC-001/plan.md"),
+    )
+
+    materialized = materialize_workflow_for_scope(workflow, change_set, scope)
+
+    assert materialized.metadata["materialized"] is True
+    assert materialized.metadata["change_set_id"] == "CHG-001"
+    assert materialized.metadata["work_item_id"] == "UC-001"
+    step = materialized.steps[0]
+    assert step.id == "plan-UC-001"
+    assert step.name == "Plan UC-001"
+    assert step.inputs == (Path("docs/changes/active/CHG-001.md"),)
+    assert step.outputs == (Path("docs/plans/active/UC-001/plan.md"),)
+    assert step.metadata["uc"] == "UC-001"
+    assert step.metadata["items"] == ["UC-001"]
+    assert unresolved_placeholders(materialized) == frozenset()
+
+
+def test_materialize_workflow_blocks_unresolved_placeholders() -> None:
+    workflow = Workflow(
+        name="workflow",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="plan",
+                kind=StepKind.AGENT,
+                name="Plan <UNKNOWN-ID>",
+                agent_id="implementation_planner",
+            ),
+        ),
+    )
+    change_set = ChangeSet(change_set_id="CHG-001", title="title")
+    scope = PlanningInputScope(
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        use_case=None,
+        planner_inputs=(),
+        executor_inputs=(),
+        e2e_goal_path=None,
+        work_item_id="MAINT-001",
+        work_item_type=WorkItemType.MAINTENANCE,
+    )
+
+    with pytest.raises(WorkflowMaterializationError) as exc:
+        materialize_workflow_for_scope(workflow, change_set, scope)
+
+    assert "<UNKNOWN-ID>" in str(exc.value)


### PR DESCRIPTION
## 구현 의도

Issue #80의 첫 개선 단위로 ChangeSet을 runtime 작업 흐름의 최상위 컨텍스트로 다루도록 정리한다.

이번 PR은 전체 자동 remediation/completion까지 한 번에 끝내기보다, ChangeSet-first 실행 계약의 기반이 되는 다음 부분을 우선 구현한다.

- active ChangeSet 조회 인터페이스 추가
- ChangeSet/work item 유효성 gate 추가
- workflow YAML placeholder를 ChangeSet/work item 기준으로 materialize
- materialized workflow manifest 기록
- `change_set_id`, `uc_id`, `work_item_id`, `run_id`, `stage` 입력을 위한 Bash/Zsh 자동완성 추가
- 관련 runtime 테스트 및 사용 문서 추가

## 구현 방법

### 1. `changes active` CLI 추가

```bash
python3 -m harness_codex changes active
```

출력 내용:

- ChangeSet ID
- title/status/path
- latest run id
- runtime readiness
- affected work item 목록
- 각 work item의 plan path / verification goal path

### 2. ChangeSet validation gate 추가

`ChangeSetResolver.validate_active_change_set()`를 추가했다.

검증 항목:

- `docs/changes/active/<CHG-ID>.md` 존재 여부
- ChangeSet ID와 active file path 일치 여부
- affected work item 존재 여부
- work item slice path 존재 여부
- use case work item 필수 문서 존재 여부
  - `use-case.md`
  - `e2e-goal.md`
- maintenance work item 필수 문서 존재 여부
  - `change-intent.md`
  - `affected-files.md`
  - `verification-goal.md`

`resolve_planning_scopes()`는 이제 planning scope를 만들기 전에 이 gate를 통과해야 한다.

### 3. workflow materializer 추가

신규 모듈:

```text
harness_codex/runtime/workflows/materializer.py
```

역할:

- `<CHG-ID>`
- `<UC-ID>`
- `<MAINT-ID>`
- `<WORK-ITEM-ID>`

위 placeholder를 ChangeSet + selected work item scope 기준으로 concrete path/value로 치환한다.

치환되지 않은 placeholder가 남으면 `WorkflowMaterializationError`로 실행을 차단한다.

### 4. runtime workflow 실행 연결

`_apply_workflow()`에서 selected scope별로 workflow를 materialize한 뒤 실행한다.

각 materialized workflow는 다음 artifact로 기록된다.

```text
.harness/runs/<RUN-ID>/materialized-workflow-<WORK-ITEM-ID>.json
```

### 5. 런타임 쉘 자동완성 추가

신규 파일:

```text
scripts/harness-completion.bash
scripts/harness-completion.zsh
docs/runtime-shell-completion.md
```

자동완성은 리포지토리 파일 시스템을 직접 탐색한다.

- ChangeSet ID: `docs/changes/active/*.md`, `docs/changes/completed/*.md`
- UC ID: `docs/use-cases/*` 또는 선택된 ChangeSet 문서의 `UC-*` 토큰
- Maintenance ID: `docs/maintenance/*` 또는 선택된 ChangeSet 문서의 `MAINT-*` 토큰
- Work item ID: UC ID + Maintenance ID + `docs/plans/{active,completed}/*`
- Run ID: `.harness/runs/*`
- Stage ID: 기본 runtime stage + `.harness/stages/<CHG-ID>/*.md`

`--repo-root`를 먼저 입력한 경우, 해당 경로를 기준으로 후보를 만든다.

예시:

```bash
harness --repo-root ../some-repo run-use-case <TAB>
harness run-use-case CHG-20260507-001 <TAB>
harness run-work-item CHG-20260507-001 <TAB>
harness resume <TAB>
```

## 검증 방법

추가/수정한 테스트:

- `tests/runtime/test_affected_use_case_resolver.py`
  - active ChangeSet 조회
  - ChangeSet에 affected work item이 없을 때 BLOCKED
  - use case 필수 slice 문서 누락 시 BLOCKED
  - maintenance 필수 문서 누락 시 BLOCKED
- `tests/runtime/test_workflow_materializer.py`
  - ChangeSet/work item 기준 placeholder 치환
  - unresolved placeholder 존재 시 실행 차단

쉘 자동완성은 다음 기준으로 수동 확인하면 된다.

```bash
source scripts/harness-completion.bash
harness run-change <TAB>
harness run-use-case <CHG-ID> <TAB>
harness run-work-item <CHG-ID> <TAB>
harness resume <TAB>
```

현재 이 작업은 GitHub 커넥터로 파일을 갱신한 것이어서, 최신 커밋 기준 로컬 pytest와 쉘 자동완성 실기동은 아직 실행하지 않았다. 병합 전 로컬 또는 CI에서 다음 명령으로 확인이 필요하다.

```bash
./venv/bin/python3 -m pytest -q tests/runtime tests/test_cli_commands.py
bash -n scripts/harness-completion.bash
```

## 관련 이슈

Closes #80