### PR TITLE
Harvest interactive 세션 ID 기반 재개 및 단계 가드 추가

### DIFF
--- a/docs/README-harvest-quickstart.md
+++ b/docs/README-harvest-quickstart.md
@@ -9,7 +9,8 @@ When a repository does not yet have current design documents, run harvest before
 ```bash
 ./harness agent-context init --description "<repo description>"
 ./harness harvest --idea "<feature idea>" --plan
-./harness harvest --idea "<feature idea>" --interactive
+./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
+./harness harvest --interactive --session-id harvest-001 --resume
 ./harness changes create-from-design --title "<change title>" --change-set-id CHG-YYYYMMDD-001
 ./harness run-change CHG-YYYYMMDD-001 --plan
 ./harness run-change CHG-YYYYMMDD-001 --apply
@@ -26,6 +27,19 @@ If `docs/design/요구사항.md` and `docs/design/유스케이스.md` already ex
 - `docs/design/요구사항.md`
 - `docs/design/유스케이스.md`
 
+Interactive harvest assigns a session id and stores a resumable session snapshot under:
+
+- `.harness/ui/sessions/<SESSION-ID>.json`
+- `.harness/ui/harvest-session.json` for legacy compatibility with the UI runtime
+
+If an interactive run is interrupted, resume it with the same session id:
+
+```bash
+./harness harvest --interactive --session-id <SESSION-ID> --resume
+```
+
+A completed session cannot be resumed as a question loop. The command reports that the session is already complete and prints the next `changes create-from-design` step.
+
 ### `changes create-from-design`
 
 `changes create-from-design` does not create design documents. It reads existing design documents and creates runtime inputs:
@@ -39,10 +53,13 @@ If `docs/design/요구사항.md` and `docs/design/유스케이스.md` already ex
 ./harness harvest --idea "<feature idea>" --plan
 ./harness harvest --idea "<feature idea>" --preview
 ./harness harvest --idea "<feature idea>" --apply
-./harness harvest --idea "<feature idea>" --interactive
+./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
+./harness harvest --interactive --session-id harvest-001 --resume
 ```
 
 - `--idea`: initial product or feature idea to turn into requirements and use-case design documents.
+- `--session-id`: interactive harvest session id. If omitted, the runtime generates one.
+- `--resume`: resume an existing interactive harvest session instead of starting a new one.
 - `--plan`: show the harvest workflow plan without changing files.
 - `--preview`: show a no-side-effect preview. It currently has the same behavior as `--plan`.
 - `--apply`: run the non-interactive harvest workflow through the agent runner.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -80,7 +80,8 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  harness harvest --idea '<feature idea>' --plan\n"
-            "  harness harvest --idea '<feature idea>' --interactive\n"
+            "  harness harvest --idea '<feature idea>' --interactive --session-id harvest-001\n"
+            "  harness harvest --interactive --session-id harvest-001 --resume\n"
             "  harness harvest --idea '<feature idea>' --apply"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -89,6 +90,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--idea",
         default="",
         help="Initial product or feature idea to harvest into requirements and use-case design documents.",
+    )
+    harvest.add_argument(
+        "--session-id",
+        default="",
+        help="Interactive harvest session id. Use with --interactive to start or resume a named session.",
+    )
+    harvest.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume an existing interactive harvest session selected by --session-id.",
     )
     _add_harvest_mode_options(harvest)
     harvest.set_defaults(func=harvest_command)
@@ -191,7 +202,12 @@ def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
         agent_context = bootstrap_agent_context(repo_root, _repo_description(args.idea))
         return "\n".join(
             [
-                run_interactive_harvest(repo_root, args.idea),
+                run_interactive_harvest(
+                    repo_root,
+                    args.idea,
+                    session_id=args.session_id,
+                    resume=args.resume,
+                ),
                 _format_agent_context_result(agent_context),
             ]
         )

--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import shutil
 from collections.abc import Callable
 from pathlib import Path
+from uuid import uuid4
 
 from harness_codex.runtime.harvest_ui import (
+    SESSION_PATH,
     HarvestUiResult,
     answer_requirements,
+    load_harvest_ui,
     start_requirements,
     start_use_cases,
 )
