### PR TITLE
Add one-command installer for new projects

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,9 @@ curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/script
 
 - `harness_codex/`, `.harness/`, `.codex/`, `tests/runtime`를 현재 프로젝트에 설치한다.
 - `venv`를 만들고 `pip`, `pytest`, `pyyaml`을 설치한다.
+- 프로젝트 루트에 짧은 실행 래퍼 `./harness`를 생성한다.
 - `ARCHITECTURE.md`, `docs/design/요구사항.md`, `docs/design/유스케이스.md`, `.codex/repository-settings.md`, `.codex/test-gate.yaml`가 없으면 생성한다.
-- `PYTHONPATH=. ./venv/bin/python3 -m harness_codex --help` smoke test를 실행한다.
+- `./harness --help` smoke test를 실행한다.
 
 기존 파일은 기본적으로 덮어쓰지 않는다. 다시 설치하며 덮어쓰려면 다음처럼 실행한다.
 
@@ -30,14 +31,14 @@ curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/script
 설치 후 다음 명령으로 프로젝트 컨텍스트와 ChangeSet을 시작한다.
 
 ```bash
-PYTHONPATH=. ./venv/bin/python3 -m harness_codex agent-context init \
+./harness agent-context init \
   --description "New project managed by harness-codex runtime"
 
-PYTHONPATH=. ./venv/bin/python3 -m harness_codex changes create-from-design \
+./harness changes create-from-design \
   --title "initial runtime setup" \
   --change-set-id CHG-YYYYMMDD-001
 
-PYTHONPATH=. ./venv/bin/python3 -m harness_codex run-change CHG-YYYYMMDD-001 --plan
+./harness run-change CHG-YYYYMMDD-001 --plan
 ```
 
 ## 1. Agent Context Bootstrap
@@ -46,7 +47,7 @@ New repositories that use this harness should bootstrap repo-local agent context
 harvest or ChangeSet execution.
 
 ```bash
-python3 -m harness_codex agent-context init --description "<repo description>"
+./harness agent-context init --description "<repo description>"
 ```
 
 The bootstrap creates a short `AGENTS.md` and cold-path context files under
@@ -226,18 +227,18 @@ Maintenance plan은 `docs/plans/completed/<MAINT-ID>/plan.md`로 이동한다.
 `.harness/runs/<run-id>/`에 저장한다.
 
 ```bash
-harness changes list
-harness changes show <CHG-ID>
-harness run-change <CHG-ID> --plan|--preview|--apply
-harness run-use-case <CHG-ID> <UC-ID> --plan|--preview|--apply
-harness run-work-item <CHG-ID> <WORK-ITEM-ID> --plan|--preview|--apply
-harness stages list <CHG-ID>
-harness artifacts show <CHG-ID> <stage>
-harness artifacts accept <CHG-ID> <stage>
-harness run-stage <CHG-ID> <stage> --plan|--preview|--apply
-harness resume <run-id>
-harness report <run-id>
-harness dashboard
+./harness changes list
+./harness changes show <CHG-ID>
+./harness run-change <CHG-ID> --plan|--preview|--apply
+./harness run-use-case <CHG-ID> <UC-ID> --plan|--preview|--apply
+./harness run-work-item <CHG-ID> <WORK-ITEM-ID> --plan|--preview|--apply
+./harness stages list <CHG-ID>
+./harness artifacts show <CHG-ID> <stage>
+./harness artifacts accept <CHG-ID> <stage>
+./harness run-stage <CHG-ID> <stage> --plan|--preview|--apply
+./harness resume <run-id>
+./harness report <run-id>
+./harness dashboard
 ```
 
 `--plan`과 `--preview`는 파일 변경이나 외부 명령 실행 없이 범위와 실행 순서만

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,46 @@
 # Harness Document Structure
 
