### PR TITLE
Optimize runtime prompt assembly and invocation artifacts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -203,3 +203,50 @@ harness dashboard
 `--plan`과 `--preview`는 파일 변경이나 외부 명령 실행 없이 범위와 실행 순서만
 보여준다. `--apply`는 `.harness/workflows/changeset-use-case-workflow.yaml`을
 로드해 runner 경계까지 진입하고 state/report/dashboard projection을 남긴다.
+
+## 9. Codex Prompt Prefix와 런타임 아티팩트
+
+OpenAI/Codex 호출 비용 최적화는 응답 캐시가 아니라 **prompt prefix 재사용**에
+맞춘다. 런타임은 에이전트 prompt를 항상 같은 섹션 순서로 조립한다.
+
+```text
+[stable] Runtime Instruction
+[stable] Repository Source of Truth
+[stable] Agent Instruction
+[stable] Skill Body
+[stable] Workflow Definition
+[stable-ish] Repository Settings
+[volatile] ChangeSet Summary
+[volatile] Work Item Slice
+[volatile] Current Execution Payload
+```
+
+규칙은 다음과 같다.
+
+- stable 섹션은 ChangeSet, work item, run id, 로그보다 항상 앞에 둔다.
+- optional 문서가 없어도 섹션 헤더는 유지하고 `<not found>`로 기록한다.
+- file traversal은 정렬된 고정 순서를 사용한다.
+- run id, temporary path, verifier output, diff, 로그는 stable prefix 앞에 두지 않는다.
+
+에이전트 호출 시 런타임은 step-local 파일과 run-root snapshot을 함께 남긴다.
+
+```text
+.harness/runs/<RUN-ID>/
+  prompt-<STEP-ID>.md
+  response-<STEP-ID>.json
+  stdout-<STEP-ID>.log
+  stderr-<STEP-ID>.log
+  usage-<STEP-ID>.json
+  steps/<STEP-ID>/
+    prompt.md
+    command.json
+    stdout.txt
+    stderr.txt
+    final-message.md
+    result.json
+```
+
+`usage-<STEP-ID>.json`은 provider가 usage metadata를 제공하면 token 값을 저장한다.
+노출되지 않는 값, 예를 들어 `cached_prompt_tokens`, 는 값을 추정하지 않고 `null`로
+남긴다. 이 런타임 아티팩트는 source of truth가 아니라 재현, resume, audit, 디버깅을
+위한 실행 증거다.

