### PR TITLE
fix(runtime): make Serena MCP patch import-safe

### DIFF
--- a/harness_codex/runtime/serena_patch.py
+++ b/harness_codex/runtime/serena_patch.py
@@ -12,13 +12,23 @@ _ORIGINAL_COMMAND_ATTR = "_harness_serena_mcp_original_command"
 
 
 def apply_serena_mcp_patch() -> None:
-    """Patch CodexCliAgentAdapter so supported projects get Serena MCP."""
+    """Patch legacy CodexCliAgentAdapter command construction when available.
+
+    Newer runtime versions build provider commands through `_resolve_provider_command`
+    instead of `CodexCliAgentAdapter._command`. Serena MCP should never break CLI
+    import or installer smoke tests, so unsupported adapter shapes are treated as
+    a safe no-op until the MCP hook is reimplemented for the current provider API.
+    """
 
     adapter_cls = runner.CodexCliAgentAdapter
     if getattr(adapter_cls, _PATCHED_ATTR, False):
         return
 
-    original_command = adapter_cls._command
+    original_command = getattr(adapter_cls, "_command", None)
+    if original_command is None:
+        setattr(adapter_cls, _PATCHED_ATTR, True)
+        return
+
     setattr(adapter_cls, _ORIGINAL_COMMAND_ATTR, original_command)
 
     def command_with_serena_mcp(self, request, final_message_path):

--- a/tests/runtime/test_serena_patch_import.py
+++ b/tests/runtime/test_serena_patch_import.py
@@ -1,0 +1,10 @@
+import importlib
+
+
+def test_serena_patch_noops_when_adapter_has_no_legacy_command() -> None:
+    runtime = importlib.import_module("harness_codex.runtime")
+    runner = importlib.import_module("harness_codex.runtime.runner")
+
+    assert runtime is not None
+    assert getattr(runner.CodexCliAgentAdapter, "_harness_serena_mcp_patch_applied") is True
+    assert not hasattr(runner.CodexCliAgentAdapter, "_command")


### PR DESCRIPTION
## 구현 의도

Closes #104.

최신 main 설치 시 installer smoke test가 `AttributeError: type object 'CodexCliAgentAdapter' has no attribute '_command'`로 실패하는 문제를 수정합니다.

현재 runner는 더 이상 `CodexCliAgentAdapter._command`를 사용하지 않고 `ConfigurableCliAgentAdapter`와 `_resolve_provider_command()` 경로로 provider command를 만듭니다. 그런데 Serena MCP patch가 구형 `_command` hook을 전제로 import 시점에 바로 접근해서 CLI import 전체를 깨뜨렸습니다.

## 구현 방법

- `harness_codex/runtime/serena_patch.py` 수정
  - `CodexCliAgentAdapter._command`가 없는 현재 adapter 구조에서는 safe no-op 처리
  - `_harness_serena_mcp_patch_applied` 플래그는 설정해서 반복 patch 시도 방지
  - legacy `_command`가 있는 경우 기존 patch 동작은 유지
- `tests/runtime/test_serena_patch_import.py` 추가
  - 현재 adapter 구조에서 `harness_codex.runtime` import가 깨지지 않는지 검증
  - `_command`가 없어도 patch applied 플래그가 설정되는지 검증

## 검증 방법

```bash
python3 -m pytest -q tests/runtime/test_serena_patch_import.py
python3 -m harness_codex --help
python3 -m harness_codex update --dry-run
```

## 참고

이 PR은 installer smoke test를 살리는 hotfix입니다. Serena MCP를 현재 `_resolve_provider_command()` 기반 provider API에 다시 주입하는 작업은 별도 enhancement로 다루는 것이 안전합니다.