### PR TITLE
[codex] Serena MCP runtime 자동 설정

### DIFF
--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -1,5 +1,9 @@
 """Core runtime model and execution abstractions."""
 
+from harness_codex.runtime.serena_patch import apply_serena_mcp_patch
+
+apply_serena_mcp_patch()
+
 from harness_codex.runtime.completion import (
     ChangeSetCompletionBlocked,
     ChangeSetCompletionResult,

--- a/harness_codex/runtime/serena_mcp.py
+++ b/harness_codex/runtime/serena_mcp.py
@@ -1,0 +1,286 @@
+"""Conditional Serena MCP setup for Codex agent runs."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SerenaMcpInstallation:
+    """Result of detecting and preparing Serena MCP for a project."""
+
+    enabled: bool
+    language_ids: tuple[str, ...] = ()
+    matched_paths: tuple[Path, ...] = ()
+    command_path: str | None = None
+    install_attempted: bool = False
+    install_succeeded: bool = False
+    install_error: str | None = None
+    codex_config_overrides: tuple[str, ...] = ()
+
+    def as_metadata(self) -> dict[str, Any]:
+        """Return JSON-safe runtime metadata."""
+
+        return {
+            "enabled": self.enabled,
+            "language_ids": list(self.language_ids),
+            "matched_paths": [str(path) for path in self.matched_paths],
+            "command_path": self.command_path,
+            "install_attempted": self.install_attempted,
+            "install_succeeded": self.install_succeeded,
+            "install_error": self.install_error,
+            "codex_config_overrides": list(self.codex_config_overrides),
+        }
+
+
+SUPPORTED_SUFFIXES = {
+    ".py": "python",
+    ".pyw": "python",
+    ".js": "typescript",
+    ".jsx": "typescript",
+    ".mjs": "typescript",
+    ".cjs": "typescript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".go": "go",
+    ".rs": "rust",
+    ".c": "cpp",
+    ".cc": "cpp",
+    ".cpp": "cpp",
+    ".cxx": "cpp",
+    ".h": "cpp",
+    ".hpp": "cpp",
+    ".cs": "csharp",
+    ".rb": "ruby",
+    ".php": "php",
+    ".swift": "swift",
+    ".scala": "scala",
+    ".sh": "bash",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".json": "json",
+    ".html": "html",
+    ".htm": "html",
+    ".css": "scss",
+    ".scss": "scss",
+    ".sass": "scss",
+    ".md": "markdown",
+    ".vue": "vue",
+    ".svelte": "svelte",
+    ".dart": "dart",
+    ".lua": "lua",
+    ".ex": "elixir",
+    ".exs": "elixir",
+    ".erl": "erlang",
+    ".hrl": "erlang",
+    ".hs": "haskell",
+    ".ml": "ocaml",
+    ".mli": "ocaml",
+    ".lean": "lean",
+    ".nix": "nix",
+    ".sol": "solidity",
+    ".zig": "zig",
+}
+
+MARKER_FILES = {
+    "pyproject.toml": "python",
+    "requirements.txt": "python",
+    "setup.py": "python",
+    "package.json": "typescript",
+    "tsconfig.json": "typescript",
+    "jsconfig.json": "typescript",
+    "go.mod": "go",
+    "cargo.toml": "rust",
+    "pom.xml": "java",
+    "build.gradle": "java",
+    "build.gradle.kts": "kotlin",
+    "settings.gradle": "java",
+    "settings.gradle.kts": "kotlin",
+    "compile_commands.json": "cpp",
+    "composer.json": "php",
+    "gemfile": "ruby",
+    "mix.exs": "elixir",
+    "package.swift": "swift",
+    "flake.nix": "nix",
+}
+
+SKIPPED_DIR_NAMES = {
+    ".git",
+    ".harness",
+    ".codex",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    "build",
+    "dist",
+    "target",
+    ".gradle",
+    ".idea",
+    ".vscode",
+}
+
+MAX_SCAN_FILES = 5_000
+INSTALL_TIMEOUT_SEC = 180
+
+
+def ensure_serena_mcp(
+    repo_root: Path,
+    workdir: Path,
+    log_dir: Path,
+) -> SerenaMcpInstallation:
+    """Install Serena when useful and return Codex MCP config overrides.
+
+    Missing optional prerequisites do not block the agent run. The failure is
+    recorded in metadata and Codex is invoked without Serena MCP.
+    """
+
+    language_ids, matched_paths = detect_supported_languages(repo_root, workdir)
+    if not language_ids:
+        return SerenaMcpInstallation(enabled=False)
+
+    serena_path = shutil.which("serena")
+    install_attempted = False
+    install_succeeded = False
+    install_error: str | None = None
+
+    if serena_path is None:
+        uv_path = shutil.which("uv")
+        if uv_path is None:
+            install_error = "uv binary not found; cannot install serena-agent"
+        else:
+            install_attempted = True
+            completed = subprocess.run(
+                [
+                    uv_path,
+                    "tool",
+                    "install",
+                    "-p",
+                    "3.13",
+                    "serena-agent@latest",
+                    "--prerelease=allow",
+                ],
+                cwd=workdir,
+                text=True,
+                capture_output=True,
+                timeout=INSTALL_TIMEOUT_SEC,
+                check=False,
+            )
+            _write_install_logs(log_dir, completed.stdout, completed.stderr)
+            install_succeeded = completed.returncode == 0
+            if install_succeeded:
+                serena_path = shutil.which("serena")
+                if serena_path is None:
+                    install_error = "serena command is not on PATH after installation"
+            else:
+                install_error = completed.stderr.strip() or completed.stdout.strip()
+
+    if serena_path is None:
+        return SerenaMcpInstallation(
+            enabled=False,
+            language_ids=language_ids,
+            matched_paths=matched_paths,
+            install_attempted=install_attempted,
+            install_succeeded=install_succeeded,
+            install_error=install_error,
+        )
+
+    return SerenaMcpInstallation(
+        enabled=True,
+        language_ids=language_ids,
+        matched_paths=matched_paths,
+        command_path=serena_path,
+        install_attempted=install_attempted,
+        install_succeeded=install_succeeded,
+        install_error=install_error,
+        codex_config_overrides=_codex_config_overrides(serena_path, workdir),
+    )
+
+
+def detect_supported_languages(
+    repo_root: Path,
+    workdir: Path,
+) -> tuple[tuple[str, ...], tuple[Path, ...]]:
+    """Detect Serena-supported language IDs and representative paths."""
+
+    scan_root = workdir if workdir.exists() else repo_root
+    matches: dict[str, Path] = {}
+    count = 0
+    for path in scan_root.rglob("*"):
+        if _is_skipped_path(path, scan_root) or not path.is_file():
+            continue
+        count += 1
+        if count > MAX_SCAN_FILES:
+            break
+        language_id = _language_for_path(path)
+        if language_id is not None and language_id not in matches:
+            matches[language_id] = _safe_relative(path, repo_root)
+
+    language_ids = tuple(sorted(matches))
+    return language_ids, tuple(matches[language_id] for language_id in language_ids)
+
+
+def _is_skipped_path(path: Path, root: Path) -> bool:
+    try:
+        parts = path.relative_to(root).parts
+    except ValueError:
+        parts = path.parts
+    return any(part in SKIPPED_DIR_NAMES for part in parts[:-1])
+
+
+def _language_for_path(path: Path) -> str | None:
+    marker_language = MARKER_FILES.get(path.name.lower())
+    if marker_language is not None:
+        return marker_language
+    return SUPPORTED_SUFFIXES.get(path.suffix) or SUPPORTED_SUFFIXES.get(path.suffix.lower())
+
+
+def _codex_config_overrides(command_path: str, workdir: Path) -> tuple[str, ...]:
+    return (
+        _toml_assignment("mcp_servers.serena.startup_timeout_sec", 15),
+        _toml_assignment("mcp_servers.serena.command", command_path),
+        _toml_assignment(
+            "mcp_servers.serena.args",
+            ["start-mcp-server", "--project-from-cwd", "--context=codex"],
+        ),
+        _toml_assignment("mcp_servers.serena.cwd", str(workdir)),
+        _toml_assignment("mcp_servers.serena.enabled", True),
+    )
+
+
+def _toml_assignment(key: str, value: object) -> str:
+    return f"{key}={_toml_value(value)}"
+
+
+def _toml_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, (tuple, list)):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    return json.dumps(str(value))
+
+
+def _safe_relative(path: Path, root: Path) -> Path:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path
+
+
+def _write_install_logs(log_dir: Path, stdout: str, stderr: str) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "serena-mcp-install-stdout.txt").write_text(stdout, encoding="utf-8")
+    (log_dir / "serena-mcp-install-stderr.txt").write_text(stderr, encoding="utf-8")

--- a/harness_codex/runtime/serena_patch.py
+++ b/harness_codex/runtime/serena_patch.py
@@ -1,0 +1,50 @@
+"""Runtime hook that wires Serena MCP into Codex agent invocations."""
+
+from __future__ import annotations
+
+import json
+
+import harness_codex.runtime.runner as runner
+from harness_codex.runtime.serena_mcp import SerenaMcpInstallation, ensure_serena_mcp
+
+_PATCHED_ATTR = "_harness_serena_mcp_patch_applied"
+_ORIGINAL_COMMAND_ATTR = "_harness_serena_mcp_original_command"
+
+
+def apply_serena_mcp_patch() -> None:
+    """Patch CodexCliAgentAdapter so supported projects get Serena MCP."""
+
+    adapter_cls = runner.CodexCliAgentAdapter
+    if getattr(adapter_cls, _PATCHED_ATTR, False):
+        return
+
+    original_command = adapter_cls._command
+    setattr(adapter_cls, _ORIGINAL_COMMAND_ATTR, original_command)
+
+    def command_with_serena_mcp(self, request, final_message_path):
+        command = original_command(self, request, final_message_path)
+        installation = ensure_serena_mcp(
+            request.context.repo_root,
+            request.context.workdir,
+            request.step_dir,
+        )
+        _write_serena_manifest(request.step_dir, installation)
+        if not installation.enabled:
+            return command
+
+        insertion_index = len(command) - 1 if command and command[-1] == "-" else len(command)
+        for config_override in installation.codex_config_overrides:
+            command[insertion_index:insertion_index] = ["-c", config_override]
+            insertion_index += 2
+        return command
+
+    adapter_cls._command = command_with_serena_mcp
+    setattr(adapter_cls, _PATCHED_ATTR, True)
+
+
+def _write_serena_manifest(step_dir, installation: SerenaMcpInstallation) -> None:
+    step_dir.mkdir(parents=True, exist_ok=True)
+    (step_dir / "serena-mcp.json").write_text(
+        json.dumps(installation.as_metadata(), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/runtime/test_serena_mcp.py
+++ b/tests/runtime/test_serena_mcp.py
@@ -1,0 +1,136 @@
+import json
+import subprocess
+from pathlib import Path
+
+from harness_codex.runtime import serena_mcp
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind, StepStatus
+from harness_codex.runtime.runner import AgentRunRequest, CodexCliAgentAdapter
+
+
+def context(repo_root: Path) -> RunContext:
+    return RunContext(
+        run_id="run-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=repo_root / ".harness/runs/run-001",
+    )
+
+
+def request(repo_root: Path) -> AgentRunRequest:
+    return AgentRunRequest(
+        step=Step(
+            id="plan-work-item",
+            kind=StepKind.AGENT,
+            name="Create plan",
+            agent_id="implementation_planner",
+            timeout_sec=30,
+        ),
+        context=context(repo_root),
+        step_dir=repo_root / ".harness/runs/run-001/steps/plan-work-item",
+        agent_config_path=repo_root / ".codex/agents/implementation_planner.toml",
+        agent_config={
+            "name": "implementation_planner",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+
+
+def test_detect_supported_languages_from_source_files(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/app.py").write_text("print('hello')\n", encoding="utf-8")
+    (tmp_path / "ui.tsx").write_text("export default function App() {}\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules/ignored.go").write_text("package ignored\n", encoding="utf-8")
+
+    language_ids, matched_paths = serena_mcp.detect_supported_languages(tmp_path, tmp_path)
+
+    assert language_ids == ("python", "typescript")
+    assert matched_paths == (Path("src/app.py"), Path("ui.tsx"))
+
+
+def test_serena_mcp_is_disabled_without_supported_language(tmp_path: Path) -> None:
+    (tmp_path / "notes.txt").write_text("plain text only\n", encoding="utf-8")
+
+    installation = serena_mcp.ensure_serena_mcp(tmp_path, tmp_path, tmp_path)
+
+    assert installation.enabled is False
+    assert installation.language_ids == ()
+    assert installation.install_attempted is False
+
+
+def test_serena_mcp_installs_when_supported_language_and_serena_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/app.py").write_text("print('hello')\n", encoding="utf-8")
+    calls: list[str] = []
+
+    def fake_which(name: str) -> str | None:
+        if name == "uv":
+            return "/usr/bin/uv"
+        if name == "serena" and calls:
+            return "/home/user/.local/bin/serena"
+        return None
+
+    def fake_run(*args, **kwargs):
+        calls.append("install")
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="installed",
+            stderr="",
+        )
+
+    monkeypatch.setattr(serena_mcp.shutil, "which", fake_which)
+    monkeypatch.setattr(serena_mcp.subprocess, "run", fake_run)
+
+    installation = serena_mcp.ensure_serena_mcp(tmp_path, tmp_path, tmp_path)
+
+    assert installation.enabled is True
+    assert installation.install_attempted is True
+    assert installation.install_succeeded is True
+    assert installation.command_path == "/home/user/.local/bin/serena"
+    assert (tmp_path / "serena-mcp-install-stdout.txt").read_text(
+        encoding="utf-8"
+    ) == "installed"
+
+
+def test_codex_cli_agent_adapter_enables_serena_mcp_for_supported_language(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    (tmp_path / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    agent_request = request(tmp_path)
+    agent_request.step_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        serena_mcp.shutil,
+        "which",
+        lambda name: "/usr/local/bin/serena" if name == "serena" else None,
+    )
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="agent stdout",
+            stderr="agent stderr",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = CodexCliAgentAdapter(codex_binary="codex-test").run(agent_request)
+
+    assert result.status == StepStatus.SUCCEEDED
+    command = json.loads((agent_request.step_dir / "command.json").read_text(encoding="utf-8"))
+    assert 'mcp_servers.serena.command="/usr/local/bin/serena"' in command
+    assert (
+        'mcp_servers.serena.args=["start-mcp-server", "--project-from-cwd", "--context=codex"]'
+    ) in command
+    assert f'mcp_servers.serena.cwd="{tmp_path}"' in command
+    manifest = json.loads((agent_request.step_dir / "serena-mcp.json").read_text(encoding="utf-8"))
+    assert manifest["enabled"] is True
+    assert manifest["language_ids"] == ["python"]


### PR DESCRIPTION
## 구현 의도

런타임에서 Codex 전담 에이전트를 호출할 때, 현재 작업 디렉터리가 Serena MCP가 지원하는 언어를 포함하면 Serena MCP를 자동으로 설치/활성화하도록 한다.

목표는 다음과 같다.

- Serena 지원 언어 프로젝트에서 Codex가 심볼/LSP 기반 탐색 MCP를 사용할 수 있게 한다.
- 지원 언어가 없거나 `uv`/`serena`가 없는 환경에서는 실행을 막지 않고, Serena MCP를 비활성화한 채 기존 Codex 실행 흐름을 유지한다.
- MCP 설치/활성화 여부를 run artifact로 남겨 이후 실패 원인 분석이 가능하게 한다.

## 구현 방법

### 1. Serena MCP 준비 모듈 추가

신규 파일:

```text
harness_codex/runtime/serena_mcp.py
```

역할:

- `workdir` 기준으로 Serena 지원 언어 감지
- `.git`, `.harness`, `.codex`, `node_modules`, `venv`, `target`, `build`, `dist` 등 불필요한 디렉터리 제외
- 지원 언어가 없으면 Serena MCP 비활성화
- `serena` 명령이 있으면 그대로 사용
- `serena` 명령이 없고 `uv`가 있으면 다음 명령으로 설치 시도

```bash
uv tool install -p 3.13 serena-agent@latest --prerelease=allow
```

- 설치 stdout/stderr를 step dir에 기록
- 설치 실패나 `uv` 누락은 blocker로 처리하지 않고 metadata에 기록

### 2. Codex CLI agent 실행에 Serena MCP 설정 주입

신규 파일:

```text
harness_codex/runtime/serena_patch.py
```

역할:

- `CodexCliAgentAdapter._command()`를 런타임 훅으로 패치
- 지원 언어 + Serena 사용 가능 상태이면 `codex exec` 명령에 다음 `-c` 설정을 추가

```text
mcp_servers.serena.startup_timeout_sec=15
mcp_servers.serena.command=<serena path>
mcp_servers.serena.args=["start-mcp-server", "--project-from-cwd", "--context=codex"]
mcp_servers.serena.cwd=<workdir>
mcp_servers.serena.enabled=true
```

- 각 agent step dir에 `serena-mcp.json` 기록

### 3. 런타임 초기화 시 훅 적용

`harness_codex/runtime/__init__.py`에서 `apply_serena_mcp_patch()`를 호출해 기존 `BasicStepRunner -> CodexCliAgentAdapter` 흐름을 유지하면서 Serena MCP 설정만 자동 주입한다.

## 검증 방법

추가 테스트:

```text
tests/runtime/test_serena_mcp.py
```

검증 내용:

- source file 기반 지원 언어 감지
- 지원 언어가 없으면 Serena MCP 비활성화
- `serena`가 없고 `uv`가 있으면 설치 시도 및 설치 로그 기록
- 지원 언어 + `serena` 사용 가능 상태에서 `codex exec` command.json에 Serena MCP 설정 주입
- `serena-mcp.json` artifact 기록

브랜치는 최신 `main` 기준으로 재작성했다.

```bash
./venv/bin/python3 -m pytest -q tests/runtime/test_agent_runner.py tests/runtime/test_serena_mcp.py
```

## 참고

기존 PR #96은 브랜치 최신화 중 닫혀 새 PR로 다시 생성한다.