### PR TITLE
Harvest sessions 명령을 main에 반영

### DIFF
--- a/docs/README-harvest-quickstart.md
+++ b/docs/README-harvest-quickstart.md
@@ -10,6 +10,7 @@ When a repository does not yet have current design documents, run harvest before
 ./harness agent-context init --description "<repo description>"
 ./harness harvest --idea "<feature idea>" --plan
 ./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
+./harness harvest sessions
 ./harness harvest --interactive --session-id harvest-001 --resume
 ./harness changes create-from-design --title "<change title>" --change-set-id CHG-YYYYMMDD-001
 ./harness run-change CHG-YYYYMMDD-001 --plan
@@ -31,6 +32,20 @@ Interactive harvest assigns a session id and stores a resumable session snapshot
 
 - `.harness/ui/sessions/<SESSION-ID>.json`
 - `.harness/ui/harvest-session.json` for legacy compatibility with the UI runtime
+
+List saved interactive sessions with:
+
+```bash
+./harness harvest sessions
+```
+
+The session list shows:
+
+- session id
+- active stage
+- requirements gate status
+- use-case readiness
+- initial idea
 
 If an interactive run is interrupted, resume it with the same session id:
 
@@ -54,12 +69,14 @@ A completed session cannot be resumed as a question loop. The command reports th
 ./harness harvest --idea "<feature idea>" --preview
 ./harness harvest --idea "<feature idea>" --apply
 ./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
