### PR TITLE
[codex] Add ubiquitous language gate to requirements harvest

### DIFF
--- a/.codex/agents/harness_requirements.toml
+++ b/.codex/agents/harness_requirements.toml
@@ -1,5 +1,5 @@
 name = "harness_requirements"
-description = "Derive functional and non-functional requirements"
+description = "Derive functional and non-functional requirements and project ubiquitous language"
 model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
@@ -9,12 +9,14 @@ You are the harness requirements documentation agent.
 
 Your job:
 - Start from the user's short initial idea.
-- Ask iterative clarification questions until requirements are specific enough to document, but ask only one focused question per turn and include your recommended answer with that question.
-- Write or update exactly this output document:
+- Ask iterative clarification questions until requirements and ubiquitous language are specific enough to document, but ask only one focused question per turn and include your recommended answer with that question.
+- Write or update exactly these output documents:
   - docs/design/요구사항.md
+  - context.md
 
 Source of truth:
-- Use the embedded ticketon-ddd style requirements standards in .codex/skills/harness-requirements/SKILL.md.
+- Use the embedded ticketon-ddd style requirements and ubiquitous language standards in .codex/skills/harness-requirements/SKILL.md.
+- If context.md already exists, read it before writing requirements and preserve existing canonical terms unless the user explicitly confirms a rename.
 - Do not depend on external blog files or repo-local reference posts at runtime.
 
 Ownership:
@@ -25,13 +27,24 @@ Ownership:
 - Do not edit skill files.
 - Do not edit agent files.
 - Do not edit use-case documents.
-- Keep file writes limited to docs/design/요구사항.md.
-- If you cannot find or write the output document, explain the reason and stop.
+- Keep file writes limited to docs/design/요구사항.md and context.md.
+- If you cannot find or write the output documents, explain the reason and stop.
 
 Discovery before questions:
-- Before asking the user a question, inspect the codebase, existing docs/design documents, .codex configuration, and build/runtime settings when those artifacts could answer it.
+- Before asking the user a question, inspect the codebase, existing docs/design documents, existing context.md, .codex configuration, and build/runtime settings when those artifacts could answer it.
 - Do not ask the user for facts you can verify locally. Record verified facts in the document, or mark them as provisional with the evidence you found.
 - If local artifacts partially answer the question, ask only for the missing decision.
+
+Ubiquitous language rules:
+- Requirements harvest must confirm ubiquitous language through grill-me before use-case harvest begins.
+- context.md is the project-wide source of truth for domain language.
+- Write confirmed language to context.md under a Ubiquitous Language section.
+- Confirm actor names, user goal names, domain concepts, state names, command candidate terms, event candidate terms, policy/rule terms, and external system names.
+- For every important term, confirm Canonical Term, Korean, English, Type, Definition, Aliases, Forbidden Terms, and Source.
+- Use context.md canonical terms when writing docs/design/요구사항.md.
+- Do not introduce conflicting terms when a canonical term already exists in context.md.
+- If a term is missing or contested, record it under Open Language Questions in context.md instead of inventing a term.
+- Forbidden Terms must not be introduced in requirements, use cases, plans, tests, or code identifiers.
 
 Requirements rules:
 - Requirements define goals and constraints the system must satisfy.
@@ -42,6 +55,7 @@ Requirements rules:
 - Do not decide detailed implementation strategies during requirements elicitation. Polling vs push, circuit breaker, retry/backoff, outbox/inbox, detailed transaction propagation, cache TTL/invalidation, and observability fields belong after DDD design in the technical-decision stage.
 - The foundational technology stack must be asked during requirements elicitation. At minimum, ask for development language, main framework, DB/storage family, Redis/cache/distributed-state need, messaging broker/framework need, runtime/deployment constraints, and build tool.
 - Business Policy Decisions must be resolved before use-case writing and event storming can be considered ready.
+- Core ubiquitous language must be resolved before use-case writing and event storming can be considered ready.
 - Foundational Technical Decisions may remain unresolved after requirements, but must be clearly separated for the DDD and technical-decision gates.
 - Functional requirements must be grouped by domain or feature area.
 - Non-functional requirements must check performance, concurrency control, data consistency, scalability, fault isolation/availability, security, failure recovery, and auditability/operability.
@@ -55,11 +69,13 @@ Requirements rules:
 Question loop:
 - Ask exactly one focused question at a time.
 - Include `Recommended answer:` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
-- After the user answers, update docs/design/요구사항.md, then choose the next single unresolved decision that blocks requirements quality.
-- Prefer questions about actors, goals, core functions, success/failure outcomes, foundational technology stack, permissions/security, external systems, traffic/latency/concurrency/consistency, fault handling, and out-of-scope boundaries.
+- After the user answers, update context.md first, update docs/design/요구사항.md using context.md canonical terms, then choose the next single unresolved decision that blocks requirements or language quality.
+- Prefer questions about actors, goals, core domain terms, state names, command/event/policy terms, alias cleanup, forbidden terms, core functions, success/failure outcomes, foundational technology stack, permissions/security, external systems, traffic/latency/concurrency/consistency, fault handling, and out-of-scope boundaries.
+- Include ubiquitous language questions before finalizing the requirements document.
 - Include non-functional requirement questions before finalizing the requirements document.
 - Include foundational technology stack questions before finalizing the requirements document.
-- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions.
-- Keep unresolved items separated into `Business Policy Decisions Needed` and `Foundational Technology Decisions Needed`.
+- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions and core Open Language Questions.
+- Keep unresolved items separated into `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, and `Open Language Questions`.
 - If business policy items remain, mark the document as not ready for use-case writing or event storming.
+- If core language questions remain, mark the document as not ready for use-case writing or event storming.
 """

--- a/.codex/agents/harness_usecases.toml
+++ b/.codex/agents/harness_usecases.toml
@@ -1,5 +1,5 @@
 name = "harness_usecases"
-description = "Derive external-actor use cases from confirmed requirements"
+description = "Derive external-actor use cases from confirmed requirements and context language"
 model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
@@ -8,12 +8,14 @@ developer_instructions = """
 You are the harness use case documentation agent.
 
 Your job:
+- Read confirmed ubiquitous language from context.md.
 - Read confirmed requirements from docs/design/요구사항.md.
 - Write or update exactly this output document:
   - docs/design/유스케이스.md
 
 Source of truth:
 - Use the embedded ticketon-ddd style use case standards in .codex/skills/harness-usecases/SKILL.md.
+- Treat context.md as the project-wide source of truth for domain language.
 - Do not depend on external blog files or repo-local reference posts at runtime.
 
 Ownership:
@@ -24,14 +26,25 @@ Ownership:
 - Do not edit skill files.
 - Do not edit agent files.
 - Do not edit requirements documents.
+- Do not edit context.md.
 - Keep file writes limited to docs/design/유스케이스.md.
 - If you cannot find or write the output document, explain the reason and stop.
 
 Readiness:
-- Read docs/design/요구사항.md before writing use cases.
+- Read context.md before writing use cases.
+- Read docs/design/요구사항.md after context.md.
+- If context.md is missing or lacks a Ubiquitous Language section, stop and ask the user to run $harness-requirements first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop because use cases would encode unconfirmed behavior.
-- Foundational Technical Decisions may remain unresolved if actor goals and business policies are clear.
+- If Open Language Questions block actor, goal, state, command, event, policy, or external-system naming, stop because use cases would encode unconfirmed language.
+- Foundational Technical Decisions may remain unresolved if actor goals, business policies, and language are clear.
+
+Ubiquitous language rules:
+- Use only canonical terms from context.md for domain concepts.
+- Use the English column from context.md for code-facing command/event/policy candidate names when such candidates are included.
+- Do not introduce new actor names, goal names, state names, command names, event names, policy names, or external system names that conflict with context.md.
+- Do not use terms listed under Forbidden Terms.
+- If a needed term is missing or ambiguous, mark the related use case detail as Needs confirmation instead of inventing behavior.
 
 Use case rules:
 - Use cases are written from the perspective of external actors.
@@ -47,12 +60,12 @@ Use case rules:
 - Policies must be written as conditions or decision criteria.
 - Every detailed use case must include Actor, Supporting Actor, Goal, Preconditions, Main Flow, Exception Flow, Result, Non-Functional Requirements.
 - If a section has no content yet, write None or Needs confirmation.
-- Do not mark use cases complete unless all use case and event-storming-readiness rules above are satisfied.
+- Do not mark use cases complete unless all use case, language, and event-storming-readiness rules above are satisfied.
 - Do not write requirements.
 
 Question loop:
-- Ask exactly one focused question at a time only when requirements are ambiguous enough to block use-case correctness.
+- Ask exactly one focused question at a time only when requirements or context language are ambiguous enough to block use-case correctness.
 - Include `Recommended answer:` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
 - After the user answers, update docs/design/유스케이스.md, then choose the next single unresolved decision that blocks use-case quality.
-- If a use case still has multiple user goals, mixed command/policy wording, multi-meaning event storming elements, or invalid command/event/policy phrasing, mark it as not complete and ask or revise before reporting readiness.
+- If a use case still has multiple user goals, mixed command/policy wording, multi-meaning event storming elements, non-canonical terms, Forbidden Terms, or invalid command/event/policy phrasing, mark it as not complete and ask or revise before reporting readiness.
 """

--- a/.codex/skills/harness-requirements/SKILL.md
+++ b/.codex/skills/harness-requirements/SKILL.md
@@ -2,8 +2,9 @@
 name: harness-requirements
 description:
   Use when a user wants to turn an early product or feature idea into a
-  requirements specification only. This skill clarifies unresolved decisions
-  through grill-me and writes docs/design/요구사항.md.
+  requirements specification and project ubiquitous language. This skill
+  clarifies unresolved decisions through grill-me and writes
+  docs/design/요구사항.md and context.md.
 ---
 
 # Harness Requirements
@@ -31,24 +32,30 @@ installed first.
 
 ## Purpose
 
-This skill turns an early idea into a requirements specification only.
+This skill turns an early idea into a requirements specification and a project
+ubiquitous language source of truth.
 
 Responsibilities are split as follows.
 
-- `$grill-me`: clarifies unresolved requirement decisions through questions.
-- `harness-requirements`: validates confirmed decisions and writes `docs/design/요구사항.md`.
-- `harness-usecases`: later reads confirmed requirements and writes `docs/design/유스케이스.md`.
+- `$grill-me`: clarifies unresolved requirement and language decisions through questions.
+- `harness-requirements`: validates confirmed decisions and writes `docs/design/요구사항.md` and `context.md`.
+- `harness-usecases`: later reads confirmed requirements and `context.md`, then writes `docs/design/유스케이스.md`.
 
-`$grill-me` only provides the questioning method. The requirements standards
-belong to this skill's `Embedded Standards`. Therefore, when running `$grill-me`,
-pass a `Grill-Me Brief` that summarizes this skill's standards.
+`$grill-me` only provides the questioning method. The requirements and ubiquitous
+language standards belong to this skill's `Embedded Standards`. Therefore, when
+running `$grill-me`, pass a `Grill-Me Brief` that summarizes this skill's
+standards.
 
 The `$grill-me` result is not the final deliverable. It is an intermediate
-decision record used to write `docs/design/요구사항.md`.
+decision record used to write `docs/design/요구사항.md` and `context.md`.
 
 If business policies are incomplete, do not report that the work is ready for
 use-case writing or Event Storming. If foundational technology choices are
 incomplete, leave them under `Foundational Technology Decisions Needed`.
+
+If ubiquitous language is incomplete, do not report that the work is ready for
+use-case writing, Event Storming, planning, or implementation. Leave unresolved
+terms under `Open Language Questions` in `context.md`.
 
 When this skill is invoked, delegate the work to the dedicated agent defined in
 `.codex/agents/harness_requirements.toml`. If the dedicated agent cannot be
@@ -75,6 +82,19 @@ Use the following standards as the source of truth for the instructions.
 - Detailed technical strategies that can be decided after design must not be confirmed during the requirements phase. Leave them under `Post-DDD Technical Decision Candidates`.
 - Before moving to use-case writing or Event Storming, there must be no unresolved business policy decisions.
 
+### Ubiquitous Language Standards
+
+- Requirements harvest must confirm ubiquitous language through `$grill-me` before use-case harvest begins.
+- Store the confirmed language in root-level `context.md` under `## 1. Ubiquitous Language` or `## Ubiquitous Language`.
+- `context.md` is the project-wide source of truth for domain language.
+- Confirm actor names, user goal names, domain concepts, state names, command candidate terms, event candidate terms, policy/rule terms, and external system names.
+- For every important term, confirm the canonical term, Korean label, English code-facing label, type, definition, aliases, forbidden terms, and source.
+- The same concept must not have multiple canonical terms.
+- Aliases may be recorded only as aliases; generated requirements, use cases, plans, tests, and code identifiers must use canonical terms.
+- Forbidden terms must not appear in newly generated docs or code identifiers.
+- Do not mix implementation technology terms with domain terms unless the business explicitly uses the same term.
+- If a required term is missing or contested, do not invent it. Record it under `Open Language Questions` in `context.md`.
+
 ## Grill-Me Brief Contract
 
 `$grill-me` only provides the questioning method. When running it, pass a brief
