### PR TITLE
Harvest interactive 세션 목록 변경을 main에 반영

### DIFF
--- a/docs/README-harvest-quickstart.md
+++ b/docs/README-harvest-quickstart.md
@@ -10,6 +10,7 @@ When a repository does not yet have current design documents, run harvest before
 ./harness agent-context init --description "<repo description>"
 ./harness harvest --idea "<feature idea>" --plan
 ./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
+./harness harvest sessions
 ./harness harvest --interactive --session-id harvest-001 --resume
 ./harness changes create-from-design --title "<change title>" --change-set-id CHG-YYYYMMDD-001
 ./harness run-change CHG-YYYYMMDD-001 --plan
@@ -31,6 +32,20 @@ Interactive harvest assigns a session id and stores a resumable session snapshot
 
 - `.harness/ui/sessions/<SESSION-ID>.json`
 - `.harness/ui/harvest-session.json` for legacy compatibility with the UI runtime
+
+List saved interactive sessions with:
+
+```bash
+./harness harvest sessions
+```
+
+The session list shows:
+
+- session id
+- active stage
+- requirements gate status
+- use-case readiness
+- initial idea
 
 If an interactive run is interrupted, resume it with the same session id:
 
@@ -54,12 +69,14 @@ A completed session cannot be resumed as a question loop. The command reports th
 ./harness harvest --idea "<feature idea>" --preview
 ./harness harvest --idea "<feature idea>" --apply
 ./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
+./harness harvest sessions
 ./harness harvest --interactive --session-id harvest-001 --resume
 ```
 
 - `--idea`: initial product or feature idea to turn into requirements and use-case design documents.
 - `--session-id`: interactive harvest session id. If omitted, the runtime generates one.
 - `--resume`: resume an existing interactive harvest session instead of starting a new one.
+- `sessions`: list saved interactive harvest sessions from `.harness/ui/sessions`.
 - `--plan`: show the harvest workflow plan without changing files.
 - `--preview`: show a no-side-effect preview. It currently has the same behavior as `--plan`.
 - `--apply`: run the non-interactive harvest workflow through the agent runner.

--- a/docs/README-harvest-quickstart.md
+++ b/docs/README-harvest-quickstart.md
@@ -9,7 +9,8 @@ When a repository does not yet have current design documents, run harvest before
 ```bash
 ./harness agent-context init --description "<repo description>"
 ./harness harvest --idea "<feature idea>" --plan
-./harness harvest --idea "<feature idea>" --interactive
+./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
+./harness harvest --interactive --session-id harvest-001 --resume
 ./harness changes create-from-design --title "<change title>" --change-set-id CHG-YYYYMMDD-001
 ./harness run-change CHG-YYYYMMDD-001 --plan
 ./harness run-change CHG-YYYYMMDD-001 --apply
@@ -26,6 +27,19 @@ If `docs/design/요구사항.md` and `docs/design/유스케이스.md` already ex
 - `docs/design/요구사항.md`
 - `docs/design/유스케이스.md`
 
+Interactive harvest assigns a session id and stores a resumable session snapshot under:
+
+- `.harness/ui/sessions/<SESSION-ID>.json`
+- `.harness/ui/harvest-session.json` for legacy compatibility with the UI runtime
+
+If an interactive run is interrupted, resume it with the same session id:
+
+```bash
+./harness harvest --interactive --session-id <SESSION-ID> --resume
+```
+
+A completed session cannot be resumed as a question loop. The command reports that the session is already complete and prints the next `changes create-from-design` step.
+
 ### `changes create-from-design`
 
 `changes create-from-design` does not create design documents. It reads existing design documents and creates runtime inputs:
@@ -39,10 +53,13 @@ If `docs/design/요구사항.md` and `docs/design/유스케이스.md` already ex
 ./harness harvest --idea "<feature idea>" --plan
 ./harness harvest --idea "<feature idea>" --preview
 ./harness harvest --idea "<feature idea>" --apply
