### PR TITLE
Support branch alias for runtime update

### DIFF
--- a/docs/runtime-update-command.md
+++ b/docs/runtime-update-command.md
@@ -13,14 +13,32 @@ The command downloads the installer from the configured harness-codex repository
 ```bash
 ./harness update --dry-run
 ./harness update --ref main
-./harness update --ref <branch-or-commit> --skip-venv
+./harness update --ref <branch-or-tag-or-commit> --skip-venv
+./harness update --branch <branch-name>
 ./harness update --repo https://github.com/omegafrog/harness-codex
 ```
 
 - `--dry-run`: print the installer command without running it.
 - `--ref`: branch, tag, or commit to install. Defaults to `main`.
+- `--branch`: branch to install. Convenience alias for `--ref` when testing a runtime branch.
 - `--repo`: GitHub repository URL. Defaults to `https://github.com/omegafrog/harness-codex`.
 - `--skip-venv`: skip venv creation and dependency installation.
+
+`--ref` and `--branch` are mutually exclusive. Use only one of them.
+
+## Testing a Runtime Branch
+
+To run a project with a runtime from a feature branch:
+
+```bash
+./harness update --branch codex/some-runtime-branch
+```
+
+The update output prints the selected ref before running the installer:
+
+```text
+Selected harness-codex ref: codex/some-runtime-branch
+```
 
 ## Warning
 

--- a/harness_codex/runtime/self_update.py
+++ b/harness_codex/runtime/self_update.py
@@ -47,8 +47,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--ref",
-        default=DEFAULT_REF,
+        default=None,
         help=f"branch, tag, or commit to install. Default: {DEFAULT_REF}",
