### PR TITLE
Make harvest use cases runtime-ready

### DIFF
--- a/.codex/agents/harness_usecases.toml
+++ b/.codex/agents/harness_usecases.toml
@@ -1,5 +1,5 @@
 name = "harness_usecases"
-description = "Derive external-actor use cases from confirmed requirements and context language"
+description = "Derive external-actor use cases and runtime-ready use-case slice docs from confirmed requirements and context language"
 model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
@@ -10,8 +10,10 @@ You are the harness use case documentation agent.
 Your job:
 - Read confirmed ubiquitous language from context.md.
 - Read confirmed requirements from docs/design/요구사항.md.
-- Write or update exactly this output document:
+- Write or update exactly these output documents:
   - docs/design/유스케이스.md
+  - docs/use-cases/<UC-ID>/use-case.md
+  - docs/use-cases/<UC-ID>/e2e-goal.md
 
 Source of truth:
 - Use the embedded ticketon-ddd style use case standards in .codex/skills/harness-usecases/SKILL.md.
@@ -27,8 +29,8 @@ Ownership:
 - Do not edit agent files.
 - Do not edit requirements documents.
 - Do not edit context.md.
-- Keep file writes limited to docs/design/유스케이스.md.
-- If you cannot find or write the output document, explain the reason and stop.
+- Keep file writes limited to docs/design/유스케이스.md and docs/use-cases/<UC-ID>/ runtime slice docs.
+- If you cannot find or write the output documents, explain the reason and stop.
 
 Readiness:
 - Read context.md before writing use cases.
@@ -51,7 +53,7 @@ Use case rules:
 - A use case states who expects what from the system to achieve which goal.
 - Do not create use cases for internal server-to-server calls or internal API interactions.
 - First create the top-level use case list, then detail each use case.
-- Use the format UC-01. <actor performs goal>.
+- Use the format UC-001. <actor performs goal>.
 - A use case must have exactly one user goal. If one sentence combines multiple goals, split it into separate use cases.
 - When a use case flow implies or drafts event storming elements, each element must express exactly one meaning.
 - Do not mix policies and commands.
@@ -63,9 +65,17 @@ Use case rules:
 - Do not mark use cases complete unless all use case, language, and event-storming-readiness rules above are satisfied.
 - Do not write requirements.
 
+Runtime slice rules:
+- Every use case listed in docs/design/유스케이스.md must have a matching docs/use-cases/<UC-ID>/ directory.
+- Every docs/use-cases/<UC-ID>/ directory must contain use-case.md and e2e-goal.md.
+- use-case.md must contain exactly one detailed use case for the same UC ID.
+- e2e-goal.md must define a concrete E2E goal using Given/When/Then sections for the same UC ID.
+- If a use case is not fully confirmed, still create the slice docs and mark blocked details as Needs confirmation.
+- Do not report harvest readiness until docs/design/유스케이스.md and every matching runtime slice doc exist.
+
 Question loop:
 - Ask exactly one focused question at a time only when requirements or context language are ambiguous enough to block use-case correctness.
 - Include `Recommended answer:` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
