### PR TITLE
[codex] Agent provider 설정 확장

### DIFF
--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -37,6 +37,7 @@ from harness_codex.runtime.runner import (
     AgentRunResult,
     BasicStepRunner,
     CodexCliAgentAdapter,
+    ConfigurableCliAgentAdapter,
     StepRunner,
 )
 from harness_codex.runtime.agent_context import (
@@ -81,6 +82,7 @@ __all__ = [
     "CommandRequest",
     "BasicStepRunner",
     "CodexCliAgentAdapter",
+    "ConfigurableCliAgentAdapter",
     "ExecutionPlan",
     "FailureKind",
     "HARNESS_FULL_WORKFLOW",

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -1,7 +1,7 @@
 """Step runner boundary for runtime execution.
 
 `StepRunner` is the adapter boundary between the pure runtime engine and
-side-effecting implementations such as Codex, shell, git, and validators.
+side-effecting implementations such as agent CLIs, shell, git, and validators.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 import tomllib
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Protocol
+from typing import Any, Mapping, Protocol, Sequence
 from pathlib import Path
 
 from harness_codex.runtime.models import (
@@ -26,7 +26,7 @@ from harness_codex.runtime.models import (
 
 @dataclass(frozen=True)
 class AgentRunRequest:
-    """Codex 전담 에이전트 호출에 필요한 입력."""
+    """전담 에이전트 호출에 필요한 입력."""
 
     step: Step
     context: RunContext
@@ -39,7 +39,7 @@ class AgentRunRequest:
 
 @dataclass(frozen=True)
 class AgentRunResult:
-    """Codex 전담 에이전트 호출 결과."""
+    """전담 에이전트 호출 결과."""
 
     status: StepStatus
     exit_code: int | None = None
@@ -58,7 +58,7 @@ class AgentAdapter(Protocol):
 class StepRunner(Protocol):
     """Adapter interface used by `RunnerEngine` to execute one step.
 
-    Implementations may call Codex, shell, git, validators, or fake test doubles.
+    Implementations may call agent CLIs, shell, git, validators, or fake test doubles.
 
     The engine depends only on this protocol and never performs those side
     effects directly.
@@ -69,8 +69,12 @@ class StepRunner(Protocol):
         ...
 
 
-class CodexCliAgentAdapter:
-    """`.codex/agents/*.toml` 설정으로 `codex exec`를 실행한다."""
+class ConfigurableCliAgentAdapter:
+    """Run agent steps through the provider configured in `.codex/agents/*.toml`.
+
+    Backward compatibility rule:
+    - when `provider` is omitted, use the existing Codex CLI command shape.
+    """
 
     def __init__(self, codex_binary: str = "codex") -> None:
         self._codex_binary = codex_binary
@@ -80,9 +84,24 @@ class CodexCliAgentAdapter:
         final_message_path = request.step_dir / "final-message.md"
         command_path = request.step_dir / "command.json"
 
-        prompt_path.write_text(_agent_prompt(request), encoding="utf-8")
+        prompt = _agent_prompt(request)
+        prompt_path.write_text(prompt, encoding="utf-8")
 
-        command = self._command(request, final_message_path)
+        provider_result = _resolve_provider_command(
+            request,
+            final_message_path,
+            default_codex_binary=self._codex_binary,
+        )
+        if isinstance(provider_result, AgentRunResult):
+            (request.step_dir / "stdout.txt").write_text("", encoding="utf-8")
+            (request.step_dir / "stderr.txt").write_text(
+                provider_result.error or "",
+                encoding="utf-8",
+            )
+            command_path.write_text("[]\n", encoding="utf-8")
+            return provider_result
+
+        command, provider_metadata = provider_result
         command_path.write_text(
             json.dumps(command, ensure_ascii=False, indent=2) + "\n",
             encoding="utf-8",
@@ -92,25 +111,30 @@ class CodexCliAgentAdapter:
             completed = subprocess.run(
                 command,
                 cwd=request.context.workdir,
-                input=prompt_path.read_text(encoding="utf-8"),
+                input=prompt,
                 text=True,
                 capture_output=True,
                 timeout=request.step.timeout_sec,
                 check=False,
             )
         except FileNotFoundError as exc:
-            error = f"codex binary not found: {self._codex_binary}"
+            binary = command[0] if command else "<empty>"
+            provider = provider_metadata["provider"]
+            error = f"agent provider binary not found: provider={provider} binary={binary}"
             (request.step_dir / "stdout.txt").write_text("", encoding="utf-8")
             (request.step_dir / "stderr.txt").write_text(error, encoding="utf-8")
             return AgentRunResult(
                 status=StepStatus.BLOCKED,
                 error=error,
-                metadata=_agent_metadata(
-                    request,
-                    prompt_path,
-                    final_message_path,
-                    error=str(exc),
-                ),
+                metadata={
+                    **_agent_metadata(
+                        request,
+                        prompt_path,
+                        final_message_path,
+                        error=str(exc),
+                    ),
+                    **provider_metadata,
+                },
             )
         except subprocess.TimeoutExpired as exc:
             stdout = _decode_process_output(exc.stdout)
@@ -124,13 +148,17 @@ class CodexCliAgentAdapter:
             return AgentRunResult(
                 status=StepStatus.FAILED,
                 error=error,
-                metadata=_agent_metadata(
-                    request,
-                    prompt_path,
-                    final_message_path,
-                    error=str(exc),
-                ),
+                metadata={
+                    **_agent_metadata(
+                        request,
+                        prompt_path,
+                        final_message_path,
+                        error=str(exc),
+                    ),
+                    **provider_metadata,
+                },
             )
+
         (request.step_dir / "stdout.txt").write_text(
             completed.stdout,
             encoding="utf-8",
@@ -139,6 +167,8 @@ class CodexCliAgentAdapter:
             completed.stderr,
             encoding="utf-8",
         )
+        if provider_metadata["provider"] == "custom_cli":
+            final_message_path.write_text(completed.stdout, encoding="utf-8")
 
         if completed.returncode != 0:
             error = completed.stderr.strip() or completed.stdout.strip()
@@ -148,59 +178,43 @@ class CodexCliAgentAdapter:
                     status=StepStatus.BLOCKED,
                     exit_code=completed.returncode,
                     error=blocker,
-                    metadata=_agent_metadata(request, prompt_path, final_message_path),
+                    metadata={
+                        **_agent_metadata(request, prompt_path, final_message_path),
+                        **provider_metadata,
+                    },
                 )
             return AgentRunResult(
                 status=StepStatus.FAILED,
                 exit_code=completed.returncode,
                 error=error,
-                metadata=_agent_metadata(request, prompt_path, final_message_path),
+                metadata={
+                    **_agent_metadata(request, prompt_path, final_message_path),
+                    **provider_metadata,
+                },
             )
 
         return AgentRunResult(
             status=StepStatus.SUCCEEDED,
             exit_code=0,
-            metadata=_agent_metadata(request, prompt_path, final_message_path),
+            metadata={
+                **_agent_metadata(request, prompt_path, final_message_path),
+                **provider_metadata,
+            },
         )
 
-    def _command(
-        self,
-        request: AgentRunRequest,
-        final_message_path: Path,
-    ) -> list[str]:
-        config = request.agent_config
-        command = [
-            self._codex_binary,
-            "exec",
-            "--cd",
-            str(request.context.workdir),
-            "-c",
-            'approval_policy="never"',
-            "--output-last-message",
-            str(final_message_path),
-        ]
 
-        model = config.get("model")
-        if isinstance(model, str) and model:
-            command.extend(["--model", model])
+class CodexCliAgentAdapter(ConfigurableCliAgentAdapter):
+    """Backward-compatible Codex adapter name.
 
-        reasoning_effort = config.get("model_reasoning_effort")
-        if isinstance(reasoning_effort, str) and reasoning_effort:
-            command.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
-
-        sandbox_mode = config.get("sandbox_mode")
-        if isinstance(sandbox_mode, str) and sandbox_mode:
-            command.extend(["--sandbox", sandbox_mode])
-
-        command.append("-")
-        return command
+    The adapter is now provider-aware. Omitted `provider` still means `codex`.
+    """
 
 
 class BasicStepRunner:
     """Local MVP adapter for record/shell/validator/git steps."""
 
     def __init__(self, agent_adapter: AgentAdapter | None = None) -> None:
-        self._agent_adapter = agent_adapter or CodexCliAgentAdapter()
+        self._agent_adapter = agent_adapter or ConfigurableCliAgentAdapter()
 
     def run(self, step: Step, context: RunContext) -> StepResult:
         step_dir = context.run_dir / "steps" / step.id
@@ -425,6 +439,108 @@ def _relative_to_repo(path: Path, context: RunContext) -> Path:
 def _load_agent_config(path: Path) -> Mapping[str, Any]:
     with path.open("rb") as file:
         return tomllib.load(file)
+
+
+def _resolve_provider_command(
+    request: AgentRunRequest,
+    final_message_path: Path,
+    *,
+    default_codex_binary: str,
+) -> tuple[list[str], dict[str, Any]] | AgentRunResult:
+    config = request.agent_config
+    provider = config.get("provider", "codex")
+    if not isinstance(provider, str) or not provider.strip():
+        return _blocked_provider_result(request, "agent provider must be a non-empty string")
+
+    provider = provider.strip()
+    if provider == "codex":
+        binary = config.get("provider_binary", default_codex_binary)
+        if not isinstance(binary, str) or not binary.strip():
+            return _blocked_provider_result(
+                request,
+                "codex provider_binary must be a non-empty string",
+                provider=provider,
+            )
+        command = _codex_command(request, final_message_path, binary.strip())
+        return command, {"provider": provider, "provider_command": command}
+
+    if provider == "custom_cli":
+        command_value = config.get("provider_command")
+        command = _custom_provider_command(command_value)
+        if command is None:
+            return _blocked_provider_result(
+                request,
+                "custom_cli provider requires provider_command as a non-empty list of strings",
+                provider=provider,
+            )
+        return command, {"provider": provider, "provider_command": command}
+
+    return _blocked_provider_result(
+        request,
+        f"unsupported agent provider: {provider}",
+        provider=provider,
+    )
+
+
+def _codex_command(
+    request: AgentRunRequest,
+    final_message_path: Path,
+    codex_binary: str,
+) -> list[str]:
+    config = request.agent_config
+    command = [
+        codex_binary,
+        "exec",
+        "--cd",
+        str(request.context.workdir),
+        "-c",
+        'approval_policy="never"',
+        "--output-last-message",
+        str(final_message_path),
+    ]
+
+    model = config.get("model")
+    if isinstance(model, str) and model:
+        command.extend(["--model", model])
+
+    reasoning_effort = config.get("model_reasoning_effort")
+    if isinstance(reasoning_effort, str) and reasoning_effort:
+        command.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
+
+    sandbox_mode = config.get("sandbox_mode")
+    if isinstance(sandbox_mode, str) and sandbox_mode:
+        command.extend(["--sandbox", sandbox_mode])
+
+    command.append("-")
+    return command
+
+
+def _custom_provider_command(value: Any) -> list[str] | None:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return None
+    command = list(value)
+    if not command:
+        return None
+    if not all(isinstance(part, str) and part for part in command):
+        return None
+    return command
+
+
+def _blocked_provider_result(
+    request: AgentRunRequest,
+    error: str,
+    *,
+    provider: str | None = None,
+) -> AgentRunResult:
+    return AgentRunResult(
+        status=StepStatus.BLOCKED,
+        error=error,
+        metadata={
+            "agent_id": request.step.agent_id,
+            "provider": provider,
+            "provider_error": error,
+        },
+    )
 
 
 def _agent_metadata(

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -14,6 +14,7 @@ from harness_codex.runtime.runner import (
     AgentRunResult,
     BasicStepRunner,
     CodexCliAgentAdapter,
+    ConfigurableCliAgentAdapter,
 )
 
 
@@ -80,6 +81,25 @@ def write_skill(repo_root: Path, skill_id: str = "harness-code-planner") -> None
             ]
         ),
         encoding="utf-8",
+    )
+
+
+def agent_request(tmp_path: Path, agent_config: dict) -> AgentRunRequest:
+    return AgentRunRequest(
+        step=Step(
+            id="execute-work-item",
+            kind=StepKind.AGENT,
+            name="Execute plan",
+            agent_id="implementation_executor",
+            skill_id="harness-plan-executor",
+            timeout_sec=30,
+        ),
+        context=context(tmp_path),
+        step_dir=tmp_path / ".harness/runs/run-001/steps/execute-work-item",
+        agent_config_path=tmp_path / ".codex/agents/implementation_executor.toml",
+        agent_config=agent_config,
+        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
+        skill_body="# Harness Plan Executor\n스킬 본문",
     )
 
 