+./harness harvest sessions
 ./harness harvest --interactive --session-id harvest-001 --resume
 ```
 
 - `--idea`: initial product or feature idea to turn into requirements and use-case design documents.
 - `--session-id`: interactive harvest session id. If omitted, the runtime generates one.
 - `--resume`: resume an existing interactive harvest session instead of starting a new one.
+- `sessions`: list saved interactive harvest sessions from `.harness/ui/sessions`.
 - `--plan`: show the harvest workflow plan without changing files.
 - `--preview`: show a no-side-effect preview. It currently has the same behavior as `--plan`.
 - `--apply`: run the non-interactive harvest workflow through the agent runner.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -37,7 +37,10 @@ from harness_codex.runtime.changes import (
     create_changeset_from_design,
 )
 from harness_codex.runtime.dashboard import dashboard_state_json
-from harness_codex.runtime.interactive_harvest import run_interactive_harvest
+from harness_codex.runtime.interactive_harvest import (
+    list_harvest_sessions,
+    run_interactive_harvest,
+)
 from harness_codex.runtime.ui_server import run_ui_server
 from harness_codex.runtime.workflows import (
     WorkflowMaterializationError,
@@ -82,6 +85,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  harness harvest --idea '<feature idea>' --plan\n"
             "  harness harvest --idea '<feature idea>' --interactive --session-id harvest-001\n"
             "  harness harvest --interactive --session-id harvest-001 --resume\n"
+            "  harness harvest sessions\n"
             "  harness harvest --idea '<feature idea>' --apply"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -100,6 +104,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--resume",
         action="store_true",
         help="Resume an existing interactive harvest session selected by --session-id.",
+    )
+    harvest.add_argument(
+        "harvest_subcommand",
+        nargs="?",
+        choices=("sessions",),
+        help="Harvest utility command. Use `sessions` to list interactive harvest sessions.",
     )
     _add_harvest_mode_options(harvest)
     harvest.set_defaults(func=harvest_command)
@@ -193,6 +203,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
+    if getattr(args, "harvest_subcommand", "") == "sessions":
+        return list_harvest_sessions(repo_root)
+
+    if not any((args.plan, args.preview, args.apply, args.interactive)):
+        raise ValueError(
+            "harvest requires one of --plan, --preview, --apply, --interactive, "
+            "or the sessions subcommand"
+        )
+
     workflow_dir = repo_root / ".harness/workflows"
     if not (workflow_dir / "harvest-workflow.yaml").exists():
         workflow_dir = Path(__file__).resolve().parents[1] / ".harness/workflows"
@@ -468,7 +487,7 @@ def _add_mode_options(parser: argparse.ArgumentParser) -> None:
 
 
 def _add_harvest_mode_options(parser: argparse.ArgumentParser) -> None:
-    mode = parser.add_mutually_exclusive_group(required=True)
+    mode = parser.add_mutually_exclusive_group(required=False)
     mode.add_argument("--plan", action="store_true", help="Show the harvest workflow plan without changing files.")
     mode.add_argument("--preview", action="store_true", help="Preview the harvest workflow without changing files; currently equivalent to --plan.")
     mode.add_argument("--apply", action="store_true", help="Run the non-interactive harvest workflow through the agent runner.")

--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from collections.abc import Callable
 from pathlib import Path
@@ -76,6 +77,55 @@ def run_interactive_harvest(
     result = start_use_cases(root)
     _persist_session(root, resolved_session_id)
     return _format_completion(result, resolved_session_id)
+
+
+def list_harvest_sessions(repo_root: Path | str) -> str:
+    """Return a table of saved interactive harvest sessions."""
+
+    root = Path(repo_root)
+    session_dir = root / INTERACTIVE_SESSION_DIR
+    if not session_dir.exists():
+        return "No harvest sessions found"
+
+    paths = sorted(
+        session_dir.glob("*.json"),
+        key=lambda item: item.stat().st_mtime,
+        reverse=True,
+    )
+    if not paths:
+        return "No harvest sessions found"
+
+    rows = []
+    for path in paths:
+        rows.append(_session_row(path))
+
+    headers = ("Session ID", "Stage", "Requirements Gate", "Use Cases", "Initial Idea")
+    widths = [
+        max(len(headers[index]), *(len(row[index]) for row in rows))
+        for index in range(len(headers))
+    ]
+    lines = ["  ".join(header.ljust(widths[index]) for index, header in enumerate(headers))]
+    lines.extend(
+        "  ".join(cell.ljust(widths[index]) for index, cell in enumerate(row))
+        for row in rows
+    )
+    return "\n".join(lines)
+
+
+def _session_row(path: Path) -> tuple[str, str, str, str, str]:
+    session_id = path.stem
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return (session_id, "ERROR", "error", "error", f"invalid session file: {exc}")
+
+    stage = str(data.get("active_stage") or "-")
+    requirements_gate = "passed" if data.get("requirements_gate_passed") else "running"
+    use_cases = "yes" if data.get("use_cases_ready") else "no"
+    initial_idea = str(data.get("initial_prompt") or "-").replace("\n", " ")
+    if len(initial_idea) > 80:
+        initial_idea = initial_idea[:77] + "..."
+    return (session_id, stage, requirements_gate, use_cases, initial_idea)
 
 
 def _resolve_session_id(value: str | None) -> str:

--- a/tests/runtime/test_interactive_harvest.py
+++ b/tests/runtime/test_interactive_harvest.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from harness_codex.runtime.interactive_harvest import run_interactive_harvest
+from harness_codex.runtime.interactive_harvest import (
+    list_harvest_sessions,
+    run_interactive_harvest,
+)
 
 
 class StopInput(Exception):
@@ -98,6 +101,53 @@ def test_interactive_harvest_resumes_saved_session(
     assert "INTERACTIVE HARVEST completed" in result
     assert "Session ID: harvest-resume-001" in result
     assert (tmp_path / "docs/design/유스케이스.md").is_file()
+
+
+def test_list_harvest_sessions_outputs_saved_sessions(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_grill_me",
+        lambda _root, _session: {"complete": True, "questions": []},
+    )
+
+    run_interactive_harvest(
+        tmp_path,
+        "build a queue system",
+        session_id="harvest-list-001",
+        input_func=lambda _prompt: "unused",
+        output_func=lambda _line: None,
+    )
+
+    output = list_harvest_sessions(tmp_path)
+
+    assert "Session ID" in output
+    assert "Stage" in output
+    assert "Requirements Gate" in output
+    assert "Use Cases" in output
+    assert "Initial Idea" in output
+    assert "harvest-list-001" in output
+    assert "useCases" in output
+    assert "passed" in output
+    assert "yes" in output
+    assert "build a queue system" in output
+
+
+def test_list_harvest_sessions_reports_invalid_session_file(tmp_path: Path) -> None:
+    session_dir = tmp_path / ".harness/ui/sessions"
+    session_dir.mkdir(parents=True)
+    (session_dir / "broken.json").write_text("not json", encoding="utf-8")
+
+    output = list_harvest_sessions(tmp_path)
+
+    assert "broken" in output
+    assert "ERROR" in output
+    assert "invalid session file" in output
+
+
+def test_list_harvest_sessions_reports_empty_state(tmp_path: Path) -> None:
+    assert list_harvest_sessions(tmp_path) == "No harvest sessions found"
 
 
 def test_interactive_harvest_blocks_completed_session_resume(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -203,6 +203,23 @@ def test_harvest_interactive_passes_session_options(
     }
 
 
+def test_harvest_sessions_command_outputs_runtime_sessions(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.cli.list_harvest_sessions",
+        lambda repo_root: f"sessions for {repo_root}",
+    )
+
+    exit_code = main(["--repo-root", str(tmp_path), "harvest", "sessions"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert f"sessions for {tmp_path}" in output
+
+
 def test_agent_context_init_creates_expected_files(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## 구현 의도

`harvest sessions` 변경이 feature branch에만 병합되어 `harness update`로 main을 받은 환경에서는 명령이 보이지 않았다. main 기준 clean branch에 세션 목록 조회 변경만 다시 적용한다.

## 포함 내용

- `./harness harvest sessions` CLI 추가
- `.harness/ui/sessions/*.json` 기반 세션 목록 조회
- 세션 없음 메시지
- 깨진 JSON 세션 파일 `ERROR` row 표시
- README 사용법 갱신
- 런타임/CLI 테스트 추가

## 사용 예시

```bash
./harness harvest sessions
```

## 검증 방법

- main commit `645682034f0eeca6fd973dfde717950562d658b4` 위에 단일 커밋으로 적용
- 변경 대상 5개 파일 확인
- 로컬 테스트 실행은 이 환경에서 수행하지 못했다.