--- a/harness_codex/runtime/prompt.py
+++ b/harness_codex/runtime/prompt.py
@@ -1,0 +1,255 @@
+"""Deterministic prompt assembly for runtime agent invocations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from harness_codex.runtime.models import RunContext, Step
+
+STABLE_PREFIX_END_MARKER = "## 7. ChangeSet Summary"
+
+RUNTIME_INSTRUCTION = """You are running as a harness-codex specialist agent.
+Follow the repository source-of-truth files, the selected agent instruction, and the selected skill.
+Keep edits inside the active ChangeSet and selected work item boundary.
+Report changed files, verification commands, and blockers clearly."""
+
+SOURCE_OF_TRUTH_FILES = (
+    Path("AGENTS.md"),
+    Path("docs/agent/context.md"),
+    Path("docs/agent/commands.md"),
+    Path("docs/agent/session-state.md"),
+)
+
+REPOSITORY_SETTINGS_FILES = (
+    Path(".codex/repository-settings.md"),
+    Path(".codex/stack-profile.yaml"),
+)
+
+
+def build_agent_prompt(
+    *,
+    step: Step,
+    context: RunContext,
+    agent_config: Mapping[str, Any],
+    agent_config_path: Path,
+    skill_path: Path | None = None,
+    skill_body: str | None = None,
+) -> str:
+    """Build one deterministic agent prompt.
+
+    Stable sections are emitted first so repeated calls can reuse provider prefix
+    caches. Volatile run IDs, ChangeSet data, selected work item data, logs, and
+    current payload are intentionally appended after the stable prefix marker.
+    """
+
+    sections = [
+        _section("1. Runtime Instruction", RUNTIME_INSTRUCTION),
+        _section("2. Repository Source of Truth", _source_of_truth(context.repo_root)),
+        _section("3. Agent Instruction", _agent_instruction(agent_config, agent_config_path)),
+        _section("4. Skill Body", _skill_body(skill_path, skill_body, context.repo_root)),
+        _section("5. Workflow Definition", _workflow_definition(context)),
+        _section("6. Repository Settings", _repository_settings(context.repo_root)),
+        _section("7. ChangeSet Summary", _changeset_summary(context)),
+        _section("8. Work Item Slice", _work_item_slice(context)),
+        _section("9. Current Execution Payload", _current_execution_payload(step, context)),
+    ]
+    return "\n\n".join(sections).rstrip() + "\n"
+
+
+def stable_prefix(prompt: str) -> str:
+    """Return the stable prefix before volatile ChangeSet/work-item sections."""
+
+    return prompt.split(STABLE_PREFIX_END_MARKER, maxsplit=1)[0]
+
+
+def _section(title: str, body: str) -> str:
+    return f"## {title}\n\n{body.strip()}"
+
+
+def _source_of_truth(repo_root: Path) -> str:
+    return _fixed_file_block(repo_root, SOURCE_OF_TRUTH_FILES)
+
+
+def _repository_settings(repo_root: Path) -> str:
+    return _fixed_file_block(repo_root, REPOSITORY_SETTINGS_FILES)
+
+
+def _fixed_file_block(repo_root: Path, paths: tuple[Path, ...]) -> str:
+    blocks: list[str] = []
+    for path in sorted(paths, key=lambda value: str(value)):
+        absolute = repo_root / path
+        if absolute.exists():
+            blocks.append(_file_block(path, absolute.read_text(encoding="utf-8")))
+        else:
+            blocks.append(_file_block(path, "<not found>"))
+    return "\n\n".join(blocks)
+
+
+def _file_block(path: Path, content: str) -> str:
+    return "\n".join(
+        [
+            f"### `{path}`",
+            "```text",
+            content.strip(),
+            "```",
+        ]
+    )
+
+
+def _agent_instruction(agent_config: Mapping[str, Any], agent_config_path: Path) -> str:
+    stable_agent_view = {
+        "name": agent_config.get("name", ""),
+        "description": agent_config.get("description", ""),
+        "model": agent_config.get("model", ""),
+        "model_reasoning_effort": agent_config.get("model_reasoning_effort", ""),
+        "sandbox_mode": agent_config.get("sandbox_mode", ""),
+        "provider": agent_config.get("provider", "codex"),
+        "agent_config_path": str(agent_config_path),
+    }
+    developer_instructions = str(agent_config.get("developer_instructions", "")).strip()
+    return "\n".join(
+        [
+            "```json",
+            _stable_json(stable_agent_view),
+            "```",
+            "",
+            "### Developer Instructions",
+            developer_instructions or "<empty>",
+        ]
+    )
+
+
+def _skill_body(
+    skill_path: Path | None,
+    skill_body: str | None,
+    repo_root: Path,
+) -> str:
+    if skill_path is None:
+        return "### Skill\n\n- Path: `<none>`\n- Body: `<none>`"
+
+    try:
+        display_path = skill_path.relative_to(repo_root)
+    except ValueError:
+        display_path = skill_path
+
+    return "\n".join(
+        [
+            f"### `{display_path}`",
+            "```markdown",
+            (skill_body or "<empty>").strip(),
+            "```",
+        ]
+    )
+
+
+def _workflow_definition(context: RunContext) -> str:
+    workflow_path = context.repo_root / ".harness/workflows" / f"{context.workflow_name}.yaml"
+    if workflow_path.exists():
+        return _file_block(
+            Path(".harness/workflows") / f"{context.workflow_name}.yaml",
+            workflow_path.read_text(encoding="utf-8"),
+        )
+    return _file_block(
+        Path(".harness/workflows") / f"{context.workflow_name}.yaml",
+        "<not found>",
+    )
+
+
+def _changeset_summary(context: RunContext) -> str:
+    change_set_path_value = context.metadata.get("change_set_path")
+    change_set_path = Path(str(change_set_path_value)) if change_set_path_value else None
+    blocks = [
+        "```json",
+        _stable_json(
+            {
+                "change_set_id": context.metadata.get("change_set_id"),
+                "change_set_path": str(change_set_path) if change_set_path else None,
+            }
+        ),
+        "```",
+    ]
+    if change_set_path is not None:
+        absolute = context.repo_root / change_set_path
+        blocks.extend(
+            [
+                "",
+                _file_block(
+                    change_set_path,
+                    absolute.read_text(encoding="utf-8") if absolute.exists() else "<not found>",
+                ),
+            ]
+        )
+    return "\n".join(blocks)
+
+
+def _work_item_slice(context: RunContext) -> str:
+    active_id = context.metadata.get("active_work_item_id")
+    active_type = context.metadata.get("active_work_item_type")
+    affected_items = context.metadata.get("affected_work_items", ())
+    active_item = None
+    if isinstance(affected_items, list):
+        active_item = next(
+            (
+                item
+                for item in affected_items
+                if isinstance(item, dict) and item.get("id") == active_id
+            ),
+            None,
+        )
+    return "\n".join(
+        [
+            "```json",
+            _stable_json(
+                {
+                    "active_work_item_id": active_id,
+                    "active_work_item_type": active_type,
+                    "active_work_item": active_item,
+                }
+            ),
+            "```",
+        ]
+    )
+
+
+def _current_execution_payload(step: Step, context: RunContext) -> str:
+    payload = {
+        "run_id": context.run_id,
+        "workflow_name": context.workflow_name,
+        "mode": context.mode.value,
+        "repo_root": str(context.repo_root),
+        "workdir": str(context.workdir),
+        "run_dir": str(context.run_dir),
+        "step": {
+            "id": step.id,
+            "kind": step.kind.value,
+            "name": step.name,
+            "agent_id": step.agent_id,
+            "skill_id": step.skill_id,
+            "command": step.command,
+            "inputs": [str(path) for path in step.inputs],
+            "outputs": [str(path) for path in step.outputs],
+            "metadata": _jsonable(step.metadata),
+        },
+        "runtime_metadata": _jsonable(context.metadata),
+    }
+    return "\n".join(["```json", _stable_json(payload), "```"])
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(_jsonable(value), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if hasattr(value, "value"):
+        return value.value
+    return value

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -1,8 +1,4 @@
-"""Step runner boundary for runtime execution.
-
-`StepRunner` is the adapter boundary between the pure runtime engine and
-side-effecting implementations such as agent CLIs, shell, git, and validators.
-"""
+"""Step runner boundary for runtime execution."""
 
 from __future__ import annotations
 
@@ -11,8 +7,8 @@ import shutil
 import subprocess
 import tomllib
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Protocol, Sequence
 from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence
 
 from harness_codex.runtime.models import (
     FailureKind,
@@ -22,6 +18,7 @@ from harness_codex.runtime.models import (
     StepResult,
     StepStatus,
 )
+from harness_codex.runtime.prompt import build_agent_prompt
 
 
 @dataclass(frozen=True)
@@ -48,33 +45,19 @@ class AgentRunResult:
 
 
 class AgentAdapter(Protocol):
-    """AGENT 단계 실행 adapter."""
-
     def run(self, request: AgentRunRequest) -> AgentRunResult:
         """전담 에이전트를 실행하고 구조화된 결과를 반환한다."""
         ...
 
 
 class StepRunner(Protocol):
-    """Adapter interface used by `RunnerEngine` to execute one step.
-
-    Implementations may call agent CLIs, shell, git, validators, or fake test doubles.
-
-    The engine depends only on this protocol and never performs those side
-    effects directly.
-    """
-
     def run(self, step: Step, context: RunContext) -> StepResult:
         """Execute one step and return a structured result."""
         ...
 
 
 class ConfigurableCliAgentAdapter:
-    """Run agent steps through the provider configured in `.codex/agents/*.toml`.
-
-    Backward compatibility rule:
-    - when `provider` is omitted, use the existing Codex CLI command shape.
-    """
+    """Run agent steps through the provider configured in `.codex/agents/*.toml`."""
 
     def __init__(self, codex_binary: str = "codex") -> None:
         self._codex_binary = codex_binary
@@ -83,9 +66,18 @@ class ConfigurableCliAgentAdapter:
         prompt_path = request.step_dir / "prompt.md"
         final_message_path = request.step_dir / "final-message.md"
         command_path = request.step_dir / "command.json"
+        request.step_dir.mkdir(parents=True, exist_ok=True)
 
-        prompt = _agent_prompt(request)
+        prompt = build_agent_prompt(
+            step=request.step,
+            context=request.context,
+            agent_config=request.agent_config,
+            agent_config_path=_relative_to_repo(request.agent_config_path, request.context),
+            skill_path=request.skill_path,
+            skill_body=request.skill_body,
+        )
         prompt_path.write_text(prompt, encoding="utf-8")
+        _write_run_root_text(request, f"prompt-{request.step.id}.md", prompt)
 
         provider_result = _resolve_provider_command(
             request,
@@ -93,12 +85,12 @@ class ConfigurableCliAgentAdapter:
             default_codex_binary=self._codex_binary,
         )
         if isinstance(provider_result, AgentRunResult):
-            (request.step_dir / "stdout.txt").write_text("", encoding="utf-8")
-            (request.step_dir / "stderr.txt").write_text(
-                provider_result.error or "",
-                encoding="utf-8",
-            )
+            stdout_path = request.step_dir / "stdout.txt"
+            stderr_path = request.step_dir / "stderr.txt"
+            stdout_path.write_text("", encoding="utf-8")
+            stderr_path.write_text(provider_result.error or "", encoding="utf-8")
             command_path.write_text("[]\n", encoding="utf-8")
+            _mirror_agent_artifacts(request, stdout_path, stderr_path, None, provider_result)
             return provider_result
 
         command, provider_metadata = provider_result
@@ -121,79 +113,63 @@ class ConfigurableCliAgentAdapter:
             binary = command[0] if command else "<empty>"
             provider = provider_metadata["provider"]
             error = f"agent provider binary not found: provider={provider} binary={binary}"
-            (request.step_dir / "stdout.txt").write_text("", encoding="utf-8")
-            (request.step_dir / "stderr.txt").write_text(error, encoding="utf-8")
-            return AgentRunResult(
+            stdout_path = request.step_dir / "stdout.txt"
+            stderr_path = request.step_dir / "stderr.txt"
+            stdout_path.write_text("", encoding="utf-8")
+            stderr_path.write_text(error, encoding="utf-8")
+            result = AgentRunResult(
                 status=StepStatus.BLOCKED,
                 error=error,
                 metadata={
-                    **_agent_metadata(
-                        request,
-                        prompt_path,
-                        final_message_path,
-                        error=str(exc),
-                    ),
+                    **_agent_metadata(request, prompt_path, final_message_path, error=str(exc)),
                     **provider_metadata,
                 },
             )
+            _mirror_agent_artifacts(request, stdout_path, stderr_path, None, result)
+            return result
         except subprocess.TimeoutExpired as exc:
             stdout = _decode_process_output(exc.stdout)
             stderr = _decode_process_output(exc.stderr)
             error = f"agent step timed out after {request.step.timeout_sec} seconds"
-            (request.step_dir / "stdout.txt").write_text(stdout, encoding="utf-8")
-            (request.step_dir / "stderr.txt").write_text(
-                stderr or error,
-                encoding="utf-8",
-            )
-            return AgentRunResult(
+            stdout_path = request.step_dir / "stdout.txt"
+            stderr_path = request.step_dir / "stderr.txt"
+            stdout_path.write_text(stdout, encoding="utf-8")
+            stderr_path.write_text(stderr or error, encoding="utf-8")
+            result = AgentRunResult(
                 status=StepStatus.FAILED,
                 error=error,
                 metadata={
-                    **_agent_metadata(
-                        request,
-                        prompt_path,
-                        final_message_path,
-                        error=str(exc),
-                    ),
+                    **_agent_metadata(request, prompt_path, final_message_path, error=str(exc)),
                     **provider_metadata,
                 },
             )
+            _mirror_agent_artifacts(request, stdout_path, stderr_path, None, result)
+            return result
 
-        (request.step_dir / "stdout.txt").write_text(
-            completed.stdout,
-            encoding="utf-8",
-        )
-        (request.step_dir / "stderr.txt").write_text(
-            completed.stderr,
-            encoding="utf-8",
-        )
+        stdout_path = request.step_dir / "stdout.txt"
+        stderr_path = request.step_dir / "stderr.txt"
+        stdout_path.write_text(completed.stdout, encoding="utf-8")
+        stderr_path.write_text(completed.stderr, encoding="utf-8")
         if provider_metadata["provider"] == "custom_cli":
             final_message_path.write_text(completed.stdout, encoding="utf-8")
 
         if completed.returncode != 0:
             error = completed.stderr.strip() or completed.stdout.strip()
             blocker = _agent_process_blocker_error(error)
-            if blocker is not None:
-                return AgentRunResult(
-                    status=StepStatus.BLOCKED,
-                    exit_code=completed.returncode,
-                    error=blocker,
-                    metadata={
-                        **_agent_metadata(request, prompt_path, final_message_path),
-                        **provider_metadata,
-                    },
-                )
-            return AgentRunResult(
-                status=StepStatus.FAILED,
+            status = StepStatus.BLOCKED if blocker is not None else StepStatus.FAILED
+            result = AgentRunResult(
+                status=status,
                 exit_code=completed.returncode,
-                error=error,
+                error=blocker or error,
                 metadata={
                     **_agent_metadata(request, prompt_path, final_message_path),
                     **provider_metadata,
                 },
             )
+            _mirror_agent_artifacts(request, stdout_path, stderr_path, final_message_path, result)
+            return result
 
-        return AgentRunResult(
+        result = AgentRunResult(
             status=StepStatus.SUCCEEDED,
             exit_code=0,
             metadata={
@@ -201,13 +177,12 @@ class ConfigurableCliAgentAdapter:
                 **provider_metadata,
             },
         )
+        _mirror_agent_artifacts(request, stdout_path, stderr_path, final_message_path, result)
+        return result
 
 
 class CodexCliAgentAdapter(ConfigurableCliAgentAdapter):
-    """Backward-compatible Codex adapter name.
-
-    The adapter is now provider-aware. Omitted `provider` still means `codex`.
-    """
+    """Backward-compatible Codex adapter name."""
 
 
 class BasicStepRunner:
@@ -231,19 +206,9 @@ class BasicStepRunner:
 
         return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
 
-    def _run_agent(
-        self,
-        step: Step,
-        context: RunContext,
-        step_dir: Path,
-    ) -> StepResult:
+    def _run_agent(self, step: Step, context: RunContext, step_dir: Path) -> StepResult:
         if not step.agent_id:
-            return _blocked_agent_result(
-                step,
-                context,
-                step_dir,
-                "agent_id is required",
-            )
+            return _blocked_agent_result(step, context, step_dir, "agent_id is required")
 
         agent_config_path = context.repo_root / ".codex/agents" / f"{step.agent_id}.toml"
         if not agent_config_path.exists():
@@ -272,12 +237,7 @@ class BasicStepRunner:
         invocation_path = step_dir / "invocation.json"
         invocation_path.write_text(
             json.dumps(
-                _agent_invocation_manifest(
-                    step,
-                    context,
-                    agent_config_path,
-                    skill_path,
-                ),
+                _agent_invocation_manifest(step, context, agent_config_path, skill_path),
                 ensure_ascii=False,
                 indent=2,
             )
@@ -313,6 +273,7 @@ class BasicStepRunner:
             + "\n",
             encoding="utf-8",
         )
+        _write_response_snapshot(context, step.id, result_path)
         return StepResult(
             step_id=step.id,
             status=result.status,
@@ -323,21 +284,12 @@ class BasicStepRunner:
             metadata=result.metadata,
         )
 
-    def _run_record(
-        self,
-        step: Step,
-        context: RunContext,
-        step_dir: Path,
-    ) -> StepResult:
-        missing = tuple(
-            path for path in step.inputs if not (context.repo_root / path).exists()
-        )
+    def _run_record(self, step: Step, context: RunContext, step_dir: Path) -> StepResult:
+        missing = tuple(path for path in step.inputs if not (context.repo_root / path).exists())
         evidence = step_dir / "record.json"
         evidence.write_text(
-            "{\n"
-            f'  "step_id": "{step.id}",\n'
-            f'  "missing_inputs": {[str(path) for path in missing]}\n'
-            "}\n",
+            json.dumps({"step_id": step.id, "missing_inputs": [str(path) for path in missing]}, indent=2)
+            + "\n",
             encoding="utf-8",
         )
         if missing:
@@ -349,25 +301,11 @@ class BasicStepRunner:
             )
         for output in step.outputs:
             (context.repo_root / output).parent.mkdir(parents=True, exist_ok=True)
-        return StepResult(
-            step_id=step.id,
-            status=StepStatus.SUCCEEDED,
-            output_path=_relative_to_repo(evidence, context),
-        )
+        return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED, output_path=_relative_to_repo(evidence, context))
 
-    def _run_command(
-        self,
-        step: Step,
-        context: RunContext,
-        step_dir: Path,
-    ) -> StepResult:
+    def _run_command(self, step: Step, context: RunContext, step_dir: Path) -> StepResult:
         if not step.command:
-            return StepResult(
-                step_id=step.id,
-                status=StepStatus.BLOCKED,
-                error="command is required",
-            )
-
+            return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error="command is required")
         completed = subprocess.run(
             step.command,
             cwd=context.workdir,
@@ -380,10 +318,7 @@ class BasicStepRunner:
         (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
         (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
         result_path = step_dir / "result.txt"
-        result_path.write_text(
-            f"exit_code={completed.returncode}\n",
-            encoding="utf-8",
-        )
+        result_path.write_text(f"exit_code={completed.returncode}\n", encoding="utf-8")
         if completed.returncode != 0:
             return StepResult(
                 step_id=step.id,
@@ -393,43 +328,25 @@ class BasicStepRunner:
                 error=completed.stderr.strip() or completed.stdout.strip(),
                 failure_kind=FailureKind.IMPLEMENTATION,
             )
-        return StepResult(
-            step_id=step.id,
-            status=StepStatus.SUCCEEDED,
-            exit_code=0,
-            output_path=_relative_to_repo(result_path, context),
-        )
+        return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED, exit_code=0, output_path=_relative_to_repo(result_path, context))
 
-    def _run_git_boundary(
-        self,
-        step: Step,
-        context: RunContext,
-        step_dir: Path,
-    ) -> StepResult:
+    def _run_git_boundary(self, step: Step, context: RunContext, step_dir: Path) -> StepResult:
         if step.command:
             return self._run_command(step, context, step_dir)
-
         if len(step.inputs) == 1 and len(step.outputs) == 1:
             source = context.repo_root / step.inputs[0]
             target = context.repo_root / step.outputs[0]
             if not source.exists():
-                return StepResult(
-                    step_id=step.id,
-                    status=StepStatus.BLOCKED,
-                    error=f"missing source: {step.inputs[0]}",
-                )
+                return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error=f"missing source: {step.inputs[0]}")
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(source), str(target))
             return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
-
-        return StepResult(
-            step_id=step.id,
-            status=StepStatus.BLOCKED,
-            error="git step requires an explicit command or one input/output move",
-        )
+        return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error="git step requires an explicit command or one input/output move")
 
 
-def _relative_to_repo(path: Path, context: RunContext) -> Path:
+def _relative_to_repo(path: Path | None, context: RunContext) -> Path:
+    if path is None:
+        return Path("-")
     try:
         return path.relative_to(context.repo_root)
     except ValueError:
@@ -441,52 +358,27 @@ def _load_agent_config(path: Path) -> Mapping[str, Any]:
         return tomllib.load(file)
 
 
-def _resolve_provider_command(
-    request: AgentRunRequest,
-    final_message_path: Path,
-    *,
-    default_codex_binary: str,
-) -> tuple[list[str], dict[str, Any]] | AgentRunResult:
+def _resolve_provider_command(request: AgentRunRequest, final_message_path: Path, *, default_codex_binary: str) -> tuple[list[str], dict[str, Any]] | AgentRunResult:
     config = request.agent_config
     provider = config.get("provider", "codex")
     if not isinstance(provider, str) or not provider.strip():
         return _blocked_provider_result(request, "agent provider must be a non-empty string")
-
     provider = provider.strip()
     if provider == "codex":
         binary = config.get("provider_binary", default_codex_binary)
         if not isinstance(binary, str) or not binary.strip():
-            return _blocked_provider_result(
-                request,
-                "codex provider_binary must be a non-empty string",
-                provider=provider,
-            )
+            return _blocked_provider_result(request, "codex provider_binary must be a non-empty string", provider=provider)
         command = _codex_command(request, final_message_path, binary.strip())
         return command, {"provider": provider, "provider_command": command}
-
     if provider == "custom_cli":
-        command_value = config.get("provider_command")
-        command = _custom_provider_command(command_value)
+        command = _custom_provider_command(config.get("provider_command"))
         if command is None:
-            return _blocked_provider_result(
-                request,
-                "custom_cli provider requires provider_command as a non-empty list of strings",
-                provider=provider,
-            )
+            return _blocked_provider_result(request, "custom_cli provider requires provider_command as a non-empty list of strings", provider=provider)
         return command, {"provider": provider, "provider_command": command}
-
-    return _blocked_provider_result(
-        request,
-        f"unsupported agent provider: {provider}",
-        provider=provider,
-    )
+    return _blocked_provider_result(request, f"unsupported agent provider: {provider}", provider=provider)
 
 
-def _codex_command(
-    request: AgentRunRequest,
-    final_message_path: Path,
-    codex_binary: str,
-) -> list[str]:
+def _codex_command(request: AgentRunRequest, final_message_path: Path, codex_binary: str) -> list[str]:
     config = request.agent_config
     command = [
         codex_binary,
@@ -498,19 +390,15 @@ def _codex_command(
         "--output-last-message",
         str(final_message_path),
     ]
-
     model = config.get("model")
     if isinstance(model, str) and model:
         command.extend(["--model", model])
-
     reasoning_effort = config.get("model_reasoning_effort")
     if isinstance(reasoning_effort, str) and reasoning_effort:
         command.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
-
     sandbox_mode = config.get("sandbox_mode")
     if isinstance(sandbox_mode, str) and sandbox_mode:
         command.extend(["--sandbox", sandbox_mode])
-
     command.append("-")
     return command
 
@@ -519,61 +407,28 @@ def _custom_provider_command(value: Any) -> list[str] | None:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
         return None
     command = list(value)
-    if not command:
-        return None
-    if not all(isinstance(part, str) and part for part in command):
+    if not command or not all(isinstance(part, str) and part for part in command):
         return None
     return command
 
 
-def _blocked_provider_result(
-    request: AgentRunRequest,
-    error: str,
-    *,
-    provider: str | None = None,
-) -> AgentRunResult:
-    return AgentRunResult(
-        status=StepStatus.BLOCKED,
-        error=error,
-        metadata={
-            "agent_id": request.step.agent_id,
-            "provider": provider,
-            "provider_error": error,
-        },
-    )
+def _blocked_provider_result(request: AgentRunRequest, error: str, *, provider: str | None = None) -> AgentRunResult:
+    return AgentRunResult(status=StepStatus.BLOCKED, error=error, metadata={"agent_id": request.step.agent_id, "provider": provider, "provider_error": error})
 
 
-def _agent_metadata(
-    request: AgentRunRequest,
-    prompt_path: Path,
-    final_message_path: Path,
-    *,
-    error: str | None = None,
-) -> dict[str, Any]:
+def _agent_metadata(request: AgentRunRequest, prompt_path: Path, final_message_path: Path, *, error: str | None = None) -> dict[str, Any]:
+    run_prompt_path = request.context.run_dir / f"prompt-{request.step.id}.md"
     metadata: dict[str, Any] = {
         "agent_id": request.step.agent_id,
-        "agent_config": str(
-            _relative_to_repo(request.agent_config_path, request.context)
-        ),
+        "agent_config": str(_relative_to_repo(request.agent_config_path, request.context)),
         "skill_id": _step_skill_id(request.step),
-        "skill_path": (
-            str(_relative_to_repo(request.skill_path, request.context))
-            if request.skill_path is not None
-            else None
-        ),
-        "invocation_path": str(
-            _relative_to_repo(request.step_dir / "invocation.json", request.context)
-        ),
+        "skill_path": str(_relative_to_repo(request.skill_path, request.context)) if request.skill_path is not None else None,
+        "invocation_path": str(_relative_to_repo(request.step_dir / "invocation.json", request.context)),
         "prompt_path": str(_relative_to_repo(prompt_path, request.context)),
-        "stdout_path": str(
-            _relative_to_repo(request.step_dir / "stdout.txt", request.context)
-        ),
-        "stderr_path": str(
-            _relative_to_repo(request.step_dir / "stderr.txt", request.context)
-        ),
-        "final_message_path": str(
-            _relative_to_repo(final_message_path, request.context)
-        ),
+        "run_prompt_path": str(_relative_to_repo(run_prompt_path, request.context)),
+        "stdout_path": str(_relative_to_repo(request.step_dir / "stdout.txt", request.context)),
+        "stderr_path": str(_relative_to_repo(request.step_dir / "stderr.txt", request.context)),
+        "final_message_path": str(_relative_to_repo(final_message_path, request.context)),
     }
     if error is not None:
         metadata["adapter_error"] = error
@@ -598,154 +453,99 @@ def _agent_process_blocker_error(output: str) -> str | None:
     return None
 
 
-def _blocked_agent_result(
-    step: Step,
-    context: RunContext,
-    step_dir: Path,
-    error: str,
-) -> StepResult:
+def _blocked_agent_result(step: Step, context: RunContext, step_dir: Path, error: str) -> StepResult:
     result_path = step_dir / "result.json"
     result_path.write_text(
         json.dumps(
-            {
-                "step_id": step.id,
-                "agent_id": step.agent_id,
-                "skill_id": _step_skill_id(step),
-                "status": StepStatus.BLOCKED.value,
-                "error": error,
-            },
+            {"step_id": step.id, "agent_id": step.agent_id, "skill_id": _step_skill_id(step), "status": StepStatus.BLOCKED.value, "error": error},
             ensure_ascii=False,
             indent=2,
         )
         + "\n",
         encoding="utf-8",
     )
-    return StepResult(
-        step_id=step.id,
-        status=StepStatus.BLOCKED,
-        output_path=_relative_to_repo(result_path, context),
-        error=error,
-        failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
-        metadata={"agent_id": step.agent_id, "skill_id": _step_skill_id(step)},
-    )
-
-
-def _agent_prompt(request: AgentRunRequest) -> str:
-    config = request.agent_config
-    instructions = config.get("developer_instructions", "")
-    context_metadata = json.dumps(
-        _jsonable(request.context.metadata),
-        ensure_ascii=False,
-        indent=2,
-    )
-    step_metadata = json.dumps(
-        _jsonable(request.step.metadata),
-        ensure_ascii=False,
-        indent=2,
-    )
-    inputs = "\n".join(f"- `{path}`" for path in request.step.inputs) or "- 없음"
-    outputs = "\n".join(f"- `{path}`" for path in request.step.outputs) or "- 없음"
-    skill_lines = _agent_prompt_skill_lines(request)
-
-    return "\n".join(
-        [
-            f"# Harness Agent Step: {request.step.id}",
-            "",
-            "아래 전담 에이전트 지시문을 기준으로 이 런타임 단계를 수행한다.",
-            "",
-            "## Agent",
-            f"- ID: `{request.step.agent_id}`",
-            f"- Name: `{config.get('name', request.step.agent_id)}`",
-            f"- Description: {config.get('description', '')}",
-            "",
-            *skill_lines,
-            "",
-            "## Developer Instructions",
-            str(instructions).strip(),
-            "",
-            "## Runtime Context",
-            f"- Run ID: `{request.context.run_id}`",
-            f"- Workflow: `{request.context.workflow_name}`",
-            f"- Step: `{request.step.id}`",
-            f"- Step name: {request.step.name}",
-            f"- Repository root: `{request.context.repo_root}`",
-            f"- Workdir: `{request.context.workdir}`",
-            f"- Run dir: `{request.context.run_dir}`",
-            "",
-            "## Step Inputs",
-            inputs,
-            "",
-            "## Step Outputs",
-            outputs,
-            "",
-            "## Step Metadata",
-            "```json",
-            step_metadata,
-            "```",
-            "",
-            "## Workflow Metadata",
-            "```json",
-            context_metadata,
-            "```",
-            "",
-            "완료 후 실제로 수행한 작업, 변경한 파일, 실행한 검증 명령, 남은 blocker를 간결하게 보고한다.",
-        ]
-    )
+    _write_response_snapshot(context, step.id, result_path)
+    return StepResult(step_id=step.id, status=StepStatus.BLOCKED, output_path=_relative_to_repo(result_path, context), error=error, failure_kind=FailureKind.ENVIRONMENT_BLOCKER, metadata={"agent_id": step.agent_id, "skill_id": _step_skill_id(step)})
 
 
 def _step_skill_id(step: Step) -> str | None:
     if step.skill_id:
         return step.skill_id
-
     skill_id = step.metadata.get("skill_id")
     if isinstance(skill_id, str) and skill_id.strip():
         return skill_id
-
     return None
 
 
-def _agent_invocation_manifest(
-    step: Step,
-    context: RunContext,
-    agent_config_path: Path,
-    skill_path: Path | None,
-) -> dict[str, Any]:
+def _agent_invocation_manifest(step: Step, context: RunContext, agent_config_path: Path, skill_path: Path | None) -> dict[str, Any]:
     return {
         "step_id": step.id,
         "agent_id": step.agent_id,
         "agent_config": str(_relative_to_repo(agent_config_path, context)),
         "skill_id": _step_skill_id(step),
-        "skill_path": (
-            str(_relative_to_repo(skill_path, context))
-            if skill_path is not None
-            else None
-        ),
+        "skill_path": str(_relative_to_repo(skill_path, context)) if skill_path is not None else None,
         "inputs": [str(path) for path in step.inputs],
         "outputs": [str(path) for path in step.outputs],
         "metadata": _jsonable(step.metadata),
     }
 
 
-def _agent_prompt_skill_lines(request: AgentRunRequest) -> list[str]:
-    skill_id = _step_skill_id(request.step)
-    if skill_id is None:
-        return [
-            "## Skill",
-            "- ID: `-`",
-            "- Path: `-`",
-        ]
+def _write_run_root_text(request: AgentRunRequest, filename: str, text: str) -> Path:
+    path = request.context.run_dir / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
 
-    lines = [
-        "## Skill",
-        f"- ID: `{skill_id}`",
-        f"- Path: `{_relative_to_repo(request.skill_path, request.context)}`",
-        "",
-        "### Skill Instructions",
-        "```markdown",
-        (request.skill_body or "").strip(),
-        "```",
-    ]
-    return lines
+
+def _mirror_agent_artifacts(
+    request: AgentRunRequest,
+    stdout_path: Path,
+    stderr_path: Path,
+    final_message_path: Path | None,
+    result: AgentRunResult,
+) -> None:
+    run_dir = request.context.run_dir
+    run_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(stdout_path, run_dir / f"stdout-{request.step.id}.log")
+    shutil.copyfile(stderr_path, run_dir / f"stderr-{request.step.id}.log")
+    response = {
+        "step_id": request.step.id,
+        "status": result.status.value,
+        "exit_code": result.exit_code,
+        "error": result.error,
+        "metadata": dict(result.metadata),
+    }
+    if final_message_path is not None and final_message_path.exists():
+        response["final_message"] = final_message_path.read_text(encoding="utf-8")
+    (run_dir / f"response-{request.step.id}.json").write_text(
+        json.dumps(response, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _write_usage_snapshot(request, result)
+
+
+def _write_response_snapshot(context: RunContext, step_id: str, result_path: Path) -> None:
+    if not result_path.exists():
+        return
+    context.run_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(result_path, context.run_dir / f"response-{step_id}.json")
+
+
+def _write_usage_snapshot(request: AgentRunRequest, result: AgentRunResult) -> None:
+    usage = result.metadata.get("usage") if isinstance(result.metadata, Mapping) else None
+    usage_payload = usage if isinstance(usage, Mapping) else {}
+    payload = {
+        "step_id": request.step.id,
+        "work_item_id": request.context.metadata.get("active_work_item_id"),
+        "change_set_id": request.context.metadata.get("change_set_id"),
+        "model": request.agent_config.get("model"),
+        "prompt_tokens": usage_payload.get("prompt_tokens"),
+        "completion_tokens": usage_payload.get("completion_tokens"),
+        "cached_prompt_tokens": usage_payload.get("cached_prompt_tokens"),
+    }
+    path = request.context.run_dir / f"usage-{request.step.id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def _jsonable(value: Any) -> Any:

--- a/tests/runtime/test_prompt_builder.py
+++ b/tests/runtime/test_prompt_builder.py
@@ -1,0 +1,189 @@
+import json
+import subprocess
+from pathlib import Path
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind, StepStatus
+from harness_codex.runtime.prompt import build_agent_prompt, stable_prefix
+from harness_codex.runtime.runner import AgentRunRequest, ConfigurableCliAgentAdapter
+
+
+def write_stable_context(repo: Path) -> None:
+    (repo / "AGENTS.md").write_text("# AGENTS\nsource of truth\n", encoding="utf-8")
+    agent_dir = repo / ".codex/agents"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "implementation_executor.toml").write_text(
+        "\n".join(
+            [
+                'name = "implementation_executor"',
+                'description = "executor"',
+                'model = "gpt-5.5"',
+                'developer_instructions = """execute carefully"""',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    skill_dir = repo / ".codex/skills/harness-plan-executor"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Skill\nexecute plan\n", encoding="utf-8")
+    workflow_dir = repo / ".harness/workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "changeset-use-case-workflow.yaml").write_text(
+        "version: 1\nworkflow:\n  name: changeset-use-case-workflow\n",
+        encoding="utf-8",
+    )
+    settings_dir = repo / ".codex"
+    (settings_dir / "repository-settings.md").write_text("# Settings\n", encoding="utf-8")
+
+
+def context(repo: Path, *, run_id: str, work_item: str) -> RunContext:
+    change_dir = repo / "docs/changes/active"
+    change_dir.mkdir(parents=True, exist_ok=True)
+    (change_dir / "CHG-001.md").write_text(
+        f"# ChangeSet CHG-001\n\nactive item {work_item}\n",
+        encoding="utf-8",
+    )
+    return RunContext(
+        run_id=run_id,
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo,
+        workdir=repo,
+        run_dir=repo / ".harness/runs" / run_id,
+        metadata={
+            "change_set_id": "CHG-001",
+            "change_set_path": "docs/changes/active/CHG-001.md",
+            "active_work_item_id": work_item,
+            "active_work_item_type": "use_case",
+            "affected_work_items": [{"id": work_item, "type": "use_case"}],
+        },
+    )
+
+
+def step() -> Step:
+    return Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute work item",
+        agent_id="implementation_executor",
+        skill_id="harness-plan-executor",
+        inputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        metadata={"stage": "execution"},
+    )
+
+
+def agent_config() -> dict:
+    return {
+        "name": "implementation_executor",
+        "description": "executor",
+        "model": "gpt-5.5",
+        "developer_instructions": "execute carefully",
+    }
+
+
+def test_prompt_order_places_stable_sections_before_volatile_sections(tmp_path: Path) -> None:
+    write_stable_context(tmp_path)
+
+    prompt = build_agent_prompt(
+        step=step(),
+        context=context(tmp_path, run_id="run-001", work_item="UC-001"),
+        agent_config=agent_config(),
+        agent_config_path=Path(".codex/agents/implementation_executor.toml"),
+        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
+        skill_body="# Skill\nexecute plan\n",
+    )
+
+    section_order = [
+        "## 1. Runtime Instruction",
+        "## 2. Repository Source of Truth",
+        "## 3. Agent Instruction",
+        "## 4. Skill Body",
+        "## 5. Workflow Definition",
+        "## 6. Repository Settings",
+        "## 7. ChangeSet Summary",
+        "## 8. Work Item Slice",
+        "## 9. Current Execution Payload",
+    ]
+    indexes = [prompt.index(section) for section in section_order]
+    assert indexes == sorted(indexes)
+    assert "run-001" not in stable_prefix(prompt)
+    assert "UC-001" not in stable_prefix(prompt)
+
+
+def test_volatile_context_does_not_change_stable_prefix(tmp_path: Path) -> None:
+    write_stable_context(tmp_path)
+
+    first = build_agent_prompt(
+        step=step(),
+        context=context(tmp_path, run_id="run-001", work_item="UC-001"),
+        agent_config=agent_config(),
+        agent_config_path=Path(".codex/agents/implementation_executor.toml"),
+        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
+        skill_body="# Skill\nexecute plan\n",
+    )
+    second = build_agent_prompt(
+        step=step(),
+        context=context(tmp_path, run_id="run-999", work_item="UC-999"),
+        agent_config=agent_config(),
+        agent_config_path=Path(".codex/agents/implementation_executor.toml"),
+        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
+        skill_body="# Skill\nexecute plan\n",
+    )
+
+    assert stable_prefix(first) == stable_prefix(second)
+    assert first != second
+
+
+def test_missing_optional_context_keeps_stable_section_order(tmp_path: Path) -> None:
+    write_stable_context(tmp_path)
+    (tmp_path / ".codex/repository-settings.md").unlink()
+
+    prompt = build_agent_prompt(
+        step=step(),
+        context=context(tmp_path, run_id="run-001", work_item="UC-001"),
+        agent_config=agent_config(),
+        agent_config_path=Path(".codex/agents/implementation_executor.toml"),
+        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
+        skill_body="# Skill\nexecute plan\n",
+    )
+
+    assert "### `.codex/repository-settings.md`" in prompt
+    assert "<not found>" in prompt
+    assert prompt.index("## 6. Repository Settings") < prompt.index("## 7. ChangeSet Summary")
+
+
+def test_agent_adapter_writes_run_root_invocation_artifacts(tmp_path: Path, monkeypatch) -> None:
+    write_stable_context(tmp_path)
+    ctx = context(tmp_path, run_id="run-001", work_item="UC-001")
+    request = AgentRunRequest(
+        step=step(),
+        context=ctx,
+        step_dir=ctx.run_dir / "steps/execute-work-item",
+        agent_config_path=tmp_path / ".codex/agents/implementation_executor.toml",
+        agent_config=agent_config(),
+        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
+        skill_body="# Skill\nexecute plan\n",
+    )
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="final answer",
+            stderr="diagnostic",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(request)
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert (ctx.run_dir / "prompt-execute-work-item.md").is_file()
+    assert (ctx.run_dir / "response-execute-work-item.json").is_file()
+    assert (ctx.run_dir / "stdout-execute-work-item.log").read_text(encoding="utf-8") == "final answer"
+    assert (ctx.run_dir / "stderr-execute-work-item.log").read_text(encoding="utf-8") == "diagnostic"
+    usage = json.loads((ctx.run_dir / "usage-execute-work-item.json").read_text(encoding="utf-8"))
+    assert usage["step_id"] == "execute-work-item"
+    assert usage["work_item_id"] == "UC-001"
+    assert usage["change_set_id"] == "CHG-001"
+    assert usage["cached_prompt_tokens"] is None


### PR DESCRIPTION
## 구현 의도

Closes #88.

Codex 호출에서 유효한 캐시는 응답 캐시가 아니라 prompt prefix 재사용이므로, 런타임의 agent prompt 조립 순서를 deterministic하게 고정하고 volatile context를 뒤로 밀었습니다. 또한 실행 재현, resume, audit, 디버깅을 위해 agent invocation artifact를 run-root에 snapshot으로 남기도록 했습니다.

## 구현 방법

- `harness_codex.runtime.prompt` 추가
  - `build_agent_prompt()`로 단일 deterministic prompt builder 제공
  - stable section을 항상 먼저 출력
    1. Runtime Instruction
    2. Repository Source of Truth
    3. Agent Instruction
    4. Skill Body
    5. Workflow Definition
    6. Repository Settings
  - volatile section을 stable prefix 뒤에 출력
    7. ChangeSet Summary
    8. Work Item Slice
    9. Current Execution Payload
  - optional 문서가 없어도 섹션 헤더와 `<not found>`를 유지
  - JSON 출력은 `sort_keys=True`로 안정화
- `ConfigurableCliAgentAdapter`가 새 prompt builder를 사용하도록 변경
- agent invocation artifact를 `.harness/runs/<RUN-ID>/`에 snapshot으로 저장
  - `prompt-<STEP-ID>.md`
  - `response-<STEP-ID>.json`
  - `stdout-<STEP-ID>.log`
  - `stderr-<STEP-ID>.log`
  - `usage-<STEP-ID>.json`
- step-local artifact도 기존대로 유지
  - `steps/<STEP-ID>/prompt.md`
  - `steps/<STEP-ID>/command.json`
  - `steps/<STEP-ID>/stdout.txt`
  - `steps/<STEP-ID>/stderr.txt`
  - `steps/<STEP-ID>/final-message.md`
  - `steps/<STEP-ID>/result.json`
- `usage-<STEP-ID>.json`은 provider usage metadata가 없으면 token 값을 추정하지 않고 `null`로 기록
- `docs/README.md`에 prompt prefix/cache와 runtime artifact 규칙 문서화

## 검증 방법

추가 테스트:

```bash
python3 -m pytest -q tests/runtime/test_prompt_builder.py
python3 -m pytest -q tests/runtime/test_agent_runner.py
```

테스트 커버리지:

- prompt section ordering이 stable → volatile 순서를 유지하는지 검증
- run id / work item id 변경이 stable prefix를 바꾸지 않는지 검증
- optional docs 누락 시에도 section order가 유지되는지 검증
- agent adapter가 run-root prompt/response/stdout/stderr/usage artifact를 쓰는지 검증

로컬 컨테이너에서는 GitHub DNS 해석 실패로 저장소 clone 및 pytest 실행은 수행하지 못했습니다. 브랜치에는 테스트를 포함했으므로 CI 또는 로컬 개발 환경에서 위 명령으로 검증하면 됩니다.

## 참고

이 PR은 semantic response cache를 구현하지 않습니다. 목적은 prompt-prefix 안정화와 로컬 runtime artifact 보존입니다.