### PR TITLE
feat(runtime): add interactive harvest CLI

### DIFF
--- a/docs/runtime-interactive-harvest.md
+++ b/docs/runtime-interactive-harvest.md
@@ -1,0 +1,52 @@
+# Interactive Harvest Runtime
+
+`harvest` is the canonical design-document creation stage. It produces or updates:
+
+- `docs/design/요구사항.md`
+- `docs/design/유스케이스.md`
+
+`changes create-from-design` does not create design documents. It reads existing design documents and creates runtime inputs:
+
+- `docs/changes/active/<CHG-ID>.md`
+- `docs/use-cases/<UC-ID>/...`
+
+## Recommended flow
+
+```bash
+./harness agent-context init --description "<repo description>"
+./harness harvest --idea "<feature idea>" --interactive
+./harness changes create-from-design --title "<change title>" --change-set-id CHG-YYYYMMDD-001
+./harness run-change CHG-YYYYMMDD-001 --plan
+./harness run-change CHG-YYYYMMDD-001 --apply
+```
+
+If `docs/design/요구사항.md` and `docs/design/유스케이스.md` already exist and are current, start from `changes create-from-design`.
+
+## Harvest modes
+
+```bash
+./harness harvest --idea "<feature idea>" --plan
+./harness harvest --idea "<feature idea>" --preview
+./harness harvest --idea "<feature idea>" --apply
+./harness harvest --idea "<feature idea>" --interactive
+```
+
+- `--plan`: show the harvest workflow plan without changing files.
+- `--preview`: show a no-side-effect preview. It currently has the same behavior as `--plan`.
+- `--apply`: run the non-interactive harvest workflow through the agent runner.
+- `--interactive`: run the Grill-Me question/answer loop in the terminal and generate design documents after the requirements gate passes.
+
+## Interactive behavior
+
+`harvest --interactive` reuses the existing runtime-backed harvest UI session service.
+
+1. Start a requirements session from `--idea`.
+2. Print current Grill-Me questions and recommended answers.
+3. Read the user's terminal answer.
+4. Save the answer into `.harness/ui/harvest-session.json`.
+5. Ask Grill-Me for the next questions.
+6. Repeat until the requirements gate passes.
+7. Generate `docs/design/요구사항.md` and `docs/design/유스케이스.md`.
+8. Print the next command: `./harness changes create-from-design --title "<change title>"`.
+
+The CLI does not keep a long-running agent process open. Each question turn delegates to the existing harvest UI service, which already owns the session state and requirements gate.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -28,8 +28,6 @@ from harness_codex.runtime import (
     decide_resume_target,
     file_checksum,
 )
