### PR TITLE
Grill-me questioning 종료 조건 및 라운드 제한 추가

### DIFF
--- a/.codex/agents/harness_requirements.toml
+++ b/.codex/agents/harness_requirements.toml
@@ -9,6 +9,7 @@ You are the harness requirements documentation agent.
 
 Your job:
 - Start from the user's short initial idea.
+- Reduce ambiguity through a time-boxed grill-me loop, then write a useful draft instead of pursuing perfect domain understanding.
 - Ask iterative clarification questions until requirements and ubiquitous language are specific enough to document, but ask only one focused question per turn and include your recommended answer with that question.
 - Write or update exactly these output documents:
   - docs/design/요구사항.md
@@ -68,13 +69,20 @@ Requirements rules:
 
 Question loop:
 - Ask exactly one focused question at a time.
+- Treat one round as up to 7 focused questions that target the current priority area.
+- Run at most 3 rounds and at most 7 total questions per round.
+- After each round, summarize what has been clarified and what remains unresolved.
+- Do not continue asking until the domain is perfect.
+- Stop asking once the information is sufficient to produce a draft.
+- After the final round, produce a draft of context.md and docs/design/요구사항.md using confirmed answers, explicit assumptions, and unresolved decision sections.
+- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Open Language Questions, or Post-DDD Technical Decision Candidates instead of extending the question loop.
 - Include `Recommended answer:` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
 - After the user answers, update context.md first, update docs/design/요구사항.md using context.md canonical terms, then choose the next single unresolved decision that blocks requirements or language quality.
 - Prefer questions about actors, goals, core domain terms, state names, command/event/policy terms, alias cleanup, forbidden terms, core functions, success/failure outcomes, foundational technology stack, permissions/security, external systems, traffic/latency/concurrency/consistency, fault handling, and out-of-scope boundaries.
 - Include ubiquitous language questions before finalizing the requirements document.
 - Include non-functional requirement questions before finalizing the requirements document.
 - Include foundational technology stack questions before finalizing the requirements document.
-- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions and core Open Language Questions.
+- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions and core Open Language Questions within the question budget.
 - Keep unresolved items separated into `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, and `Open Language Questions`.
 - If business policy items remain, mark the document as not ready for use-case writing or event storming.
 - If core language questions remain, mark the document as not ready for use-case writing or event storming.

--- a/.codex/skills/harness-requirements/SKILL.md
+++ b/.codex/skills/harness-requirements/SKILL.md
@@ -3,7 +3,7 @@ name: harness-requirements
 description:
   Use when a user wants to turn an early product or feature idea into a
   requirements specification and project ubiquitous language. This skill
-  clarifies unresolved decisions through grill-me and writes
+  clarifies unresolved decisions through a time-boxed grill-me flow and writes
   docs/design/요구사항.md and context.md.
 ---
 
@@ -37,14 +37,14 @@ ubiquitous language source of truth.
 
 Responsibilities are split as follows.
 
-- `$grill-me`: clarifies unresolved requirement and language decisions through questions.
+- `$grill-me`: clarifies unresolved requirement and language decisions through a bounded question loop.
 - `harness-requirements`: validates confirmed decisions and writes `docs/design/요구사항.md` and `context.md`.
 - `harness-usecases`: later reads confirmed requirements and `context.md`, then writes `docs/design/유스케이스.md`.
 
 `$grill-me` only provides the questioning method. The requirements and ubiquitous
 language standards belong to this skill's `Embedded Standards`. Therefore, when
 running `$grill-me`, pass a `Grill-Me Brief` that summarizes this skill's
-standards.
+standards and the bounded questioning rule.
 
 The `$grill-me` result is not the final deliverable. It is an intermediate
 decision record used to write `docs/design/요구사항.md` and `context.md`.
@@ -100,15 +100,39 @@ Use the following standards as the source of truth for the instructions.
 `$grill-me` only provides the questioning method. When running it, pass a brief
 that summarizes this skill's standards.
 
+### Question Budget and Completion Rule
+
+The grill-me phase must reduce ambiguity enough to produce a useful draft. It
+must not continue asking until the domain is perfect.
+
+Rules:
+
+- Run at most 3 rounds.
+- Treat one round as up to 7 focused questions that target the current priority area.
+- Ask one focused question at a time when interacting with the user.
+- Ask at most 7 total questions per round.
+- After each round, summarize what has been clarified and what remains unresolved.
+- Stop once main actors, actor goals, core business policies, and core ubiquitous language are clear enough to produce a draft.
+- If the question budget is exhausted, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
+- If uncertainty remains, record it under `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Open Language Questions`, or `Post-DDD Technical Decision Candidates` instead of extending the question loop.
+- After the final round, produce a draft of `context.md` and `docs/design/요구사항.md`.
+
 ### Brief Contents
 
 ```text
 You are conducting an interview to clarify requirements and confirm ubiquitous language.
 
 Questioning method:
