### PR TITLE
Implement ChangeSet final completion gate

### DIFF
--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -89,3 +89,18 @@ steps:
     metadata:
       stage: complete
       scope: work_item
+
+  - id: complete-change-set
+    kind: record
+    name: Complete active ChangeSet when all affected work items are completed
+    needs: [complete-work-item-plan]
+    inputs:
+      - docs/changes/active/<CHG-ID>.md
+    outputs:
+      - docs/changes/completed/<CHG-ID>.md
+      - .harness/runs/<RUN-ID>/changeset-completion-report.md
+    metadata:
+      stage: complete
+      scope: change_set
+      condition: all_affected_work_item_plans_completed
+      fail_closed: true

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -1,5 +1,10 @@
 """Core runtime model and execution abstractions."""
 
+from harness_codex.runtime.completion import (
+    ChangeSetCompletionBlocked,
+    ChangeSetCompletionResult,
+    complete_change_set_if_ready,
+)
 from harness_codex.runtime.engine import (
     ExecutionPlan,
     RunnerEngine,
@@ -79,6 +84,8 @@ __all__ = [
     "AgentContextFileResult",
     "AgentRunRequest",
     "AgentRunResult",
+    "ChangeSetCompletionBlocked",
+    "ChangeSetCompletionResult",
     "CommandRequest",
     "BasicStepRunner",
     "CodexCliAgentAdapter",
@@ -124,6 +131,7 @@ __all__ = [
     "Workflow",
     "WorkflowValidationError",
     "bootstrap_agent_context",
+    "complete_change_set_if_ready",
     "decide_resume_target",
     "file_checksum",
 ]

--- a/harness_codex/runtime/completion.py
+++ b/harness_codex/runtime/completion.py
@@ -1,0 +1,288 @@
+"""ChangeSet final completion gate and archive workflow."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from harness_codex.runtime.changes.models import ChangeSet
+
+
+class ChangeSetCompletionBlocked(RuntimeError):
+    """Raised when a ChangeSet is not ready for final completion."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+@dataclass(frozen=True)
+class ChangeSetCompletionResult:
+    """Result of a ChangeSet final completion attempt."""
+
+    change_set_id: str
+    active_path: Path
+    completed_path: Path
+    report_path: Path
+    completed_work_items: tuple[str, ...]
+    completed_plan_paths: tuple[Path, ...]
+    run_id: str | None = None
+    already_completed: bool = False
+
+
+def complete_change_set_if_ready(
+    repo_root: Path | str,
+    change_set: ChangeSet,
+    *,
+    run_id: str | None = None,
+) -> ChangeSetCompletionResult:
+    """Move an active ChangeSet to completed when all work items are done.
+
+    The gate is intentionally fail-closed: it requires completed plans for every
+    affected work item, no remaining active plans, and a successful run report.
+    Runtime evidence under `.harness/runs` is preserved and a completion report
+    is written next to the run report.
+    """
+
+    root = Path(repo_root)
+    active_path = Path("docs/changes/active") / f"{change_set.change_set_id}.md"
+    completed_path = Path("docs/changes/completed") / f"{change_set.change_set_id}.md"
+    absolute_active = root / active_path
+    absolute_completed = root / completed_path
+
+    work_items = change_set.ordered_work_items()
+    work_item_ids = tuple(item.work_item_id for item in work_items)
+    completed_plan_paths = tuple(
+        Path("docs/plans/completed") / item_id / "plan.md"
+        for item_id in work_item_ids
+    )
+
+    effective_run_id = run_id or _latest_run_id_for_change_set(root, change_set.change_set_id)
+    report_path = (
+        Path(".harness/runs") / effective_run_id / "changeset-completion-report.md"
+        if effective_run_id
+        else Path(".harness/runs/UNKNOWN/changeset-completion-report.md")
+    )
+
+    if absolute_completed.exists() and not absolute_active.exists():
+        return ChangeSetCompletionResult(
+            change_set_id=change_set.change_set_id,
+            active_path=active_path,
+            completed_path=completed_path,
+            report_path=report_path,
+            completed_work_items=work_item_ids,
+            completed_plan_paths=completed_plan_paths,
+            run_id=effective_run_id,
+            already_completed=True,
+        )
+
+    if absolute_completed.exists() and absolute_active.exists():
+        raise ChangeSetCompletionBlocked(
+            "completed ChangeSet already exists while active ChangeSet still exists: "
+            f"{completed_path}"
+        )
+
+    if not absolute_active.exists():
+        raise ChangeSetCompletionBlocked(
+            f"active ChangeSet file does not exist: {active_path}"
+        )
+
+    if change_set.path is not None and change_set.path != active_path:
+        raise ChangeSetCompletionBlocked(
+            "ChangeSet ID and active path do not match: "
+            f"id={change_set.change_set_id} path={change_set.path}"
+        )
+
+    if not work_items:
+        raise ChangeSetCompletionBlocked("ChangeSet has no affected work items")
+
+    blocked_statuses = tuple(
+        f"{item.work_item_id}:{item.status}"
+        for item in work_items
+        if item.status.strip().lower() in {"failed", "blocked"}
+    )
+    if blocked_statuses:
+        raise ChangeSetCompletionBlocked(
+            "affected work items are failed or blocked: "
+            + ", ".join(blocked_statuses)
+        )
+
+    missing_completed_plans = tuple(
+        path for path in completed_plan_paths if not (root / path).exists()
+    )
+    if missing_completed_plans:
+        raise ChangeSetCompletionBlocked(
+            "missing completed work item plans: "
+            + ", ".join(str(path) for path in missing_completed_plans)
+        )
+
+    active_plan_paths = tuple(
+        Path("docs/plans/active") / item_id / "plan.md"
+        for item_id in work_item_ids
+        if (root / "docs/plans/active" / item_id / "plan.md").exists()
+    )
+    if active_plan_paths:
+        raise ChangeSetCompletionBlocked(
+            "active work item plans still exist: "
+            + ", ".join(str(path) for path in active_plan_paths)
+        )
+
+    if effective_run_id is None:
+        raise ChangeSetCompletionBlocked(
+            f"no run state found for ChangeSet {change_set.change_set_id}"
+        )
+
+    run_report, run_report_path = _load_successful_run_report(
+        root,
+        effective_run_id,
+        work_item_ids,
+    )
+
+    absolute_completed.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(absolute_active), str(absolute_completed))
+
+    _write_completion_report(
+        root,
+        report_path,
+        change_set=change_set,
+        run_id=effective_run_id,
+        active_path=active_path,
+        completed_path=completed_path,
+        completed_work_items=work_item_ids,
+        completed_plan_paths=completed_plan_paths,
+        run_report_path=run_report_path,
+        run_report=run_report,
+    )
+
+    return ChangeSetCompletionResult(
+        change_set_id=change_set.change_set_id,
+        active_path=active_path,
+        completed_path=completed_path,
+        report_path=report_path,
+        completed_work_items=work_item_ids,
+        completed_plan_paths=completed_plan_paths,
+        run_id=effective_run_id,
+    )
+
+
+def _latest_run_id_for_change_set(repo_root: Path, change_set_id: str) -> str | None:
+    runs_dir = repo_root / ".harness/runs"
+    if not runs_dir.exists():
+        return None
+
+    candidates: list[tuple[float, str]] = []
+    for state_path in runs_dir.glob("*/state.json"):
+        try:
+            data = json.loads(state_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if data.get("change_set_id") == change_set_id:
+            candidates.append((state_path.stat().st_mtime, state_path.parent.name))
+
+    if not candidates:
+        return None
+    return sorted(candidates)[-1][1]
+
+
+def _load_successful_run_report(
+    repo_root: Path,
+    run_id: str,
+    work_item_ids: tuple[str, ...],
+) -> tuple[Mapping[str, Any], Path]:
+    report_path = Path(".harness/runs") / run_id / "report.json"
+    absolute_report_path = repo_root / report_path
+    if not absolute_report_path.exists():
+        raise ChangeSetCompletionBlocked(f"latest run report does not exist: {report_path}")
+
+    report = json.loads(absolute_report_path.read_text(encoding="utf-8"))
+    if report.get("status") != "succeeded":
+        raise ChangeSetCompletionBlocked(
+            f"latest run did not succeed: run_id={run_id} status={report.get('status', '-') }"
+        )
+
+    failed_or_blocked = tuple(
+        item_id
+        for item_id in tuple(report.get("failed_use_cases", ()))
+        + tuple(report.get("blocked_use_cases", ()))
+        if item_id in work_item_ids
+    )
+    if failed_or_blocked:
+        raise ChangeSetCompletionBlocked(
+            "latest run report contains failed or blocked work items: "
+            + ", ".join(failed_or_blocked)
+        )
+
+    work_item_reports = tuple(report.get("work_item_reports", ()))
+    for item in work_item_reports:
+        item_id = str(item.get("work_item_id", ""))
+        if item_id in work_item_ids and item.get("status") != "succeeded":
+            raise ChangeSetCompletionBlocked(
+                "latest run report contains non-succeeded work item result: "
+                f"{item_id}:{item.get('status', '-')}"
+            )
+
+    return report, report_path
+
+
+def _write_completion_report(
+    repo_root: Path,
+    report_path: Path,
+    *,
+    change_set: ChangeSet,
+    run_id: str,
+    active_path: Path,
+    completed_path: Path,
+    completed_work_items: tuple[str, ...],
+    completed_plan_paths: tuple[Path, ...],
+    run_report_path: Path,
+    run_report: Mapping[str, Any],
+) -> None:
+    path = repo_root / report_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    work_item_lines = [
+        "| Work Item | Completed Plan |",
+        "| --- | --- |",
+        *[
+            f"| `{item_id}` | `{plan_path}` |"
+            for item_id, plan_path in zip(completed_work_items, completed_plan_paths)
+        ],
+    ]
+    verification_result = run_report.get("status", "-")
+    work_item_results = run_report.get("work_item_reports", ())
+    verification_lines = [
+        f"- Run report: `{run_report_path}`",
+        f"- Run status: {verification_result}",
+    ]
+    for item in work_item_results:
+        item_id = item.get("work_item_id", "-")
+        status = item.get("status", "-")
+        verification_goal = item.get("verification_goal_path", "-")
+        verification_lines.append(
+            f"- `{item_id}`: status={status}, verification_goal=`{verification_goal}`"
+        )
+
+    path.write_text(
+        "\n".join(
+            [
+                f"# ChangeSet Completion Report {change_set.change_set_id}",
+                "",
+                f"- ChangeSet: `{change_set.change_set_id}`",
+                f"- Run ID: `{run_id}`",
+                "- Status: completed",
+                f"- Active path: `{active_path}`",
+                f"- Completed path: `{completed_path}`",
+                "",
+                "## Completed Work Items",
+                *work_item_lines,
+                "",
+                "## Verification",
+                *verification_lines,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )

--- a/tests/runtime/test_changeset_completion.py
+++ b/tests/runtime/test_changeset_completion.py
@@ -1,0 +1,172 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from harness_codex.runtime import (
+    ChangeSetCompletionBlocked,
+    complete_change_set_if_ready,
+)
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+
+
+CHANGESET = """# ChangeSet CHG-001
+
+## 1. 메타데이터
+|항목|값|
+|---|---|
+|ChangeSet ID|`CHG-001`|
+|상태|active|
+
+## 5. 영향 유스케이스
+|UC ID|유스케이스 이름|영향 유형|Slice 경로|상태|
+|---|---|---|---|---|
+|`UC-001`|결제 승인|update|`docs/use-cases/UC-001/`|planned|
+|`UC-002`|결제 취소|update|`docs/use-cases/UC-002/`|planned|
+"""
+
+
+def write_active_changeset(repo: Path) -> None:
+    active = repo / "docs/changes/active"
+    active.mkdir(parents=True)
+    (active / "CHG-001.md").write_text(CHANGESET, encoding="utf-8")
+
+
+def load_changeset(repo: Path):
+    return parse_changeset_markdown(
+        (repo / "docs/changes/active/CHG-001.md").read_text(encoding="utf-8"),
+        path=Path("docs/changes/active/CHG-001.md"),
+    )
+
+
+def write_completed_plan(repo: Path, work_item_id: str) -> None:
+    path = repo / "docs/plans/completed" / work_item_id / "plan.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(f"# Plan {work_item_id}\n", encoding="utf-8")
+
+
+def write_successful_run(repo: Path, *, status: str = "succeeded") -> None:
+    run_dir = repo / ".harness/runs/run-001"
+    run_dir.mkdir(parents=True)
+    (run_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-001",
+                "change_set_id": "CHG-001",
+                "workflow_name": "changeset-use-case-workflow",
+                "mode": "apply",
+                "affected_use_cases": ["UC-001", "UC-002"],
+                "affected_work_items": ["UC-001", "UC-002"],
+                "status": status,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "report.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-001",
+                "change_set_id": "CHG-001",
+                "workflow_name": "changeset-use-case-workflow",
+                "mode": "apply",
+                "status": status,
+                "affected_use_cases": ["UC-001", "UC-002"],
+                "failed_use_cases": [],
+                "blocked_use_cases": [],
+                "work_item_reports": [
+                    {
+                        "work_item_id": "UC-001",
+                        "work_item_type": "use_case",
+                        "active_plan_path": "docs/plans/active/UC-001/plan.md",
+                        "completed_plan_path": "docs/plans/completed/UC-001/plan.md",
+                        "status": "succeeded",
+                        "verification_goal_path": "docs/use-cases/UC-001/e2e-goal.md",
+                    },
+                    {
+                        "work_item_id": "UC-002",
+                        "work_item_type": "use_case",
+                        "active_plan_path": "docs/plans/active/UC-002/plan.md",
+                        "completed_plan_path": "docs/plans/completed/UC-002/plan.md",
+                        "status": "succeeded",
+                        "verification_goal_path": "docs/use-cases/UC-002/e2e-goal.md",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_complete_changeset_moves_active_file_and_writes_report(tmp_path: Path) -> None:
+    write_active_changeset(tmp_path)
+    write_completed_plan(tmp_path, "UC-001")
+    write_completed_plan(tmp_path, "UC-002")
+    write_successful_run(tmp_path)
+
+    result = complete_change_set_if_ready(tmp_path, load_changeset(tmp_path), run_id="run-001")
+
+    assert result.completed_path == Path("docs/changes/completed/CHG-001.md")
+    assert result.completed_work_items == ("UC-001", "UC-002")
+    assert not (tmp_path / "docs/changes/active/CHG-001.md").exists()
+    assert (tmp_path / "docs/changes/completed/CHG-001.md").exists()
+    report = (tmp_path / ".harness/runs/run-001/changeset-completion-report.md").read_text(
+        encoding="utf-8"
+    )
+    assert "# ChangeSet Completion Report CHG-001" in report
+    assert "`docs/plans/completed/UC-001/plan.md`" in report
+    assert "status=succeeded" in report
+
+
+def test_complete_changeset_rejects_missing_completed_plan(tmp_path: Path) -> None:
+    write_active_changeset(tmp_path)
+    write_completed_plan(tmp_path, "UC-001")
+    write_successful_run(tmp_path)
+
+    with pytest.raises(ChangeSetCompletionBlocked) as exc:
+        complete_change_set_if_ready(tmp_path, load_changeset(tmp_path), run_id="run-001")
+
+    assert "missing completed work item plans" in exc.value.reason
+    assert (tmp_path / "docs/changes/active/CHG-001.md").exists()
+
+
+def test_complete_changeset_rejects_active_plan_left_behind(tmp_path: Path) -> None:
+    write_active_changeset(tmp_path)
+    write_completed_plan(tmp_path, "UC-001")
+    write_completed_plan(tmp_path, "UC-002")
+    active_plan = tmp_path / "docs/plans/active/UC-002/plan.md"
+    active_plan.parent.mkdir(parents=True)
+    active_plan.write_text("# still active\n", encoding="utf-8")
+    write_successful_run(tmp_path)
+
+    with pytest.raises(ChangeSetCompletionBlocked) as exc:
+        complete_change_set_if_ready(tmp_path, load_changeset(tmp_path), run_id="run-001")
+
+    assert "active work item plans still exist" in exc.value.reason
+    assert (tmp_path / "docs/changes/active/CHG-001.md").exists()
+
+
+def test_complete_changeset_rejects_failed_latest_run(tmp_path: Path) -> None:
+    write_active_changeset(tmp_path)
+    write_completed_plan(tmp_path, "UC-001")
+    write_completed_plan(tmp_path, "UC-002")
+    write_successful_run(tmp_path, status="failed")
+
+    with pytest.raises(ChangeSetCompletionBlocked) as exc:
+        complete_change_set_if_ready(tmp_path, load_changeset(tmp_path), run_id="run-001")
+
+    assert "latest run did not succeed" in exc.value.reason
+
+
+def test_complete_changeset_is_idempotent_after_archive(tmp_path: Path) -> None:
+    write_active_changeset(tmp_path)
+    write_completed_plan(tmp_path, "UC-001")
+    write_completed_plan(tmp_path, "UC-002")
+    write_successful_run(tmp_path)
+    change_set = load_changeset(tmp_path)
+
+    first = complete_change_set_if_ready(tmp_path, change_set, run_id="run-001")
+    second = complete_change_set_if_ready(tmp_path, change_set, run_id="run-001")
+
+    assert first.already_completed is False
+    assert second.already_completed is True
+    assert second.completed_path == Path("docs/changes/completed/CHG-001.md")


### PR DESCRIPTION
## 구현 의도

Closes #91.

ChangeSet-first runtime에서 개별 work item plan은 completed로 이동할 수 있지만, ChangeSet 자체를 최종 완료 처리하는 gate가 없었습니다. 이 PR은 모든 affected work item이 완료되고 최신 run report가 성공 상태일 때만 active ChangeSet을 completed로 이동하는 최종 완료 처리를 추가합니다.

## 구현 방법

- `harness_codex.runtime.completion` 모듈 추가
  - `complete_change_set_if_ready()`로 ChangeSet completion gate 구현
  - 모든 affected work item의 completed plan 존재 여부 확인
  - 남아 있는 active plan이 있으면 fail-closed
  - 최신 run report가 `succeeded`가 아니면 completion 거부
  - failed/blocked work item result가 있으면 completion 거부
  - `docs/changes/active/<CHG-ID>.md`를 `docs/changes/completed/<CHG-ID>.md`로 이동
  - `.harness/runs/<RUN-ID>/changeset-completion-report.md` 작성
  - 이미 completed 상태인 경우 idempotent하게 결과 반환
- `harness_codex.runtime.__init__`에서 completion API export
- `.harness/workflows/changeset-use-case-workflow.yaml`에 `complete-change-set` 단계 추가
- completion gate 단위 테스트 추가
  - 성공 완료
  - completed plan 누락
  - active plan 잔존
  - failed latest run
  - 반복 completion idempotency

## 검증 방법

- 추가 테스트: `tests/runtime/test_changeset_completion.py`
- 변경 파일 비교 확인:
  - `.harness/workflows/changeset-use-case-workflow.yaml`
  - `harness_codex/runtime/__init__.py`
  - `harness_codex/runtime/completion.py`
  - `tests/runtime/test_changeset_completion.py`

로컬 컨테이너에서는 GitHub DNS 해석 실패로 저장소 clone 및 전체 pytest 실행은 수행하지 못했습니다. PR에는 completion gate 테스트를 포함했으므로 CI 또는 로컬 개발 환경에서 아래 명령으로 검증하면 됩니다.

```bash
python3 -m pytest -q tests/runtime/test_changeset_completion.py
python3 -m pytest -q tests/runtime
```