@@ -83,7 +103,7 @@ that summarizes this skill's standards.
 ### Brief Contents
 
 ```text
-You are conducting an interview to clarify requirements.
+You are conducting an interview to clarify requirements and confirm ubiquitous language.
 
 Questioning method:
 - Ask up to three focused questions at a time when at least three unresolved decisions remain.
@@ -95,6 +115,7 @@ Questioning method:
 Judgment standards:
 - Follow the Embedded Standards from harness-requirements.
 - Business policies must be confirmed before use-case writing and DDD/Event Storming.
+- Ubiquitous language must be confirmed before use-case writing and DDD/Event Storming.
 - Foundational technologies are confirmed in the later part of the requirements phase.
 - Detailed technical strategies must not be confirmed as requirements; separate them as post-DDD candidates.
 - Do not write use cases in this phase.
@@ -105,29 +126,48 @@ Question priority:
 3. Scope
 4. Actors
 5. Goals per actor
-6. Core features
-7. Success/failure outcomes
-8. Business policies
-9. Authorization/security/audit trail
-10. External systems
-11. Non-functional requirements
-12. Foundational technologies
-13. Out-of-scope items
+6. Core domain terms and concept names
+7. State names
+8. Command/event/policy candidate terms
+9. Alias and forbidden-term cleanup
+10. Core features
+11. Success/failure outcomes
+12. Business policies
+13. Authorization/security/audit trail
+14. External systems
+15. Non-functional requirements
+16. Foundational technologies
+17. Out-of-scope items
+
+Ubiquitous language confirmation criteria:
+- Same concept has exactly one canonical term.
+- Korean and English/code-facing names are confirmed.
+- Term type is clear: Actor, Goal, Domain Concept, State, Command Candidate, Event Candidate, Policy, External System, or Other.
+- Aliases and forbidden terms are recorded.
+- Missing terms are recorded in `Open Language Questions` instead of invented.
 
 Completion criteria:
 - Main actors and their goals are separated enough for functional requirements.
 - Functional and non-functional requirement candidates can be written.
 - There are no unresolved core business policies.
 - Foundational technologies are confirmed or separated as needing confirmation.
+- Core ubiquitous language is confirmed and can be written to `context.md`.
 
 Output format:
 ## Confirmed Decisions
 - ...
 
+## Confirmed Ubiquitous Language
+| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
+|---|---|---|---|---|---|---|---|
+| ... | ... | ... | ... | ... | ... | ... | grill-me |
+
 ## Needs Confirmation
 ### Business Policy Decisions Needed
 - ...
 ### Foundational Technology Decisions Needed
+- ...
+### Open Language Questions
 - ...
 ### Post-DDD Technical Decision Candidates
 - ...
@@ -135,34 +175,38 @@ Output format:
 ## Documentation Input
 ### Content for requirements.md
 - ...
+### Content for context.md
+- ...
 ```
 
 ## Invocation
 
 When the user invokes `$harness-requirements` with an early idea or a `$grill-me`
-result, treat it as a request to write requirements only.
+result, treat it as a request to write requirements and project language only.
 
 Dedicated agent:
 
 - agent id: `harness_requirements`
 - config: `.codex/agents/harness_requirements.toml`
-- output file:
+- output files:
   - `docs/design/요구사항.md`
+  - `context.md`
 
 Execution rules:
 
 - If the dedicated agent cannot be found or cannot run, the current agent must not perform the work as a fallback.
 - Explain the reason for the failure and stop.
 - The dedicated agent must not modify code, settings, skill files, agent files, or use-case documents.
-- The dedicated agent may only write to `docs/design/요구사항.md`.
+- The dedicated agent may only write to `docs/design/요구사항.md` and `context.md`.
 
 ```text
 You are the harness requirements documentation agent.
 
-Write or update only docs/design/요구사항.md based on the user's early idea and the `$grill-me` result.
+Write or update only docs/design/요구사항.md and context.md based on the user's early idea and the `$grill-me` result.
 
-Owned file:
+Owned files:
 - docs/design/요구사항.md
+- context.md
 
 Rules:
 - Do not modify code, settings, skill files, agent files, or use-case documents.
@@ -171,35 +215,67 @@ Rules:
 - Use this skill's Embedded Standards as the judgment criteria.
 - If `$grill-me` is needed, create and pass a brief that follows the Grill-Me Brief Contract.
 - Do not confirm core requirements without a `$grill-me` result or existing evidence.
+- Do not confirm core ubiquitous language without a `$grill-me` result or existing evidence.
 - Distinguish confirmed, candidate, and needs-confirmation non-functional requirements.
 - Confirm foundational technologies in the later part of the requirements phase.
+- Confirm canonical domain terms, English code-facing names, aliases, and forbidden terms.
+- Write confirmed ubiquitous language to context.md.
+- Record unresolved language decisions under Open Language Questions in context.md.
+- Use context.md canonical terms when writing docs/design/요구사항.md.
 - Do not confirm detailed technical strategies as requirements.
 - Do not write use cases.
-- Write deliverables only to the owned file.
+- Write deliverables only to the owned files.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```
 
 ## Workflow
 
 1. **Confirm standards**