@@ -15,44 +19,103 @@ from harness_codex.runtime.harvest_ui import (
 InputFunc = Callable[[str], str]
 OutputFunc = Callable[[str], None]
 
+INTERACTIVE_SESSION_DIR = Path(".harness/ui/sessions")
+
 
 def run_interactive_harvest(
     repo_root: Path | str,
     idea: str,
     *,
+    session_id: str | None = None,
+    resume: bool = False,
     input_func: InputFunc = input,
     output_func: OutputFunc = print,
 ) -> str:
-    """Run the Grill-Me-backed harvest loop in a terminal.
+    """Run or resume the Grill-Me-backed harvest loop in a terminal.
 
-    The local harvest UI already owns the question/answer session state and the
-    requirements gate. This wrapper exposes the same lifecycle for CLI users:
-    start requirements, answer current questions until the gate passes, then
-    generate use cases.
+    The harvest UI service still owns the question/answer state. This wrapper
+    adds a stable session id so a Ctrl-C interrupted interactive run can be
+    resumed from the saved local session file.
     """
 
-    prompt = idea.strip()
-    if not prompt:
-        raise ValueError("--idea is required when using --interactive")
+    root = Path(repo_root)
+    resolved_session_id = _resolve_session_id(session_id)
 
-    result = start_requirements(repo_root, prompt)
-    output_func(_format_session_header(result))
+    if resume:
+        _restore_session(root, resolved_session_id)
+        result = load_harvest_ui(root)
+        _persist_session(root, resolved_session_id)
+        if not result.initial_prompt:
+            raise ValueError(f"harvest session is empty: {resolved_session_id}")
+        if result.use_cases_ready:
+            raise ValueError(_completed_session_message(resolved_session_id))
+        output_func(_format_session_header(result, resolved_session_id, resumed=True))
+    else:
+        prompt = idea.strip()
+        if not prompt:
+            raise ValueError("--idea is required when using --interactive")
+        if _session_file(root, resolved_session_id).exists():
+            raise ValueError(
+                f"harvest session already exists: {resolved_session_id}. "
+                "Use --resume with this session id instead."
+            )
+        result = start_requirements(root, prompt)
+        _persist_session(root, resolved_session_id)
+        output_func(_format_session_header(result, resolved_session_id, resumed=False))
 
     while not result.requirements_gate_passed:
         output_func(_format_questions(result))
         answer = input_func("Answer: ").strip()
         if not answer:
             raise ValueError("answer is required")
-        result = answer_requirements(repo_root, answer)
+        _restore_session(root, resolved_session_id)
+        result = answer_requirements(root, answer)
+        _persist_session(root, resolved_session_id)
 
-    result = start_use_cases(repo_root)
-    return _format_completion(result)
+    _restore_session(root, resolved_session_id)
+    result = start_use_cases(root)
+    _persist_session(root, resolved_session_id)
+    return _format_completion(result, resolved_session_id)
 
 
-def _format_session_header(result: HarvestUiResult) -> str:
+def _resolve_session_id(value: str | None) -> str:
+    text = (value or "").strip()
+    return text or f"harvest-{uuid4().hex[:12]}"
+
+
+def _session_file(root: Path, session_id: str) -> Path:
+    return root / INTERACTIVE_SESSION_DIR / f"{session_id}.json"
+
+
+def _restore_session(root: Path, session_id: str) -> None:
+    source = _session_file(root, session_id)
+    if not source.exists():
+        raise ValueError(f"harvest session not found: {session_id}")
+    target = root / SESSION_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
+
+
+def _persist_session(root: Path, session_id: str) -> None:
+    source = root / SESSION_PATH
+    if not source.exists():
+        raise ValueError("harvest session state was not written")
+    target = _session_file(root, session_id)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
+
+
+def _format_session_header(
+    result: HarvestUiResult,
+    session_id: str,
+    *,
+    resumed: bool,
+) -> str:
+    verb = "resumed" if resumed else "started"
     return "\n".join(
         [
-            "INTERACTIVE HARVEST started",
+            f"INTERACTIVE HARVEST {verb}",
+            f"Session ID: {session_id}",
             f"Initial idea: {result.initial_prompt}",
             f"Active stage: {result.active_stage}",
         ]
@@ -69,14 +132,26 @@ def _format_questions(result: HarvestUiResult) -> str:
     return "\n".join(lines)
 
 
-def _format_completion(result: HarvestUiResult) -> str:
+def _format_completion(result: HarvestUiResult, session_id: str) -> str:
     return "\n".join(
         [
             "INTERACTIVE HARVEST completed",
+            f"Session ID: {session_id}",
             "Requirements gate: passed",
             "Generated artifacts:",
             "- docs/design/요구사항.md",
             "- docs/design/유스케이스.md",
+            "Next step:",
+            './harness changes create-from-design --title "<change title>"',
+        ]
+    )
+
+
+def _completed_session_message(session_id: str) -> str:
+    return "\n".join(
+        [
+            f"harvest session already completed: {session_id}",
+            "Current stage: useCases",
             "Next step:",
             './harness changes create-from-design --title "<change title>"',
         ]

--- a/tests/runtime/test_interactive_harvest.py
+++ b/tests/runtime/test_interactive_harvest.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
+import pytest
+
 from harness_codex.runtime.interactive_harvest import run_interactive_harvest
+
+
+class StopInput(Exception):
+    pass
 
 
 def test_interactive_harvest_reuses_harvest_ui_gate(
@@ -29,17 +35,97 @@ def test_interactive_harvest_reuses_harvest_ui_gate(
     result = run_interactive_harvest(
         tmp_path,
         "build a queue system",
+        session_id="harvest-test-001",
         input_func=lambda _prompt: "Customer uses the queue system.",
         output_func=output_lines.append,
     )
 
     assert calls == [0, 1]
     assert "INTERACTIVE HARVEST completed" in result
+    assert "Session ID: harvest-test-001" in result
     assert "./harness changes create-from-design" in result
+    assert any("Session ID: harvest-test-001" in line for line in output_lines)
     assert any("Who is the primary actor?" in line for line in output_lines)
     assert (tmp_path / "docs/design/요구사항.md").is_file()
     assert (tmp_path / "docs/design/유스케이스.md").is_file()
     assert (tmp_path / ".harness/ui/harvest-session.json").is_file()
+    assert (tmp_path / ".harness/ui/sessions/harvest-test-001.json").is_file()
+
+
+def test_interactive_harvest_resumes_saved_session(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls = []
+
+    def fake_grill_me(_root: Path, session: dict) -> dict:
+        calls.append(len(session["clarifications"]))
+        if len(session["clarifications"]) >= 1:
+            return {"complete": True, "questions": []}
+        return {
+            "complete": False,
+            "questions": [
+                {
+                    "question": "Who is the primary actor?",
+                    "recommended": "Customer",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
+
+    with pytest.raises(StopInput):
+        run_interactive_harvest(
+            tmp_path,
+            "build a queue system",
+            session_id="harvest-resume-001",
+            input_func=lambda _prompt: (_ for _ in ()).throw(StopInput()),
+            output_func=lambda _line: None,
+        )
+
+    assert (tmp_path / ".harness/ui/sessions/harvest-resume-001.json").is_file()
+
+    result = run_interactive_harvest(
+        tmp_path,
+        "",
+        session_id="harvest-resume-001",
+        resume=True,
+        input_func=lambda _prompt: "Customer uses the queue system.",
+        output_func=lambda _line: None,
+    )
+
+    assert calls == [0, 1]
+    assert "INTERACTIVE HARVEST completed" in result
+    assert "Session ID: harvest-resume-001" in result
+    assert (tmp_path / "docs/design/유스케이스.md").is_file()
+
+
+def test_interactive_harvest_blocks_completed_session_resume(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_grill_me",
+        lambda _root, _session: {"complete": True, "questions": []},
+    )
+
+    run_interactive_harvest(
+        tmp_path,
+        "build a queue system",
+        session_id="harvest-complete-001",
+        input_func=lambda _prompt: "unused",
+        output_func=lambda _line: None,
+    )
+
+    with pytest.raises(ValueError, match="harvest session already completed"):
+        run_interactive_harvest(
+            tmp_path,
+            "",
+            session_id="harvest-complete-001",
+            resume=True,
+            input_func=lambda _prompt: "unused",
+            output_func=lambda _line: None,
+        )
 
 
 def test_interactive_harvest_requires_idea(tmp_path: Path) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -161,6 +161,48 @@ def test_harvest_plan_outputs_runtime_harvester_stage(
     assert not (tmp_path / "AGENTS.md").exists()
 
 
+def test_harvest_interactive_passes_session_options(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def fake_run_interactive_harvest(repo_root, idea, *, session_id=None, resume=False):
+        captured["repo_root"] = repo_root
+        captured["idea"] = idea
+        captured["session_id"] = session_id
+        captured["resume"] = resume
+        return "interactive harvest ok"
+
+    monkeypatch.setattr(
+        "harness_codex.cli.run_interactive_harvest",
+        fake_run_interactive_harvest,
+    )
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "harvest",
+            "--interactive",
+            "--session-id",
+            "harvest-001",
+            "--resume",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "interactive harvest ok" in output
+    assert captured == {
+        "repo_root": tmp_path,
+        "idea": "",
+        "session_id": "harvest-001",
+        "resume": True,
+    }
+
+
 def test_agent_context_init_creates_expected_files(
     tmp_path: Path,
     capsys,
@@ -387,5 +429,5 @@ def test_dashboard_outputs_work_item_state(tmp_path: Path, capsys) -> None:
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert '"id": "MAINT-001"' in output
-    assert '"type": "maintenance"' in output
+    assert '\"id\": \"MAINT-001\"' in output
+    assert '\"type\": \"maintenance\"' in output


### PR DESCRIPTION
Closes #112

## 구현 의도

`harvest --interactive`가 중간에 멈춰도 같은 세션을 식별하고 이어서 실행할 수 있도록 세션 ID 기반 재개 흐름을 완성했다.

또한 이미 완료된 세션을 다시 질문 루프로 실행하려 하면 현재 단계와 다음 실행 가능한 명령을 안내하고 중단하도록 했다.

## 구현 방법

- `harness_codex/runtime/interactive_harvest.py`
  - interactive harvest에 `session_id`, `resume` 인자를 추가했다.
  - 새 실행 시 세션 ID를 생성하거나 사용자가 지정한 ID를 사용한다.
  - `.harness/ui/sessions/<SESSION-ID>.json`에 세션 스냅샷을 저장한다.
  - resume 흐름에서 세션 파일을 기존 `.harness/ui/harvest-session.json`으로 복원한 뒤 기존 harvest UI 런타임을 재사용한다.
  - 완료된 세션을 재개하려 하면 오류를 출력하고 다음 단계인 `changes create-from-design`를 안내한다.

- `harness_codex/cli.py`
  - `harvest` parser에 `--session-id`를 추가했다.
  - `harvest` parser에 `--resume`을 추가했다.
  - `harvest_command()`에서 `run_interactive_harvest(..., session_id=args.session_id, resume=args.resume)`로 전달하도록 연결했다.
  - help 예시에 start/resume 명령을 추가했다.

- `tests/runtime/test_interactive_harvest.py`
  - 세션 ID 출력 및 세션 파일 저장 검증을 추가했다.
  - 중단된 세션을 같은 ID로 재개하는 테스트를 추가했다.
  - 이미 완료된 세션을 다시 재개하려 할 때 오류가 나는지 검증했다.

- `tests/test_cli_commands.py`
  - CLI에서 `--session-id`, `--resume`이 `run_interactive_harvest`까지 전달되는지 검증했다.

- `docs/README-harvest-quickstart.md`
  - `--session-id`, `--resume` 사용법과 세션 저장 경로를 문서화했다.

## 사용 예시

```bash
./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
./harness harvest --interactive --session-id harvest-001 --resume
```

## 검증 방법

- GitHub compare 기준 변경 파일 확인:
  - `docs/README-harvest-quickstart.md`
  - `harness_codex/cli.py`
  - `harness_codex/runtime/interactive_harvest.py`
  - `tests/runtime/test_interactive_harvest.py`
  - `tests/test_cli_commands.py`
- 추가 테스트:
  - interactive harvest session id 저장
  - 중단 세션 재개
  - 완료 세션 재실행 차단
  - CLI option 전달

로컬 테스트 실행은 이 환경에서 수행하지 못했다.

## Checklist

- [x] interactive harvest 세션 ID 저장
- [x] session id별 상태 파일 저장
- [x] 중단된 세션 재개용 런타임 함수 추가
- [x] 완료 세션 재실행 차단
- [x] 문서 업데이트
- [x] 런타임 테스트 추가
- [x] CLI argparse 옵션 연결
- [x] CLI 레벨 테스트 추가
