### PR TITLE
feat(runtime): wire Serena MCP into provider command pipeline

### DIFF
--- a/harness_codex/runtime/serena_patch.py
+++ b/harness_codex/runtime/serena_patch.py
@@ -12,13 +12,23 @@ _ORIGINAL_COMMAND_ATTR = "_harness_serena_mcp_original_command"
 
 
 def apply_serena_mcp_patch() -> None:
-    """Patch CodexCliAgentAdapter so supported projects get Serena MCP."""
+    """Patch legacy CodexCliAgentAdapter command construction when available.
+
+    Newer runtime versions build provider commands through `_resolve_provider_command`
+    instead of `CodexCliAgentAdapter._command`. Serena MCP should never break CLI
+    import or installer smoke tests, so unsupported adapter shapes are treated as
+    a safe no-op until the MCP hook is reimplemented for the current provider API.
+    """
 
     adapter_cls = runner.CodexCliAgentAdapter
     if getattr(adapter_cls, _PATCHED_ATTR, False):
         return
 
-    original_command = adapter_cls._command
+    original_command = getattr(adapter_cls, "_command", None)
+    if original_command is None:
+        setattr(adapter_cls, _PATCHED_ATTR, True)
+        return
+
     setattr(adapter_cls, _ORIGINAL_COMMAND_ATTR, original_command)
 
     def command_with_serena_mcp(self, request, final_message_path):

--- a/harness_codex/runtime/serena_patch.py
+++ b/harness_codex/runtime/serena_patch.py
@@ -8,48 +8,52 @@ import harness_codex.runtime.runner as runner
 from harness_codex.runtime.serena_mcp import SerenaMcpInstallation, ensure_serena_mcp
 
 _PATCHED_ATTR = "_harness_serena_mcp_patch_applied"
-_ORIGINAL_COMMAND_ATTR = "_harness_serena_mcp_original_command"
+_ORIGINAL_RESOLVER_ATTR = "_harness_serena_mcp_original_provider_resolver"
 
 
 def apply_serena_mcp_patch() -> None:
-    """Patch legacy CodexCliAgentAdapter command construction when available.
-
-    Newer runtime versions build provider commands through `_resolve_provider_command`
-    instead of `CodexCliAgentAdapter._command`. Serena MCP should never break CLI
-    import or installer smoke tests, so unsupported adapter shapes are treated as
-    a safe no-op until the MCP hook is reimplemented for the current provider API.
-    """
-
-    adapter_cls = runner.CodexCliAgentAdapter
-    if getattr(adapter_cls, _PATCHED_ATTR, False):
+    """Patch provider command construction so Codex runs can use Serena MCP."""
+    if getattr(runner, _PATCHED_ATTR, False):
         return
-
-    original_command = getattr(adapter_cls, "_command", None)
-    if original_command is None:
-        setattr(adapter_cls, _PATCHED_ATTR, True)
+    original_resolver = getattr(runner, "_resolve_provider_command", None)
+    if original_resolver is None:
+        setattr(runner, _PATCHED_ATTR, True)
         return
+    setattr(runner, _ORIGINAL_RESOLVER_ATTR, original_resolver)
 