-   Use `Embedded Standards`, `Grill-Me Brief Contract`, and the document template as the working standards.
+   Use `Embedded Standards`, `Grill-Me Brief Contract`, and the document templates as the working standards.
 
 2. **Inspect inputs**
-   Review the early idea, `$grill-me` result, existing requirements, relevant code, docs, and settings.
+   Review the early idea, `$grill-me` result, existing requirements, existing `context.md`, relevant code, docs, and settings.
 
 3. **Decide whether to run Grill-Me**
-   If decisions are missing, create a brief that follows the `Grill-Me Brief Contract` and run `$grill-me`.
+   If requirement or language decisions are missing, create a brief that follows the `Grill-Me Brief Contract` and run `$grill-me`.
 
 4. **Validate decisions**
-   Split the `$grill-me` result into confirmed decisions, needs-confirmation items, and post-DDD candidates.
+   Split the `$grill-me` result into confirmed decisions, needs-confirmation items, confirmed language, open language questions, and post-DDD candidates.
    Do not confirm items that fail the standards.
 
-5. **Write requirements**
-   Write or update `docs/design/요구사항.md`, separating functional and non-functional requirements.
+5. **Write requirements and language**
+   Write or update `context.md` first, then write or update `docs/design/요구사항.md` using the canonical terms from `context.md`.
 
 6. **Confirm completion**
    If business policies are unresolved, do not report readiness for use-case writing or Event Storming.
-   Collect remaining unresolved items in a needs-confirmation section.
+   If ubiquitous language has unresolved core terms, do not report readiness for use-case writing or Event Storming.
+   Collect remaining unresolved items in needs-confirmation sections.
+
+## Context Document Template
+
+`context.md` must follow this structure.
+
+```markdown
+# Project Context
+
+## 1. Ubiquitous Language
+
+| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
+|---|---|---|---|---|---|---|---|
+| ... | ... | ... | ... | ... | ... | ... | grill-me |
+
+## 2. Naming Rules
+
+- Documents must use `Canonical Term`.
+- Code class, method, package, command, event, and policy identifiers must use `English`.
+- User-facing text should use `Korean`.
+- `Forbidden Terms` must not be used in new documents, plans, tests, or code identifiers.
+- Aliases are recorded only for migration/search context and must not be introduced as new canonical language.
+
+## 3. Open Language Questions
+
+- ...
+```
 
 ## Requirements Document Template
 

--- a/.codex/skills/harness-requirements/references/agent-prompt.md
+++ b/.codex/skills/harness-requirements/references/agent-prompt.md
@@ -5,25 +5,29 @@ Use this prompt when spawning a worker agent for `$harness-requirements`.
 ```text
 You are the harness requirements documentation agent.
 
-Start from the user's initial idea and ask iterative questions until requirements are specific enough to document.
-Follow the ticketon-ddd style requirements standards and template embedded in the skill.
+Start from the user's initial idea and ask iterative questions until requirements and ubiquitous language are specific enough to document.
+Follow the ticketon-ddd style requirements, language, and template standards embedded in the skill.
 Do not depend on external blog files or repo-local reference posts at runtime.
 
-Owned file:
+Owned files:
 - docs/design/요구사항.md
+- context.md
 
 Rules:
 - Do not revert edits made by others.
 - Do not edit code, settings, skill files, agent files, or use-case documents.
-- Inspect codebase, existing docs, and settings before asking the user a question that local artifacts could answer.
+- Inspect codebase, existing docs, existing context.md, and settings before asking the user a question that local artifacts could answer.
 - Do not guess unclear decisions.
 - Do not finalize non-functional requirements from assumptions.
 - Ask up to three focused questions at a time when at least three unresolved decisions remain.
 - Ask fewer than three only when fewer unresolved decisions remain.
 - Include `Recommended answer:` with every question.
-- After the user answers, update docs/design/요구사항.md, then ask the next most important unresolved requirement decision.
+- Confirm ubiquitous language through grill-me before use-case harvest.
+- Update context.md first with confirmed canonical terms, Korean names, English code-facing names, definitions, aliases, forbidden terms, and open language questions.
+- Use context.md canonical terms when updating docs/design/요구사항.md.
+- After the user answers, update context.md and docs/design/요구사항.md, then ask the next most important unresolved requirement or language decision.
 - Split functional and non-functional requirements.
-- Separate unresolved items into Business Policy Decisions Needed and Foundational Technology Decisions Needed.
+- Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, and Open Language Questions.
 - Ask foundational technology stack questions before treating requirements as complete.
 - Do not write use cases.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.

--- a/.codex/skills/harness-usecases/SKILL.md
+++ b/.codex/skills/harness-usecases/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: harness-usecases
 description:
-  Use after requirements exist to turn confirmed requirements into external-actor
-  use cases only. This skill writes docs/design/유스케이스.md.
+  Use after requirements and context.md exist to turn confirmed requirements
+  into external-actor use cases only. This skill writes docs/design/유스케이스.md.
 ---
 
 # Harness Use Cases
@@ -13,12 +13,13 @@ This skill turns confirmed requirements into a use case document only.
 
 Responsibilities are split as follows.
 
-- `harness-requirements`: writes `docs/design/요구사항.md`.
-- `harness-usecases`: validates requirements readiness and writes `docs/design/유스케이스.md`.
+- `harness-requirements`: writes `docs/design/요구사항.md` and the project-wide language source `context.md`.
+- `harness-usecases`: validates requirements and ubiquitous language readiness, then writes `docs/design/유스케이스.md`.
 
-If requirements do not exist, or if core business policy decisions remain
-unresolved, stop and ask the user to run `$harness-requirements` first. Do not
-invent missing requirements.
+If requirements do not exist, if `context.md` does not exist, if core ubiquitous
+language is unresolved, or if core business policy decisions remain unresolved,
+stop and ask the user to run `$harness-requirements` first. Do not invent missing
+requirements or missing domain terms.
 
 When this skill is invoked, delegate the work to the dedicated agent defined in
 `.codex/agents/harness_usecases.toml`. If the dedicated agent cannot be found
@@ -28,6 +29,16 @@ stop.
 ## Embedded Standards
 
 Use the following standards as the source of truth for the instructions.
+
+### Ubiquitous Language Standards
+
+- Read `context.md` before writing or updating use cases.
+- Treat `context.md` as the project-wide source of truth for domain language.
+- Use only the canonical terms defined in the `Ubiquitous Language` table.
+- Use the table's `English` names for code-facing command/event/policy candidates when such candidates are included.
+- Do not introduce new actor names, goal names, domain concepts, state names, command names, event names, policy names, or external system names that conflict with `context.md`.
+- Do not use terms listed under `Forbidden Terms`.
+- If a needed term is missing or ambiguous, stop or mark the related use case detail as `Needs confirmation`; record the missing term as an `Open Language Question` instead of inventing behavior.
 
 ### Use Case Standards
 
@@ -60,23 +71,27 @@ Execution rules:
 
 - If the dedicated agent cannot be found or cannot run, the current agent must not perform the work as a fallback.
 - Explain the reason for the failure and stop.
-- The dedicated agent must not modify code, settings, skill files, agent files, or requirements documents.
+- The dedicated agent must not modify code, settings, skill files, agent files, requirements documents, or `context.md`.
 - The dedicated agent may only write to `docs/design/유스케이스.md`.
 
 ```text
 You are the harness use case documentation agent.
 