-./harness harvest --idea "<feature idea>" --interactive
+./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
+./harness harvest --interactive --session-id harvest-001 --resume
 ```
 
 - `--idea`: initial product or feature idea to turn into requirements and use-case design documents.
+- `--session-id`: interactive harvest session id. If omitted, the runtime generates one.
+- `--resume`: resume an existing interactive harvest session instead of starting a new one.
 - `--plan`: show the harvest workflow plan without changing files.
 - `--preview`: show a no-side-effect preview. It currently has the same behavior as `--plan`.
 - `--apply`: run the non-interactive harvest workflow through the agent runner.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -37,7 +37,10 @@ from harness_codex.runtime.changes import (
     create_changeset_from_design,
 )
 from harness_codex.runtime.dashboard import dashboard_state_json
-from harness_codex.runtime.interactive_harvest import run_interactive_harvest
+from harness_codex.runtime.interactive_harvest import (
+    list_harvest_sessions,
+    run_interactive_harvest,
+)
 from harness_codex.runtime.ui_server import run_ui_server
 from harness_codex.runtime.workflows import (
     WorkflowMaterializationError,
@@ -82,6 +85,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  harness harvest --idea '<feature idea>' --plan\n"
             "  harness harvest --idea '<feature idea>' --interactive --session-id harvest-001\n"
             "  harness harvest --interactive --session-id harvest-001 --resume\n"
+            "  harness harvest sessions\n"
             "  harness harvest --idea '<feature idea>' --apply"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -100,6 +104,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--resume",
         action="store_true",
         help="Resume an existing interactive harvest session selected by --session-id.",
+    )
+    harvest.add_argument(
+        "harvest_subcommand",
+        nargs="?",
+        choices=("sessions",),
+        help="Harvest utility command. Use `sessions` to list interactive harvest sessions.",
     )
     _add_harvest_mode_options(harvest)
     harvest.set_defaults(func=harvest_command)
@@ -193,6 +203,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
+    if getattr(args, "harvest_subcommand", "") == "sessions":
+        return list_harvest_sessions(repo_root)
+
+    if not any((args.plan, args.preview, args.apply, args.interactive)):
+        raise ValueError(
+            "harvest requires one of --plan, --preview, --apply, --interactive, "
+            "or the sessions subcommand"
+        )
+
     workflow_dir = repo_root / ".harness/workflows"
     if not (workflow_dir / "harvest-workflow.yaml").exists():
         workflow_dir = Path(__file__).resolve().parents[1] / ".harness/workflows"
@@ -468,7 +487,7 @@ def _add_mode_options(parser: argparse.ArgumentParser) -> None:
 
 
 def _add_harvest_mode_options(parser: argparse.ArgumentParser) -> None:
-    mode = parser.add_mutually_exclusive_group(required=True)
+    mode = parser.add_mutually_exclusive_group(required=False)
     mode.add_argument("--plan", action="store_true", help="Show the harvest workflow plan without changing files.")
     mode.add_argument("--preview", action="store_true", help="Preview the harvest workflow without changing files; currently equivalent to --plan.")
     mode.add_argument("--apply", action="store_true", help="Run the non-interactive harvest workflow through the agent runner.")

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -80,7 +80,8 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  harness harvest --idea '<feature idea>' --plan\n"
-            "  harness harvest --idea '<feature idea>' --interactive\n"
+            "  harness harvest --idea '<feature idea>' --interactive --session-id harvest-001\n"
+            "  harness harvest --interactive --session-id harvest-001 --resume\n"
             "  harness harvest --idea '<feature idea>' --apply"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -89,6 +90,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--idea",
         default="",
         help="Initial product or feature idea to harvest into requirements and use-case design documents.",
+    )
+    harvest.add_argument(
+        "--session-id",
+        default="",
+        help="Interactive harvest session id. Use with --interactive to start or resume a named session.",
+    )
+    harvest.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume an existing interactive harvest session selected by --session-id.",
     )
     _add_harvest_mode_options(harvest)
     harvest.set_defaults(func=harvest_command)
@@ -191,7 +202,12 @@ def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
         agent_context = bootstrap_agent_context(repo_root, _repo_description(args.idea))
         return "\n".join(
             [
-                run_interactive_harvest(repo_root, args.idea),
+                run_interactive_harvest(
+                    repo_root,
+                    args.idea,
+                    session_id=args.session_id,
+                    resume=args.resume,
+                ),
                 _format_agent_context_result(agent_context),
             ]
         )

--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import shutil
 from collections.abc import Callable
 from pathlib import Path
+from uuid import uuid4
 
 from harness_codex.runtime.harvest_ui import (
+    SESSION_PATH,
     HarvestUiResult,
     answer_requirements,
+    load_harvest_ui,
     start_requirements,
     start_use_cases,
 )
@@ -15,44 +19,103 @@ from harness_codex.runtime.harvest_ui import (
 InputFunc = Callable[[str], str]
 OutputFunc = Callable[[str], None]
 
+INTERACTIVE_SESSION_DIR = Path(".harness/ui/sessions")
+
 
 def run_interactive_harvest(
     repo_root: Path | str,
     idea: str,
     *,
+    session_id: str | None = None,
+    resume: bool = False,
     input_func: InputFunc = input,
     output_func: OutputFunc = print,
 ) -> str:
-    """Run the Grill-Me-backed harvest loop in a terminal.
+    """Run or resume the Grill-Me-backed harvest loop in a terminal.
 
-    The local harvest UI already owns the question/answer session state and the
-    requirements gate. This wrapper exposes the same lifecycle for CLI users:
-    start requirements, answer current questions until the gate passes, then
-    generate use cases.
+    The harvest UI service still owns the question/answer state. This wrapper
+    adds a stable session id so a Ctrl-C interrupted interactive run can be
+    resumed from the saved local session file.
     """
 
-    prompt = idea.strip()
-    if not prompt:
-        raise ValueError("--idea is required when using --interactive")
+    root = Path(repo_root)
+    resolved_session_id = _resolve_session_id(session_id)
 
-    result = start_requirements(repo_root, prompt)
-    output_func(_format_session_header(result))
+    if resume:
+        _restore_session(root, resolved_session_id)
+        result = load_harvest_ui(root)
+        _persist_session(root, resolved_session_id)
+        if not result.initial_prompt:
+            raise ValueError(f"harvest session is empty: {resolved_session_id}")
+        if result.use_cases_ready:
+            raise ValueError(_completed_session_message(resolved_session_id))
+        output_func(_format_session_header(result, resolved_session_id, resumed=True))
+    else:
+        prompt = idea.strip()
+        if not prompt:
+            raise ValueError("--idea is required when using --interactive")
+        if _session_file(root, resolved_session_id).exists():
+            raise ValueError(
+                f"harvest session already exists: {resolved_session_id}. "
+                "Use --resume with this session id instead."
+            )
+        result = start_requirements(root, prompt)
+        _persist_session(root, resolved_session_id)
+        output_func(_format_session_header(result, resolved_session_id, resumed=False))
 
     while not result.requirements_gate_passed:
         output_func(_format_questions(result))
         answer = input_func("Answer: ").strip()
         if not answer:
             raise ValueError("answer is required")
-        result = answer_requirements(repo_root, answer)
+        _restore_session(root, resolved_session_id)
+        result = answer_requirements(root, answer)
+        _persist_session(root, resolved_session_id)
 
-    result = start_use_cases(repo_root)
-    return _format_completion(result)
+    _restore_session(root, resolved_session_id)
+    result = start_use_cases(root)
+    _persist_session(root, resolved_session_id)
+    return _format_completion(result, resolved_session_id)
 
 
-def _format_session_header(result: HarvestUiResult) -> str:
+def _resolve_session_id(value: str | None) -> str:
+    text = (value or "").strip()
+    return text or f"harvest-{uuid4().hex[:12]}"
+
+
+def _session_file(root: Path, session_id: str) -> Path:
+    return root / INTERACTIVE_SESSION_DIR / f"{session_id}.json"
+
+
+def _restore_session(root: Path, session_id: str) -> None:
+    source = _session_file(root, session_id)
+    if not source.exists():
+        raise ValueError(f"harvest session not found: {session_id}")
+    target = root / SESSION_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
+
+
+def _persist_session(root: Path, session_id: str) -> None:
+    source = root / SESSION_PATH
+    if not source.exists():
+        raise ValueError("harvest session state was not written")
+    target = _session_file(root, session_id)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
+
+
+def _format_session_header(
+    result: HarvestUiResult,
+    session_id: str,
+    *,
+    resumed: bool,
+) -> str:
+    verb = "resumed" if resumed else "started"
     return "\n".join(
         [
-            "INTERACTIVE HARVEST started",
+            f"INTERACTIVE HARVEST {verb}",
+            f"Session ID: {session_id}",
             f"Initial idea: {result.initial_prompt}",
             f"Active stage: {result.active_stage}",
         ]
@@ -69,14 +132,26 @@ def _format_questions(result: HarvestUiResult) -> str:
     return "\n".join(lines)
 
 
-def _format_completion(result: HarvestUiResult) -> str:
+def _format_completion(result: HarvestUiResult, session_id: str) -> str:
     return "\n".join(
         [
             "INTERACTIVE HARVEST completed",
+            f"Session ID: {session_id}",
             "Requirements gate: passed",
             "Generated artifacts:",
             "- docs/design/요구사항.md",
             "- docs/design/유스케이스.md",
+            "Next step:",
+            './harness changes create-from-design --title "<change title>"',
+        ]
+    )
+
+
+def _completed_session_message(session_id: str) -> str:
+    return "\n".join(
+        [
+            f"harvest session already completed: {session_id}",
+            "Current stage: useCases",
             "Next step:",
             './harness changes create-from-design --title "<change title>"',
         ]

--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from collections.abc import Callable
 from pathlib import Path
@@ -76,6 +77,55 @@ def run_interactive_harvest(
     result = start_use_cases(root)
     _persist_session(root, resolved_session_id)
     return _format_completion(result, resolved_session_id)
+
+
+def list_harvest_sessions(repo_root: Path | str) -> str:
+    """Return a table of saved interactive harvest sessions."""
+
+    root = Path(repo_root)
+    session_dir = root / INTERACTIVE_SESSION_DIR
+    if not session_dir.exists():
+        return "No harvest sessions found"
+
+    paths = sorted(
+        session_dir.glob("*.json"),
+        key=lambda item: item.stat().st_mtime,
+        reverse=True,
+    )
+    if not paths:
+        return "No harvest sessions found"
+
+    rows = []
+    for path in paths:
+        rows.append(_session_row(path))
+
+    headers = ("Session ID", "Stage", "Requirements Gate", "Use Cases", "Initial Idea")
+    widths = [
+        max(len(headers[index]), *(len(row[index]) for row in rows))
+        for index in range(len(headers))
+    ]
+    lines = ["  ".join(header.ljust(widths[index]) for index, header in enumerate(headers))]
+    lines.extend(
+        "  ".join(cell.ljust(widths[index]) for index, cell in enumerate(row))
+        for row in rows
+    )
+    return "\n".join(lines)
+
+
+def _session_row(path: Path) -> tuple[str, str, str, str, str]:
+    session_id = path.stem
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return (session_id, "ERROR", "error", "error", f"invalid session file: {exc}")
+
+    stage = str(data.get("active_stage") or "-")
+    requirements_gate = "passed" if data.get("requirements_gate_passed") else "running"
+    use_cases = "yes" if data.get("use_cases_ready") else "no"
+    initial_idea = str(data.get("initial_prompt") or "-").replace("\n", " ")
+    if len(initial_idea) > 80:
+        initial_idea = initial_idea[:77] + "..."
+    return (session_id, stage, requirements_gate, use_cases, initial_idea)
 
 
 def _resolve_session_id(value: str | None) -> str:

--- a/tests/runtime/test_interactive_harvest.py
+++ b/tests/runtime/test_interactive_harvest.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from harness_codex.runtime.interactive_harvest import run_interactive_harvest
+from harness_codex.runtime.interactive_harvest import (
+    list_harvest_sessions,
+    run_interactive_harvest,
+)
 
 
 class StopInput(Exception):
@@ -98,6 +101,53 @@ def test_interactive_harvest_resumes_saved_session(
     assert "INTERACTIVE HARVEST completed" in result
     assert "Session ID: harvest-resume-001" in result
     assert (tmp_path / "docs/design/유스케이스.md").is_file()
+
+
+def test_list_harvest_sessions_outputs_saved_sessions(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_grill_me",
+        lambda _root, _session: {"complete": True, "questions": []},
+    )
+
+    run_interactive_harvest(
+        tmp_path,
+        "build a queue system",
+        session_id="harvest-list-001",
+        input_func=lambda _prompt: "unused",
+        output_func=lambda _line: None,
+    )
+
+    output = list_harvest_sessions(tmp_path)
+
+    assert "Session ID" in output
+    assert "Stage" in output
+    assert "Requirements Gate" in output
+    assert "Use Cases" in output
+    assert "Initial Idea" in output
+    assert "harvest-list-001" in output
+    assert "useCases" in output
+    assert "passed" in output
+    assert "yes" in output
+    assert "build a queue system" in output
+
+
+def test_list_harvest_sessions_reports_invalid_session_file(tmp_path: Path) -> None:
+    session_dir = tmp_path / ".harness/ui/sessions"
+    session_dir.mkdir(parents=True)
+    (session_dir / "broken.json").write_text("not json", encoding="utf-8")
+
+    output = list_harvest_sessions(tmp_path)
+
+    assert "broken" in output
+    assert "ERROR" in output
+    assert "invalid session file" in output
+
+
+def test_list_harvest_sessions_reports_empty_state(tmp_path: Path) -> None:
+    assert list_harvest_sessions(tmp_path) == "No harvest sessions found"
 
 
 def test_interactive_harvest_blocks_completed_session_resume(

--- a/tests/runtime/test_interactive_harvest.py
+++ b/tests/runtime/test_interactive_harvest.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
+import pytest
+
 from harness_codex.runtime.interactive_harvest import run_interactive_harvest
+
+
+class StopInput(Exception):
+    pass
 
 
 def test_interactive_harvest_reuses_harvest_ui_gate(
@@ -29,17 +35,97 @@ def test_interactive_harvest_reuses_harvest_ui_gate(
     result = run_interactive_harvest(
         tmp_path,
         "build a queue system",
+        session_id="harvest-test-001",
         input_func=lambda _prompt: "Customer uses the queue system.",
         output_func=output_lines.append,
     )
 
     assert calls == [0, 1]
     assert "INTERACTIVE HARVEST completed" in result
+    assert "Session ID: harvest-test-001" in result
     assert "./harness changes create-from-design" in result
+    assert any("Session ID: harvest-test-001" in line for line in output_lines)
     assert any("Who is the primary actor?" in line for line in output_lines)
     assert (tmp_path / "docs/design/요구사항.md").is_file()
     assert (tmp_path / "docs/design/유스케이스.md").is_file()
     assert (tmp_path / ".harness/ui/harvest-session.json").is_file()
+    assert (tmp_path / ".harness/ui/sessions/harvest-test-001.json").is_file()
+
+
+def test_interactive_harvest_resumes_saved_session(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls = []
+
+    def fake_grill_me(_root: Path, session: dict) -> dict:
+        calls.append(len(session["clarifications"]))
+        if len(session["clarifications"]) >= 1:
+            return {"complete": True, "questions": []}
+        return {
+            "complete": False,
+            "questions": [
+                {
+                    "question": "Who is the primary actor?",
+                    "recommended": "Customer",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
+
+    with pytest.raises(StopInput):
+        run_interactive_harvest(
+            tmp_path,
+            "build a queue system",
+            session_id="harvest-resume-001",
+            input_func=lambda _prompt: (_ for _ in ()).throw(StopInput()),
+            output_func=lambda _line: None,
+        )
+
+    assert (tmp_path / ".harness/ui/sessions/harvest-resume-001.json").is_file()
+
+    result = run_interactive_harvest(
+        tmp_path,
+        "",
+        session_id="harvest-resume-001",
+        resume=True,
+        input_func=lambda _prompt: "Customer uses the queue system.",
+        output_func=lambda _line: None,
+    )
+
+    assert calls == [0, 1]
+    assert "INTERACTIVE HARVEST completed" in result
+    assert "Session ID: harvest-resume-001" in result
+    assert (tmp_path / "docs/design/유스케이스.md").is_file()
+
+
+def test_interactive_harvest_blocks_completed_session_resume(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_grill_me",
+        lambda _root, _session: {"complete": True, "questions": []},
+    )
+
+    run_interactive_harvest(
+        tmp_path,
+        "build a queue system",
+        session_id="harvest-complete-001",
+        input_func=lambda _prompt: "unused",
+        output_func=lambda _line: None,
+    )
+
+    with pytest.raises(ValueError, match="harvest session already completed"):
+        run_interactive_harvest(
+            tmp_path,
+            "",
+            session_id="harvest-complete-001",
+            resume=True,
+            input_func=lambda _prompt: "unused",
+            output_func=lambda _line: None,
+        )
 
 
 def test_interactive_harvest_requires_idea(tmp_path: Path) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -203,6 +203,23 @@ def test_harvest_interactive_passes_session_options(
     }
 
 
+def test_harvest_sessions_command_outputs_runtime_sessions(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.cli.list_harvest_sessions",
+        lambda repo_root: f"sessions for {repo_root}",
+    )
+
+    exit_code = main(["--repo-root", str(tmp_path), "harvest", "sessions"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert f"sessions for {tmp_path}" in output
+
+
 def test_agent_context_init_creates_expected_files(
     tmp_path: Path,
     capsys,

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -161,6 +161,48 @@ def test_harvest_plan_outputs_runtime_harvester_stage(
     assert not (tmp_path / "AGENTS.md").exists()
 
 
+def test_harvest_interactive_passes_session_options(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def fake_run_interactive_harvest(repo_root, idea, *, session_id=None, resume=False):
+        captured["repo_root"] = repo_root
+        captured["idea"] = idea
+        captured["session_id"] = session_id
+        captured["resume"] = resume
+        return "interactive harvest ok"
+
+    monkeypatch.setattr(
+        "harness_codex.cli.run_interactive_harvest",
+        fake_run_interactive_harvest,
+    )
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "harvest",
+            "--interactive",
+            "--session-id",
+            "harvest-001",
+            "--resume",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "interactive harvest ok" in output
+    assert captured == {
+        "repo_root": tmp_path,
+        "idea": "",
+        "session_id": "harvest-001",
+        "resume": True,
+    }
+
+
 def test_agent_context_init_creates_expected_files(
     tmp_path: Path,
     capsys,
@@ -387,5 +429,5 @@ def test_dashboard_outputs_work_item_state(tmp_path: Path, capsys) -> None:
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert '"id": "MAINT-001"' in output
-    assert '"type": "maintenance"' in output
+    assert '\"id\": \"MAINT-001\"' in output
+    assert '\"type\": \"maintenance\"' in output


### PR DESCRIPTION
## 구현 의도

PR #115가 `codex/112-interactive-resume` 브랜치로 병합되어 main에 반영되지 않은 상태였기 때문에, 해당 브랜치의 최신 harvest interactive 세션 변경을 main에 반영한다.

## 포함 내용

- `./harness harvest sessions` CLI 추가
- `.harness/ui/sessions/*.json` 기반 세션 목록 조회
- 세션 없음 메시지
- 깨진 JSON 세션 파일 `ERROR` row 표시
- README 사용법 갱신
- 런타임/CLI 테스트 추가

## 사용 예시

```bash
./harness harvest sessions
```

## 검증 방법

- GitHub compare 기준 변경 파일 확인:
  - `docs/README-harvest-quickstart.md`
  - `harness_codex/cli.py`
  - `harness_codex/runtime/interactive_harvest.py`
  - `tests/runtime/test_interactive_harvest.py`
  - `tests/test_cli_commands.py`
- 로컬 테스트 실행은 이 환경에서 수행하지 못했다.

## 참고

- #113은 main에 병합됨
- #115는 `codex/112-interactive-resume`에 병합되었고, 이 PR이 그 결과를 main으로 가져온다.