### PR TITLE
[codex] 런타임 쉘 자동완성 추가

### DIFF
--- a/docs/runtime-shell-completion.md
+++ b/docs/runtime-shell-completion.md
@@ -1,0 +1,80 @@
+# Runtime Shell Completion
+
+`harness` 런타임은 Bash/Zsh 자동완성 스크립트를 제공한다.
+
+자동완성은 현재 리포지토리 파일 시스템을 직접 탐색한다. 따라서 `change_set_id`, `uc_id`, `work_item_id`, `run_id`, `stage` 같은 파라미터를 외우지 않고 `Tab`으로 후보를 볼 수 있다.
+
+## Bash
+
+리포지토리 루트에서 다음을 실행한다.
+
+```bash
+source scripts/harness-completion.bash
+```
+
+항상 켜두려면 `~/.bashrc`에 추가한다.
+
+```bash
+source /path/to/harness-codex/scripts/harness-completion.bash
+```
+
+## Zsh
+
+리포지토리 루트에서 다음을 실행한다.
+
+```zsh
+source scripts/harness-completion.zsh
+```
+
+항상 켜두려면 `~/.zshrc`에 추가한다.
+
+```zsh
+source /path/to/harness-codex/scripts/harness-completion.zsh
+```
+
+## 자동완성 대상
+
+| 명령 | 자동완성 후보 |
+| --- | --- |
+| `harness changes show <TAB>` | `docs/changes/active/*.md`, `docs/changes/completed/*.md`의 ChangeSet ID |
+| `harness run-change <TAB>` | ChangeSet ID |
+| `harness run-use-case <CHG-ID> <TAB>` | 해당 ChangeSet 문서에 포함된 `UC-*` ID |
+| `harness run-work-item <CHG-ID> <TAB>` | 해당 ChangeSet 문서에 포함된 `UC-*`, `MAINT-*` ID |
+| `harness stages list <TAB>` | ChangeSet ID |
+| `harness artifacts show <CHG-ID> <TAB>` | 런타임 stage ID |
+| `harness artifacts accept <CHG-ID> <TAB>` | 런타임 stage ID |
+| `harness run-stage <CHG-ID> <TAB>` | 런타임 stage ID |
+| `harness resume <TAB>` | `.harness/runs/*`의 run ID |
+| `harness report <TAB>` | `.harness/runs/*`의 run ID |
+| `harness changes create-from-design --uc <TAB>` | `docs/use-cases/*`의 UC ID |
+| `harness changes create-from-design --change-set-id <TAB>` | ChangeSet ID |
+
+## Repo root 탐색 기준
+
+기본 탐색 루트는 현재 Git 리포지토리 루트다.
+
+다른 경로를 기준으로 후보를 찾고 싶으면 `--repo-root`를 먼저 입력한다.
+
+```bash
+harness --repo-root ../other-project run-use-case <TAB>
+```
+
+이 경우 자동완성은 `../other-project/docs/changes/active`, `../other-project/docs/use-cases`, `../other-project/docs/maintenance`, `../other-project/.harness/runs`를 기준으로 후보를 만든다.
+
+## 후보 산출 규칙
+
+- ChangeSet ID: `docs/changes/active/*.md`, `docs/changes/completed/*.md`의 파일명 stem
+- UC ID: `docs/use-cases/*` 디렉토리명 또는 선택된 ChangeSet 문서 안의 `UC-*` 토큰
+- Maintenance ID: `docs/maintenance/*` 디렉토리명 또는 선택된 ChangeSet 문서 안의 `MAINT-*` 토큰
+- Work item ID: UC ID + Maintenance ID + `docs/plans/{active,completed}/*` 디렉토리명
+- Run ID: `.harness/runs/*` 디렉토리명
+- Stage ID: 런타임 기본 stage 이름 + `.harness/stages/<CHG-ID>/*.md`의 파일명 stem
+
+## 예시
+
+```bash
+harness run-use-case CHG-20260507-001 UC-001 --preview
+harness run-work-item CHG-20260507-001 MAINT-001 --plan
+harness artifacts show CHG-20260507-001 verify-work-item
+harness resume run-abc123def456
+```

