### PR TITLE
[codex] run-use-case 빈 ChangeSet 인자 자동완성 수정

### DIFF
--- a/scripts/harness-completion.bash
+++ b/scripts/harness-completion.bash
@@ -5,11 +5,20 @@
 # Registered commands:
 #   harness ...
 #   ./harness ...
+#
+# If Bash does not dispatch completion for ./harness in your environment,
+# use `harness ...` via an alias or symlink, or enable default dispatch with:
+#   HARNESS_ENABLE_DEFAULT_COMPLETION=1 source scripts/harness-completion.bash
 
 _harness_compgen() {
   local candidates="$1"
   local cur="$2"
   COMPREPLY=( $(compgen -W "$candidates" -- "$cur") )
+}
+
+_harness_is_launcher() {
+  local command_name="${COMP_WORDS[0]##*/}"
+  [[ "$command_name" == "harness" ]]
 }
 
 _harness_repo_root() {
@@ -184,6 +193,8 @@ _harness_options_for_command() {
 }
 
 _harness() {
+  _harness_is_launcher || return 124
+
   local cur prev commands global_options
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -231,7 +242,6 @@ _harness() {
       case "$sub" in
         "") _harness_compgen "list active show create-from-design" "$cur" ;;
         show)
-          # harness changes show CHG-<TAB>
           [[ ${#words[@]} -le 2 ]] && _harness_compgen "$(_harness_change_ids)" "$cur"
           ;;
       esac
@@ -240,7 +250,7 @@ _harness() {
       [[ -z "$sub" ]] && _harness_compgen "init" "$cur"
       ;;
     run-change)
-      # harness run-change CHG-<TAB>
+      # harness run-change <TAB> or harness run-change CHG-<TAB>
       if [[ ${#words[@]} -le 1 ]]; then
         _harness_compgen "$(_harness_change_ids)" "$cur"
       else
@@ -248,10 +258,10 @@ _harness() {
       fi
       ;;
     run-use-case)
-      # harness run-use-case CHG-<TAB>
+      # ./harness run-use-case <TAB> or ./harness run-use-case CHG-<TAB>
       if [[ ${#words[@]} -le 1 ]]; then
         _harness_compgen "$(_harness_change_ids)" "$cur"
-      # harness run-use-case CHG-001 UC-<TAB>
+      # ./harness run-use-case CHG-001 <TAB> or ./harness run-use-case CHG-001 UC-<TAB>
       elif [[ ${#words[@]} -le 2 ]]; then
         _harness_compgen "$(_harness_use_case_ids_for_change "${words[1]}")" "$cur"
       else
@@ -259,10 +269,8 @@ _harness() {
       fi
       ;;
     run-work-item)
-      # harness run-work-item CHG-<TAB>
       if [[ ${#words[@]} -le 1 ]]; then
         _harness_compgen "$(_harness_change_ids)" "$cur"
-      # harness run-work-item CHG-001 WORK-ITEM-<TAB>
       elif [[ ${#words[@]} -le 2 ]]; then
         _harness_compgen "$(_harness_work_item_ids_for_change "${words[1]}")" "$cur"
       else
@@ -304,4 +312,8 @@ _harness() {
   return 0
 }
 
-complete -F _harness harness ./harness
+complete -o bashdefault -o default -F _harness harness ./harness
+
+if [[ "${HARNESS_ENABLE_DEFAULT_COMPLETION:-}" == "1" ]]; then
+  complete -o bashdefault -o default -D -F _harness
+fi

--- a/scripts/test-harness-completion.bash
+++ b/scripts/test-harness-completion.bash
@@ -34,13 +34,19 @@ assert_contains() {
   fi
 }
 
-change_candidates="$(run_completion harness --repo-root "$repo_root" run-use-case CHG-)"
-assert_contains "$change_candidates" "CHG-20260520-001"
+change_candidates_empty="$(run_completion harness --repo-root "$repo_root" run-use-case "")"
+assert_contains "$change_candidates_empty" "CHG-20260520-001"
+
+change_candidates_prefix="$(run_completion harness --repo-root "$repo_root" run-use-case CHG-)"
+assert_contains "$change_candidates_prefix" "CHG-20260520-001"
 
 uc_candidates="$(run_completion harness --repo-root "$repo_root" run-use-case CHG-20260520-001 UC-)"
 assert_contains "$uc_candidates" "UC-001"
 
-local_launcher_candidates="$(run_completion ./harness --repo-root "$repo_root" run-use-case CHG-)"
-assert_contains "$local_launcher_candidates" "CHG-20260520-001"
+local_launcher_candidates_empty="$(run_completion ./harness --repo-root "$repo_root" run-use-case "")"
+assert_contains "$local_launcher_candidates_empty" "CHG-20260520-001"
+
+local_launcher_candidates_prefix="$(run_completion ./harness --repo-root "$repo_root" run-use-case CHG-)"
+assert_contains "$local_launcher_candidates_prefix" "CHG-20260520-001"
 
 printf 'completion smoke test passed\n'


### PR DESCRIPTION
## 구현 의도

`./harness run-use-case <TAB>`처럼 `run-use-case`까지만 입력한 뒤 Tab을 눌렀을 때 ChangeSet ID 후보가 떠야 한다.

사용자가 기대하는 동작은 다음 두 케이스다.

```bash
./harness run-use-case <TAB>
./harness run-use-case CHG-<TAB>
```

둘 다 `docs/changes/active/*.md`, `docs/changes/completed/*.md`에서 찾은 ChangeSet ID를 후보로 보여야 한다.

## 구현 방법

### 1. 로컬 런처 dispatch 보강

`scripts/harness-completion.bash`에 `_harness_is_launcher()`를 추가했다.

`COMP_WORDS[0]`의 basename이 `harness`인지 확인해서 다음 실행 형태를 모두 처리한다.

```bash
harness ...
./harness ...
```

또한 completion 등록에 `-o bashdefault -o default`를 추가해서 로컬 경로 실행 시에도 기본 completion 동작과 함께 동작하도록 했다.

```bash
complete -o bashdefault -o default -F _harness harness ./harness
```

환경에 따라 `./harness`에 completion dispatch가 걸리지 않는 경우를 위해 opt-in default dispatch도 추가했다.

```bash
HARNESS_ENABLE_DEFAULT_COMPLETION=1 source scripts/harness-completion.bash
```

### 2. 빈 ChangeSet 인자 자리 검증

`run-use-case` 분기를 다음 케이스에 맞춰 명확히 했다.

- `./harness run-use-case <TAB>`
  - ChangeSet ID 후보 완성
- `./harness run-use-case CHG-<TAB>`
  - ChangeSet ID 후보 완성
- `./harness run-use-case CHG-001 <TAB>`
  - 해당 ChangeSet의 UC ID 후보 완성

### 3. smoke test 강화

`scripts/test-harness-completion.bash`에 다음 케이스를 추가했다.

- `harness --repo-root <tmp> run-use-case <TAB>`
- `harness --repo-root <tmp> run-use-case CHG-<TAB>`
- `./harness --repo-root <tmp> run-use-case <TAB>`
- `./harness --repo-root <tmp> run-use-case CHG-<TAB>`

각 케이스에서 `CHG-20260520-001` 후보가 나오는지 검증한다.

## 검증 방법

브랜치는 최신 `main` 기준으로 정리했다.

```text
behind_by: 0
ahead_by: 2
changed files:
- scripts/harness-completion.bash
- scripts/test-harness-completion.bash
```

로컬에서는 다음으로 확인하면 된다.

```bash
bash -n scripts/harness-completion.bash
bash scripts/test-harness-completion.bash
source scripts/harness-completion.bash
./harness run-use-case <TAB>
./harness run-use-case CHG-<TAB>
```

만약 `./harness` 경로 실행에 completion dispatch가 안 걸리는 셸 환경이면 다음 방식으로 source한다.

```bash
HARNESS_ENABLE_DEFAULT_COMPLETION=1 source scripts/harness-completion.bash
```