### PR TITLE
feat(cli): add harness update command

### DIFF
--- a/docs/runtime-update-command.md
+++ b/docs/runtime-update-command.md
@@ -1,0 +1,35 @@
+# Harness Update Command
+
+Installed projects can update their embedded harness-codex runtime with:
+
+```bash
+./harness update
+```
+
+The command downloads the installer from the configured harness-codex repository and reruns it with `--force --target <repo-root>`.
+
+## Options
+
+```bash
+./harness update --dry-run
+./harness update --ref main
+./harness update --ref <branch-or-commit> --skip-venv
+./harness update --repo https://github.com/omegafrog/harness-codex
+```
+
+- `--dry-run`: print the installer command without running it.
+- `--ref`: branch, tag, or commit to install. Defaults to `main`.
+- `--repo`: GitHub repository URL. Defaults to `https://github.com/omegafrog/harness-codex`.
+- `--skip-venv`: skip venv creation and dependency installation.
+
+## Warning
+
+`./harness update` runs the installer with `--force`. It may overwrite:
+
+- `harness_codex/`
+- `.harness/`
+- `.codex/`
+- `tests/runtime/`
+- `./harness`
+
+Back up local changes to harness runtime files before updating.

--- a/harness_codex/__main__.py
+++ b/harness_codex/__main__.py
@@ -1,6 +1,15 @@
 """Run `python3 -m harness_codex` as the harness CLI."""
 
-from harness_codex.cli import main
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from harness_codex.cli import main as cli_main
+from harness_codex.runtime.self_update import main as update_main
 
 
-raise SystemExit(main())
+if len(sys.argv) > 1 and sys.argv[1] == "update":
+    raise SystemExit(update_main(sys.argv[2:], repo_root=Path.cwd()))
+
+raise SystemExit(cli_main())

