### PR TITLE
Optimize Grill-Me prompt context and log tails

### DIFF
--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -17,6 +17,14 @@ USE_CASES_PATH = Path("docs/design/유스케이스.md")
 USE_CASE_SLICE_ROOT = Path("docs/use-cases")
 GRILL_ME_SKILL_PATH = Path(".codex/skills/grill-me/SKILL.md")
 
+SMALL_DOC_TOKEN_LIMIT = 3000
+MAX_SECTION_TOKENS = 4000
+MAX_CONTEXT_SUMMARY_TOKENS = 1500
+MAX_HISTORY_ITEMS = 20
+MAX_STDOUT_TAIL_LINES = 50
+MAX_STDERR_TAIL_LINES = 200
+_APPROX_CHARS_PER_TOKEN = 4
+
 
 @dataclass(frozen=True)
 class HarvestUiResult:
@@ -458,14 +466,70 @@ def _run_grill_me(root: Path, session: dict[str, Any]) -> dict[str, Any]:
         timeout=300,
         check=False,
     )
-    (run_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
-    (run_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    _write_grill_me_logs(run_dir, command, completed)
     if completed.returncode != 0:
-        error = completed.stderr.strip() or completed.stdout.strip()
-        raise ValueError(f"Grill-Me execution failed: {error}")
+        raise ValueError(_grill_me_failure_message(run_dir, command, completed))
 
     final_message = final_message_path.read_text(encoding="utf-8")
     return _parse_grill_me_json(final_message)
+
+
+def _write_grill_me_logs(
+    run_dir: Path,
+    command: list[str],
+    completed: subprocess.CompletedProcess[str],
+) -> None:
+    stdout_tail = _tail_lines(completed.stdout, MAX_STDOUT_TAIL_LINES)
+    stderr_tail = _tail_lines(completed.stderr, MAX_STDERR_TAIL_LINES)
+    (run_dir / "stdout.log").write_text(completed.stdout, encoding="utf-8")
+    (run_dir / "stderr.log").write_text(completed.stderr, encoding="utf-8")
+    (run_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
+    (run_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    (run_dir / "stdout.tail.log").write_text(stdout_tail, encoding="utf-8")
+    (run_dir / "stderr.tail.log").write_text(stderr_tail, encoding="utf-8")
+    (run_dir / "run-report.json").write_text(
+        json.dumps(
+            {
+                "command": command,
+                "exit_code": completed.returncode,
+                "logs": {
+                    "stdout_path": str(run_dir / "stdout.log"),
+                    "stderr_path": str(run_dir / "stderr.log"),
+                    "stdout_tail_path": str(run_dir / "stdout.tail.log"),
+                    "stderr_tail_path": str(run_dir / "stderr.tail.log"),
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _grill_me_failure_message(
+    run_dir: Path,
+    command: list[str],
+    completed: subprocess.CompletedProcess[str],
+) -> str:
+    stderr_tail = _tail_lines(completed.stderr, MAX_STDERR_TAIL_LINES).strip()
+    stdout_tail = _tail_lines(completed.stdout, MAX_STDOUT_TAIL_LINES).strip()
+    details = {
+        "command": command,
+        "exit_code": completed.returncode,
+        "stdout_tail": stdout_tail,
+        "stderr_tail": stderr_tail,
+        "full_log_path": str(run_dir),
+    }
+    return "Grill-Me execution failed: " + json.dumps(details, ensure_ascii=False)
+
+
+def _tail_lines(text: str, limit: int) -> str:
+    if not text:
+        return ""
+    lines = text.splitlines()
+    tail = lines[-limit:]
+    return "\n".join(tail) + ("\n" if text.endswith("\n") or tail else "")
 
 
 def _grill_me_prompt(root: Path, session: dict[str, Any], skill_path: Path) -> str:
@@ -473,8 +537,9 @@ def _grill_me_prompt(root: Path, session: dict[str, Any], skill_path: Path) -> s
         encoding="utf-8"
     )
     grill_me_skill = skill_path.read_text(encoding="utf-8")
-    asked_questions = _asked_questions(session)
+    answered_questions = _asked_questions(session)
     pending_questions = session.get("pending_questions") or []
+    repository_context = _grill_me_repository_context(root, session)
     return f"""Use $grill-me to clarify requirements.
 
 Return only JSON with keys: complete, questions, requirements_markdown, context_markdown.
@@ -492,17 +557,29 @@ Question repetition rules:
 - context_markdown must follow the root context.md structure from harness-requirements and include the Ubiquitous Language table.
 - requirements_markdown must use canonical terms from context_markdown.
 
+Context budget rules:
+- Full documents and raw stdout/stderr are source artifacts, not default prompt context.
+- Use the repository context snapshot below as the only document context unless a small document is explicitly included there.
+- When a document is marked truncated, ask for or update only the relevant section instead of relying on the omitted full text.
+- The full document paths in the snapshot are authoritative source locations for writes.
+
 Initial prompt:
 {session["initial_prompt"]}
 
 Answered question history:
-{json.dumps(asked_questions, ensure_ascii=False, indent=2)}
+{json.dumps(answered_questions[-MAX_HISTORY_ITEMS:], ensure_ascii=False, indent=2)}
+
+Answered question history omitted count:
+{max(0, len(answered_questions) - MAX_HISTORY_ITEMS)}
 
 Clarification history:
-{json.dumps(session["clarifications"], ensure_ascii=False, indent=2)}
+{json.dumps(_compact_clarification_history(session), ensure_ascii=False, indent=2)}
 
 Pending question queue:
 {json.dumps(pending_questions, ensure_ascii=False, indent=2)}
+
+Repository context snapshot:
+{json.dumps(repository_context, ensure_ascii=False, indent=2)}
 
 Harness requirements standards:
 {requirements_skill}
@@ -510,6 +587,147 @@ Harness requirements standards:
 Grill-Me skill:
 {grill_me_skill}
 """
+
+
+def _compact_clarification_history(session: dict[str, Any]) -> list[dict[str, Any]]:
+    clarifications = list(session.get("clarifications", []))
+    omitted = max(0, len(clarifications) - MAX_HISTORY_ITEMS)
+    compact = clarifications[-MAX_HISTORY_ITEMS:]
+    if omitted:
+        return [
+            {
+                "omitted_count": omitted,
+                "reason": "older clarifications omitted from Grill-Me prompt context budget",
+            }
+        ] + compact
+    return compact
+
+
+def _grill_me_repository_context(root: Path, session: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "policy": {
+            "small_doc_token_limit": SMALL_DOC_TOKEN_LIMIT,
+            "max_section_tokens": MAX_SECTION_TOKENS,
+            "max_context_summary_tokens": MAX_CONTEXT_SUMMARY_TOKENS,
+            "note": "Full documents stay on disk; prompt includes only small documents or bounded snapshots.",
+        },
+        "documents": [
+            _document_prompt_snapshot(root, CONTEXT_PATH, session, MAX_CONTEXT_SUMMARY_TOKENS),
+            _document_prompt_snapshot(root, REQUIREMENTS_PATH, session, MAX_SECTION_TOKENS),
+            _document_prompt_snapshot(root, USE_CASES_PATH, session, MAX_SECTION_TOKENS),
+        ],
+    }
+
+
+def _document_prompt_snapshot(
+    root: Path,
+    relative_path: Path,
+    session: dict[str, Any],
+    section_token_limit: int,
+) -> dict[str, Any]:
+    path = root / relative_path
+    if not path.exists():
+        return {
+            "path": str(relative_path),
+            "exists": False,
+            "included": False,
+            "reason": "missing",
+        }
+    text = path.read_text(encoding="utf-8")
+    estimated_tokens = _estimate_tokens(text)
+    if estimated_tokens <= SMALL_DOC_TOKEN_LIMIT:
+        return {
+            "path": str(relative_path),
+            "exists": True,
+            "included": True,
+            "truncated": False,
+            "estimated_tokens": estimated_tokens,
+            "content": text,
+        }
+    slice_text = _extract_relevant_markdown_slice(text, session, section_token_limit)
+    return {
+        "path": str(relative_path),
+        "exists": True,
+        "included": True,
+        "truncated": True,
+        "estimated_tokens": estimated_tokens,
+        "included_estimated_tokens": _estimate_tokens(slice_text),
+        "content": slice_text,
+    }
+
+
+def _extract_relevant_markdown_slice(
+    text: str,
+    session: dict[str, Any],
+    token_limit: int,
+) -> str:
+    char_limit = token_limit * _APPROX_CHARS_PER_TOKEN
+    sections = _markdown_sections(text)
+    if not sections:
+        return _truncate_text(text, char_limit)
+    terms = _context_terms(session)
+    scored = []
+    for index, section in enumerate(sections):
+        score = 0
+        lowered = section.lower()
+        for term in terms:
+            if term and term.lower() in lowered:
+                score += 3
+        if index == 0:
+            score += 2
+        if "open" in lowered or "grill" in lowered or "clarification" in lowered:
+            score += 1
+        scored.append((score, index, section))
+    selected: list[str] = []
+    total = 0
+    for _score, _index, section in sorted(scored, key=lambda item: (-item[0], item[1])):
+        if total >= char_limit:
+            break
+        remaining = char_limit - total
+        piece = section if len(section) <= remaining else _truncate_text(section, remaining)
+        selected.append(piece.rstrip())
+        total += len(piece)
+    return "\n\n".join(selected).strip()
+
+
+def _markdown_sections(text: str) -> list[str]:
+    sections: list[str] = []
+    current: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("#") and current:
+            sections.append("\n".join(current).strip())
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        sections.append("\n".join(current).strip())
+    return [section for section in sections if section]
+
+
+def _context_terms(session: dict[str, Any]) -> list[str]:
+    terms = [str(session.get("initial_prompt", ""))]
+    current = _current_question(session)
+    if current:
+        terms.append(str(current.get("question", "")))
+        terms.append(str(current.get("recommended", "")))
+    for item in session.get("pending_questions") or []:
+        terms.append(str(item.get("question", "")))
+        terms.append(str(item.get("recommended", "")))
+    for item in session.get("clarifications", [])[-5:]:
+        terms.append(str(item.get("answer", "")))
+        for question in item.get("questions") or []:
+            terms.append(str(question.get("question", "")))
+    return [term.strip() for term in terms if term and term.strip()]
+
+
+def _truncate_text(text: str, char_limit: int) -> str:
+    if len(text) <= char_limit:
+        return text
+    return text[: max(0, char_limit - 80)].rstrip() + "\n\n[... truncated by Grill-Me prompt context budget ...]"
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, (len(text) + _APPROX_CHARS_PER_TOKEN - 1) // _APPROX_CHARS_PER_TOKEN)
 
 
 def _asked_questions(session: dict[str, Any]) -> list[dict[str, str]]:

--- a/tests/runtime/test_harvest_ui_grill_me_command.py
+++ b/tests/runtime/test_harvest_ui_grill_me_command.py
@@ -2,16 +2,27 @@ import json
 import subprocess
 from pathlib import Path
 
-from harness_codex.runtime.harvest_ui import GRILL_ME_SKILL_PATH, _run_grill_me
+import pytest
+
+from harness_codex.runtime.harvest_ui import (
+    GRILL_ME_SKILL_PATH,
+    REQUIREMENTS_PATH,
+    _grill_me_prompt,
+    _run_grill_me,
+)
+
+
+def _write_skills(root: Path) -> None:
+    skill_path = root / GRILL_ME_SKILL_PATH
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Grill Me\n", encoding="utf-8")
+    requirements_skill = root / ".codex/skills/harness-requirements/SKILL.md"
+    requirements_skill.parent.mkdir(parents=True, exist_ok=True)
+    requirements_skill.write_text("# Requirements\n", encoding="utf-8")
 
 
 def test_grill_me_command_skips_git_repo_check(tmp_path: Path, monkeypatch) -> None:
-    skill_path = tmp_path / GRILL_ME_SKILL_PATH
-    skill_path.parent.mkdir(parents=True)
-    skill_path.write_text("# Grill Me\n", encoding="utf-8")
-    requirements_skill = tmp_path / ".codex/skills/harness-requirements/SKILL.md"
-    requirements_skill.parent.mkdir(parents=True)
-    requirements_skill.write_text("# Requirements\n", encoding="utf-8")
+    _write_skills(tmp_path)
 
     captured = {}
 
@@ -37,3 +48,72 @@ def test_grill_me_command_skips_git_repo_check(tmp_path: Path, monkeypatch) -> N
     assert result == {"complete": True, "questions": []}
     assert "--skip-git-repo-check" in captured["command"]
     assert captured["command"].index("--skip-git-repo-check") > captured["command"].index(str(tmp_path))
+
+
+def test_grill_me_prompt_uses_bounded_document_snapshot(tmp_path: Path) -> None:
+    _write_skills(tmp_path)
+    (tmp_path / REQUIREMENTS_PATH).parent.mkdir(parents=True, exist_ok=True)
+    large_body = "\n".join(f"- repeated requirement line {index}" for index in range(2000))
+    (tmp_path / REQUIREMENTS_PATH).write_text(
+        "# Requirements\n\n## Relevant\n- payment queue\n\n## Very Large Section\n" + large_body,
+        encoding="utf-8",
+    )
+
+    prompt = _grill_me_prompt(
+        tmp_path,
+        {
+            "initial_prompt": "payment queue",
+            "clarifications": [],
+            "current_question": None,
+            "current_questions": [],
+            "pending_questions": [],
+        },
+        tmp_path / GRILL_ME_SKILL_PATH,
+    )
+
+    assert "Repository context snapshot" in prompt
+    assert "Full documents and raw stdout/stderr are source artifacts" in prompt
+    assert '"truncated": true' in prompt
+    assert "repeated requirement line 1999" not in prompt
+    assert str(REQUIREMENTS_PATH) in prompt
+
+
+def test_grill_me_failure_reports_tail_and_log_paths(tmp_path: Path, monkeypatch) -> None:
+    _write_skills(tmp_path)
+
+    def fake_run(command, **kwargs):
+        stdout = "\n".join(f"out {index}" for index in range(80))
+        stderr = "\n".join(f"err {index}" for index in range(260))
+        return subprocess.CompletedProcess(command, 2, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(ValueError) as exc_info:
+        _run_grill_me(
+            tmp_path,
+            {
+                "initial_prompt": "build feature",
+                "clarifications": [],
+            },
+        )
+
+    message = str(exc_info.value)
+    assert "stdout_tail" in message
+    assert "stderr_tail" in message
+    assert "full_log_path" in message
+    assert "out 0" not in message
+    assert "out 79" in message
+    assert "err 0" not in message
+    assert "err 259" in message
+
+    run_dirs = list((tmp_path / ".harness/ui/grill-me-runs").iterdir())
+    assert len(run_dirs) == 1
+    run_dir = run_dirs[0]
+    assert (run_dir / "stdout.log").is_file()
+    assert (run_dir / "stderr.log").is_file()
+    assert (run_dir / "stdout.tail.log").is_file()
+    assert (run_dir / "stderr.tail.log").is_file()
+    report = json.loads((run_dir / "run-report.json").read_text(encoding="utf-8"))
+    assert report["exit_code"] == 2
+    assert report["logs"]["stdout_path"].endswith("stdout.log")
+    assert report["logs"]["stderr_tail_path"].endswith("stderr.tail.log")


### PR DESCRIPTION
## 구현 의도

Issue #131의 `grill-me` 입력 컨텍스트 토큰 최적화를 구현합니다.

기존 흐름은 Grill-Me 실행 시 세션 history와 skill 본문을 직접 prompt에 넣고, 실패 시 stdout/stderr 기반 에러를 만들 수 있어 문서/로그가 커질수록 토큰이 불필요하게 증가할 수 있었습니다.

## 구현 방법

- Grill-Me prompt에 `Repository context snapshot`을 추가했습니다.
- `docs/design/요구사항.md`, `docs/design/유스케이스.md`, `context.md`는 source of truth로 파일에 유지하되, prompt에는 작은 문서만 전문 포함하고 큰 문서는 관련 section snapshot만 포함하도록 했습니다.
- 문서 크기/섹션 크기 제한 상수를 추가했습니다.
  - `SMALL_DOC_TOKEN_LIMIT`
  - `MAX_SECTION_TOKENS`
  - `MAX_CONTEXT_SUMMARY_TOKENS`
- clarification history는 최근 항목 중심으로 압축하고 omitted count를 남기도록 했습니다.
- stdout/stderr는 전체를 `.log` 파일로 저장하고, 별도 tail 파일과 `run-report.json`을 남기도록 했습니다.
- Grill-Me 실패 메시지는 전체 로그가 아니라 다음 정보만 포함하도록 변경했습니다.
  - command
  - exit_code
  - stdout_tail
  - stderr_tail
  - full_log_path
- 기존 호환성을 위해 `stdout.txt`, `stderr.txt`도 계속 저장합니다.

## 검증 방법

테스트를 추가/수정했습니다.

- 큰 `요구사항.md`가 prompt에 전체 주입되지 않고 bounded snapshot으로 들어가는지 검증
- 실패 시 stdout/stderr 전체가 아니라 tail과 log path만 에러 메시지에 포함되는지 검증
- `stdout.log`, `stderr.log`, `stdout.tail.log`, `stderr.tail.log`, `run-report.json` 생성 검증
- 기존 codex command 구성 검증 유지

로컬에서는 네트워크 제한으로 저장소 clone/pytest 실행은 수행하지 못했습니다. 대신 GitHub 커넥터로 파일을 직접 수정하고 브랜치 diff를 확인했습니다.

## 변경 파일

- `harness_codex/runtime/harvest_ui.py`
- `tests/runtime/test_harvest_ui_grill_me_command.py`

Closes #131