-## 0. Agent Context Bootstrap
+## 0. Quick install for a new repository
+
+새 빈 프로젝트에서는 GitHub의 installer를 내려받아 런타임 파일과 최소 문서 구조를 한 번에 초기화할 수 있다.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash
+```
+
+기본 동작:
+
+- `harness_codex/`, `.harness/`, `.codex/`, `tests/runtime`를 현재 프로젝트에 설치한다.
+- `venv`를 만들고 `pip`, `pytest`, `pyyaml`을 설치한다.
+- `ARCHITECTURE.md`, `docs/design/요구사항.md`, `docs/design/유스케이스.md`, `.codex/repository-settings.md`, `.codex/test-gate.yaml`가 없으면 생성한다.
+- `PYTHONPATH=. ./venv/bin/python3 -m harness_codex --help` smoke test를 실행한다.
+
+기존 파일은 기본적으로 덮어쓰지 않는다. 다시 설치하며 덮어쓰려면 다음처럼 실행한다.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --force
+```
+
+특정 ref나 대상 디렉터리를 지정할 수도 있다.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --ref main --target /path/to/project
+```
+
+설치 후 다음 명령으로 프로젝트 컨텍스트와 ChangeSet을 시작한다.
+
+```bash
+PYTHONPATH=. ./venv/bin/python3 -m harness_codex agent-context init \
+  --description "New project managed by harness-codex runtime"
+
+PYTHONPATH=. ./venv/bin/python3 -m harness_codex changes create-from-design \
+  --title "initial runtime setup" \
+  --change-set-id CHG-YYYYMMDD-001
+
+PYTHONPATH=. ./venv/bin/python3 -m harness_codex run-change CHG-YYYYMMDD-001 --plan
+```
+
+## 1. Agent Context Bootstrap
 
 New repositories that use this harness should bootstrap repo-local agent context before
 harvest or ChangeSet execution.
@@ -17,14 +57,14 @@ bootstrap preserves it and records that decision in `docs/agent/session-state.md
 changes create-from-design` runs it after generating ChangeSet and use-case slice
 documents.
 
-## 1. 목적
+## 2. 목적
 
 이 문서는 ChangeSet과 유스케이스 slice 기반 실행 구조를 정의한다.
 목표는 구현 요청마다 변경 의도와 영향을 명시하고, planner/executor가 전체
 `docs/design/**`를 매번 다시 분석하지 않고 승인된 유스케이스 범위만 읽도록
 입력 경계를 고정하는 것이다.
 
-## 2. 표준 구조
+## 3. 표준 구조
 
 ```text
 docs/
@@ -79,7 +119,7 @@ docs/
 `docs/changes/active`, `docs/changes/completed`, `docs/plans/active`,
 `docs/plans/completed`는 실제 실행 상태를 표현한다.
 
-## 3. ChangeSet 규칙
+## 4. ChangeSet 규칙
 
 ChangeSet은 하나의 구현 요청 또는 문서 변경 요청을 나타낸다.
 각 ChangeSet은 다음 내용을 반드시 포함한다.
@@ -96,7 +136,7 @@ ChangeSet은 하나의 구현 요청 또는 문서 변경 요청을 나타낸다
 모든 영향 유스케이스의 plan이 완료되고 검증이 통과하면 같은 파일을
 `docs/changes/completed/<CHG-ID>.md`로 이동한다.
 
-## 4. 유스케이스 Slice 규칙
+## 5. 유스케이스 Slice 규칙
 
 `docs/use-cases/<UC-ID>/`는 특정 유스케이스를 구현 가능한 단위로 좁힌
 executor-facing 문서 집합이다.
@@ -113,7 +153,7 @@ executor-facing 문서 집합이다.
 입력으로 사용한다. 공통 설계가 필요할 때만 `docs/design/**`를 보조 입력으로
 참조한다.
 
-## 5. Maintenance Slice 규칙
+## 6. Maintenance Slice 규칙
 
 `docs/maintenance/<MAINT-ID>/`는 특정 유스케이스로 표현하기 어려운
 리팩토링, 버그 수정, 테스트 보강, 인프라 변경, 문서 정리 같은 유지보수성
@@ -141,7 +181,7 @@ Maintenance slice는 이벤트 스토밍이나 UC E2E goal을 요구하지 않�
 계획 파일은 `docs/plans/active/<MAINT-ID>/plan.md`에 생성하고, 완료 후
 `docs/plans/completed/<MAINT-ID>/plan.md`로 이동한다.
 
-## 6. Canonical Design 관계
+## 7. Canonical Design 관계
 
 `docs/design/**`는 전체 제품/도메인 수준의 canonical 문서다.
 `docs/use-cases/<UC-ID>/**`는 특정 유스케이스 실행을 위한 slice 문서다.
@@ -159,7 +199,7 @@ Maintenance slice는 이벤트 스토밍이나 UC E2E goal을 요구하지 않�
 - 전체 `docs/design/이벤트 스토밍.md`는 summary/index로 유지할 수 있지만,
   UC 구현 계획의 직접 입력은 `docs/use-cases/<UC-ID>/event-storming.md`다.
 
-## 7. Plan 이동 규칙
+## 8. Plan 이동 규칙
 
 유스케이스별 plan은 `docs/plans/active/<UC-ID>/plan.md`에 생성한다.
 Maintenance별 plan은 `docs/plans/active/<MAINT-ID>/plan.md`에 생성한다.
@@ -180,7 +220,7 @@ Maintenance plan은 `docs/plans/completed/<MAINT-ID>/plan.md`로 이동한다.
 검증 실패는 work item 유형에 맞춰 `implementation failure`, `scope conflict`,
 `environment blocker`, `verification goal unclear`로 분류한다.
 
-## 8. 런타임 CLI
+## 9. 런타임 CLI
 
 로컬 런타임은 ChangeSet 아래 work item을 조회하고 실행 상태를
 `.harness/runs/<run-id>/`에 저장한다.
@@ -204,7 +244,7 @@ harness dashboard
 보여준다. `--apply`는 `.harness/workflows/changeset-use-case-workflow.yaml`을
 로드해 runner 경계까지 진입하고 state/report/dashboard projection을 남긴다.
 
-## 9. Codex Prompt Prefix와 런타임 아티팩트
+## 10. Codex Prompt Prefix와 런타임 아티팩트
 
 OpenAI/Codex 호출 비용 최적화는 응답 캐시가 아니라 **prompt prefix 재사용**에
 맞춘다. 런타임은 에이전트 prompt를 항상 같은 섹션 순서로 조립한다.

--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -107,12 +107,37 @@ copy_file_if_missing() {
   echo "created: ${dst#$TARGET_DIR/}"
 }
 
+create_launcher() {
+  local dst="$TARGET_DIR/harness"
+  if [[ -e "$dst" && "$FORCE" -ne 1 ]]; then
+    echo "skip existing: harness"
+    return
+  fi
+  cat > "$dst" <<'LAUNCHER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -x "$ROOT_DIR/venv/bin/python3" ]]; then
+  PYTHON_BIN="$ROOT_DIR/venv/bin/python3"
+else
+  PYTHON_BIN="$(command -v python3)"
+fi
+
+cd "$ROOT_DIR"
+PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}" exec "$PYTHON_BIN" -m harness_codex "$@"
+LAUNCHER
+  chmod +x "$dst"
+  echo "created: harness"
+}
+
 copy_dir "$SRC_DIR/harness_codex" "$TARGET_DIR/harness_codex"
 copy_dir "$SRC_DIR/.harness" "$TARGET_DIR/.harness"
 copy_dir "$SRC_DIR/.codex" "$TARGET_DIR/.codex"
 
 mkdir -p "$TARGET_DIR/tests"
 copy_dir "$SRC_DIR/tests/runtime" "$TARGET_DIR/tests/runtime"
+create_launcher
 
 mkdir -p \
   "$TARGET_DIR/docs/design" \
@@ -157,15 +182,14 @@ if [[ "$SKIP_VENV" -ne 1 ]]; then
     echo "skip existing: venv"
   fi
   "$TARGET_DIR/venv/bin/python3" -m pip install -U pip pytest pyyaml
-  PYTHON_BIN="$TARGET_DIR/venv/bin/python3"
 else
-  PYTHON_BIN="$(command -v python3)"
+  echo "Skipping venv setup"
 fi
 
 echo "Running harness CLI smoke test"
 (
   cd "$TARGET_DIR"
-  PYTHONPATH=. "$PYTHON_BIN" -m harness_codex --help >/dev/null
+  ./harness --help >/dev/null
 )
 
 cat <<EOF
@@ -174,8 +198,8 @@ harness-codex installed successfully.
 
 Next commands:
   cd "$TARGET_DIR"
-  PYTHONPATH=. ./venv/bin/python3 -m harness_codex agent-context init --description "New project managed by harness-codex runtime"
-  PYTHONPATH=. ./venv/bin/python3 -m harness_codex changes create-from-design --title "initial runtime setup" --change-set-id CHG-$(date +%Y%m%d)-001
-  PYTHONPATH=. ./venv/bin/python3 -m harness_codex run-change CHG-$(date +%Y%m%d)-001 --plan
+  ./harness agent-context init --description "New project managed by harness-codex runtime"
+  ./harness changes create-from-design --title "initial runtime setup" --change-set-id CHG-$(date +%Y%m%d)-001
+  ./harness run-change CHG-$(date +%Y%m%d)-001 --plan
 
 EOF

--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HARNESS_REPO="${HARNESS_CODEX_REPO:-https://github.com/omegafrog/harness-codex}"
+HARNESS_REF="${HARNESS_CODEX_REF:-main}"
+TARGET_DIR="${HARNESS_CODEX_TARGET:-$PWD}"
+FORCE=0
+SKIP_VENV=0
+
+usage() {
+  cat <<'USAGE'
+Install harness-codex runtime files into the current project.
+
+Usage:
+  bash scripts/install-harness-codex.sh [--force] [--skip-venv] [--ref <git-ref>] [--target <dir>]
+
+Environment:
+  HARNESS_CODEX_REPO    GitHub repository URL. Default: https://github.com/omegafrog/harness-codex
+  HARNESS_CODEX_REF     Branch, tag, or commit to download. Default: main
+  HARNESS_CODEX_TARGET  Target project directory. Default: current directory
+
+Examples:
+  curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --force
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --skip-venv)
+      SKIP_VENV=1
+      shift
+      ;;
+    --ref)
+      HARNESS_REF="${2:?--ref requires a value}"
+      shift 2
+      ;;
+    --target)
+      TARGET_DIR="${2:?--target requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+need_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need_command curl
+need_command tar
+need_command python3
+
+mkdir -p "$TARGET_DIR"
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ARCHIVE_URL="$HARNESS_REPO/archive/${HARNESS_REF}.tar.gz"
+echo "Downloading harness-codex from $ARCHIVE_URL"
+curl -fsSL "$ARCHIVE_URL" -o "$TMP_DIR/harness-codex.tar.gz"
+tar -xzf "$TMP_DIR/harness-codex.tar.gz" -C "$TMP_DIR"
+SRC_DIR="$(find "$TMP_DIR" -maxdepth 1 -type d -name 'harness-codex-*' | head -n 1)"
+
+if [[ -z "${SRC_DIR:-}" || ! -d "$SRC_DIR" ]]; then
+  echo "Failed to locate extracted harness-codex source directory" >&2
+  exit 1
+fi
+
+copy_dir() {
+  local src="$1"
+  local dst="$2"
+  if [[ -e "$dst" && "$FORCE" -ne 1 ]]; then
+    echo "skip existing: ${dst#$TARGET_DIR/}"
+    return
+  fi
+  rm -rf "$dst"
+  mkdir -p "$(dirname "$dst")"
+  cp -R "$src" "$dst"
+  echo "installed: ${dst#$TARGET_DIR/}"
+}
+
+copy_file_if_missing() {
+  local dst="$1"
+  local content="$2"
+  if [[ -e "$dst" && "$FORCE" -ne 1 ]]; then
+    echo "skip existing: ${dst#$TARGET_DIR/}"
+    return
+  fi
+  mkdir -p "$(dirname "$dst")"
+  printf '%s\n' "$content" > "$dst"
+  echo "created: ${dst#$TARGET_DIR/}"
+}
+
+copy_dir "$SRC_DIR/harness_codex" "$TARGET_DIR/harness_codex"
+copy_dir "$SRC_DIR/.harness" "$TARGET_DIR/.harness"
+copy_dir "$SRC_DIR/.codex" "$TARGET_DIR/.codex"
+
+mkdir -p "$TARGET_DIR/tests"
+copy_dir "$SRC_DIR/tests/runtime" "$TARGET_DIR/tests/runtime"
+
+mkdir -p \
+  "$TARGET_DIR/docs/design" \
+  "$TARGET_DIR/docs/changes/active" \
+  "$TARGET_DIR/docs/changes/completed" \
+  "$TARGET_DIR/docs/use-cases" \
+  "$TARGET_DIR/docs/maintenance" \
+  "$TARGET_DIR/docs/plans/active" \
+  "$TARGET_DIR/docs/plans/completed"
+
+copy_file_if_missing "$TARGET_DIR/ARCHITECTURE.md" '# Architecture
+
+TBD
+'
+
+copy_file_if_missing "$TARGET_DIR/docs/design/요구사항.md" '# 요구사항
+
+TBD
+'
+
+copy_file_if_missing "$TARGET_DIR/docs/design/유스케이스.md" '# 유스케이스
+
+TBD
+'
+
+copy_file_if_missing "$TARGET_DIR/.codex/repository-settings.md" '# Repository Settings
+
+## Test Command
+./venv/bin/python3 -m pytest -q -s tests/runtime
+'
+
+copy_file_if_missing "$TARGET_DIR/.codex/test-gate.yaml" 'required:
+  - name: runtime
+    command: ./venv/bin/python3 -m pytest -q -s tests/runtime
+'
+
+if [[ "$SKIP_VENV" -ne 1 ]]; then
+  if [[ ! -d "$TARGET_DIR/venv" ]]; then
+    echo "Creating Python venv"
+    python3 -m venv "$TARGET_DIR/venv"
+  else
+    echo "skip existing: venv"
+  fi
+  "$TARGET_DIR/venv/bin/python3" -m pip install -U pip pytest pyyaml
+  PYTHON_BIN="$TARGET_DIR/venv/bin/python3"
+else
+  PYTHON_BIN="$(command -v python3)"
+fi
+
+echo "Running harness CLI smoke test"
+(
+  cd "$TARGET_DIR"
+  PYTHONPATH=. "$PYTHON_BIN" -m harness_codex --help >/dev/null
+)
+
+cat <<EOF
+
+harness-codex installed successfully.
+
+Next commands:
+  cd "$TARGET_DIR"
+  PYTHONPATH=. ./venv/bin/python3 -m harness_codex agent-context init --description "New project managed by harness-codex runtime"
+  PYTHONPATH=. ./venv/bin/python3 -m harness_codex changes create-from-design --title "initial runtime setup" --change-set-id CHG-$(date +%Y%m%d)-001
+  PYTHONPATH=. ./venv/bin/python3 -m harness_codex run-change CHG-$(date +%Y%m%d)-001 --plan
+
+EOF


### PR DESCRIPTION
## 구현 의도

새 빈 프로젝트에서 harness-codex 런타임을 시작할 때 필요한 반복 작업과 긴 실행 명령을 줄이기 위해 one-command installer와 짧은 launcher를 추가했습니다.

Closes #94

## 구현 방법

- `scripts/install-harness-codex.sh` 추가
  - GitHub archive에서 harness-codex를 다운로드합니다.
  - `harness_codex/`, `.harness/`, `.codex/`, `tests/runtime`를 대상 프로젝트에 복사합니다.
  - `docs/**`, `ARCHITECTURE.md`, `.codex/repository-settings.md`, `.codex/test-gate.yaml` 최소 구조를 생성합니다.
  - 기본적으로 기존 파일은 덮어쓰지 않고, `--force` 옵션일 때만 덮어씁니다.
  - `venv`를 만들고 `pytest`, `pyyaml`을 설치합니다.
  - 프로젝트 루트에 `./harness` 실행 래퍼를 생성합니다.
  - smoke test는 `./harness --help`로 수행합니다.
- `docs/README.md` 상단에 새 프로젝트 quick install 섹션을 추가했습니다.
- README의 런타임 CLI 예시를 긴 `PYTHONPATH=. ./venv/bin/python3 -m harness_codex ...` 대신 `./harness ...` 기준으로 정리했습니다.

## 사용 예시

설치:

```bash
curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash
```

설치 후:

```bash
./harness agent-context init --description "New project managed by harness-codex runtime"
./harness changes create-from-design --title "initial runtime setup" --change-set-id CHG-YYYYMMDD-001
./harness run-change CHG-YYYYMMDD-001 --plan
```

옵션 예시:

```bash
curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --force
curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --ref main --target /path/to/project
```

## 검증 방법

- GitHub compare 기준 변경 파일 확인
  - `docs/README.md`
  - `scripts/install-harness-codex.sh`
- 스크립트는 `bash -n` 기준 문법 검사를 통과하도록 점검했습니다.
- 스크립트에는 smoke test로 `./harness --help`를 실행하도록 포함했습니다.

## 참고

현재 도구 환경에서는 실제 외부 shell에서 GitHub archive 다운로드와 `curl | bash` 설치 전체를 수행하지는 못했습니다. PR 검토 시 깨끗한 임시 디렉터리에서 installer를 한 번 실행해보는 것을 권장합니다.