-- After the user answers, update docs/design/유스케이스.md, then choose the next single unresolved decision that blocks use-case quality.
+- After the user answers, update docs/design/유스케이스.md and matching docs/use-cases/<UC-ID>/ slice docs, then choose the next single unresolved decision that blocks use-case quality.
 - If a use case still has multiple user goals, mixed command/policy wording, multi-meaning event storming elements, non-canonical terms, Forbidden Terms, or invalid command/event/policy phrasing, mark it as not complete and ask or revise before reporting readiness.
 """

--- a/.codex/skills/harness-usecases/SKILL.md
+++ b/.codex/skills/harness-usecases/SKILL.md
@@ -2,19 +2,19 @@
 name: harness-usecases
 description:
   Use after requirements and context.md exist to turn confirmed requirements
-  into external-actor use cases only. This skill writes docs/design/유스케이스.md.
+  into external-actor use cases and runtime-ready use-case slice documents.
 ---
 
 # Harness Use Cases
 
 ## Purpose
 
-This skill turns confirmed requirements into a use case document only.
+This skill turns confirmed requirements into both the canonical use case document and runtime-ready use case slice documents.
 
 Responsibilities are split as follows.
 
 - `harness-requirements`: writes `docs/design/요구사항.md` and the project-wide language source `context.md`.
-- `harness-usecases`: validates requirements and ubiquitous language readiness, then writes `docs/design/유스케이스.md`.
+- `harness-usecases`: validates requirements and ubiquitous language readiness, then writes `docs/design/유스케이스.md` plus `docs/use-cases/<UC-ID>/use-case.md` and `docs/use-cases/<UC-ID>/e2e-goal.md` for every harvested use case.
 
 If requirements do not exist, if `context.md` does not exist, if core ubiquitous
 language is unresolved, or if core business policy decisions remain unresolved,
@@ -44,7 +44,7 @@ Use the following standards as the source of truth for the instructions.
 
 - Write use cases around the goals of external actors.
 - Do not define internal server/API interactions as use cases.
-- Use case names in this format: `UC-01. Actor performs goal`.
+- Use case names in this format: `UC-001. Actor performs goal`.
 - Each use case must contain exactly one user goal.
 - Split combined goals into separate use cases.
 - When a detailed flow implies commands, events, or policies, each sentence must have a single meaning.
@@ -55,32 +55,54 @@ Use the following standards as the source of truth for the instructions.
 - A use case that does not satisfy these rules is not complete.
 - If a requirement is ambiguous, mark the related use case detail as `Needs confirmation` instead of inventing behavior.
 
+### Runtime Slice Document Standards
+
+For every harvested use case ID, write a runtime slice directory:
+
+```text
+docs/use-cases/<UC-ID>/
+  use-case.md
+  e2e-goal.md
+```
+
+Rules:
+- Use stable three-digit UC IDs such as `UC-001`, `UC-002`, and `UC-003`.
+- The canonical `docs/design/유스케이스.md` list and every slice directory must use the same UC ID and title.
+- `docs/use-cases/<UC-ID>/use-case.md` must contain the detailed use case for exactly one use case.
+- `docs/use-cases/<UC-ID>/e2e-goal.md` must define the end-to-end verification goal for that same use case.
+- If the use case is not fully confirmed, still create both slice documents and mark ambiguous sections as `Needs confirmation`.
+- Do not leave a harvested use case only in `docs/design/유스케이스.md`; it must have matching runtime slice documents.
+
 ## Invocation
 
 When the user invokes `$harness-usecases` with existing requirements or a
-requirements decision record, treat it as a request to write use cases only.
+requirements decision record, treat it as a request to write use cases and runtime-ready use-case slices.
 
 Dedicated agent:
 
 - agent id: `harness_usecases`
 - config: `.codex/agents/harness_usecases.toml`
-- output file:
+- output files:
   - `docs/design/유스케이스.md`
+  - `docs/use-cases/<UC-ID>/use-case.md`
+  - `docs/use-cases/<UC-ID>/e2e-goal.md`
 
 Execution rules:
 
 - If the dedicated agent cannot be found or cannot run, the current agent must not perform the work as a fallback.
 - Explain the reason for the failure and stop.
 - The dedicated agent must not modify code, settings, skill files, agent files, requirements documents, or `context.md`.
-- The dedicated agent may only write to `docs/design/유스케이스.md`.
+- The dedicated agent may only write to `docs/design/유스케이스.md` and `docs/use-cases/<UC-ID>/` slice documents.
 
 ```text
 You are the harness use case documentation agent.
 
-Write or update only docs/design/유스케이스.md based on context.md, docs/design/요구사항.md, and any confirmed decision record.
+Write or update docs/design/유스케이스.md and matching runtime slice docs under docs/use-cases/<UC-ID>/ based on context.md, docs/design/요구사항.md, and any confirmed decision record.
 
-Owned file:
+Owned files:
 - docs/design/유스케이스.md
+- docs/use-cases/<UC-ID>/use-case.md
+- docs/use-cases/<UC-ID>/e2e-goal.md
 
 Rules:
 - Do not modify code, settings, skill files, agent files, requirements documents, or context.md.
@@ -95,7 +117,8 @@ Rules:
 - Write use cases around a single goal of an external actor.
 - Do not turn internal server/API flows into use cases.
 - Separate commands, events, and policies by meaning and sentence form.
-- Write deliverables only to the owned file.
+- Write deliverables only to the owned files.
+- Every harvested UC must have docs/use-cases/<UC-ID>/use-case.md and docs/use-cases/<UC-ID>/e2e-goal.md.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```
 
@@ -114,10 +137,18 @@ Rules:
 4. **Derive actor goals**
    Extract external actors and one goal per actor from confirmed functional requirements, using only canonical terms from `context.md`.
 
-5. **Write use cases**
+5. **Assign stable use case IDs**
+   Assign IDs in `UC-001` format. Preserve existing IDs when updating an existing `docs/design/유스케이스.md`.
+
+6. **Write canonical use cases**
    Write or update `docs/design/유스케이스.md`, using one external actor goal per use case and the canonical language from `context.md`.
 
-6. **Confirm completion**
+7. **Write runtime slice docs**
+   For every canonical use case, write or update:
+   - `docs/use-cases/<UC-ID>/use-case.md`
+   - `docs/use-cases/<UC-ID>/e2e-goal.md`
+
+8. **Confirm completion**
    If any use case still has multiple goals, mixed command/policy wording, multi-meaning event-storming candidates, non-canonical language, or Forbidden Terms, mark it as `Needs confirmation`.
    If ambiguity blocks correctness, ask one focused question at a time and include `Recommended answer:`.
 
@@ -137,10 +168,10 @@ Rules:
 
 ## 2. High-Level Use Case List
 ### <Actor Group>
-- UC-01. ...
+- UC-001. ...
 
 ## 3. Use Case Details
-## UC-01. <Actor performs goal>
+## UC-001. <Actor performs goal>
 **Actor**
 - ...
 
@@ -194,6 +225,65 @@ Rules:
 
 ## 5. Needs Confirmation
 - ...
+```
+
+## Runtime Slice Templates
+
+`docs/use-cases/<UC-ID>/use-case.md` must follow this structure.
+
+```markdown
+# <UC-ID>. <Actor performs goal>
+
+## Actor
+- ...
+
+## Supporting Actor
+- ...
+
+## Goal
+- ...
+
+## Preconditions
+- ...
+
+## Main Flow
+1. ...
+
+## Exception Flow
+- ...
+
+## Result
+- ...
+
+## Non-Functional Requirements
+- ...
+
+## Needs Confirmation
+- None
+```
+
+`docs/use-cases/<UC-ID>/e2e-goal.md` must follow this structure.
+
+```markdown
+# <UC-ID> E2E Goal
+
+## Goal
+- ...
+
+## Given
+- ...
+
+## When
+- ...
+
+## Then
+- ...
+
+## Verification Notes
+- ...
+
+## Needs Confirmation
+- None
 ```
 
 Even when a use case has no supporting actors, exception flow, or non-functional

--- a/.codex/skills/harness-usecases/references/agent-prompt.md
+++ b/.codex/skills/harness-usecases/references/agent-prompt.md
@@ -5,12 +5,14 @@ Use this prompt when spawning a worker agent for `$harness-usecases`.
 ```text
 You are the harness use case documentation agent.
 
-Read context.md first, then read docs/design/요구사항.md, and write external-actor use cases only.
-Follow the ticketon-ddd style use case, ubiquitous language, and template standards embedded in the skill.
+Read context.md first, then read docs/design/요구사항.md, and write external-actor use cases plus runtime-ready use-case slice docs.
+Follow the ticketon-ddd style use case, ubiquitous language, runtime slice, and template standards embedded in the skill.
 Do not depend on external blog files or repo-local reference posts at runtime.
 
-Owned file:
+Owned files:
 - docs/design/유스케이스.md
+- docs/use-cases/<UC-ID>/use-case.md
+- docs/use-cases/<UC-ID>/e2e-goal.md
 
 Rules:
 - Do not revert edits made by others.
@@ -29,6 +31,10 @@ Rules:
 - Do not mix policies and commands.
 - Commands must be imperative, events past tense, policies conditions or decision criteria.
 - Mark incomplete use cases as Needs confirmation instead of inventing behavior.
+- Use stable UC IDs in `UC-001` format.
+- Every harvested use case must be present in `docs/design/유스케이스.md` and have matching `docs/use-cases/<UC-ID>/use-case.md` and `docs/use-cases/<UC-ID>/e2e-goal.md`.
+- `use-case.md` must contain the detailed single-UC flow.
+- `e2e-goal.md` must contain the E2E goal with Given/When/Then sections.
 - Ask one focused question at a time only when requirements or language are ambiguous enough to block correctness.
 - Include `Recommended answer:` with every question.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.

--- a/.harness/workflows/harvest-workflow.yaml
+++ b/.harness/workflows/harvest-workflow.yaml
@@ -3,7 +3,7 @@ version: 1
 workflow:
   name: harness-harvest-workflow
   mode: apply
-  description: Harvest product intent into canonical requirements, ubiquitous language, then use-case documents.
+  description: Harvest product intent into canonical requirements, ubiquitous language, then runtime-ready use-case documents.
 
 sandbox:
   kind: worktree
@@ -72,7 +72,7 @@ steps:
 
   - id: harvest-use-cases
     kind: agent
-    name: Derive use cases from confirmed requirements and ubiquitous language
+    name: Derive runtime-ready use case docs from confirmed requirements and ubiquitous language
     agent_id: harness_usecases
     skill_id: harness-usecases
     needs:
@@ -82,10 +82,17 @@ steps:
       - docs/design/요구사항.md
     outputs:
       - docs/design/유스케이스.md
+      - docs/use-cases
     timeout_sec: 3600
     metadata:
       stage: harvest
-      scope: canonical_use_cases
+      scope: runtime_ready_use_cases
       language_source: context.md
+      slice_outputs:
+        root: docs/use-cases
+        required_per_use_case:
+          - use-case.md
+          - e2e-goal.md
       output_gate:
         - docs/design/유스케이스.md
+        - docs/use-cases

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -383,6 +383,7 @@ def _codex_command(request: AgentRunRequest, final_message_path: Path, codex_bin
     command = [
         codex_binary,
         "exec",
+        "--skip-git-repo-check",
         "--cd",
         str(request.context.workdir),
         "-c",

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -236,7 +236,7 @@ def test_configurable_agent_adapter_uses_codex_provider_by_default(
     assert result.status == StepStatus.SUCCEEDED
     assert result.metadata["provider"] == "codex"
     command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
-    assert command[:2] == ["codex-test", "exec"]
+    assert command[:3] == ["codex-test", "exec", "--skip-git-repo-check"]
     assert "--ask-for-approval" not in command
     assert 'approval_policy="never"' in command
     assert "--output-last-message" in command
@@ -279,7 +279,7 @@ def test_configurable_agent_adapter_uses_explicit_codex_binary(
 
     assert result.status == StepStatus.SUCCEEDED
     command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
-    assert command[:2] == ["codex-explicit", "exec"]
+    assert command[:3] == ["codex-explicit", "exec", "--skip-git-repo-check"]
 
 
 def test_configurable_agent_adapter_uses_custom_cli_provider(
@@ -316,6 +316,7 @@ def test_configurable_agent_adapter_uses_custom_cli_provider(
     command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
     assert command == ["my-agent", "run", "--stdin"]
     assert "--model" not in command
+    assert "--skip-git-repo-check" not in command
     assert calls[0][1]["input"] == (request.step_dir / "prompt.md").read_text(
         encoding="utf-8"
     )
@@ -386,7 +387,7 @@ def test_codex_cli_agent_adapter_keeps_backward_compatible_name(
 
     assert result.status == StepStatus.SUCCEEDED
     command = json.loads((request.step_dir / "command.json").read_text(encoding="utf-8"))
-    assert command[:2] == ["codex-test", "exec"]
+    assert command[:3] == ["codex-test", "exec", "--skip-git-repo-check"]
 
 
 def test_configurable_agent_adapter_blocks_when_provider_binary_is_missing(

--- a/tests/test_usecase_slice_harvest_instructions.py
+++ b/tests/test_usecase_slice_harvest_instructions.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_usecase_harvester_writes_runtime_ready_slice_docs() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-usecases/SKILL.md",
+        REPO_ROOT / ".codex/agents/harness_usecases.toml",
+        REPO_ROOT / ".codex/skills/harness-usecases/references/agent-prompt.md",
+        REPO_ROOT / ".harness/workflows/harvest-workflow.yaml",
+    )
+
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert "docs/use-cases" in text
+        assert "use-case.md" in text
+        assert "e2e-goal.md" in text


### PR DESCRIPTION
## Summary

- Update harvest use-case outputs to include `docs/use-cases` slice docs.
- Update use-case harvester instructions to write `use-case.md` and `e2e-goal.md` per UC.
- Add `--skip-git-repo-check` to child Codex exec commands.
- Add regression tests for both changes.

Closes #120
Closes #121

## Verification

Not run locally here.