### PR TITLE
Harvest Grill-Me 세션 선저장 및 단일 질문 답변 큐 처리 추가

### DIFF
--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -34,18 +34,10 @@ class HarvestUiResult:
 
 def start_requirements(root: Path | str, prompt: str) -> HarvestUiResult:
     root_path = Path(root)
-    session = {
-        "initial_prompt": prompt.strip(),
-        "clarifications": [],
-        "current_question": None,
-        "current_questions": [],
-        "requirements_gate_passed": False,
-        "active_stage": "requirements",
-        "use_cases_ready": False,
-        "runtime_error": "",
-    }
+    session = _new_session(prompt)
     if not session["initial_prompt"]:
         raise ValueError("initial prompt is required")
+    _write_session(root_path, session)
     _advance_grill_me(root_path, session)
     _write_requirements_doc(root_path, session)
     _write_session(root_path, session)
@@ -58,21 +50,26 @@ def answer_requirements(root: Path | str, answer: str) -> HarvestUiResult:
     normalized_answer = answer.strip()
     if not normalized_answer:
         raise ValueError("answer is required")
-    questions = session.get("current_questions") or []
-    if not questions:
+    current_question = _current_question(session)
+    if current_question is None:
         raise ValueError("no active Grill-Me question")
     session["clarifications"].append(
         {
             "questions": [
-                {"question": item.get("question", ""), "recommended": item.get("recommended", "")}
-                for item in questions
+                {
+                    "question": current_question.get("question", ""),
+                    "recommended": current_question.get("recommended", ""),
+                }
             ],
             "answer": normalized_answer,
         }
     )
     session["current_questions"] = []
     session["current_question"] = None
-    _advance_grill_me(root_path, session)
+    if session.get("pending_questions"):
+        _activate_next_pending_question(session)
+    else:
+        _advance_grill_me(root_path, session)
     _write_requirements_doc(root_path, session)
     _write_session(root_path, session)
     return _result(root_path, session)
@@ -96,19 +93,25 @@ def load_harvest_ui(root: Path | str) -> HarvestUiResult:
     if session is None:
         session = _session_from_requirements_doc(root_path)
     if session is None:
-        session = {
-            "initial_prompt": "",
-            "clarifications": [],
-            "current_question": None,
-            "current_questions": [],
-            "requirements_gate_passed": False,
-            "active_stage": "requirements",
-            "use_cases_ready": False,
-            "runtime_error": "",
-        }
+        session = _new_session("")
     else:
+        _normalize_session(session)
         _resume_if_needed(root_path, session)
     return _result(root_path, session)
+
+
+def _new_session(prompt: str) -> dict[str, Any]:
+    return {
+        "initial_prompt": prompt.strip(),
+        "clarifications": [],
+        "current_question": None,
+        "current_questions": [],
+        "pending_questions": [],
+        "requirements_gate_passed": False,
+        "active_stage": "requirements",
+        "use_cases_ready": False,
+        "runtime_error": "",
+    }
 
 
 def _workflow_projection() -> dict[str, Any]:
@@ -126,11 +129,24 @@ def _load_or_recover_session(root: Path) -> dict[str, Any]:
         session = _session_from_requirements_doc(root)
     if session is None:
         raise ValueError("harvest session has not started")
+    _normalize_session(session)
+    return session
+
+
+def _normalize_session(session: dict[str, Any]) -> None:
     session["clarifications"] = [
         _normalize_clarification(item)
         for item in session.get("clarifications", [])
     ]
-    return session
+    session.setdefault("pending_questions", [])
+    current = session.get("current_question")
+    current_questions = session.get("current_questions") or []
+    if current is None and current_questions:
+        session["current_question"] = current_questions[0]
+    if session.get("current_question"):
+        session["current_questions"] = [session["current_question"]]
+    else:
+        session["current_questions"] = []
 
 
 def _load_session(root: Path) -> dict[str, Any] | None:
@@ -143,7 +159,11 @@ def _load_session(root: Path) -> dict[str, Any] | None:
 def _resume_if_needed(root: Path, session: dict[str, Any]) -> None:
     if session["requirements_gate_passed"]:
         return
-    if session.get("current_questions"):
+    if session.get("current_question") or session.get("current_questions"):
+        return
+    if session.get("pending_questions"):
+        _activate_next_pending_question(session)
+        _write_session(root, session)
         return
     try:
         _advance_grill_me(root, session)
@@ -167,6 +187,7 @@ def _session_from_requirements_doc(root: Path) -> dict[str, Any] | None:
         "clarifications": list(clarifications),
         "current_question": None,
         "current_questions": [],
+        "pending_questions": [],
         "requirements_gate_passed": gate_passed,
         "active_stage": "requirements",
         "use_cases_ready": (root / USE_CASES_PATH).exists(),
@@ -196,7 +217,8 @@ def _parse_grill_me_rows(text: str) -> list[dict[str, Any]]:
             {"question": item, "recommended": ""}
             for item in _split_recovered_questions(question_text)
         ]
-        rows.append({"questions": questions, "answer": answer})
+        for question in questions:
+            rows.append({"questions": [question], "answer": answer})
     return rows
 
 
@@ -209,7 +231,16 @@ def _split_recovered_questions(text: str) -> list[str]:
 
 def _normalize_clarification(item: dict[str, Any]) -> dict[str, Any]:
     if "questions" in item and isinstance(item["questions"], list):
-        return item
+        return {
+            "questions": [
+                {
+                    "question": str(question.get("question", "")),
+                    "recommended": str(question.get("recommended", "")),
+                }
+                for question in item["questions"]
+            ],
+            "answer": str(item.get("answer", "")),
+        }
     question = str(item.get("question", "")).strip()
     recommended = str(item.get("recommended", "")).strip()
     return {
@@ -245,12 +276,8 @@ def _result(root: Path, session: dict[str, Any]) -> HarvestUiResult:
             "requirements_passed" if gate_passed else "requirements_running"
         )
     )
-    current_questions = (
-        ()
-        if gate_passed or not session_started
-        else tuple(session.get("current_questions") or [])
-    )
-    current_question = current_questions[0] if current_questions else None
+    current_question = _current_question(session) if session_started and not gate_passed else None
+    current_questions = (current_question,) if current_question else ()
     return HarvestUiResult(
         initial_prompt=session["initial_prompt"],
         status=status,
@@ -267,17 +294,112 @@ def _result(root: Path, session: dict[str, Any]) -> HarvestUiResult:
     )
 
 
+def _current_question(session: dict[str, Any]) -> dict[str, Any] | None:
+    current = session.get("current_question")
+    if isinstance(current, dict) and current.get("question"):
+        return current
+    current_questions = session.get("current_questions") or []
+    if current_questions:
+        return current_questions[0]
+    return None
+
+
+def _activate_next_pending_question(session: dict[str, Any]) -> None:
+    pending = list(session.get("pending_questions") or [])
+    if not pending:
+        session["current_question"] = None
+        session["current_questions"] = []
+        session["pending_questions"] = []
+        return
+    next_question = pending.pop(0)
+    session["current_question"] = next_question
+    session["current_questions"] = [next_question]
+    session["pending_questions"] = pending
+
+
 def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
     result = _run_grill_me(root, session)
     if result["complete"]:
         session["requirements_gate_passed"] = True
         session["current_question"] = None
         session["current_questions"] = []
+        session["pending_questions"] = []
     else:
-        session["requirements_gate_passed"] = False
-        session["current_questions"] = result["questions"]
-        session["current_question"] = result["questions"][0]
+        filtered_questions = _filter_new_questions(result["questions"], session)
+        if not filtered_questions:
+            session["requirements_gate_passed"] = True
+            session["current_question"] = None
+            session["current_questions"] = []
+            session["pending_questions"] = []
+        else:
+            session["requirements_gate_passed"] = False
+            session["current_question"] = filtered_questions[0]
+            session["current_questions"] = [filtered_questions[0]]
+            session["pending_questions"] = filtered_questions[1:]
     session["runtime_error"] = ""