-from harness_codex.runtime.dashboard import dashboard_state_json
-from harness_codex.runtime.ui_server import run_ui_server
 from harness_codex.runtime.changes import (
     ChangeSet,
     ChangeSetResolver,
@@ -38,6 +36,9 @@ from harness_codex.runtime.changes import (
     PlanningBlocked,
     create_changeset_from_design,
 )
+from harness_codex.runtime.dashboard import dashboard_state_json
+from harness_codex.runtime.interactive_harvest import run_interactive_harvest
+from harness_codex.runtime.ui_server import run_ui_server
 from harness_codex.runtime.workflows import (
     WorkflowMaterializationError,
     load_named_workflow,
@@ -53,7 +54,12 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         output = args.func(args, repo_root)
-    except (NoActiveChangeSetsError, DesignBridgeError, WorkflowMaterializationError) as exc:
+    except (
+        NoActiveChangeSetsError,
+        DesignBridgeError,
+        WorkflowMaterializationError,
+        ValueError,
+    ) as exc:
         print(str(exc), file=sys.stderr)
         return 2
 
@@ -68,13 +74,23 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo-root", default=".")
     subparsers = parser.add_subparsers(required=True)
 
-    harvest = subparsers.add_parser("harvest")
+    harvest = subparsers.add_parser(
+        "harvest",
+        description="Harvest a product idea into canonical design documents.",
+        epilog=(
+            "Examples:\n"
+            "  harness harvest --idea '<feature idea>' --plan\n"
+            "  harness harvest --idea '<feature idea>' --interactive\n"
+            "  harness harvest --idea '<feature idea>' --apply"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     harvest.add_argument(
         "--idea",
         default="",
-        help="Initial product or feature idea to harvest into design documents.",
+        help="Initial product or feature idea to harvest into requirements and use-case design documents.",
     )
-    _add_mode_options(harvest)
+    _add_harvest_mode_options(harvest)
     harvest.set_defaults(func=harvest_command)
 
     agent_context = subparsers.add_parser("agent-context")
@@ -166,19 +182,25 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
-    mode = _selected_mode(args)
     workflow_dir = repo_root / ".harness/workflows"
     if not (workflow_dir / "harvest-workflow.yaml").exists():
         workflow_dir = Path(__file__).resolve().parents[1] / ".harness/workflows"
     workflow = load_named_workflow("harvest-workflow", workflows_dir=workflow_dir)
 
+    if getattr(args, "interactive", False):
+        agent_context = bootstrap_agent_context(repo_root, _repo_description(args.idea))
+        return "\n".join(
+            [
+                run_interactive_harvest(repo_root, args.idea),
+                _format_agent_context_result(agent_context),
+            ]
+        )
+
+    mode = _selected_mode(args)
     if mode in (RunMode.PLAN, RunMode.PREVIEW):
         return _format_harvest_plan(workflow, mode, args.idea)
 
-    agent_context = bootstrap_agent_context(
-        repo_root,
-        _repo_description(args.idea),
-    )
+    agent_context = bootstrap_agent_context(repo_root, _repo_description(args.idea))
     state, result = _apply_harvest_workflow(repo_root, workflow, args.idea)
     return "\n".join(
         [
@@ -429,11 +451,15 @@ def _add_mode_options(parser: argparse.ArgumentParser) -> None:
     mode.add_argument("--apply", action="store_true")
 
 
-def _format_scopes(
-    change_set: ChangeSet,
-    scopes: tuple,
-    mode: RunMode,
-) -> str:
+def _add_harvest_mode_options(parser: argparse.ArgumentParser) -> None:
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--plan", action="store_true", help="Show the harvest workflow plan without changing files.")
+    mode.add_argument("--preview", action="store_true", help="Preview the harvest workflow without changing files; currently equivalent to --plan.")
+    mode.add_argument("--apply", action="store_true", help="Run the non-interactive harvest workflow through the agent runner.")
+    mode.add_argument("--interactive", action="store_true", help="Run the Grill-Me question/answer loop in the terminal and generate design docs after the requirements gate passes.")
+
+
+def _format_scopes(change_set: ChangeSet, scopes: tuple, mode: RunMode) -> str:
     lines = [
         f"Mode: {mode.value}",
         f"ChangeSet: {change_set.change_set_id}",
@@ -531,25 +557,6 @@ def _repo_description(value: str) -> str:
     return "Repository managed by the harness workflow."
 
 
-def _create_run_state(
-    repo_root: Path,
-    change_set: ChangeSet,
-    affected_use_cases: tuple[str, ...],
-) -> str:
-    run_id = f"run-{uuid4().hex[:12]}"
-    state = RunState(
-        run_id=run_id,
-        change_set_id=change_set.change_set_id,
-        workflow_name="changeset-use-case-workflow",
-        mode=RunMode.APPLY,
-        affected_use_cases=affected_use_cases,
-        current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
-        status=RunStatus.PENDING,
-    )
-    RunStateStore(repo_root).save(state)
-    return run_id
-
-
 def _apply_harvest_workflow(repo_root: Path, workflow, idea: str):
     run_id = f"run-{uuid4().hex[:12]}"
     run_dir = repo_root / ".harness/runs" / run_id
@@ -607,11 +614,7 @@ def _apply_harvest_workflow(repo_root: Path, workflow, idea: str):
     return state, result
 
 
-def _harvest_artifact_state(
-    repo_root: Path,
-    stage: str,
-    path: Path,
-) -> StageArtifactState:
+def _harvest_artifact_state(repo_root: Path, stage: str, path: Path) -> StageArtifactState:
     absolute_path = repo_root / path
     checksum = file_checksum(absolute_path) if absolute_path.exists() else ""
     return StageArtifactState(
@@ -624,11 +627,7 @@ def _harvest_artifact_state(
     )
 
 
-def _apply_workflow(
-    repo_root: Path,
-    change_set: ChangeSet,
-    scopes: tuple,
-):
+def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
     run_id = f"run-{uuid4().hex[:12]}"
     affected_use_cases = tuple(
         scope.use_case.uc_id for scope in scopes if scope.use_case is not None
@@ -718,7 +717,8 @@ def _apply_workflow(
             WorkItemLoopState(
                 work_item_id=scope.display_id,
                 work_item_type=scope.work_item_type,
-                active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.display_id}/plan.md"),
+                active_plan_path=scope.plan_path
+                or Path(f"docs/plans/active/{scope.display_id}/plan.md"),
                 status=result_by_work_item.get(scope.display_id, final_result).status,
                 current_step_id=scope.current_stage,
                 verification_status=result_by_work_item.get(scope.display_id, final_result).status.value,
@@ -729,7 +729,8 @@ def _apply_workflow(
         use_case_states=tuple(
             UseCaseLoopState(
                 uc_id=scope.use_case.uc_id,
-                active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.use_case.uc_id}/plan.md"),
+                active_plan_path=scope.plan_path
+                or Path(f"docs/plans/active/{scope.use_case.uc_id}/plan.md"),
                 status=result_by_work_item.get(scope.display_id, final_result).status,
                 blocker=result_by_work_item.get(scope.display_id, final_result).blocker,
             )
@@ -752,7 +753,8 @@ def _apply_workflow(
                 WorkItemReport(
                     work_item_id=scope.display_id,
                     work_item_type=scope.work_item_type,
-                    active_plan_path=scope.plan_path or Path(f"docs/plans/active/{scope.display_id}/plan.md"),
+                    active_plan_path=scope.plan_path
+                    or Path(f"docs/plans/active/{scope.display_id}/plan.md"),
                     status=result_by_work_item.get(scope.display_id, final_result).status,
                     current_stage=scope.current_stage,
                     verification_goal_path=scope.verification_goal_path,

--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -1,0 +1,83 @@
+"""Terminal interface for the runtime-backed harvest session service."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from harness_codex.runtime.harvest_ui import (
+    HarvestUiResult,
+    answer_requirements,
+    start_requirements,
+    start_use_cases,
+)
+
+InputFunc = Callable[[str], str]
+OutputFunc = Callable[[str], None]
+
+
+def run_interactive_harvest(
+    repo_root: Path | str,
+    idea: str,
+    *,
+    input_func: InputFunc = input,
+    output_func: OutputFunc = print,
+) -> str:
+    """Run the Grill-Me-backed harvest loop in a terminal.
+
+    The local harvest UI already owns the question/answer session state and the
+    requirements gate. This wrapper exposes the same lifecycle for CLI users:
+    start requirements, answer current questions until the gate passes, then
+    generate use cases.
+    """
+
+    prompt = idea.strip()
+    if not prompt:
+        raise ValueError("--idea is required when using --interactive")
+
+    result = start_requirements(repo_root, prompt)
+    output_func(_format_session_header(result))
+
+    while not result.requirements_gate_passed:
+        output_func(_format_questions(result))
+        answer = input_func("Answer: ").strip()
+        if not answer:
+            raise ValueError("answer is required")
+        result = answer_requirements(repo_root, answer)
+
+    result = start_use_cases(repo_root)
+    return _format_completion(result)
+
+
+def _format_session_header(result: HarvestUiResult) -> str:
+    return "\n".join(
+        [
+            "INTERACTIVE HARVEST started",
+            f"Initial idea: {result.initial_prompt}",
+            f"Active stage: {result.active_stage}",
+        ]
+    )
+
+
+def _format_questions(result: HarvestUiResult) -> str:
+    lines = ["", "Grill-Me questions:"]
+    for index, item in enumerate(result.current_questions, start=1):
+        lines.append(f"{index}. {item.get('question', '')}")
+        recommended = item.get("recommended", "")
+        if recommended:
+            lines.append(f"   Recommended answer: {recommended}")
+    return "\n".join(lines)
+
+
+def _format_completion(result: HarvestUiResult) -> str:
+    return "\n".join(
+        [
+            "INTERACTIVE HARVEST completed",
+            "Requirements gate: passed",
+            "Generated artifacts:",
+            "- docs/design/요구사항.md",
+            "- docs/design/유스케이스.md",
+            "Next step:",
+            './harness changes create-from-design --title "<change title>"',
+        ]
+    )

--- a/tests/runtime/test_interactive_harvest.py
+++ b/tests/runtime/test_interactive_harvest.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from harness_codex.runtime.interactive_harvest import run_interactive_harvest
+
+
+def test_interactive_harvest_reuses_harvest_ui_gate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls = []
+
+    def fake_grill_me(_root: Path, session: dict) -> dict:
+        calls.append(len(session["clarifications"]))
+        if len(session["clarifications"]) >= 1:
+            return {"complete": True, "questions": []}
+        return {
+            "complete": False,
+            "questions": [
+                {
+                    "question": "Who is the primary actor?",
+                    "recommended": "Customer",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
+    output_lines: list[str] = []
+
+    result = run_interactive_harvest(
+        tmp_path,
+        "build a queue system",
+        input_func=lambda _prompt: "Customer uses the queue system.",
+        output_func=output_lines.append,
+    )
+
+    assert calls == [0, 1]
+    assert "INTERACTIVE HARVEST completed" in result
+    assert "./harness changes create-from-design" in result
+    assert any("Who is the primary actor?" in line for line in output_lines)
+    assert (tmp_path / "docs/design/요구사항.md").is_file()
+    assert (tmp_path / "docs/design/유스케이스.md").is_file()
+    assert (tmp_path / ".harness/ui/harvest-session.json").is_file()
+
+
+def test_interactive_harvest_requires_idea(tmp_path: Path) -> None:
+    try:
+        run_interactive_harvest(tmp_path, "  ")
+    except ValueError as exc:
+        assert "--idea is required" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")

--- a/tests/runtime/test_interactive_harvest_cli.py
+++ b/tests/runtime/test_interactive_harvest_cli.py
@@ -1,0 +1,28 @@
+import pytest
+
+from harness_codex.cli import build_parser, main
+
+
+def test_harvest_help_includes_interactive_option(capsys) -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["harvest", "--help"])
+
+    output = capsys.readouterr().out
+    assert "--interactive" in output
+    assert "Grill-Me question/answer loop" in output
+
+
+def test_harvest_interactive_requires_idea(tmp_path, capsys) -> None:
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "harvest",
+            "--interactive",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "--idea is required" in captured.err


### PR DESCRIPTION
## 구현 의도

Closes #99.

런타임 CLI가 기존 local harvest UI의 Grill-Me 질문/답변 루프를 터미널에서도 제공하도록 `harvest --interactive` 모드를 추가했습니다.

기존 `harvest --apply`는 workflow runner 기반 비대화형 실행이므로, 사용자가 요구사항 gate가 통과될 때까지 직접 답변하는 UX를 제공하지 못했습니다. 이번 변경은 기존 `harness_codex.runtime.harvest_ui`의 session/gate 로직을 재사용해 CLI에서도 동일한 흐름을 사용할 수 있게 합니다.

## 구현 방법

- `harness_codex/runtime/interactive_harvest.py` 추가
  - `start_requirements()`로 requirements 세션 시작
  - `current_questions`를 터미널에 출력
  - `input()`으로 답변을 받아 `answer_requirements()` 호출
  - `requirements_gate_passed`가 될 때까지 반복
  - gate 통과 후 `start_use_cases()` 호출
  - 생성 산출물과 다음 명령을 안내
- `harness_codex/cli.py` 수정
  - `harvest --interactive` 옵션 추가
  - `harvest --help` 설명 보강
  - `--plan`, `--preview`, `--apply`, `--interactive`를 상호 배타 모드로 유지
  - 빈 `--idea` 입력은 exit code 2로 실패
- 문서 추가
  - `docs/runtime-interactive-harvest.md`에 interactive harvest 사용법과 `create-from-design` 관계 설명 추가

## 검증 방법

추가한 테스트:

- `tests/runtime/test_interactive_harvest.py`
  - 기존 harvest UI gate/session 로직을 재사용하는지 검증
  - 질문 출력 → 답변 입력 → gate 통과 → use-case 생성 흐름 검증
  - 빈 idea 방어 검증
- `tests/runtime/test_interactive_harvest_cli.py`
  - `harvest --help`에 `--interactive`가 노출되는지 검증
  - `harvest --interactive`에서 `--idea`가 없으면 실패하는지 검증

검증 명령:

```bash
python3 -m pytest -q tests/runtime/test_interactive_harvest.py tests/runtime/test_interactive_harvest_cli.py
python3 -m pytest -q tests/test_cli_commands.py tests/runtime/test_harvest_ui.py
```

## 참고

`docs/README.md`의 quick start도 직접 갱신하려 했지만, GitHub write tool의 안전 검사에서 기존 README 전체 교체 요청이 차단되어 별도 문서 `docs/runtime-interactive-harvest.md`로 추가했습니다. PR 리뷰 후 README 링크 추가만 별도 커밋으로 처리하면 됩니다.