### PR TITLE
docs(cli): document harvest options and design bridge flow

### DIFF
--- a/docs/README-harvest-quickstart.md
+++ b/docs/README-harvest-quickstart.md
@@ -1,0 +1,53 @@
+# Harvest Quickstart and CLI Options
+
+This document explains the `harvest` command options and the relationship between design documents and ChangeSet runtime inputs.
+
+## Recommended startup flow
+
+When a repository does not yet have current design documents, run harvest before creating a ChangeSet.
+
+```bash
+./harness agent-context init --description "<repo description>"
+./harness harvest --idea "<feature idea>" --plan
+./harness harvest --idea "<feature idea>" --interactive
+./harness changes create-from-design --title "<change title>" --change-set-id CHG-YYYYMMDD-001
+./harness run-change CHG-YYYYMMDD-001 --plan
+./harness run-change CHG-YYYYMMDD-001 --apply
+```
+
+If `docs/design/요구사항.md` and `docs/design/유스케이스.md` already exist and are current, start from `changes create-from-design`.
+
+## What each command does
+
+### `harvest`
+
+`harvest` creates or updates canonical design documents:
+
+- `docs/design/요구사항.md`
+- `docs/design/유스케이스.md`
+
+### `changes create-from-design`
+
+`changes create-from-design` does not create design documents. It reads existing design documents and creates runtime inputs:
+
+- `docs/changes/active/<CHG-ID>.md`
+- `docs/use-cases/<UC-ID>/...`
+
+## Harvest modes
+
+```bash
+./harness harvest --idea "<feature idea>" --plan
+./harness harvest --idea "<feature idea>" --preview
+./harness harvest --idea "<feature idea>" --apply
+./harness harvest --idea "<feature idea>" --interactive
+```
+
+- `--idea`: initial product or feature idea to turn into requirements and use-case design documents.
+- `--plan`: show the harvest workflow plan without changing files.
+- `--preview`: show a no-side-effect preview. It currently has the same behavior as `--plan`.
+- `--apply`: run the non-interactive harvest workflow through the agent runner.
+- `--interactive`: run the Grill-Me question/answer loop in the terminal and generate design documents after the requirements gate passes.
+
+## Help expectation
+
+`./harness harvest --help` should be enough to understand these options without opening the source code.


### PR DESCRIPTION
## 구현 의도

Closes #98.

`./harness harvest --help`와 문서만 보고도 `--idea`, `--plan`, `--preview`, `--apply`, `--interactive`의 의미와 `harvest → changes create-from-design → run-change` 실행 순서를 알 수 있도록 문서를 보강했습니다.

PR #100에서 `harvest --help` 옵션 설명은 이미 CLI에 반영되었습니다. 이 PR은 #98의 README/문서 보강 요구를 별도 quickstart 문서로 보완합니다.

## 구현 방법

- `docs/README-harvest-quickstart.md` 추가
  - `harvest`가 canonical design 문서 생성/갱신 단계임을 명시
  - `changes create-from-design`는 design 문서를 만드는 명령이 아니라, 기존 `docs/design/요구사항.md`, `docs/design/유스케이스.md`에서 ChangeSet/use-case slice를 만드는 bridge 명령임을 명시
  - `agent-context init → harvest → changes create-from-design → run-change` 흐름 추가
  - design 문서가 이미 최신이면 `changes create-from-design`부터 시작할 수 있음을 명시
  - `--idea`, `--plan`, `--preview`, `--apply`, `--interactive` 옵션 의미 정리

## 검증 방법

문서 변경만 포함합니다.

확인한 내용:

- harvest 옵션 설명이 문서에 포함됨
- quickstart에 `harvest` 단계가 `create-from-design` 앞에 위치함
- `create-from-design`의 입력 문서와 역할 오해를 줄이는 설명이 포함됨

관련 CLI help 보강은 이미 merge된 PR #100에서 처리되었습니다.