+
+
+def _filter_new_questions(
+    questions: list[dict[str, str]],
+    session: dict[str, Any],
+) -> list[dict[str, str]]:
+    seen = _asked_question_keys(session)
+    filtered: list[dict[str, str]] = []
+    for question in questions:
+        text = str(question.get("question", "")).strip()
+        if not text:
+            continue
+        key = _question_key(text)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        filtered.append(question)
+    return filtered
+
+
+def _asked_question_keys(session: dict[str, Any]) -> set[str]:
+    keys: set[str] = set()
+    for item in session.get("clarifications", []):
+        for question in item.get("questions") or []:
+            key = _question_key(str(question.get("question", "")))
+            if key:
+                keys.add(key)
+    for question in session.get("pending_questions") or []:
+        key = _question_key(str(question.get("question", "")))
+        if key:
+            keys.add(key)
+    current = _current_question(session)
+    if current:
+        key = _question_key(str(current.get("question", "")))
+        if key:
+            keys.add(key)
+    return keys
+
+
+def _question_key(text: str) -> str:
+    normalized = re.sub(r"[^0-9a-zA-Z가-힣]+", "", text).lower()
+    stop_words = (
+        "무엇인가요",
+        "무엇입니까",
+        "무엇인지",
+        "어떤",
+        "알려주세요",
+        "확인해주세요",
+        "해주세요",
+        "인가요",
+        "입니까",
+        "please",
+        "what",
+        "which",
+        "tell",
+        "about",
+        "the",
+        "a",
+        "an",
+    )
+    for word in stop_words:
+        normalized = normalized.replace(word, "")
+    return normalized[:120]
 
 
 def _run_grill_me(root: Path, session: dict[str, Any]) -> dict[str, Any]:
@@ -329,17 +451,32 @@ def _grill_me_prompt(root: Path, session: dict[str, Any], skill_path: Path) -> s
         encoding="utf-8"
     )
     grill_me_skill = skill_path.read_text(encoding="utf-8")
+    asked_questions = _asked_questions(session)
+    pending_questions = session.get("pending_questions") or []
     return f"""Use $grill-me to clarify requirements.
 
 Return only JSON with keys: complete, questions.
 When incomplete, return up to exactly 3 questions in questions[].
 Each question object must have keys: question, recommended.
 
+Question repetition rules:
+- Do not ask any question already present in Answered question history.
+- Do not ask any question already present in Pending question queue.
+- Do not ask semantically equivalent questions to any answered or pending question.
+- If a previous answer is partial, ask only for the missing detail and explicitly narrow the question.
+- Generate questions only from unresolved/open decisions.
+
 Initial prompt:
 {session["initial_prompt"]}
 
+Answered question history:
+{json.dumps(asked_questions, ensure_ascii=False, indent=2)}
+
 Clarification history:
 {json.dumps(session["clarifications"], ensure_ascii=False, indent=2)}
+
+Pending question queue:
+{json.dumps(pending_questions, ensure_ascii=False, indent=2)}
 
 Harness requirements standards:
 {requirements_skill}
@@ -347,6 +484,20 @@ Harness requirements standards:
 Grill-Me skill:
 {grill_me_skill}
 """
+
+
+def _asked_questions(session: dict[str, Any]) -> list[dict[str, str]]:
+    questions: list[dict[str, str]] = []
+    for item in session.get("clarifications", []):
+        answer = str(item.get("answer", ""))
+        for question in item.get("questions") or []:
+            questions.append(
+                {
+                    "question": str(question.get("question", "")),
+                    "answer": answer,
+                }
+            )
+    return questions
 
 
 def _parse_grill_me_json(text: str) -> dict[str, Any]:
@@ -390,19 +541,21 @@ def _write_requirements_doc(root: Path, session: dict[str, Any]) -> None:
         "",
         "## Grill-Me Clarifications",
         "",
-        "| ID | Questions | Answer |",
+        "| ID | Question | Answer |",
         "| --- | --- | --- |",
     ]
     for index, item in enumerate(session["clarifications"], start=1):
         questions = item.get("questions") or []
-        question_text = "<br>".join(
-            f"{idx}. {question.get('question', '')}"
-            for idx, question in enumerate(questions, start=1)
-        )
+        question_text = questions[0].get("question", "") if questions else ""
         lines.append(f"| GM-{index:03d} | {question_text} | {item.get('answer', '')} |")
-    if session.get("current_questions"):
+    if _current_question(session) or session.get("pending_questions"):
         lines.extend(["", "## Open Language Questions", ""])
-        for index, item in enumerate(session["current_questions"], start=1):
+        queue = []
+        current = _current_question(session)
+        if current:
+            queue.append(current)
+        queue.extend(session.get("pending_questions") or [])
+        for index, item in enumerate(queue, start=1):
             recommended = item.get("recommended", "")
             suffix = f" Recommended: {recommended}" if recommended else ""
             lines.append(f"- Q{index}: {item.get('question', '')}{suffix}")

--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -60,6 +60,7 @@ def run_interactive_harvest(
                 f"harvest session already exists: {resolved_session_id}. "
                 "Use --resume with this session id instead."
             )
+        _write_initial_named_session(root, resolved_session_id, prompt)
         result = start_requirements(root, prompt)
         _persist_session(root, resolved_session_id)
         output_func(_format_session_header(result, resolved_session_id, resumed=False))
@@ -135,6 +136,23 @@ def _resolve_session_id(value: str | None) -> str:
 
 def _session_file(root: Path, session_id: str) -> Path:
     return root / INTERACTIVE_SESSION_DIR / f"{session_id}.json"
+
+
+def _write_initial_named_session(root: Path, session_id: str, prompt: str) -> None:
+    payload = {
+        "initial_prompt": prompt,
+        "clarifications": [],
+        "current_question": None,
+        "current_questions": [],
+        "pending_questions": [],
+        "requirements_gate_passed": False,
+        "active_stage": "requirements",
+        "use_cases_ready": False,
+        "runtime_error": "question_generating",
+    }
+    target = _session_file(root, session_id)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def _restore_session(root: Path, session_id: str) -> None:

--- a/harness_codex/runtime/workflows/materializer.py
+++ b/harness_codex/runtime/workflows/materializer.py
@@ -26,10 +26,12 @@ def materialize_workflow_for_scope(
     workflow: Workflow,
     change_set: ChangeSet,
     scope: PlanningInputScope,
+    *,
+    run_id: str = "",
 ) -> Workflow:
     """Return a workflow whose placeholders are bound to one ChangeSet work item."""
 