-- Ask up to three focused questions at a time when at least three unresolved decisions remain.
-- Ask fewer than three only when fewer unresolved decisions remain.
+- Use a time-boxed questioning loop, not an unbounded interview.
+- Run at most 3 rounds.
+- Ask at most 7 total questions per round.
+- Ask one focused question at a time when interacting with the user.
 - Include `Recommended answer:` with each question.
+- After each round, summarize what has been clarified and what remains unresolved.
+- Do not continue asking until the domain is perfect.
+- Stop when the information is sufficient to produce a useful draft.
+- After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
+- If uncertainty remains, record it under `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Open Language Questions`, or `Post-DDD Technical Decision Candidates`.
 - If the answer can be found in the codebase, existing documents, or settings, inspect them first.
 - Follow decision dependencies and resolve the most important unresolved item first.
 
@@ -149,9 +173,9 @@ Ubiquitous language confirmation criteria:
 Completion criteria:
 - Main actors and their goals are separated enough for functional requirements.
 - Functional and non-functional requirement candidates can be written.
-- There are no unresolved core business policies.
+- There are no unresolved core business policies, or the remaining items are explicitly recorded as not-ready blockers.
 - Foundational technologies are confirmed or separated as needing confirmation.
-- Core ubiquitous language is confirmed and can be written to `context.md`.
+- Core ubiquitous language is confirmed and can be written to `context.md`, or unresolved terms are explicitly recorded under `Open Language Questions`.
 
 Output format:
 ## Confirmed Decisions
@@ -199,35 +223,6 @@ Execution rules:
 - The dedicated agent must not modify code, settings, skill files, agent files, or use-case documents.
 - The dedicated agent may only write to `docs/design/요구사항.md` and `context.md`.
 
-```text
-You are the harness requirements documentation agent.
-
-Write or update only docs/design/요구사항.md and context.md based on the user's early idea and the `$grill-me` result.
-
-Owned files:
-- docs/design/요구사항.md
-- context.md
-
-Rules:
-- Do not modify code, settings, skill files, agent files, or use-case documents.
-- Do not revert existing user changes.
-- `$grill-me` only provides the questioning method.
-- Use this skill's Embedded Standards as the judgment criteria.
-- If `$grill-me` is needed, create and pass a brief that follows the Grill-Me Brief Contract.
-- Do not confirm core requirements without a `$grill-me` result or existing evidence.
-- Do not confirm core ubiquitous language without a `$grill-me` result or existing evidence.
-- Distinguish confirmed, candidate, and needs-confirmation non-functional requirements.
-- Confirm foundational technologies in the later part of the requirements phase.
-- Confirm canonical domain terms, English code-facing names, aliases, and forbidden terms.
-- Write confirmed ubiquitous language to context.md.
-- Record unresolved language decisions under Open Language Questions in context.md.
-- Use context.md canonical terms when writing docs/design/요구사항.md.
-- Do not confirm detailed technical strategies as requirements.
-- Do not write use cases.
-- Write deliverables only to the owned files.
-- If the dedicated agent cannot be found or cannot run, explain the reason and stop.
-```
-
 ## Workflow
 
 1. **Confirm standards**
@@ -237,7 +232,7 @@ Rules:
    Review the early idea, `$grill-me` result, existing requirements, existing `context.md`, relevant code, docs, and settings.
 
 3. **Decide whether to run Grill-Me**
-   If requirement or language decisions are missing, create a brief that follows the `Grill-Me Brief Contract` and run `$grill-me`.
+   If requirement or language decisions are missing, create a brief that follows the `Grill-Me Brief Contract` and run `$grill-me` within the question budget.
 
 4. **Validate decisions**
    Split the `$grill-me` result into confirmed decisions, needs-confirmation items, confirmed language, open language questions, and post-DDD candidates.
@@ -249,7 +244,7 @@ Rules:
 6. **Confirm completion**
    If business policies are unresolved, do not report readiness for use-case writing or Event Storming.
    If ubiquitous language has unresolved core terms, do not report readiness for use-case writing or Event Storming.
-   Collect remaining unresolved items in needs-confirmation sections.
+   Collect remaining unresolved items in needs-confirmation sections instead of continuing the question loop beyond the budget.
 
 ## Context Document Template
 

--- a/.codex/skills/harness-requirements/references/agent-prompt.md
+++ b/.codex/skills/harness-requirements/references/agent-prompt.md
@@ -19,13 +19,20 @@ Rules:
 - Inspect codebase, existing docs, existing context.md, and settings before asking the user a question that local artifacts could answer.
 - Do not guess unclear decisions.
 - Do not finalize non-functional requirements from assumptions.