@@ -182,24 +202,13 @@ def test_basic_step_runner_blocks_agent_without_skill(tmp_path: Path) -> None:
     assert "missing skill config" in (result.error or "")
 
 
-def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
+def test_configurable_agent_adapter_uses_codex_provider_by_default(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    write_agent_config(tmp_path, agent_id="implementation_executor")
-    request = AgentRunRequest(
-        step=Step(
-            id="execute-work-item",
-            kind=StepKind.AGENT,
-            name="Execute plan",
-            agent_id="implementation_executor",
-            skill_id="harness-plan-executor",
-            timeout_sec=30,
-        ),
-        context=context(tmp_path),
-        step_dir=tmp_path / ".harness/runs/run-001/steps/execute-work-item",
-        agent_config_path=tmp_path / ".codex/agents/implementation_executor.toml",
-        agent_config={
+    request = agent_request(
+        tmp_path,
+        {
             "name": "implementation_executor",
             "description": "test agent",
             "model": "gpt-5.4",
@@ -207,8 +216,6 @@ def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
             "sandbox_mode": "workspace-write",
             "developer_instructions": "테스트 지시문",
         },
-        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
-        skill_body="# Harness Plan Executor\n스킬 본문",
     )
     request.step_dir.mkdir(parents=True)
     calls = []
@@ -224,9 +231,10 @@ def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    result = CodexCliAgentAdapter(codex_binary="codex-test").run(request)
+    result = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(request)
 
     assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata["provider"] == "codex"
     command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
     assert command[:2] == ["codex-test", "exec"]
     assert "--ask-for-approval" not in command
@@ -247,21 +255,147 @@ def test_codex_cli_agent_adapter_writes_prompt_command_and_logs(
     assert calls[0][1]["timeout"] == 30
 
 
-def test_codex_cli_agent_adapter_blocks_when_codex_binary_is_missing(
+def test_configurable_agent_adapter_uses_explicit_codex_binary(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    request = AgentRunRequest(
-        step=Step(
-            id="plan-work-item",
-            kind=StepKind.AGENT,
-            name="Create plan",
-            agent_id="implementation_planner",
-        ),
-        context=context(tmp_path),
-        step_dir=tmp_path / ".harness/runs/run-001/steps/plan-work-item",
-        agent_config_path=tmp_path / ".codex/agents/implementation_planner.toml",
-        agent_config={
+    request = agent_request(
+        tmp_path,
+        {
+            "name": "implementation_executor",
+            "provider": "codex",
+            "provider_binary": "codex-explicit",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ConfigurableCliAgentAdapter(codex_binary="codex-default").run(request)
+
+    assert result.status == StepStatus.SUCCEEDED
+    command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
+    assert command[:2] == ["codex-explicit", "exec"]
+
+
+def test_configurable_agent_adapter_uses_custom_cli_provider(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    request = agent_request(
+        tmp_path,
+        {
+            "name": "implementation_executor",
+            "provider": "custom_cli",
+            "provider_command": ["my-agent", "run", "--stdin"],
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="custom final message",
+            stderr="custom stderr",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ConfigurableCliAgentAdapter().run(request)
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata["provider"] == "custom_cli"
+    command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
+    assert command == ["my-agent", "run", "--stdin"]
+    assert "--model" not in command
+    assert calls[0][1]["input"] == (request.step_dir / "prompt.md").read_text(
+        encoding="utf-8"
+    )
+    assert (request.step_dir / "final-message.md").read_text(encoding="utf-8") == (
+        "custom final message"
+    )
+
+
+def test_configurable_agent_adapter_blocks_custom_cli_without_command(
+    tmp_path: Path,
+) -> None:
+    request = agent_request(
+        tmp_path,
+        {
+            "name": "implementation_executor",
+            "provider": "custom_cli",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+
+    result = ConfigurableCliAgentAdapter().run(request)
+
+    assert result.status == StepStatus.BLOCKED
+    assert "provider_command" in (result.error or "")
+    assert result.metadata["provider"] == "custom_cli"
+
+
+def test_configurable_agent_adapter_blocks_unknown_provider(
+    tmp_path: Path,
+) -> None:
+    request = agent_request(
+        tmp_path,
+        {
+            "name": "implementation_executor",
+            "provider": "other",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+
+    result = ConfigurableCliAgentAdapter().run(request)
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.error == "unsupported agent provider: other"
+    assert result.metadata["provider"] == "other"
+
+
+def test_codex_cli_agent_adapter_keeps_backward_compatible_name(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    request = agent_request(
+        tmp_path,
+        {
+            "name": "implementation_executor",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = CodexCliAgentAdapter(codex_binary="codex-test").run(request)
+
+    assert result.status == StepStatus.SUCCEEDED
+    command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
+    assert command[:2] == ["codex-test", "exec"]
+
+
+def test_configurable_agent_adapter_blocks_when_provider_binary_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    request = agent_request(
+        tmp_path,
+        {
             "name": "implementation_planner",
             "developer_instructions": "테스트 지시문",
         },
@@ -273,30 +407,24 @@ def test_codex_cli_agent_adapter_blocks_when_codex_binary_is_missing(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    result = CodexCliAgentAdapter(codex_binary="missing-codex").run(request)
+    result = ConfigurableCliAgentAdapter(codex_binary="missing-codex").run(request)
 
     assert result.status == StepStatus.BLOCKED
-    assert result.error == "codex binary not found: missing-codex"
+    assert result.error == (
+        "agent provider binary not found: provider=codex binary=missing-codex"
+    )
     assert (request.step_dir / "stderr.txt").read_text(encoding="utf-8") == (
-        "codex binary not found: missing-codex"
+        "agent provider binary not found: provider=codex binary=missing-codex"
     )
 
 
-def test_codex_cli_agent_adapter_blocks_on_usage_limit(
+def test_configurable_agent_adapter_blocks_on_usage_limit(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    request = AgentRunRequest(
-        step=Step(
-            id="plan-work-item",
-            kind=StepKind.AGENT,
-            name="Create plan",
-            agent_id="implementation_planner",
-        ),
-        context=context(tmp_path),
-        step_dir=tmp_path / ".harness/runs/run-001/steps/plan-work-item",
-        agent_config_path=tmp_path / ".codex/agents/implementation_planner.toml",
-        agent_config={
+    request = agent_request(
+        tmp_path,
+        {
             "name": "implementation_planner",
             "developer_instructions": "테스트 지시문",
         },
@@ -313,28 +441,20 @@ def test_codex_cli_agent_adapter_blocks_on_usage_limit(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    result = CodexCliAgentAdapter(codex_binary="codex-test").run(request)
+    result = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(request)
 
     assert result.status == StepStatus.BLOCKED
     assert result.exit_code == 1
     assert "usage limit" in (result.error or "")
 
 
-def test_codex_cli_agent_adapter_reports_usage_limit_before_warnings(
+def test_configurable_agent_adapter_reports_usage_limit_before_warnings(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    request = AgentRunRequest(
-        step=Step(
-            id="plan-work-item",
-            kind=StepKind.AGENT,
-            name="Create plan",
-            agent_id="implementation_planner",
-        ),
-        context=context(tmp_path),
-        step_dir=tmp_path / ".harness/runs/run-001/steps/plan-work-item",
-        agent_config_path=tmp_path / ".codex/agents/implementation_planner.toml",
-        agent_config={
+    request = agent_request(
+        tmp_path,
+        {
             "name": "implementation_planner",
             "developer_instructions": "테스트 지시문",
         },
@@ -354,7 +474,7 @@ def test_codex_cli_agent_adapter_reports_usage_limit_before_warnings(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    result = CodexCliAgentAdapter(codex_binary="codex-test").run(request)
+    result = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(request)
 
     assert result.status == StepStatus.BLOCKED
     assert result.error == "ERROR: You've hit your usage limit. Try again later."


### PR DESCRIPTION
## 구현 의도

Issue #82의 개선 단위로 runtime agent 실행 경계가 Codex CLI에 고정되지 않도록 provider 선택 지점을 추가한다.

Codex는 기존 동작과 호환되는 기본 provider로 유지하되, agent config에서 `provider`를 지정하면 custom CLI provider를 사용할 수 있게 했다.

## 구현 방법

### 1. Provider-neutral adapter 추가

기존 `CodexCliAgentAdapter` 중심 구조에 `ConfigurableCliAgentAdapter`를 추가했다.

- `BasicStepRunner` 기본 adapter는 `ConfigurableCliAgentAdapter`를 사용한다.
- `CodexCliAgentAdapter`는 기존 import/API 호환을 위해 유지한다.
- `provider`가 없으면 기존처럼 `codex exec` 명령을 구성한다.

### 2. agent config provider 파싱

지원 provider:

```toml
# 기본값: codex
provider = "codex"
provider_binary = "codex"
```

```toml
provider = "custom_cli"
provider_command = ["my-agent", "run", "--stdin"]
```

동작 규칙:

- `provider` 생략 시 `codex`
- `provider = "codex"`이면 기존 Codex command shape 유지
- `provider_binary`가 있으면 Codex binary override
- `provider = "custom_cli"`이면 `provider_command`를 그대로 실행
- custom CLI에는 Codex 전용 옵션(`--model`, `--sandbox`, `approval_policy`)을 붙이지 않음
- prompt는 stdin으로 전달
- custom CLI의 stdout은 `final-message.md`에도 기록

### 3. BLOCKED 처리 개선

다음 경우 명확히 BLOCKED 처리한다.

- 알 수 없는 provider
- `custom_cli`인데 `provider_command`가 없거나 비어 있음
- provider binary를 찾을 수 없음

metadata에는 `provider`, `provider_command`, `provider_error` 등을 기록한다.

## 검증 방법

추가/수정한 테스트:

- provider 미지정 시 기존 Codex command 유지
- 명시적 `provider = "codex"`와 `provider_binary` 적용
- `provider = "custom_cli"`일 때 custom command 사용
- custom provider에는 Codex 전용 옵션 미삽입
- custom provider stdout을 `final-message.md`로 기록
- provider command 누락 시 BLOCKED
- unknown provider 시 BLOCKED
- 기존 `CodexCliAgentAdapter` 이름 호환 유지
- provider binary missing / usage limit 처리 유지

로컬 pytest는 현재 환경에서 직접 실행하지 못했다. CI 또는 로컬에서 다음 명령으로 확인 필요:

```bash
./venv/bin/python3 -m pytest -q tests/runtime/test_agent_runner.py
```

## 관련 이슈

Closes #82