--- a/scripts/harness-completion.bash
+++ b/scripts/harness-completion.bash
@@ -1,0 +1,297 @@
+# Bash completion for the harness CLI.
+# Source this file from a harness-codex repository checkout:
+#   source scripts/harness-completion.bash
+
+_harness_compgen() {
+  local candidates="$1"
+  local cur="$2"
+  COMPREPLY=( $(compgen -W "$candidates" -- "$cur") )
+}
+
+_harness_repo_root() {
+  local i word
+  for ((i = 1; i < COMP_CWORD; i++)); do
+    word="${COMP_WORDS[i]}"
+    if [[ "$word" == "--repo-root" && $((i + 1)) -lt ${#COMP_WORDS[@]} ]]; then
+      printf '%s\n' "${COMP_WORDS[i + 1]}"
+      return
+    fi
+  done
+
+  local git_root
+  git_root="$(git rev-parse --show-toplevel 2>/dev/null)" || true
+  if [[ -n "$git_root" ]]; then
+    printf '%s\n' "$git_root"
+  else
+    printf '%s\n' "."
+  fi
+}
+
+_harness_stem() {
+  local name="${1##*/}"
+  printf '%s\n' "${name%.md}"
+}
+
+_harness_change_ids() {
+  local root file dir
+  root="$(_harness_repo_root)"
+  for dir in "$root/docs/changes/active" "$root/docs/changes/completed"; do
+    for file in "$dir"/*.md; do
+      [[ -f "$file" ]] && _harness_stem "$file"
+    done
+  done | sort -u
+}
+
+_harness_use_case_ids() {
+  local root dir
+  root="$(_harness_repo_root)"
+  for dir in "$root/docs/use-cases"/*; do
+    [[ -d "$dir" ]] && printf '%s\n' "${dir##*/}"
+  done | sort -u
+}
+
+_harness_maintenance_ids() {
+  local root dir
+  root="$(_harness_repo_root)"
+  for dir in "$root/docs/maintenance"/*; do
+    [[ -d "$dir" ]] && printf '%s\n' "${dir##*/}"
+  done | sort -u
+}
+
+_harness_work_item_ids() {
+  {
+    _harness_use_case_ids
+    _harness_maintenance_ids
+    local root dir
+    root="$(_harness_repo_root)"
+    for dir in "$root/docs/plans/active"/* "$root/docs/plans/completed"/*; do
+      [[ -d "$dir" ]] && printf '%s\n' "${dir##*/}"
+    done
+  } | sort -u
+}
+
+_harness_change_file() {
+  local root="$(_harness_repo_root)"
+  local change_id="$1"
+  local file
+  for file in \
+    "$root/docs/changes/active/$change_id.md" \
+    "$root/docs/changes/completed/$change_id.md"; do
+    [[ -f "$file" ]] && { printf '%s\n' "$file"; return; }
+  done
+}
+
+_harness_ids_for_change() {
+  local change_id="$1"
+  local file
+  file="$(_harness_change_file "$change_id")"
+  if [[ -n "$file" ]]; then
+    grep -Eho '\b(UC|MAINT)-[A-Za-z0-9._-]+' "$file" | sort -u
+  fi
+}
+
+_harness_use_case_ids_for_change() {
+  local change_id="$1"
+  local ids
+  ids="$(_harness_ids_for_change "$change_id" | grep '^UC-' || true)"
+  if [[ -n "$ids" ]]; then
+    printf '%s\n' "$ids"
+  else
+    _harness_use_case_ids
+  fi
+}
+
+_harness_work_item_ids_for_change() {
+  local change_id="$1"
+  local ids
+  ids="$(_harness_ids_for_change "$change_id")"
+  if [[ -n "$ids" ]]; then
+    printf '%s\n' "$ids"
+  else
+    _harness_work_item_ids
+  fi
+}
+
+_harness_run_ids() {
+  local root dir
+  root="$(_harness_repo_root)"
+  for dir in "$root/.harness/runs"/*; do
+    [[ -d "$dir" ]] && printf '%s\n' "${dir##*/}"
+  done | sort -u
+}
+
+_harness_stage_ids() {
+  local change_id="$1"
+  local root file
+  root="$(_harness_repo_root)"
+  printf '%s\n' \
+    requirements \
+    use_cases \
+    change_set \
+    plan-work-item \
+    execute-work-item \
+    verify-work-item \
+    classify-verification-result \
+    complete-work-item-plan
+
+  if [[ -n "$change_id" ]]; then
+    for file in "$root/.harness/stages/$change_id"/*.md; do
+      [[ -f "$file" ]] && _harness_stem "$file"
+    done
+  fi
+}
+
+_harness_non_option_words() {
+  local i word skip_next=0
+  for ((i = 1; i < COMP_CWORD; i++)); do
+    word="${COMP_WORDS[i]}"
+    if (( skip_next )); then
+      skip_next=0
+      continue
+    fi
+    case "$word" in
+      --repo-root|--idea|--description|--title|--change-set-id|--related-issue|--uc|--host|--port|--session-id)
+        skip_next=1
+        ;;
+      --*)
+        ;;
+      *)
+        printf '%s\n' "$word"
+        ;;
+    esac
+  done
+}
+
+_harness_options_for_command() {
+  local cmd="$1" sub="$2"
+  case "$cmd" in
+    harvest) printf '%s\n' "--idea --session-id --resume --plan --preview --apply --interactive" ;;
+    agent-context)
+      [[ "$sub" == "init" ]] && printf '%s\n' "--description --force" || true
+      ;;
+    changes)
+      [[ "$sub" == "create-from-design" ]] && printf '%s\n' "--title --change-set-id --related-issue --uc --force" || true
+      ;;
+    run-change|run-use-case|run-work-item|run-stage)
+      printf '%s\n' "--plan --preview --apply"
+      ;;
+    ui-server) printf '%s\n' "--host --port" ;;
+  esac
+}
+
+_harness() {
+  local cur prev commands global_options
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  commands="harvest agent-context changes run-change run-use-case run-work-item stages artifacts run-stage resume report dashboard ui-server"
+  global_options="--repo-root"
+
+  case "$prev" in
+    --repo-root)
+      COMPREPLY=( $(compgen -d -- "$cur") )
+      return 0
+      ;;
+    --uc)
+      _harness_compgen "$(_harness_use_case_ids)" "$cur"
+      return 0
+      ;;
+    --change-set-id)
+      _harness_compgen "$(_harness_change_ids)" "$cur"
+      return 0
+      ;;
+    --title|--related-issue|--idea|--description|--host|--port|--session-id)
+      return 0
+      ;;
+  esac
+
+  local -a words
+  mapfile -t words < <(_harness_non_option_words)
+  local cmd="${words[0]:-}"
+  local sub="${words[1]:-}"
+
+  if [[ "$cur" == --* ]]; then
+    _harness_compgen "$global_options $(_harness_options_for_command "$cmd" "$sub")" "$cur"
+    return 0
+  fi
+
+  if [[ -z "$cmd" ]]; then
+    _harness_compgen "$commands $global_options" "$cur"
+    return 0
+  fi
+
+  case "$cmd" in
+    harvest)
+      [[ ${#words[@]} -le 1 ]] && _harness_compgen "sessions" "$cur"
+      ;;
+    changes)
+      case "$sub" in
+        "") _harness_compgen "list active show create-from-design" "$cur" ;;
+        show)
+          [[ ${#words[@]} -le 2 ]] && _harness_compgen "$(_harness_change_ids)" "$cur"
+          ;;
+      esac
+      ;;
+    agent-context)
+      [[ -z "$sub" ]] && _harness_compgen "init" "$cur"
+      ;;
+    run-change)
+      if [[ ${#words[@]} -le 1 ]]; then
+        _harness_compgen "$(_harness_change_ids)" "$cur"
+      else
+        _harness_compgen "--plan --preview --apply" "$cur"
+      fi
+      ;;
+    run-use-case)
+      if [[ ${#words[@]} -le 1 ]]; then
+        _harness_compgen "$(_harness_change_ids)" "$cur"
+      elif [[ ${#words[@]} -le 2 ]]; then
+        _harness_compgen "$(_harness_use_case_ids_for_change "${words[1]}")" "$cur"
+      else
+        _harness_compgen "--plan --preview --apply" "$cur"
+      fi
+      ;;
+    run-work-item)
+      if [[ ${#words[@]} -le 1 ]]; then
+        _harness_compgen "$(_harness_change_ids)" "$cur"
+      elif [[ ${#words[@]} -le 2 ]]; then
+        _harness_compgen "$(_harness_work_item_ids_for_change "${words[1]}")" "$cur"
+      else
+        _harness_compgen "--plan --preview --apply" "$cur"
+      fi
+      ;;
+    stages)
+      if [[ -z "$sub" ]]; then
+        _harness_compgen "list" "$cur"
+      elif [[ "$sub" == "list" && ${#words[@]} -le 2 ]]; then
+        _harness_compgen "$(_harness_change_ids)" "$cur"
+      fi
+      ;;
+    artifacts)
+      if [[ -z "$sub" ]]; then
+        _harness_compgen "show accept" "$cur"
+      elif [[ "$sub" == "show" || "$sub" == "accept" ]]; then
+        if [[ ${#words[@]} -le 2 ]]; then
+          _harness_compgen "$(_harness_change_ids)" "$cur"
+        elif [[ ${#words[@]} -le 3 ]]; then
+          _harness_compgen "$(_harness_stage_ids "${words[2]}")" "$cur"
+        fi
+      fi
+      ;;
+    run-stage)
+      if [[ ${#words[@]} -le 1 ]]; then
+        _harness_compgen "$(_harness_change_ids)" "$cur"
+      elif [[ ${#words[@]} -le 2 ]]; then
+        _harness_compgen "$(_harness_stage_ids "${words[1]}")" "$cur"
+      else
+        _harness_compgen "--plan --preview --apply" "$cur"
+      fi
+      ;;
+    resume|report)
+      [[ ${#words[@]} -le 1 ]] && _harness_compgen "$(_harness_run_ids)" "$cur"
+      ;;
+  esac
+
+  return 0
+}
+
+complete -F _harness harness

--- a/scripts/harness-completion.zsh
+++ b/scripts/harness-completion.zsh
@@ -1,0 +1,14 @@
+#compdef harness
+# Zsh wrapper for the harness Bash completion.
+# Source this file from a harness-codex repository checkout:
+#   source scripts/harness-completion.zsh
+
+autoload -Uz bashcompinit
+bashcompinit
+
+local completion_file="${0:A:h}/harness-completion.bash"
+if [[ -f "$completion_file" ]]; then
+  source "$completion_file"
+else
+  print -u2 "harness completion not found: $completion_file"
+fi


### PR DESCRIPTION
## 구현 의도

런타임 명령을 실행할 때 `change_set_id`, `uc_id`, `work_item_id`, `run_id`, `stage`를 매번 직접 기억해서 입력해야 하는 불편을 줄인다.

특히 ChangeSet-first runtime에서는 다음 명령들이 리포지토리 안의 문서 ID를 자주 요구한다.

- `harness changes show <CHG-ID>`
- `harness run-change <CHG-ID>`
- `harness run-use-case <CHG-ID> <UC-ID>`
- `harness run-work-item <CHG-ID> <WORK-ITEM-ID>`
- `harness artifacts show <CHG-ID> <STAGE>`
- `harness resume <RUN-ID>`

이 PR은 위 ID들을 리포지토리 파일 시스템에서 탐색해 Bash/Zsh `Tab` 자동완성으로 제공한다.

## 구현 방법

### 1. Bash completion 추가

신규 파일:

```text
scripts/harness-completion.bash
```

자동완성 함수 `_harness`를 등록하고, 현재 입력 중인 명령 위치에 따라 후보를 다르게 생성한다.

후보 산출 기준:

- ChangeSet ID
  - `docs/changes/active/*.md`
  - `docs/changes/completed/*.md`
- UC ID
  - `docs/use-cases/*`
  - 선택된 ChangeSet 문서 안의 `UC-*` 토큰
- Maintenance ID
  - `docs/maintenance/*`
  - 선택된 ChangeSet 문서 안의 `MAINT-*` 토큰
- Work item ID
  - UC ID + Maintenance ID
  - `docs/plans/active/*`
  - `docs/plans/completed/*`
- Run ID
  - `.harness/runs/*`
- Stage ID
  - 기본 runtime stage 이름
  - `.harness/stages/<CHG-ID>/*.md`

`--repo-root`가 먼저 입력된 경우, 해당 경로를 기준으로 후보를 만든다.

```bash
harness --repo-root ../some-repo run-use-case <TAB>
```

### 2. Zsh wrapper 추가

신규 파일:

```text
scripts/harness-completion.zsh
```

`bashcompinit`을 통해 Bash completion 스크립트를 Zsh에서도 재사용한다.

### 3. 사용 문서 추가

신규 파일:

```text
docs/runtime-shell-completion.md
```

문서에는 다음 내용을 정리했다.

- Bash/Zsh에서 source 하는 방법
- `.bashrc`, `.zshrc`에 상시 등록하는 방법
- 명령별 자동완성 후보
- `--repo-root` 기준 탐색 방식
- 후보 산출 규칙
- 사용 예시

## 검증 방법

브랜치를 최신 `main`으로 강제 정렬한 뒤 자동완성 변경 3개 파일만 다시 적용했다.

비교 결과:

```text
base: main
head: changeset-first-runtime
behind_by: 0
ahead_by: 3
changed files:
- docs/runtime-shell-completion.md
- scripts/harness-completion.bash
- scripts/harness-completion.zsh
```

GitHub 커넥터로 파일을 추가했기 때문에 로컬 셸에서 직접 `Tab` 동작까지는 실행하지 않았다.

병합 전 다음 명령으로 확인하면 된다.

```bash
bash -n scripts/harness-completion.bash
source scripts/harness-completion.bash
harness run-change <TAB>
harness run-use-case <CHG-ID> <TAB>
harness run-work-item <CHG-ID> <TAB>
harness resume <TAB>
```

Zsh 환경에서는 다음을 확인한다.

```zsh
source scripts/harness-completion.zsh
harness run-change <TAB>
```

## 관련

Follow-up for #81