-- Ask up to three focused questions at a time when at least three unresolved decisions remain.
-- Ask fewer than three only when fewer unresolved decisions remain.
+- Use a time-boxed grill-me loop rather than an unbounded interview.
+- Run at most 3 rounds.
+- Ask at most 7 total questions per round.
+- Ask one focused question at a time when interacting with the user.
 - Include `Recommended answer:` with every question.
+- After each round, summarize what has been clarified and what remains unresolved.
+- Do not continue asking until the domain is perfect.
+- Stop when the information is sufficient to produce a useful draft.
+- After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
+- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Open Language Questions, or Post-DDD Technical Decision Candidates.
 - Confirm ubiquitous language through grill-me before use-case harvest.
 - Update context.md first with confirmed canonical terms, Korean names, English code-facing names, definitions, aliases, forbidden terms, and open language questions.
 - Use context.md canonical terms when updating docs/design/요구사항.md.
-- After the user answers, update context.md and docs/design/요구사항.md, then ask the next most important unresolved requirement or language decision.
+- After the user answers, update context.md and docs/design/요구사항.md, then ask the next most important unresolved requirement or language decision within the question budget.
 - Split functional and non-functional requirements.
 - Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, and Open Language Questions.
 - Ask foundational technology stack questions before treating requirements as complete.

--- a/tests/test_harvester_skill_instructions.py
+++ b/tests/test_harvester_skill_instructions.py
@@ -21,6 +21,23 @@ def test_harvester_skills_ask_one_question_with_recommendation() -> None:
         assert "3-7" not in text
 
 
+def test_requirements_grill_me_questioning_is_time_boxed() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
+        REPO_ROOT / ".codex/agents/harness_requirements.toml",
+        REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
+    )
+
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert "at most 3 rounds" in text
+        assert "at most 7 total questions per round" in text
+        assert "After each round" in text
+        assert "not continue asking until the domain is perfect" in text
+        assert "produce a draft" in text
+        assert "Open Language Questions" in text
+
+
 def test_requirements_skill_explores_local_context_before_questions() -> None:
     skill = (REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md").read_text(
         encoding="utf-8"


### PR DESCRIPTION
Closes #110

## 구현 의도

`harness-requirements`의 grill-me questioning이 종료 조건 없이 계속 이어질 수 있는 문제를 막기 위해 질문 예산과 종료 기준을 명문화했다.

질문 단계의 목표를 “완벽한 도메인 이해”가 아니라 “초안 문서를 작성할 수 있을 만큼 모호성을 줄이는 것”으로 제한한다.

## 구현 방법

- `.codex/skills/harness-requirements/SKILL.md`
  - Grill-Me Brief Contract에 `Question Budget and Completion Rule` 섹션을 추가했다.
  - 최대 3라운드, 라운드당 최대 7개 질문 제한을 명시했다.
  - 각 라운드 이후 요약하도록 했다.
  - 충분한 정보가 모이면 질문을 멈추고 `context.md`, `docs/design/요구사항.md` 초안을 생성하도록 했다.
  - 남은 불확실성은 `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Open Language Questions`, `Post-DDD Technical Decision Candidates`에 기록하도록 했다.

- `.codex/agents/harness_requirements.toml`
  - dedicated requirements agent의 question loop에 동일한 질문 예산과 종료 규칙을 반영했다.
  - “도메인이 완벽해질 때까지 질문하지 말고, draft를 만들 수 있으면 멈춘다”는 기준을 추가했다.

- `.codex/skills/harness-requirements/references/agent-prompt.md`
  - worker agent prompt에도 동일한 time-boxed grill-me 규칙을 반영했다.

- `tests/test_harvester_skill_instructions.py`
  - requirements skill, agent config, prompt reference가 모두 질문 예산과 종료 조건을 포함하는지 검증하는 회귀 테스트를 추가했다.

## 검증 방법

- 정적 diff 확인:
  - 변경 파일 4개
  - branch `codex/110-limit-grill-me-questioning`이 `main` 대비 4 commits ahead, 0 behind임을 확인했다.
- 추가된 테스트가 다음 문구를 검증하도록 작성했다.
  - `at most 3 rounds`
  - `at most 7 total questions per round`
  - `After each round`
  - `not continue asking until the domain is perfect`
  - `produce a draft`
  - `Open Language Questions`

로컬 테스트 실행은 이 환경에서 수행하지 못했다.

## Checklist

- [x] 최대 3라운드 제한 추가
- [x] 라운드당 최대 7개 질문 제한 추가
- [x] 각 라운드 이후 요약 규칙 추가
- [x] 종료 조건 명문화
- [x] `Open Questions` 계열 기록 규칙 추가
- [x] 마지막 라운드 이후 초안 생성 규칙 추가
- [x] 회귀 테스트 추가