-Write or update only docs/design/유스케이스.md based on docs/design/요구사항.md and any confirmed decision record.
+Write or update only docs/design/유스케이스.md based on context.md, docs/design/요구사항.md, and any confirmed decision record.
 
 Owned file:
 - docs/design/유스케이스.md
 
 Rules:
-- Do not modify code, settings, skill files, agent files, or requirements documents.
+- Do not modify code, settings, skill files, agent files, requirements documents, or context.md.
 - Do not revert existing user changes.
-- Read docs/design/요구사항.md first.
+- Read context.md first.
+- Read docs/design/요구사항.md after context.md.
+- If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-requirements first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop because use cases would encode unconfirmed behavior.
+- If Open Language Questions block actor, goal, state, command, event, policy, or external-system naming, stop because use cases would encode unconfirmed language.
+- Use context.md canonical terms and avoid Forbidden Terms.
 - Write use cases around a single goal of an external actor.
 - Do not turn internal server/API flows into use cases.
 - Separate commands, events, and policies by meaning and sentence form.
@@ -86,21 +101,24 @@ Rules:
 
 ## Workflow
 
-1. **Inspect requirements**
+1. **Inspect context language**
+   Read `context.md` first. Confirm that the Ubiquitous Language table exists and that required actor/goal/domain terms are present.
+
+2. **Inspect requirements**
    Read `docs/design/요구사항.md` and any explicit user-provided decision record.
 
-2. **Check readiness**
-   Stop if requirements are missing or unresolved business policy decisions remain.
+3. **Check readiness**
+   Stop if requirements are missing, `context.md` is missing, unresolved business policy decisions remain, or open language questions block use-case naming.
    Foundational technology decisions may remain unresolved if they do not affect actor goals.
 
-3. **Derive actor goals**
-   Extract external actors and one goal per actor from confirmed functional requirements.
+4. **Derive actor goals**
+   Extract external actors and one goal per actor from confirmed functional requirements, using only canonical terms from `context.md`.
 
-4. **Write use cases**
-   Write or update `docs/design/유스케이스.md`, using one external actor goal per use case.
+5. **Write use cases**
+   Write or update `docs/design/유스케이스.md`, using one external actor goal per use case and the canonical language from `context.md`.
 
-5. **Confirm completion**
-   If any use case still has multiple goals, mixed command/policy wording, or multi-meaning event-storming candidates, mark it as `Needs confirmation`.
+6. **Confirm completion**
+   If any use case still has multiple goals, mixed command/policy wording, multi-meaning event-storming candidates, non-canonical language, or Forbidden Terms, mark it as `Needs confirmation`.
    If ambiguity blocks correctness, ask one focused question at a time and include `Recommended answer:`.
 
 ## Use Case Document Template

--- a/.codex/skills/harness-usecases/references/agent-prompt.md
+++ b/.codex/skills/harness-usecases/references/agent-prompt.md
@@ -5,8 +5,8 @@ Use this prompt when spawning a worker agent for `$harness-usecases`.
 ```text
 You are the harness use case documentation agent.
 
-Read docs/design/요구사항.md and write external-actor use cases only.
-Follow the ticketon-ddd style use case standards and template embedded in the skill.
+Read context.md first, then read docs/design/요구사항.md, and write external-actor use cases only.
+Follow the ticketon-ddd style use case, ubiquitous language, and template standards embedded in the skill.
 Do not depend on external blog files or repo-local reference posts at runtime.
 
 Owned file:
@@ -14,9 +14,13 @@ Owned file:
 
 Rules:
 - Do not revert edits made by others.
-- Do not edit code, settings, skill files, agent files, or requirements documents.
+- Do not edit code, settings, skill files, agent files, requirements documents, or context.md.
+- If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-requirements first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop and explain that use cases need confirmed policy.
+- If Open Language Questions block naming, stop and explain that use cases need confirmed ubiquitous language.
+- Use only context.md canonical terms for actors, goals, domain concepts, states, command/event/policy candidates, and external systems.
+- Do not use terms listed under Forbidden Terms.
 - Write use cases from external actor goals only.
 - Do not create use cases for internal server/API interactions.
 - Every use case must have exactly one user goal.
@@ -25,7 +29,7 @@ Rules:
 - Do not mix policies and commands.
 - Commands must be imperative, events past tense, policies conditions or decision criteria.
 - Mark incomplete use cases as Needs confirmation instead of inventing behavior.
-- Ask one focused question at a time only when requirements are ambiguous enough to block correctness.
+- Ask one focused question at a time only when requirements or language are ambiguous enough to block correctness.
 - Include `Recommended answer:` with every question.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```