+    )
+    parser.add_argument(
+        "--branch",
+        default=None,
+        help="branch to install. Convenience alias for --ref.",
     )
     parser.add_argument(
         "--skip-venv",
@@ -69,15 +74,17 @@ def run_self_update(
     *,
     runner: Runner = subprocess.run,
 ) -> str:
+    selected_ref = _selected_ref(args)
     command = build_update_command(
         repo_root.resolve(),
         repo=args.repo,
-        ref=args.ref,
+        ref=selected_ref,
         skip_venv=args.skip_venv,
     )
     warning = _warning()
+    selected = f"Selected harness-codex ref: {selected_ref}"
     if args.dry_run:
-        return "\n".join([warning, "Dry run. Command:", command])
+        return "\n".join([warning, selected, "Dry run. Command:", command])
 
     completed = runner(
         command,
@@ -97,7 +104,7 @@ def run_self_update(
             "harness update failed"
             + (f":\n{output}" if output else f" with exit code {completed.returncode}")
         )
-    return "\n".join([warning, output, "harness-codex update completed."]).strip()
+    return "\n".join([warning, selected, output, "harness-codex update completed."]).strip()
 
 
 def build_update_command(
@@ -125,6 +132,18 @@ def build_update_command(
     if skip_venv:
         parts.append("--skip-venv")
     return " ".join(parts)
+
+
+def _selected_ref(args: argparse.Namespace) -> str:
+    ref = getattr(args, "ref", None)
+    branch = getattr(args, "branch", None)
+    if ref and branch:
+        raise ValueError("use either --ref or --branch, not both")
+    selected = branch or ref or DEFAULT_REF
+    selected = str(selected).strip()
+    if not selected:
+        raise ValueError("selected ref must not be empty")
+    return selected
 
 
 def _installer_url(repo: str, ref: str) -> str:

--- a/tests/runtime/test_self_update.py
+++ b/tests/runtime/test_self_update.py
@@ -2,7 +2,7 @@ import subprocess
 from argparse import Namespace
 from pathlib import Path
 
-from harness_codex.runtime.self_update import build_update_command, run_self_update
+from harness_codex.runtime.self_update import build_parser, build_update_command, run_self_update
 
 
 def test_build_update_command_defaults_to_force_target_and_ref(tmp_path: Path) -> None:
@@ -21,6 +21,14 @@ def test_build_update_command_supports_skip_venv(tmp_path: Path) -> None:
     assert "--skip-venv" in command
 
 
+def test_update_parser_accepts_branch_alias() -> None:
+    args = build_parser().parse_args(["--branch", "codex/runtime-test", "--dry-run"])
+
+    assert args.branch == "codex/runtime-test"
+    assert args.ref is None
+    assert args.dry_run is True
+
+
 def test_run_self_update_dry_run_does_not_call_runner(tmp_path: Path) -> None:
     called = False
 
@@ -34,6 +42,7 @@ def test_run_self_update_dry_run_does_not_call_runner(tmp_path: Path) -> None:
         Namespace(
             repo="https://github.com/omegafrog/harness-codex",
             ref="main",
+            branch=None,
             skip_venv=True,
             dry_run=True,
         ),
@@ -42,8 +51,44 @@ def test_run_self_update_dry_run_does_not_call_runner(tmp_path: Path) -> None:
 
     assert called is False
     assert "Dry run. Command:" in output
+    assert "Selected harness-codex ref: main" in output
     assert "--skip-venv" in output
     assert "may overwrite" in output
+
+
+def test_run_self_update_uses_branch_alias_for_ref(tmp_path: Path) -> None:
+    output = run_self_update(
+        tmp_path,
+        Namespace(
+            repo="https://github.com/omegafrog/harness-codex",
+            ref=None,
+            branch="codex/runtime-test",
+            skip_venv=True,
+            dry_run=True,
+        ),
+    )
+
+    assert "Selected harness-codex ref: codex/runtime-test" in output
+    assert "https://raw.githubusercontent.com/omegafrog/harness-codex/codex/runtime-test/scripts/install-harness-codex.sh" in output
+    assert "--ref codex/runtime-test" in output
+
+
+def test_run_self_update_rejects_ref_and_branch_together(tmp_path: Path) -> None:
+    try:
+        run_self_update(
+            tmp_path,
+            Namespace(
+                repo="https://github.com/omegafrog/harness-codex",
+                ref="main",
+                branch="codex/runtime-test",
+                skip_venv=False,
+                dry_run=True,
+            ),
+        )
+    except ValueError as exc:
+        assert "use either --ref or --branch" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
 
 
 def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
@@ -58,6 +103,7 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
         Namespace(
             repo="https://github.com/omegafrog/harness-codex",
             ref="main",
+            branch=None,
             skip_venv=True,
             dry_run=False,
         ),
@@ -70,6 +116,7 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
     assert f"--target {tmp_path}" in command
     assert calls[0][1]["cwd"] == tmp_path
     assert calls[0][1]["shell"] is True
+    assert "Selected harness-codex ref: main" in output
     assert output.endswith("harness-codex update completed.")
 
 
@@ -83,6 +130,7 @@ def test_run_self_update_reports_failed_installer(tmp_path: Path) -> None:
             Namespace(
                 repo="https://github.com/omegafrog/harness-codex",
                 ref="main",
+                branch=None,
                 skip_venv=False,
                 dry_run=False,
             ),


### PR DESCRIPTION
## 구현 의도

Issue #133의 요청대로 특정 브랜치 버전의 런타임을 쉽게 업데이트/실행해볼 수 있도록 `harness update` 명령을 개선합니다.

기존에도 `--ref`는 있었지만, 브랜치 테스트 목적을 명확히 드러내는 `--branch` alias가 없었고, update 결과에 어떤 ref가 선택되었는지 명시적으로 남지 않았습니다.

## 구현 방법

- `harness update --branch <branch-name>` 옵션을 추가했습니다.
- `--branch`는 `--ref`의 convenience alias로 동작합니다.
- `--ref`와 `--branch`를 동시에 지정하면 `ValueError`로 실패하도록 했습니다.
- ref/branch 미지정 시 기존처럼 `main`을 사용합니다.
- dry-run 및 실제 update 출력에 `Selected harness-codex ref: <ref>`를 남기도록 했습니다.
- `docs/runtime-update-command.md`에 브랜치 런타임 테스트 예시를 추가했습니다.

## 검증 방법

테스트를 추가/수정했습니다.

- parser가 `--branch`를 받는지 검증
- dry-run에서 `--branch`가 installer URL과 `--ref` 인자로 반영되는지 검증
- `--ref`와 `--branch` 동시 지정 시 실패하는지 검증
- 기존 `--ref`, `--skip-venv`, dry-run, installer 실행 테스트 유지

로컬 pytest는 이 환경의 저장소 clone/실행 제한 때문에 수행하지 못했습니다. GitHub 커넥터로 파일 변경과 main 대비 diff는 확인했습니다.

## 변경 파일

- `harness_codex/runtime/self_update.py`
- `tests/runtime/test_self_update.py`
- `docs/runtime-update-command.md`

Closes #133