### PR TITLE
[codex] run-use-case ChangeSet ID 자동완성 보강

### DIFF
--- a/scripts/harness-completion.bash
+++ b/scripts/harness-completion.bash
@@ -1,6 +1,10 @@
 # Bash completion for the harness CLI.
 # Source this file from a harness-codex repository checkout:
 #   source scripts/harness-completion.bash
+#
+# Registered commands:
+#   harness ...
+#   ./harness ...
 
 _harness_compgen() {
   local candidates="$1"
@@ -141,7 +145,7 @@ _harness_stage_ids() {
   fi
 }
 
-_harness_non_option_words() {
+_harness_non_option_words_before_cursor() {
   local i word skip_next=0
   for ((i = 1; i < COMP_CWORD; i++)); do
     word="${COMP_WORDS[i]}"
@@ -205,7 +209,7 @@ _harness() {
   esac
 
   local -a words
-  mapfile -t words < <(_harness_non_option_words)
+  mapfile -t words < <(_harness_non_option_words_before_cursor)
   local cmd="${words[0]:-}"
   local sub="${words[1]:-}"
 
@@ -227,6 +231,7 @@ _harness() {
       case "$sub" in
         "") _harness_compgen "list active show create-from-design" "$cur" ;;
         show)
+          # harness changes show CHG-<TAB>
           [[ ${#words[@]} -le 2 ]] && _harness_compgen "$(_harness_change_ids)" "$cur"
           ;;
       esac
@@ -235,6 +240,7 @@ _harness() {
       [[ -z "$sub" ]] && _harness_compgen "init" "$cur"
       ;;
     run-change)
+      # harness run-change CHG-<TAB>
       if [[ ${#words[@]} -le 1 ]]; then
         _harness_compgen "$(_harness_change_ids)" "$cur"
       else
@@ -242,8 +248,10 @@ _harness() {
       fi
       ;;
     run-use-case)
+      # harness run-use-case CHG-<TAB>
       if [[ ${#words[@]} -le 1 ]]; then
         _harness_compgen "$(_harness_change_ids)" "$cur"
+      # harness run-use-case CHG-001 UC-<TAB>
       elif [[ ${#words[@]} -le 2 ]]; then
         _harness_compgen "$(_harness_use_case_ids_for_change "${words[1]}")" "$cur"
       else
@@ -251,8 +259,10 @@ _harness() {
       fi
       ;;
     run-work-item)
+      # harness run-work-item CHG-<TAB>
       if [[ ${#words[@]} -le 1 ]]; then
         _harness_compgen "$(_harness_change_ids)" "$cur"
+      # harness run-work-item CHG-001 WORK-ITEM-<TAB>
       elif [[ ${#words[@]} -le 2 ]]; then
         _harness_compgen "$(_harness_work_item_ids_for_change "${words[1]}")" "$cur"
       else
@@ -294,4 +304,4 @@ _harness() {
   return 0
 }
 
-complete -F _harness harness
+complete -F _harness harness ./harness

--- a/scripts/test-harness-completion.bash
+++ b/scripts/test-harness-completion.bash
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(mktemp -d)"
+trap 'rm -rf "$repo_root"' EXIT
+
+mkdir -p "$repo_root/docs/changes/active" "$repo_root/docs/use-cases/UC-001"
+cat > "$repo_root/docs/changes/active/CHG-20260520-001.md" <<'CHANGESET'
+# ChangeSet CHG-20260520-001
+
+| UC ID | Name |
+| --- | --- |
+| `UC-001` | Sample use case |
+CHANGESET
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/harness-completion.bash"
+
+run_completion() {
+  COMP_WORDS=("$@")
+  COMP_CWORD=$((${#COMP_WORDS[@]} - 1))
+  COMPREPLY=()
+  _harness
+  printf '%s\n' "${COMPREPLY[@]}"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fxq "$needle" <<< "$haystack"; then
+    printf 'expected completion candidate not found: %s\n' "$needle" >&2
+    printf 'actual candidates:\n%s\n' "$haystack" >&2
+    exit 1
+  fi
+}
+
+change_candidates="$(run_completion harness --repo-root "$repo_root" run-use-case CHG-)"
+assert_contains "$change_candidates" "CHG-20260520-001"
+
+uc_candidates="$(run_completion harness --repo-root "$repo_root" run-use-case CHG-20260520-001 UC-)"
+assert_contains "$uc_candidates" "UC-001"
+
+local_launcher_candidates="$(run_completion ./harness --repo-root "$repo_root" run-use-case CHG-)"
+assert_contains "$local_launcher_candidates" "CHG-20260520-001"
+
+printf 'completion smoke test passed\n'


### PR DESCRIPTION
## 구현 의도

`harness run-use-case CHG-<TAB>` 위치에서 ChangeSet ID가 바로 완성되도록 보강한다.

기존 자동완성은 여러 위치에서 ChangeSet ID 후보를 제공했지만, 사용자가 기대한 핵심 동작은 다음이다.

```bash
harness run-use-case CHG-<TAB>
```

위 시점의 첫 번째 위치 인자 자체가 `docs/changes/active/*.md`, `docs/changes/completed/*.md`에서 찾은 ChangeSet ID 후보로 완성되어야 한다.

## 구현 방법

### 1. `run-use-case` ChangeSet ID 위치를 명시적으로 처리

`scripts/harness-completion.bash`에서 `run-use-case` 분기를 다음처럼 명확히 했다.

- `harness run-use-case CHG-<TAB>`
  - ChangeSet ID 후보 완성
- `harness run-use-case CHG-001 UC-<TAB>`
  - 선택된 ChangeSet에 포함된 UC ID 후보 완성

같은 방식으로 `run-change`, `run-work-item`도 첫 번째 위치 인자에서 ChangeSet ID를 완성하도록 주석과 분기를 명확히 했다.

### 2. 로컬 실행 형태 유지

자동완성 등록은 다음 두 실행 형태를 모두 지원한다.

```bash
harness ...
./harness ...
```

### 3. smoke test 추가

신규 파일:

```text
scripts/test-harness-completion.bash
```

테스트 내용:

- 임시 repo에 `docs/changes/active/CHG-20260520-001.md` 생성
- `harness --repo-root <tmp> run-use-case CHG-` completion 호출
- 후보에 `CHG-20260520-001`이 포함되는지 검증
- `harness --repo-root <tmp> run-use-case CHG-20260520-001 UC-` completion 호출
- 후보에 `UC-001`이 포함되는지 검증
- `./harness --repo-root <tmp> run-use-case CHG-` completion 호출
- 후보에 `CHG-20260520-001`이 포함되는지 검증

## 검증 방법

커넥터 환경에서는 실제 Bash completion 실행까지는 수행하지 못했다.

로컬에서는 다음 명령으로 검증하면 된다.

```bash
bash -n scripts/harness-completion.bash
bash scripts/test-harness-completion.bash
source scripts/harness-completion.bash
harness run-use-case CHG-<TAB>
```

현재 브랜치 상태는 최신 `main` 대비 다음 두 파일만 변경된다.

```text
scripts/harness-completion.bash
scripts/test-harness-completion.bash
```