--- a/.harness/workflows/harvest-workflow.yaml
+++ b/.harness/workflows/harvest-workflow.yaml
@@ -11,20 +11,15 @@ sandbox:
 steps:
   - id: harvest-requirements
     kind: agent
-    name: Derive requirements and confirm ubiquitous language from the initial product idea
+    name: Derive requirements from the initial product idea
     agent_id: harness_requirements
     skill_id: harness-requirements
     outputs:
-      - context.md
       - docs/design/요구사항.md
     timeout_sec: 3600
     metadata:
       stage: harvest
       scope: canonical_requirements
-      language_gate:
-        output: context.md
-        section: Ubiquitous Language
-        source: grill-me
       bootstrap_outputs:
         - AGENTS.md
         - docs/agent/context.md
@@ -32,14 +27,35 @@ steps:
         - docs/agent/session-state.md
         - docs/agent/token-reduction-report.md
       output_gate:
-        - context.md
         - docs/design/요구사항.md
+
+  - id: confirm-ubiquitous-language
+    kind: agent
+    name: Confirm ubiquitous language through grill-me and write context.md
+    agent_id: harness_requirements
+    skill_id: harness-requirements
+    needs:
+      - harvest-requirements
+    inputs:
+      - docs/design/요구사항.md
+    outputs:
+      - context.md
+    timeout_sec: 3600
+    metadata:
+      stage: harvest
+      scope: ubiquitous_language
+      language_gate:
+        output: context.md
+        section: Ubiquitous Language
+        source: grill-me
+      output_gate:
+        - context.md
 
   - id: validate-context-language
     kind: validator
     name: Validate confirmed ubiquitous language before use-case harvest
     needs:
-      - harvest-requirements
+      - confirm-ubiquitous-language
     command: python3 -m harness_codex.context_language --repo-root .
     timeout_sec: 300
     inputs:

--- a/.harness/workflows/harvest-workflow.yaml
+++ b/.harness/workflows/harvest-workflow.yaml
@@ -3,7 +3,7 @@ version: 1
 workflow:
   name: harness-harvest-workflow
   mode: apply
-  description: Harvest product intent into canonical requirements, then use-case documents.
+  description: Harvest product intent into canonical requirements, ubiquitous language, then use-case documents.
 
 sandbox:
   kind: worktree
@@ -11,15 +11,20 @@ sandbox:
 steps:
   - id: harvest-requirements
     kind: agent
-    name: Derive requirements from the initial product idea
+    name: Derive requirements and confirm ubiquitous language from the initial product idea
     agent_id: harness_requirements
     skill_id: harness-requirements
     outputs:
+      - context.md
       - docs/design/요구사항.md
     timeout_sec: 3600
     metadata:
       stage: harvest
       scope: canonical_requirements
+      language_gate:
+        output: context.md
+        section: Ubiquitous Language
+        source: grill-me
       bootstrap_outputs:
         - AGENTS.md
         - docs/agent/context.md
@@ -27,16 +32,37 @@ steps:
         - docs/agent/session-state.md
         - docs/agent/token-reduction-report.md
       output_gate:
+        - context.md
         - docs/design/요구사항.md
+
+  - id: validate-context-language
+    kind: validator
+    name: Validate confirmed ubiquitous language before use-case harvest
+    needs:
+      - harvest-requirements
+    command: python3 -m harness_codex.context_language --repo-root .
+    timeout_sec: 300
+    inputs:
+      - context.md
+      - docs/design/요구사항.md
+    metadata:
+      stage: harvest
+      scope: ubiquitous_language
+      checks:
+        - context.md exists
+        - canonical terms are unique
+        - required ubiquitous language table columns exist
+        - forbidden terms do not appear in generated docs
 
   - id: harvest-use-cases
     kind: agent
-    name: Derive use cases from confirmed requirements
+    name: Derive use cases from confirmed requirements and ubiquitous language
     agent_id: harness_usecases
     skill_id: harness-usecases
     needs:
-      - harvest-requirements
+      - validate-context-language
     inputs:
+      - context.md
       - docs/design/요구사항.md
     outputs:
       - docs/design/유스케이스.md
@@ -44,5 +70,6 @@ steps:
     metadata:
       stage: harvest
       scope: canonical_use_cases
+      language_source: context.md
       output_gate:
         - docs/design/유스케이스.md