-    setattr(adapter_cls, _ORIGINAL_COMMAND_ATTR, original_command)
-
-    def command_with_serena_mcp(self, request, final_message_path):
-        command = original_command(self, request, final_message_path)
-        installation = ensure_serena_mcp(
-            request.context.repo_root,
-            request.context.workdir,
-            request.step_dir,
+    def resolve_provider_command_with_serena(request, final_message_path, *, default_codex_binary):
+        provider_result = original_resolver(
+            request,
+            final_message_path,
+            default_codex_binary=default_codex_binary,
         )
-        _write_serena_manifest(request.step_dir, installation)
-        if not installation.enabled:
-            return command
+        if isinstance(provider_result, runner.AgentRunResult):
+            return provider_result
+        command, metadata = provider_result
+        if metadata.get("provider") != "codex":
+            return command, metadata
+        command, serena_metadata = _inject_serena_mcp(request, command)
+        return command, {**metadata, "provider_command": command, "serena_mcp": serena_metadata}
 
-        insertion_index = len(command) - 1 if command and command[-1] == "-" else len(command)
-        for config_override in installation.codex_config_overrides:
-            command[insertion_index:insertion_index] = ["-c", config_override]
-            insertion_index += 2
-        return command
+    runner._resolve_provider_command = resolve_provider_command_with_serena
+    setattr(runner, _PATCHED_ATTR, True)
 
-    adapter_cls._command = command_with_serena_mcp
-    setattr(adapter_cls, _PATCHED_ATTR, True)
+
+def _inject_serena_mcp(request, command: list[str]) -> tuple[list[str], dict]:
+    installation = ensure_serena_mcp(
+        request.context.repo_root,
+        request.context.workdir,
+        request.step_dir,
+    )
+    _write_serena_manifest(request.step_dir, installation)
+    if not installation.enabled:
+        return command, installation.as_metadata()
+    patched_command = list(command)
+    insertion_index = len(patched_command) - 1 if patched_command and patched_command[-1] == "-" else len(patched_command)
+    for config_override in installation.codex_config_overrides:
+        patched_command[insertion_index:insertion_index] = ["-c", config_override]
+        insertion_index += 2
+    return patched_command, installation.as_metadata()
 
 
 def _write_serena_manifest(step_dir, installation: SerenaMcpInstallation) -> None:

--- a/tests/runtime/test_serena_patch_import.py
+++ b/tests/runtime/test_serena_patch_import.py
@@ -1,0 +1,10 @@
+import importlib
+
+
+def test_serena_patch_noops_when_adapter_has_no_legacy_command() -> None:
+    runtime = importlib.import_module("harness_codex.runtime")
+    runner = importlib.import_module("harness_codex.runtime.runner")
+
+    assert runtime is not None
+    assert getattr(runner.CodexCliAgentAdapter, "_harness_serena_mcp_patch_applied") is True
+    assert not hasattr(runner.CodexCliAgentAdapter, "_command")

--- a/tests/runtime/test_serena_patch_import.py
+++ b/tests/runtime/test_serena_patch_import.py
@@ -1,10 +1,11 @@
 import importlib
 
 
-def test_serena_patch_noops_when_adapter_has_no_legacy_command() -> None:
+def test_serena_patch_wraps_current_provider_resolver() -> None:
     runtime = importlib.import_module("harness_codex.runtime")
     runner = importlib.import_module("harness_codex.runtime.runner")
 
     assert runtime is not None
-    assert getattr(runner.CodexCliAgentAdapter, "_harness_serena_mcp_patch_applied") is True
+    assert getattr(runner, "_harness_serena_mcp_patch_applied") is True
+    assert hasattr(runner, "_harness_serena_mcp_original_provider_resolver")
     assert not hasattr(runner.CodexCliAgentAdapter, "_command")

--- a/tests/runtime/test_serena_provider_pipeline.py
+++ b/tests/runtime/test_serena_provider_pipeline.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime import runner, serena_mcp
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind
+from harness_codex.runtime.runner import AgentRunRequest
+
+
+def _request(repo_root: Path, *, provider: str = "codex") -> AgentRunRequest:
+    return AgentRunRequest(
+        step=Step(
+            id="agent-step",
+            kind=StepKind.AGENT,
+            name="Agent step",
+            agent_id="agent",
+            timeout_sec=30,
+        ),
+        context=RunContext(
+            run_id="run-serena",
+            workflow_name="workflow",
+            mode=RunMode.APPLY,
+            repo_root=repo_root,
+            workdir=repo_root,
+            run_dir=repo_root / ".harness/runs/run-serena",
+        ),
+        step_dir=repo_root / ".harness/runs/run-serena/steps/agent-step",
+        agent_config_path=repo_root / ".codex/agents/agent.toml",
+        agent_config={
+            "name": "agent",
+            "provider": provider,
+            "provider_command": ["custom-agent"],
+        },
+    )
+
+
+def test_codex_provider_command_injects_serena_mcp(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    request = _request(tmp_path)
+    request.step_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        serena_mcp.shutil,
+        "which",
+        lambda name: "/usr/local/bin/serena" if name == "serena" else None,
+    )
+
+    command, metadata = runner._resolve_provider_command(
+        request,
+        request.step_dir / "final-message.md",
+        default_codex_binary="codex-test",
+    )
+
+    assert command[0] == "codex-test"
+    assert command[-1] == "-"
+    assert 'mcp_servers.serena.command="/usr/local/bin/serena"' in command
+    assert 'mcp_servers.serena.enabled=true' in command
+    assert metadata["provider"] == "codex"
+    assert metadata["provider_command"] == command
+    assert metadata["serena_mcp"]["enabled"] is True
+    manifest = json.loads((request.step_dir / "serena-mcp.json").read_text(encoding="utf-8"))
+    assert manifest["enabled"] is True
+
+
+def test_custom_cli_provider_does_not_inject_serena_mcp(tmp_path: Path, monkeypatch) -> None:
+    request = _request(tmp_path, provider="custom_cli")
+    request.step_dir.mkdir(parents=True)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("custom_cli must not call ensure_serena_mcp")
+
+    monkeypatch.setattr("harness_codex.runtime.serena_patch.ensure_serena_mcp", fail_if_called)
+
+    command, metadata = runner._resolve_provider_command(
+        request,
+        request.step_dir / "final-message.md",
+        default_codex_binary="codex-test",
+    )
+
+    assert command == ["custom-agent"]
+    assert metadata["provider"] == "custom_cli"
+    assert "serena_mcp" not in metadata
+    assert not (request.step_dir / "serena-mcp.json").exists()


### PR DESCRIPTION
## 구현 의도

Closes #106.

Serena MCP 자동 설정을 현재 runner 구조에 맞게 다시 연결합니다.

기존 구현은 구형 `CodexCliAgentAdapter._command` monkey patch에 의존했습니다. 현재 runner는 `ConfigurableCliAgentAdapter`와 `_resolve_provider_command()` / `_codex_command()` 경로로 provider command를 만들기 때문에, 구형 hook은 import를 깨뜨리거나 no-op으로만 동작했습니다.

## 구현 방법

- `harness_codex/runtime/serena_patch.py` 수정
  - legacy `CodexCliAgentAdapter._command` patch 대신 `runner._resolve_provider_command()`를 wrapping
  - provider가 `codex`일 때만 Serena MCP 감지/설정 주입
  - provider가 `custom_cli`이면 Serena 주입을 건너뜀
  - `ensure_serena_mcp()` 결과가 enabled이면 Codex command의 마지막 stdin marker `-` 앞에 `-c mcp_servers.serena...` 설정을 삽입
  - `serena-mcp.json` manifest를 step directory에 기록
  - Serena 미설치/미지원 언어/설치 실패는 agent 실행을 막지 않고 metadata/manifest에만 기록
- `tests/runtime/test_serena_patch_import.py` 갱신
  - import 시 provider resolver가 안전하게 patch되는지 검증
- `tests/runtime/test_serena_provider_pipeline.py` 추가
  - codex provider command에 Serena MCP 설정이 주입되는지 검증
  - custom_cli provider에는 Serena MCP가 주입되지 않는지 검증

## 검증 방법

```bash
python3 -m pytest -q tests/runtime/test_serena_patch_import.py tests/runtime/test_serena_provider_pipeline.py
python3 -m harness_codex --help
python3 -m harness_codex update --dry-run
```

## 참고

이 PR은 #105의 import-safe 방향을 포함하지만 no-op에 머무르지 않고 현재 provider command pipeline에 Serena MCP를 실제로 다시 연결합니다. #105가 먼저 merge되더라도 이 PR은 동일 방향에서 정상 rebase/merge 가능합니다.