--- a/harness_codex/runtime/self_update.py
+++ b/harness_codex/runtime/self_update.py
@@ -1,0 +1,151 @@
+"""Self-update helper for installed harness-codex runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+DEFAULT_REPO = "https://github.com/omegafrog/harness-codex"
+DEFAULT_REF = "main"
+INSTALLER_PATH = "scripts/install-harness-codex.sh"
+
+
+class Runner(Protocol):
+    def __call__(self, *args, **kwargs) -> subprocess.CompletedProcess[str]:
+        ...
+
+
+def main(argv: list[str] | None = None, *, repo_root: Path | str = ".") -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        output = run_self_update(Path(repo_root), args)
+    except ValueError as exc:
+        print(str(exc))
+        return 2
+    if output:
+        print(output)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="harness update",
+        description="Update the installed harness-codex runtime in this project.",
+        epilog=(
+            "Warning: update runs the installer with --force and may overwrite "
+            "harness_codex/, .harness/, .codex/, tests/runtime, and the harness launcher."
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"harness-codex repository URL. Default: {DEFAULT_REPO}",
+    )
+    parser.add_argument(
+        "--ref",
+        default=DEFAULT_REF,
+        help=f"branch, tag, or commit to install. Default: {DEFAULT_REF}",
+    )
+    parser.add_argument(
+        "--skip-venv",
+        action="store_true",
+        help="Skip venv creation and dependency installation.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the installer command without running it.",
+    )
+    return parser
+
+
+def run_self_update(
+    repo_root: Path,
+    args: argparse.Namespace,
+    *,
+    runner: Runner = subprocess.run,
+) -> str:
+    command = build_update_command(
+        repo_root.resolve(),
+        repo=args.repo,
+        ref=args.ref,
+        skip_venv=args.skip_venv,
+    )
+    warning = _warning()
+    if args.dry_run:
+        return "\n".join([warning, "Dry run. Command:", command])
+
+    completed = runner(
+        command,
+        cwd=repo_root,
+        shell=True,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    output = "\n".join(
+        part.strip()
+        for part in (completed.stdout, completed.stderr)
+        if part and part.strip()
+    )
+    if completed.returncode != 0:
+        raise ValueError(
+            "harness update failed"
+            + (f":\n{output}" if output else f" with exit code {completed.returncode}")
+        )
+    return "\n".join([warning, output, "harness-codex update completed."]).strip()
+
+
+def build_update_command(
+    repo_root: Path,
+    *,
+    repo: str = DEFAULT_REPO,
+    ref: str = DEFAULT_REF,
+    skip_venv: bool = False,
+) -> str:
+    installer_url = _installer_url(repo, ref)
+    parts = [
+        "curl",
+        "-fsSL",
+        shlex.quote(installer_url),
+        "|",
+        "bash",
+        "-s",
+        "--",
+        "--force",
+        "--target",
+        shlex.quote(str(repo_root)),
+        "--ref",
+        shlex.quote(ref),
+    ]
+    if skip_venv:
+        parts.append("--skip-venv")
+    return " ".join(parts)
+
+
+def _installer_url(repo: str, ref: str) -> str:
+    text = repo.rstrip("/")
+    if text.endswith(".git"):
+        text = text[:-4]
+    prefix = "https://github.com/"
+    if not text.startswith(prefix):
+        raise ValueError("--repo must be a https://github.com/<owner>/<repo> URL")
+    owner_repo = text[len(prefix) :]
+    if owner_repo.count("/") != 1:
+        raise ValueError("--repo must be a https://github.com/<owner>/<repo> URL")
+    return f"https://raw.githubusercontent.com/{owner_repo}/{ref}/{INSTALLER_PATH}"
+
+
+def _warning() -> str:
+    return (
+        "Warning: update uses installer --force and may overwrite "
+        "harness_codex/, .harness/, .codex/, tests/runtime, and ./harness."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_self_update.py
+++ b/tests/runtime/test_self_update.py
@@ -1,0 +1,95 @@
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+
+from harness_codex.runtime.self_update import build_update_command, run_self_update
+
+
+def test_build_update_command_defaults_to_force_target_and_ref(tmp_path: Path) -> None:
+    command = build_update_command(tmp_path, repo="https://github.com/omegafrog/harness-codex", ref="main")
+
+    assert "curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh" in command
+    assert "bash -s -- --force" in command
+    assert f"--target {tmp_path}" in command
+    assert "--ref main" in command
+
+
+def test_build_update_command_supports_skip_venv(tmp_path: Path) -> None:
+    command = build_update_command(tmp_path, ref="feature-x", skip_venv=True)
+
+    assert "--ref feature-x" in command
+    assert "--skip-venv" in command
+
+
+def test_run_self_update_dry_run_does_not_call_runner(tmp_path: Path) -> None:
+    called = False
+
+    def runner(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("runner should not be called")
+
+    output = run_self_update(
+        tmp_path,
+        Namespace(
+            repo="https://github.com/omegafrog/harness-codex",
+            ref="main",
+            skip_venv=True,
+            dry_run=True,
+        ),
+        runner=runner,
+    )
+
+    assert called is False
+    assert "Dry run. Command:" in output
+    assert "--skip-venv" in output
+    assert "may overwrite" in output
+
+
+def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
+    calls = []
+
+    def runner(*args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="installed", stderr="")
+
+    output = run_self_update(
+        tmp_path,
+        Namespace(
+            repo="https://github.com/omegafrog/harness-codex",
+            ref="main",
+            skip_venv=True,
+            dry_run=False,
+        ),
+        runner=runner,
+    )
+
+    assert calls
+    command = calls[0][0][0]
+    assert "--force" in command
+    assert f"--target {tmp_path}" in command
+    assert calls[0][1]["cwd"] == tmp_path
+    assert calls[0][1]["shell"] is True
+    assert output.endswith("harness-codex update completed.")
+
+
+def test_run_self_update_reports_failed_installer(tmp_path: Path) -> None:
+    def runner(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=1, stdout="", stderr="boom")
+
+    try:
+        run_self_update(
+            tmp_path,
+            Namespace(
+                repo="https://github.com/omegafrog/harness-codex",
+                ref="main",
+                skip_venv=False,
+                dry_run=False,
+            ),
+            runner=runner,
+        )
+    except ValueError as exc:
+        assert "harness update failed" in str(exc)
+        assert "boom" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
## 구현 의도

Closes #102.

기존 프로젝트에 설치된 harness-codex 런타임을 업데이트하려면 사용자가 installer `curl | bash -s -- --force` 명령을 직접 기억해야 했습니다. 이제 설치된 `./harness` 런처에서 바로 업데이트할 수 있도록 `./harness update` 명령을 추가했습니다.

## 구현 방법

- `harness_codex/runtime/self_update.py` 추가
  - 공식 installer raw URL 생성
  - `--force --target <repo-root> --ref <ref>` 형태의 업데이트 명령 구성
  - `--repo`, `--ref`, `--skip-venv`, `--dry-run` 지원
  - `--dry-run`이면 실제 실행 없이 명령만 출력
  - 실패 시 installer stdout/stderr를 포함해 오류 반환
  - `.harness/`, `.codex/`, `harness_codex/`, `tests/runtime`, `./harness` 덮어쓰기 주의 문구 출력
- `harness_codex/__main__.py` 수정
  - `python3 -m harness_codex update ...`를 기존 CLI parser 진입 전 self-update로 라우팅
  - 설치된 `./harness update`가 그대로 동작하도록 연결
- `docs/runtime-update-command.md` 추가
  - 사용법, 옵션, overwrite 주의사항 문서화

## 검증 방법

추가한 테스트:

- `tests/runtime/test_self_update.py`
  - 기본 update 명령이 installer URL, `--force`, `--target`, `--ref`를 포함하는지 검증
  - `--skip-venv`가 명령에 포함되는지 검증
  - `--dry-run`이 runner를 호출하지 않는지 검증
  - 실제 실행 경로가 `subprocess.run(..., shell=True, cwd=<repo-root>)`로 호출되는지 검증
  - installer 실패 시 `ValueError`로 실패 내용을 전달하는지 검증

검증 명령:

```bash
python3 -m pytest -q tests/runtime/test_self_update.py
```

수동 확인 명령:

```bash
./harness update --dry-run
./harness update --ref main --skip-venv --dry-run
```