-    replacements = materialization_replacements(change_set, scope)
+    replacements = materialization_replacements(change_set, scope, run_id=run_id)
     steps = tuple(_materialize_step(step, replacements) for step in workflow.steps)
     materialized = replace(
         workflow,
@@ -54,6 +56,8 @@ def materialize_workflow_for_scope(
 def materialization_replacements(
     change_set: ChangeSet,
     scope: PlanningInputScope,
+    *,
+    run_id: str = "",
 ) -> dict[str, str]:
     """Return placeholder replacement values for a ChangeSet work item scope."""
 
@@ -64,6 +68,7 @@ def materialization_replacements(
         "<UC-ID>": uc_id,
         "<MAINT-ID>": maint_id,
         "<WORK-ITEM-ID>": scope.display_id,
+        "<RUN-ID>": run_id,
     }
 
 

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import json
 import pytest
 
 from harness_codex.runtime.harvest_ui import (
@@ -14,7 +15,7 @@ from harness_codex.runtime.harvest_ui import (
 
 def fake_grill_me(_root: Path, session: dict) -> dict:
     index = len(session["clarifications"])
-    if index >= 1:
+    if index >= 3:
         return {"complete": True, "questions": []}
     return {
         "complete": False,
@@ -28,7 +29,7 @@ def fake_grill_me(_root: Path, session: dict) -> dict:
     }
 
 
-def test_harvest_ui_runs_requirements_then_use_cases(
+def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -39,15 +40,29 @@ def test_harvest_ui_runs_requirements_then_use_cases(
     assert result.active_stage == "requirements"
     assert result.requirements_gate_passed is False
     assert result.current_question is not None
-    assert len(result.current_questions) == 3
+    assert len(result.current_questions) == 1
+    assert result.current_question["question"] == "Question 1.1?"
     assert (tmp_path / REQUIREMENTS_PATH).is_file()
+    assert (tmp_path / ".harness/ui/harvest-session.json").is_file()
     assert not (tmp_path / USE_CASES_PATH).exists()
 
-    result = answer_requirements(
-        tmp_path,
-        "1. member\n2. enter success and denied failure\n3. python fastapi",
-    )
+    session = json.loads((tmp_path / ".harness/ui/harvest-session.json").read_text(encoding="utf-8"))
+    assert len(session["pending_questions"]) == 2
 
+    result = answer_requirements(tmp_path, "answer 1")
+
+    assert result.requirements_gate_passed is False
+    assert result.current_question is not None
+    assert result.current_question["question"] == "Question 1.2?"
+    assert len(result.clarifications) == 1
+    assert len(result.clarifications[0]["questions"]) == 1
+    assert result.clarifications[0]["questions"][0]["question"] == "Question 1.1?"
+
+    result = answer_requirements(tmp_path, "answer 2")
+    assert result.current_question is not None
+    assert result.current_question["question"] == "Question 1.3?"
+
+    result = answer_requirements(tmp_path, "answer 3")
     assert result.requirements_gate_passed is True
     assert result.use_cases_ready is False
     assert result.current_question is None
@@ -56,8 +71,74 @@ def test_harvest_ui_runs_requirements_then_use_cases(
 
     assert result.active_stage == "useCases"
     assert result.use_cases_ready is True
-    assert "Runtime step: harvest-use-cases" in result.use_cases_markdown
     assert (tmp_path / USE_CASES_PATH).is_file()
+
+
+def test_harvest_ui_filters_duplicate_grill_me_questions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def duplicate_grill_me(_root: Path, session: dict) -> dict:
+        if len(session["clarifications"]) >= 1:
+            return {
+                "complete": False,
+                "questions": [
+                    {"question": "Who is the primary actor?", "recommended": "User"},
+                    {"question": "What is the success outcome?", "recommended": "Queued"},
+                ],
+            }
+        return {
+            "complete": False,
+            "questions": [
+                {"question": "Who is the primary actor?", "recommended": "User"},
+            ],
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", duplicate_grill_me)
+
+    result = start_requirements(tmp_path, "build a queue system")
+    assert result.current_question is not None
+    assert result.current_question["question"] == "Who is the primary actor?"
+
+    result = answer_requirements(tmp_path, "Customer")
+
+    assert result.current_question is not None
+    assert result.current_question["question"] == "What is the success outcome?"
+
+
+def test_grill_me_prompt_includes_answered_and_pending_questions(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".codex/skills"
+    (skill_dir / "harness-requirements").mkdir(parents=True)
+    (skill_dir / "grill-me").mkdir(parents=True)
+    (skill_dir / "harness-requirements/SKILL.md").write_text("requirements", encoding="utf-8")
+    (skill_dir / "grill-me/SKILL.md").write_text("grill", encoding="utf-8")
+
+    from harness_codex.runtime.harvest_ui import _grill_me_prompt
+
+    prompt = _grill_me_prompt(
+        tmp_path,
+        {
+            "initial_prompt": "queue system",
+            "clarifications": [
+                {
+                    "questions": [{"question": "Who uses it?", "recommended": "Customer"}],
+                    "answer": "Customer",
+                }
+            ],
+            "current_question": None,
+            "current_questions": [],
+            "pending_questions": [{"question": "What is success?", "recommended": "Entry"}],
+        },
+        skill_dir / "grill-me/SKILL.md",
+    )
+
+    assert "Answered question history" in prompt
+    assert "Pending question queue" in prompt
+    assert "Do not ask semantically equivalent questions" in prompt
+    assert "Who uses it?" in prompt
+    assert "What is success?" in prompt
 
 
 def test_harvest_ui_blocks_use_cases_until_requirements_pass(
@@ -73,7 +154,7 @@ def test_harvest_ui_blocks_use_cases_until_requirements_pass(
     )
     start_requirements(tmp_path, "build a queue system")
 
-    with pytest.raises(ValueError, match="requirements gate must pass"):
+    with pytest.raises(ValueError, match="requirements gate has not passed"):
         start_use_cases(tmp_path)
 
 
@@ -114,4 +195,5 @@ def test_harvest_ui_recovers_session_from_requirements_doc(
     assert result.initial_prompt == "calculator"
     assert result.clarifications[0]["answer"] == "me"
     assert result.current_questions
+    assert len(result.current_questions) == 1
     assert (tmp_path / ".harness/ui/harvest-session.json").is_file()

--- a/tests/runtime/test_interactive_harvest.py
+++ b/tests/runtime/test_interactive_harvest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import json
 import pytest
 
 from harness_codex.runtime.interactive_harvest import (
@@ -53,6 +54,31 @@ def test_interactive_harvest_reuses_harvest_ui_gate(
     assert (tmp_path / "docs/design/유스케이스.md").is_file()
     assert (tmp_path / ".harness/ui/harvest-session.json").is_file()
     assert (tmp_path / ".harness/ui/sessions/harvest-test-001.json").is_file()
+
+
+def test_interactive_harvest_creates_named_session_before_grill_me(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def failing_grill_me(_root: Path, _session: dict) -> dict:
+        raise ValueError("boom")
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", failing_grill_me)
+
+    with pytest.raises(ValueError, match="boom"):
+        run_interactive_harvest(
+            tmp_path,
+            "build a queue system",
+            session_id="harvest-early-001",
+            input_func=lambda _prompt: "unused",
+            output_func=lambda _line: None,
+        )
+
+    session_path = tmp_path / ".harness/ui/sessions/harvest-early-001.json"
+    assert session_path.is_file()
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    assert session["initial_prompt"] == "build a queue system"
+    assert session["runtime_error"] == "question_generating"
 
 
 def test_interactive_harvest_resumes_saved_session(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -49,6 +49,28 @@ def write_changeset(repo: Path) -> None:
     active_dir = repo / "docs/changes/active"
     active_dir.mkdir(parents=True)
     (active_dir / "CHG-001.md").write_text(CHANGESET, encoding="utf-8")
+    write_use_case_slice(repo, "UC-001")
+
+
+def write_use_case_slice(repo: Path, uc_id: str) -> None:
+    use_case_dir = repo / "docs/use-cases" / uc_id
+    use_case_dir.mkdir(parents=True)
+    (use_case_dir / "use-case.md").write_text(
+        f"# {uc_id}\n\n## Goal\n- Verify runtime planning scope.\n",
+        encoding="utf-8",
+    )
+    (use_case_dir / "e2e-goal.md").write_text(
+        f"# {uc_id} E2E Goal\n\n- Verify end-to-end behavior.\n",
+        encoding="utf-8",
+    )
+    (use_case_dir / "event-storming.md").write_text(
+        f"# {uc_id} Event Storming\n",
+        encoding="utf-8",
+    )
+    (use_case_dir / "affected-files.md").write_text(
+        f"# {uc_id} Affected Files\n",
+        encoding="utf-8",
+    )
 
 
 def write_maintenance_changeset(repo: Path) -> None:


### PR DESCRIPTION
Closes #118

## 구현 의도

Harvest interactive Grill-Me 과정에서 질문 묶음 전체를 한 번에 보여주고 답변 하나를 묶음 전체에 저장하던 구조를 개선한다.

목표는 다음과 같다.

- harvest 시작 즉시 세션 파일을 생성해 Ctrl-C/실패 시에도 세션 흔적을 남긴다.
- Grill-Me가 최대 3개의 질문을 생성하더라도 런타임은 한 번에 1개 질문만 사용자에게 보여준다.
- 답변은 현재 질문 1개에만 연결해 저장한다.
- 남은 질문은 pending queue에 보관한다.
- 이미 답변했거나 pending 상태인 질문과 같거나 의미상 유사한 질문을 반복하지 않도록 한다.

## 구현 방법

### `harness_codex/runtime/harvest_ui.py`

- `pending_questions` 큐를 세션 상태에 추가했다.
- `start_requirements()`에서 Grill-Me 호출 전에 `.harness/ui/harvest-session.json`을 먼저 저장하도록 변경했다.
- `_advance_grill_me()`가 Grill-Me 결과 질문을 current 1개 + pending N개로 분리하도록 변경했다.
- `answer_requirements()`는 현재 질문 1개만 `clarifications`에 저장하도록 변경했다.
- pending 질문이 남아 있으면 다음 Grill-Me 호출 없이 큐에서 다음 질문을 활성화한다.
- pending 질문이 없을 때만 Grill-Me를 다시 호출한다.
- `_grill_me_prompt()`에 다음 이력을 명시적으로 추가했다.
  - Answered question history
  - Clarification history
  - Pending question queue
- `_grill_me_prompt()`에 중복/유사 질문 금지 규칙을 추가했다.
- `_filter_new_questions()`와 `_question_key()`로 명백한 중복 질문을 런타임에서 필터링한다.
- 요구사항 문서의 Grill-Me Clarifications 표를 질문-답변 단위로 기록하도록 변경했다.

### `harness_codex/runtime/interactive_harvest.py`

- named session 파일을 Grill-Me 호출 전에 먼저 생성하도록 `_write_initial_named_session()`을 추가했다.
- 초기 named session에는 `runtime_error=question_generating`을 기록한다.

### 테스트

- `tests/runtime/test_harvest_ui.py`
  - Grill-Me가 3개 질문을 반환해도 result는 1개 질문만 노출하는지 검증
  - 답변이 현재 질문 1개에만 저장되는지 검증
  - pending 질문이 순서대로 활성화되는지 검증
  - 중복 질문 필터링 검증
  - 프롬프트에 answered/pending question context와 유사 질문 금지 규칙이 포함되는지 검증

- `tests/runtime/test_interactive_harvest.py`
  - Grill-Me 실패 전에 named session 파일이 먼저 생성되는지 검증

## 검증 방법

- GitHub compare 기준 변경 파일 확인:
  - `harness_codex/runtime/harvest_ui.py`
  - `harness_codex/runtime/interactive_harvest.py`
  - `tests/runtime/test_harvest_ui.py`
  - `tests/runtime/test_interactive_harvest.py`
- 로컬 테스트 실행은 이 환경에서 수행하지 못했다.

## 사용상 변화

이제 Grill-Me가 내부적으로 3개 질문을 생성해도 CLI에는 한 번에 하나만 표시된다.

```text
Grill-Me questions:
1. Who is the primary actor?
Answer:
```

답변 후에는 pending queue의 다음 질문이 표시되고, 모든 pending 질문이 답변된 뒤에만 Grill-Me를 다시 호출한다.