--- a/harness_codex/context_language.py
+++ b/harness_codex/context_language.py
@@ -1,0 +1,194 @@
+"""Validate the project ubiquitous language source of truth."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+REQUIRED_COLUMNS = (
+    "Canonical Term",
+    "Korean",
+    "English",
+    "Type",
+    "Definition",
+    "Aliases",
+    "Forbidden Terms",
+    "Source",
+)
+
+DEFAULT_SCAN_PATHS = (
+    Path("docs/design"),
+    Path("docs/use-cases"),
+    Path("docs/plans"),
+)
+
+
+@dataclass(frozen=True)
+class LanguageTerm:
+    canonical_term: str
+    korean: str
+    english: str
+    term_type: str
+    definition: str
+    aliases: tuple[str, ...]
+    forbidden_terms: tuple[str, ...]
+    source: str
+
+
+class ContextLanguageError(ValueError):
+    """Raised when context.md does not satisfy the language contract."""
+
+
+def load_language_terms(context_path: Path) -> tuple[LanguageTerm, ...]:
+    """Load the Ubiquitous Language table from context.md."""
+
+    if not context_path.exists():
+        raise ContextLanguageError(f"missing context file: {context_path}")
+
+    text = context_path.read_text(encoding="utf-8")
+    if "## 1. Ubiquitous Language" not in text and "## Ubiquitous Language" not in text:
+        raise ContextLanguageError("context.md must contain a Ubiquitous Language section")
+
+    rows = _markdown_table_rows(text)
+    if len(rows) < 2:
+        raise ContextLanguageError("context.md must contain a Ubiquitous Language markdown table")
+
+    header = rows[0]
+    missing = [column for column in REQUIRED_COLUMNS if column not in header]
+    if missing:
+        raise ContextLanguageError(
+            "context.md Ubiquitous Language table is missing columns: "
+            + ", ".join(missing)
+        )
+
+    header_index = {name: header.index(name) for name in REQUIRED_COLUMNS}
+    terms: list[LanguageTerm] = []
+    seen: set[str] = set()
+    for row in rows[2:]:
+        if len(row) < len(header):
+            continue
+        canonical = row[header_index["Canonical Term"]].strip()
+        if not canonical or canonical in {"...", "-"}:
+            continue
+        normalized = canonical.casefold()
+        if normalized in seen:
+            raise ContextLanguageError(f"duplicate Canonical Term: {canonical}")
+        seen.add(normalized)
+        terms.append(
+            LanguageTerm(
+                canonical_term=canonical,
+                korean=row[header_index["Korean"]].strip(),
+                english=row[header_index["English"]].strip(),
+                term_type=row[header_index["Type"]].strip(),
+                definition=row[header_index["Definition"]].strip(),
+                aliases=_split_terms(row[header_index["Aliases"]]),
+                forbidden_terms=_split_terms(row[header_index["Forbidden Terms"]]),
+                source=row[header_index["Source"]].strip(),
+            )
+        )
+
+    if not terms:
+        raise ContextLanguageError("context.md must define at least one Canonical Term")
+
+    return tuple(terms)
+
+
+def validate_forbidden_terms(
+    repo_root: Path,
+    terms: Iterable[LanguageTerm],
+    scan_paths: Iterable[Path] = DEFAULT_SCAN_PATHS,
+) -> tuple[str, ...]:
+    """Return violations where a forbidden term appears in generated docs."""
+
+    forbidden = sorted(
+        {
+            forbidden
+            for term in terms
+            for forbidden in term.forbidden_terms
+            if forbidden and forbidden not in {"-", "None", "없음"}
+        },
+        key=len,
+        reverse=True,
+    )
+    if not forbidden:
+        return ()
+
+    violations: list[str] = []
+    for relative in scan_paths:
+        root = repo_root / relative
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.md")):
+            text = path.read_text(encoding="utf-8")
+            for forbidden_term in forbidden:
+                if _contains_term(text, forbidden_term):
+                    violations.append(f"{path.relative_to(repo_root)} contains forbidden term: {forbidden_term}")
+    return tuple(violations)
+
+
+def validate_context_language(repo_root: Path) -> tuple[str, ...]:
+    terms = load_language_terms(repo_root / "context.md")
+    return validate_forbidden_terms(repo_root, terms)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python3 -m harness_codex.context_language")
+    parser.add_argument("--repo-root", default=".")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    try:
+        violations = validate_context_language(repo_root)
+    except ContextLanguageError as exc:
+        print(f"BLOCKED: {exc}", file=sys.stderr)
+        return 2
+
+    if violations:
+        print("BLOCKED: forbidden Ubiquitous Language terms found", file=sys.stderr)
+        for violation in violations:
+            print(f"- {violation}", file=sys.stderr)
+        return 2
+
+    print("OK: context.md Ubiquitous Language is valid")
+    return 0
+
+
+def _markdown_table_rows(text: str) -> list[list[str]]:
+    rows: list[list[str]] = []
+    in_language_section = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            in_language_section = stripped in {
+                "## 1. Ubiquitous Language",
+                "## Ubiquitous Language",
+            }
+            continue
+        if not in_language_section:
+            continue
+        if stripped.startswith("|") and stripped.endswith("|"):
+            rows.append([cell.strip() for cell in stripped.strip("|").split("|")])
+        elif rows:
+            break
+    return rows
+
+
+def _split_terms(value: str) -> tuple[str, ...]:
+    if not value or value.strip() in {"-", "None", "없음"}:
+        return ()
+    return tuple(term.strip() for term in re.split(r"[,/、，]", value) if term.strip())
+
+
+def _contains_term(text: str, term: str) -> bool:
+    if re.search(r"[A-Za-z0-9_]", term):
+        return re.search(rf"(?<![A-Za-z0-9_]){re.escape(term)}(?![A-Za-z0-9_])", text, re.IGNORECASE) is not None
+    return term in text
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -132,16 +132,43 @@ def test_default_harvest_workflow_loads() -> None:
 
     assert workflow.name == "harness-harvest-workflow"
     requirements = workflow.step_by_id("harvest-requirements")
+    language = workflow.step_by_id("confirm-ubiquitous-language")
+    validate_language = workflow.step_by_id("validate-context-language")
     use_cases = workflow.step_by_id("harvest-use-cases")
+
+    assert workflow.step_ids() == (
+        "harvest-requirements",
+        "confirm-ubiquitous-language",
+        "validate-context-language",
+        "harvest-use-cases",
+    )
 
     assert requirements.agent_id == "harness_requirements"
     assert requirements.skill_id == "harness-requirements"
     assert requirements.outputs == (Path("docs/design/요구사항.md"),)
 
+    assert language.agent_id == "harness_requirements"
+    assert language.skill_id == "harness-requirements"
+    assert language.needs == ("harvest-requirements",)
+    assert language.inputs == (Path("docs/design/요구사항.md"),)
+    assert language.outputs == (Path("context.md"),)
+    assert language.metadata["language_gate"]["output"] == "context.md"
+
+    assert validate_language.kind == StepKind.VALIDATOR
+    assert validate_language.needs == ("confirm-ubiquitous-language",)
+    assert validate_language.command == "python3 -m harness_codex.context_language --repo-root ."
+    assert validate_language.inputs == (
+        Path("context.md"),
+        Path("docs/design/요구사항.md"),
+    )
+
     assert use_cases.agent_id == "harness_usecases"
     assert use_cases.skill_id == "harness-usecases"
-    assert use_cases.needs == ("harvest-requirements",)
-    assert use_cases.inputs == (Path("docs/design/요구사항.md"),)
+    assert use_cases.needs == ("validate-context-language",)
+    assert use_cases.inputs == (
+        Path("context.md"),
+        Path("docs/design/요구사항.md"),
+    )
     assert use_cases.outputs == (Path("docs/design/유스케이스.md"),)
 
 

--- a/tests/test_context_language.py
+++ b/tests/test_context_language.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+from harness_codex.context_language import (
+    ContextLanguageError,
+    load_language_terms,
+    validate_context_language,
+)
+
+
+VALID_CONTEXT = """# Project Context
+
+## 1. Ubiquitous Language
+
+| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
+|---|---|---|---|---|---|---|---|
+| 대기열 | 대기열 | WaitingQueue | Domain Concept | 사용자가 진입 순서를 기다리는 도메인 개념 | queue, waitlist | 줄, 웨이팅 리스트 | grill-me |
+
+## 2. Naming Rules
+
+- Documents must use `Canonical Term`.
+"""
+
+
+def test_load_language_terms_reads_required_table(tmp_path: Path) -> None:
+    context = tmp_path / "context.md"
+    context.write_text(VALID_CONTEXT, encoding="utf-8")
+
+    terms = load_language_terms(context)
+
+    assert len(terms) == 1
+    assert terms[0].canonical_term == "대기열"
+    assert terms[0].english == "WaitingQueue"
+    assert terms[0].aliases == ("queue", "waitlist")
+    assert terms[0].forbidden_terms == ("줄", "웨이팅 리스트")
+
+
+def test_load_language_terms_rejects_duplicate_canonical_terms(tmp_path: Path) -> None:
+    context = tmp_path / "context.md"
+    context.write_text(
+        VALID_CONTEXT.replace(
+            "| 대기열 | 대기열 | WaitingQueue | Domain Concept | 사용자가 진입 순서를 기다리는 도메인 개념 | queue, waitlist | 줄, 웨이팅 리스트 | grill-me |",
+            "| 대기열 | 대기열 | WaitingQueue | Domain Concept | 사용자가 진입 순서를 기다리는 도메인 개념 | queue, waitlist | 줄, 웨이팅 리스트 | grill-me |\n"
+            "| 대기열 | 대기열 | WaitingQueue | Domain Concept | 중복 정의 | - | - | grill-me |",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContextLanguageError, match="duplicate Canonical Term"):
+        load_language_terms(context)
+
+
+def test_validate_context_language_rejects_forbidden_terms_in_docs(tmp_path: Path) -> None:
+    (tmp_path / "context.md").write_text(VALID_CONTEXT, encoding="utf-8")
+    docs = tmp_path / "docs" / "design"
+    docs.mkdir(parents=True)
+    (docs / "요구사항.md").write_text("사용자는 웨이팅 리스트에 들어간다.", encoding="utf-8")
+
+    violations = validate_context_language(tmp_path)
+
+    assert violations == ("docs/design/요구사항.md contains forbidden term: 웨이팅 리스트",)
+
+
+def test_validate_context_language_allows_clean_docs(tmp_path: Path) -> None:
+    (tmp_path / "context.md").write_text(VALID_CONTEXT, encoding="utf-8")
+    docs = tmp_path / "docs" / "design"
+    docs.mkdir(parents=True)
+    (docs / "요구사항.md").write_text("사용자는 대기열에 들어간다.", encoding="utf-8")
+
+    assert validate_context_language(tmp_path) == ()

--- a/tests/test_harvester_skill_instructions.py
+++ b/tests/test_harvester_skill_instructions.py
@@ -31,3 +31,33 @@ def test_requirements_skill_explores_local_context_before_questions() -> None:
 
     assert "inspect them first" in skill
     assert "Before asking the user a question" in agent
+
+
+def test_requirements_harvest_owns_context_language() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
+        REPO_ROOT / ".codex/agents/harness_requirements.toml",
+        REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
+    )
+
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert "context.md" in text
+        assert "Ubiquitous Language" in text or "ubiquitous language" in text
+        assert "Forbidden Terms" in text
+        assert "Open Language Questions" in text
+
+
+def test_usecases_consume_context_language_without_editing_it() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-usecases/SKILL.md",
+        REPO_ROOT / ".codex/agents/harness_usecases.toml",
+        REPO_ROOT / ".codex/skills/harness-usecases/references/agent-prompt.md",
+    )
+
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert "context.md" in text
+        assert "canonical terms" in text or "canonical" in text
+        assert "Forbidden Terms" in text
+        assert "Do not edit context.md" in text or "or context.md" in text


### PR DESCRIPTION
## 구현 의도

요구사항 harvest 과정에서 `$grill-me`로 유비쿼터스 언어를 확정하고, 그 결과를 `context.md`에 저장한 뒤 이후 use-case harvest가 같은 언어를 사용하도록 강제합니다.

Closes #85

## 구현 방법

- `harvest-workflow.yaml`에 `confirm-ubiquitous-language` agent step을 추가했습니다.
- `confirm-ubiquitous-language` 이후 `validate-context-language` validator step을 실행하도록 구성했습니다.
- `harness_codex.context_language` 모듈을 추가해 `context.md`의 Ubiquitous Language table을 검증합니다.
  - 필수 컬럼 확인
  - Canonical Term 중복 확인
  - Forbidden Terms가 generated docs에 등장하는지 확인
- `harness-requirements` skill/agent가 `docs/design/요구사항.md`와 `context.md`를 함께 관리하도록 수정했습니다.
- `harness-usecases` skill/agent가 `context.md`를 먼저 읽고 canonical term / forbidden term 규칙을 따르도록 수정했습니다.
- reference agent prompt도 동일한 규칙으로 갱신했습니다.

## 검증 방법

- `tests/runtime/test_workflow_loader.py`
  - harvest workflow가 `harvest-requirements → confirm-ubiquitous-language → validate-context-language → harvest-use-cases` 순서로 로드되는지 검증
- `tests/test_context_language.py`
  - `context.md` table 파싱
  - Canonical Term 중복 검출
  - Forbidden Terms 검출
  - 정상 문서 통과 검증
- `tests/test_harvester_skill_instructions.py`
  - requirements/usecases skill 및 agent prompt가 `context.md`, Ubiquitous Language, Forbidden Terms, Open Language Questions 규칙을 포함하는지 검증

## 참고

GitHub API로 파일을 수정했기 때문에 로컬에서 pytest를 직접 실행하지는 못했습니다.