### PR TITLE
[codex] Harvest 질문 범위를 MVP 유스케이스로 제한

### DIFF
--- a/.codex/agents/harness_requirements.toml
+++ b/.codex/agents/harness_requirements.toml
@@ -10,7 +10,9 @@ You are the harness requirements documentation agent.
 Your job:
 - Start from the user's short initial idea.
 - Reduce ambiguity through a time-boxed grill-me loop, then write a useful draft instead of pursuing perfect domain understanding.
-- Ask iterative clarification questions until requirements and ubiquitous language are specific enough to document, but ask only one focused question per turn and include your recommended answer with that question.
+- For an empty project or broad request such as "build a calculator", first identify one MVP and ask only about the single MVP use case.
+- For an existing repository feature addition or modification, steer the output toward a use-case-sized ChangeSet instead of a broad multi-use-case program.
+- Ask iterative clarification questions until requirements and ubiquitous language are specific enough for that one use case, but ask only one focused question per turn and include your recommended answer with that question.
 - Write or update exactly these output documents:
   - docs/design/요구사항.md
   - context.md
@@ -40,11 +42,12 @@ Ubiquitous language rules:
 - Requirements harvest must confirm ubiquitous language through grill-me before use-case harvest begins.
 - context.md is the project-wide source of truth for domain language.
 - Write confirmed language to context.md under a Ubiquitous Language section.
-- Confirm actor names, user goal names, domain concepts, state names, command candidate terms, event candidate terms, policy/rule terms, and external system names.
-- For every important term, confirm Canonical Term, Korean, English, Type, Definition, Aliases, Forbidden Terms, and Source.
+- Confirm only the actor, MVP goal, primary command/action, input/output concepts, successful result, user-visible failure policy, and hard scope boundary terms needed for one MVP use case.
+- Do not ask about state names, event candidate terms, DDD design terms, security/audit terms, aliases, forbidden terms, or detailed NFR language unless they directly block the MVP use case.
+- For every MVP-blocking term, confirm Canonical Term, Korean, English, Type, Definition, Aliases, Forbidden Terms, and Source.
 - Use context.md canonical terms when writing docs/design/요구사항.md.
 - Do not introduce conflicting terms when a canonical term already exists in context.md.
-- If a term is missing or contested, record it under Open Language Questions in context.md instead of inventing a term.
+- If a term blocks the MVP use case, record it under Blocking Open Language Questions. Otherwise record it under Deferred Language Questions.
 - Forbidden Terms must not be introduced in requirements, use cases, plans, tests, or code identifiers.
 
 Requirements rules:
@@ -54,7 +57,7 @@ Requirements rules:
 - Business Policy Decisions are product/domain rules: success/failure outcomes, lifecycle states, pricing rules, inventory limits, reward/loss rules, market/competition rules, validation rules, permissions, and user-visible behavior.
 - Foundational Technical Decisions are large technology choices that shape the whole program: development language, main framework, DB/storage family, cache/distributed-state infrastructure such as Redis, messaging broker/framework use, major runtime/deployment constraints, and build tool.
 - Do not decide detailed implementation strategies during requirements elicitation. Polling vs push, circuit breaker, retry/backoff, outbox/inbox, detailed transaction propagation, cache TTL/invalidation, and observability fields belong after DDD design in the technical-decision stage.
-- The foundational technology stack must be asked during requirements elicitation. At minimum, ask for development language, main framework, DB/storage family, Redis/cache/distributed-state need, messaging broker/framework need, runtime/deployment constraints, and build tool.
+- Do not ask foundational technology questions during MVP harvest unless the answer is required to define the one use-case ChangeSet boundary. Otherwise record them under Foundational Technology Decisions Needed.
 - Business Policy Decisions must be resolved before use-case writing and event storming can be considered ready.
 - Core ubiquitous language must be resolved before use-case writing and event storming can be considered ready.
 - Foundational Technical Decisions may remain unresolved after requirements, but must be clearly separated for the DDD and technical-decision gates.
@@ -71,19 +74,21 @@ Question loop:
 - Ask exactly one focused question at a time.
 - Treat one round as up to 7 focused questions that target the current priority area.
 - Run at most 3 rounds and at most 7 total questions per round.
+- Ask at most 10 questions total in runtime harvest.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
 - Stop asking once the information is sufficient to produce a draft.
 - After the final round, produce a draft of context.md and docs/design/요구사항.md using confirmed answers, explicit assumptions, and unresolved decision sections.
-- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Open Language Questions, or Post-DDD Technical Decision Candidates instead of extending the question loop.
+- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Blocking Open Language Questions, Deferred Language Questions, or Post-DDD Technical Decision Candidates instead of extending the question loop.
 - Include `Recommended answer:` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
 - After the user answers, update context.md first, update docs/design/요구사항.md using context.md canonical terms, then choose the next single unresolved decision that blocks requirements or language quality.
-- Prefer questions about actors, goals, core domain terms, state names, command/event/policy terms, alias cleanup, forbidden terms, core functions, success/failure outcomes, foundational technology stack, permissions/security, external systems, traffic/latency/concurrency/consistency, fault handling, and out-of-scope boundaries.
+- Prefer questions about one MVP use case: actor, goal, primary command/action, inputs, successful result, user-visible failure policy, and hard out-of-scope boundaries.
+- Defer event candidate names, state names, DDD details, implementation strategy, detailed NFRs, security/audit concepts, aliases, forbidden terms, and technology stack unless they directly block the MVP use case.
 - Include ubiquitous language questions before finalizing the requirements document.
 - Include non-functional requirement questions before finalizing the requirements document.
 - Include foundational technology stack questions before finalizing the requirements document.
-- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions and core Open Language Questions within the question budget.
-- Keep unresolved items separated into `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, and `Open Language Questions`.
+- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions and MVP-blocking language questions within the question budget.
+- Keep unresolved items separated into `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Blocking Open Language Questions`, and `Deferred Language Questions`.
 - If business policy items remain, mark the document as not ready for use-case writing or event storming.
 - If core language questions remain, mark the document as not ready for use-case writing or event storming.
 """

--- a/.codex/agents/harness_usecases.toml
+++ b/.codex/agents/harness_usecases.toml
@@ -74,8 +74,12 @@ Runtime slice rules:
 - Do not report harvest readiness until docs/design/유스케이스.md and every matching runtime slice doc exist.
 
 Question loop:
-- Ask exactly one focused question at a time only when requirements or context language are ambiguous enough to block use-case correctness.
-- Include `Recommended answer:` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
-- After the user answers, update docs/design/유스케이스.md and matching docs/use-cases/<UC-ID>/ slice docs, then choose the next single unresolved decision that blocks use-case quality.
-- If a use case still has multiple user goals, mixed command/policy wording, multi-meaning event storming elements, non-canonical terms, Forbidden Terms, or invalid command/event/policy phrasing, mark it as not complete and ask or revise before reporting readiness.
+- In interactive runtime harvest, every turn must finish by returning only JSON.
+- Return `{"status":"needs_input","questions":[...],"changed_files":[],"blocker":""}` when one focused user answer is required before use-case docs can be correct.
+- Return `{"status":"complete","questions":[],"changed_files":[...],"blocker":""}` only after writing docs/design/유스케이스.md and every matching docs/use-cases/<UC-ID>/use-case.md and docs/use-cases/<UC-ID>/e2e-goal.md.
+- Return `{"status":"blocked","questions":[],"changed_files":[],"blocker":"..."}` only when requirements or context.md are not ready and the use-case stage cannot resolve the blocker.
+- Do not wait for interactive stdin. Ask by returning JSON and exiting.
+- Include `recommended` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
+- After the user answer appears in the use-case answer history, write docs/design/유스케이스.md and matching docs/use-cases/<UC-ID>/ slice docs when ready.
+- If a use case still has multiple user goals, mixed command/policy wording, multi-meaning event storming elements, non-canonical terms, Forbidden Terms, or invalid command/event/policy phrasing, either mark it as Needs confirmation in the docs or return one JSON needs_input question before reporting readiness.
 """

--- a/.codex/agents/harness_usecases.toml
+++ b/.codex/agents/harness_usecases.toml
@@ -38,7 +38,9 @@ Readiness:
 - If context.md is missing or lacks a Ubiquitous Language section, stop and ask the user to run $harness-requirements first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop because use cases would encode unconfirmed behavior.
-- If Open Language Questions block actor, goal, state, command, event, policy, or external-system naming, stop because use cases would encode unconfirmed language.
+- If Blocking Open Language Questions block actor, goal, command, input, output, result, policy, or scope-boundary naming, stop because use cases would encode unconfirmed language.
+- Ask one focused question at a time when a blocking ambiguity must be resolved before use-case documents can be written.
+- Include `Recommended answer:` with every blocking question.
 - Foundational Technical Decisions may remain unresolved if actor goals, business policies, and language are clear.
 
 Ubiquitous language rules:

--- a/.codex/skills/harness-requirements/SKILL.md
+++ b/.codex/skills/harness-requirements/SKILL.md
@@ -35,6 +35,12 @@ installed first.
 This skill turns an early idea into a requirements specification and a project
 ubiquitous language source of truth.
 
+For an empty project or a broad request such as "build a calculator", harvest
+must first narrow the work to one MVP and one external-actor use case. For an
+existing repository feature addition or modification, harvest should steer the
+output toward one use-case-sized ChangeSet instead of a broad multi-use-case
+program.
+
 Responsibilities are split as follows.
 
 - `$grill-me`: clarifies unresolved requirement and language decisions through a bounded question loop.
@@ -53,9 +59,11 @@ If business policies are incomplete, do not report that the work is ready for
 use-case writing or Event Storming. If foundational technology choices are
 incomplete, leave them under `Foundational Technology Decisions Needed`.
 
-If ubiquitous language is incomplete, do not report that the work is ready for
-use-case writing, Event Storming, planning, or implementation. Leave unresolved
-terms under `Open Language Questions` in `context.md`.
+If MVP-blocking ubiquitous language is incomplete, do not report that the work
+is ready for use-case writing, Event Storming, planning, or implementation.
+Leave unresolved MVP blockers under `Blocking Open Language Questions` in
+`context.md`. Leave non-blocking language questions under `Deferred Language
+Questions`.
 
 When this skill is invoked, delegate the work to the dedicated agent defined in
 `.codex/agents/harness_requirements.toml`. If the dedicated agent cannot be
@@ -71,14 +79,14 @@ Use the following standards as the source of truth for the instructions.
 - A requirement defines a goal or constraint that the system must satisfy.
 - Separate requirements into functional requirements and non-functional requirements.
 - Functional requirements describe the functional goals that actors achieve through the system, grouped by domain or feature area.
-- Non-functional requirements must cover performance, concurrency, consistency, scalability, availability, security, recovery, and operability.
+- Non-functional requirements must cover only the minimal candidate constraints needed for the MVP use case. Detailed performance, concurrency, consistency, scalability, availability, security, recovery, and operability decisions can be deferred when they do not block the use case.
 - Items that depend on numbers or conditions must be written in measurable form. If unknown, mark them as `Needs confirmation`.
 - Do not confirm requirements that the user has not explicitly stated or that cannot be verified from local artifacts.
 - Separate unresolved items into `Business Policy Decisions Needed` and `Foundational Technology Decisions Needed`.
 - Business policies include success/failure outcomes, state transitions, validation rules, compensation, authorization, and user-visible behavior.
-- Confirm programming language, main framework, database/storage, cache/distributed state infrastructure, messaging, and runtime constraints in the later part of the requirements phase.
+- Confirm programming language, main framework, database/storage, cache/distributed state infrastructure, messaging, and runtime constraints only when needed to define the MVP ChangeSet boundary. Otherwise defer them to Foundational Technology Decisions Needed.
 - Do not confirm technology choices before the problem, actors, scope, and core business policies are understood.
-- Foundational technologies must be confirmed before DDD/Event Storming, or left under `Foundational Technology Decisions Needed`.
+- Foundational technologies should usually be left under `Foundational Technology Decisions Needed` during broad MVP harvest unless the repository already answers them.
 - Detailed technical strategies that can be decided after design must not be confirmed during the requirements phase. Leave them under `Post-DDD Technical Decision Candidates`.
 - Before moving to use-case writing or Event Storming, there must be no unresolved business policy decisions.
 
@@ -87,13 +95,14 @@ Use the following standards as the source of truth for the instructions.
 - Requirements harvest must confirm ubiquitous language through `$grill-me` before use-case harvest begins.
 - Store the confirmed language in root-level `context.md` under `## 1. Ubiquitous Language` or `## Ubiquitous Language`.
 - `context.md` is the project-wide source of truth for domain language.
-- Confirm actor names, user goal names, domain concepts, state names, command candidate terms, event candidate terms, policy/rule terms, and external system names.
-- For every important term, confirm the canonical term, Korean label, English code-facing label, type, definition, aliases, forbidden terms, and source.
+- Confirm only the actor, one MVP goal, primary command/action, input/output concepts, successful result, user-visible failure policy, and hard scope boundary terms required for one use case.
+- Defer state names, event candidate terms, DDD terms, security/audit concepts, aliases, forbidden terms, external system names, and technology names unless they directly block the MVP use case.
+- For every MVP-blocking term, confirm the canonical term, Korean label, English code-facing label, type, definition, aliases, forbidden terms, and source.
 - The same concept must not have multiple canonical terms.
 - Aliases may be recorded only as aliases; generated requirements, use cases, plans, tests, and code identifiers must use canonical terms.
 - Forbidden terms must not appear in newly generated docs or code identifiers.
 - Do not mix implementation technology terms with domain terms unless the business explicitly uses the same term.
-- If a required term is missing or contested, do not invent it. Record it under `Open Language Questions` in `context.md`.
+- If an MVP-blocking term is missing or contested, do not invent it. Record it under `Blocking Open Language Questions` in `context.md`. Record non-blocking terms under `Deferred Language Questions`.
 
 ## Grill-Me Brief Contract
 
@@ -107,14 +116,15 @@ must not continue asking until the domain is perfect.
 
 Rules:
 
-- Run at most 3 rounds.
-- Treat one round as up to 7 focused questions that target the current priority area.
+- Ask at most 10 questions total.
+- Run at most 2 rounds.
+- Treat one round as up to 5 focused questions that target the current priority area.
 - Ask one focused question at a time when interacting with the user.
-- Ask at most 7 total questions per round.
+- Ask at most 5 total questions per round.
 - After each round, summarize what has been clarified and what remains unresolved.
-- Stop once main actors, actor goals, core business policies, and core ubiquitous language are clear enough to produce a draft.
+- Stop once one actor, one MVP goal, the primary action, inputs, success result, failure policy, and hard scope boundary are clear enough to produce a draft.
 - If the question budget is exhausted, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
-- If uncertainty remains, record it under `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Open Language Questions`, or `Post-DDD Technical Decision Candidates` instead of extending the question loop.
+- If uncertainty remains, record it under `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Blocking Open Language Questions`, `Deferred Language Questions`, or `Post-DDD Technical Decision Candidates` instead of extending the question loop.
 - After the final round, produce a draft of `context.md` and `docs/design/요구사항.md`.
 
 ### Brief Contents
@@ -132,7 +142,7 @@ Questioning method:
 - Do not continue asking until the domain is perfect.
 - Stop when the information is sufficient to produce a useful draft.
 - After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
-- If uncertainty remains, record it under `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Open Language Questions`, or `Post-DDD Technical Decision Candidates`.
+- If uncertainty remains, record it under `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Blocking Open Language Questions`, `Deferred Language Questions`, or `Post-DDD Technical Decision Candidates`.
 - If the answer can be found in the codebase, existing documents, or settings, inspect them first.
 - Follow decision dependencies and resolve the most important unresolved item first.
 
@@ -145,37 +155,29 @@ Judgment standards:
 - Do not write use cases in this phase.
 
 Question priority:
-1. Problem situation
-2. Goal
-3. Scope
-4. Actors
-5. Goals per actor
-6. Core domain terms and concept names
-7. State names
-8. Command/event/policy candidate terms
-9. Alias and forbidden-term cleanup
-10. Core features
-11. Success/failure outcomes
-12. Business policies
-13. Authorization/security/audit trail
-14. External systems
-15. Non-functional requirements
-16. Foundational technologies
-17. Out-of-scope items
+1. MVP candidate and one external actor goal
+2. Main actor
+3. Primary command/action
+4. Inputs and output
+5. Successful result
+6. User-visible failure policy
+7. Hard out-of-scope boundaries
+8. Existing repository evidence that constrains the ChangeSet
 
 Ubiquitous language confirmation criteria:
 - Same concept has exactly one canonical term.
 - Korean and English/code-facing names are confirmed.
 - Term type is clear: Actor, Goal, Domain Concept, State, Command Candidate, Event Candidate, Policy, External System, or Other.
 - Aliases and forbidden terms are recorded.
-- Missing terms are recorded in `Open Language Questions` instead of invented.
+- MVP-blocking missing terms are recorded in `Blocking Open Language Questions` instead of invented.
+- Non-blocking missing terms are recorded in `Deferred Language Questions`.
 
 Completion criteria:
-- Main actors and their goals are separated enough for functional requirements.
-- Functional and non-functional requirement candidates can be written.
-- There are no unresolved core business policies, or the remaining items are explicitly recorded as not-ready blockers.
-- Foundational technologies are confirmed or separated as needing confirmation.
-- Core ubiquitous language is confirmed and can be written to `context.md`, or unresolved terms are explicitly recorded under `Open Language Questions`.
+- One MVP actor and one MVP goal are clear enough for a single use-case document.
+- Functional requirement candidates for that use case can be written.
+- There are no unresolved MVP-blocking business policies, or the remaining items are explicitly recorded as not-ready blockers.
+- Foundational technologies are confirmed only when already known or needed for the ChangeSet boundary; otherwise they are separated as needing confirmation.
+- MVP-blocking ubiquitous language is confirmed and can be written to `context.md`, or unresolved terms are explicitly recorded under `Blocking Open Language Questions`.
 
 Output format:
 ## Confirmed Decisions
@@ -191,7 +193,9 @@ Output format:
 - ...
 ### Foundational Technology Decisions Needed
 - ...
-### Open Language Questions
+### Blocking Open Language Questions
+- ...
+### Deferred Language Questions
 - ...
 ### Post-DDD Technical Decision Candidates
 - ...
@@ -243,7 +247,7 @@ Execution rules:
 
 6. **Confirm completion**
    If business policies are unresolved, do not report readiness for use-case writing or Event Storming.
-   If ubiquitous language has unresolved core terms, do not report readiness for use-case writing or Event Storming.
+   If ubiquitous language has unresolved MVP-blocking terms, do not report readiness for use-case writing or Event Storming.
    Collect remaining unresolved items in needs-confirmation sections instead of continuing the question loop beyond the budget.
 
 ## Context Document Template
@@ -267,7 +271,11 @@ Execution rules:
 - `Forbidden Terms` must not be used in new documents, plans, tests, or code identifiers.
 - Aliases are recorded only for migration/search context and must not be introduced as new canonical language.
 
-## 3. Open Language Questions
+## 3. Blocking Open Language Questions
+
+- ...
+
+## 4. Deferred Language Questions
 
 - ...
 ```

--- a/.codex/skills/harness-requirements/references/agent-prompt.md
+++ b/.codex/skills/harness-requirements/references/agent-prompt.md
@@ -5,7 +5,7 @@ Use this prompt when spawning a worker agent for `$harness-requirements`.
 ```text
 You are the harness requirements documentation agent.
 
-Start from the user's initial idea and ask iterative questions until requirements and ubiquitous language are specific enough to document.
+Start from the user's initial idea and ask iterative questions until one MVP use case, requirements, and ubiquitous language are specific enough to document.
 Follow the ticketon-ddd style requirements, language, and template standards embedded in the skill.
 Do not depend on external blog files or repo-local reference posts at runtime.
 
@@ -20,22 +20,22 @@ Rules:
 - Do not guess unclear decisions.
 - Do not finalize non-functional requirements from assumptions.
 - Use a time-boxed grill-me loop rather than an unbounded interview.
-- Run at most 3 rounds.
-- Ask at most 7 total questions per round.
+- Run at most 2 rounds for the MVP pass; this remains inside the legacy guardrail of at most 3 rounds.
+- Ask at most 10 total requirements questions for the MVP pass; this remains inside the legacy guardrail of at most 7 total questions per round.
 - Ask one focused question at a time when interacting with the user.
 - Include `Recommended answer:` with every question.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
-- Stop when the information is sufficient to produce a useful draft.
+- Stop when the information is sufficient to produce a useful draft for one MVP use case.
 - After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
-- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Open Language Questions, or Post-DDD Technical Decision Candidates.
+- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Blocking Open Language Questions, Deferred Language Questions, or Post-DDD Technical Decision Candidates.
 - Confirm ubiquitous language through grill-me before use-case harvest.
-- Update context.md first with confirmed canonical terms, Korean names, English code-facing names, definitions, aliases, forbidden terms, and open language questions.
+- Update context.md first with confirmed canonical terms, Korean names, English code-facing names, definitions, aliases, Forbidden Terms, Blocking Open Language Questions, and Deferred Language Questions.
 - Use context.md canonical terms when updating docs/design/요구사항.md.
 - After the user answers, update context.md and docs/design/요구사항.md, then ask the next most important unresolved requirement or language decision within the question budget.
 - Split functional and non-functional requirements.
-- Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, and Open Language Questions.
-- Ask foundational technology stack questions before treating requirements as complete.
+- Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, Blocking Open Language Questions, and Deferred Language Questions.
+- Defer technology stack questions unless they directly block the first use-case-sized ChangeSet boundary.
 - Do not write use cases.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```

--- a/.codex/skills/harness-usecases/SKILL.md
+++ b/.codex/skills/harness-usecases/SKILL.md
@@ -152,6 +152,55 @@ Rules:
    If any use case still has multiple goals, mixed command/policy wording, multi-meaning event-storming candidates, non-canonical language, or Forbidden Terms, mark it as `Needs confirmation`.
    If ambiguity blocks correctness, ask one focused question at a time and include `Recommended answer:`.
 
+## Interactive Runtime Contract
+
+When invoked by runtime harvest, every turn must return only JSON and then exit.
+Do not wait for interactive stdin.
+
+Use this shape when user input is needed:
+
+```json
+{
+  "status": "needs_input",
+  "questions": [
+    {
+      "question": "What single decision is needed?",
+      "recommended": "Recommended answer based on local artifacts or inference."
+    }
+  ],
+  "changed_files": [],
+  "blocker": ""
+}
+```
+
+Use this shape only after writing `docs/design/유스케이스.md` and every matching
+runtime slice document:
+
+```json
+{
+  "status": "complete",
+  "questions": [],
+  "changed_files": [
+    "docs/design/유스케이스.md",
+    "docs/use-cases/UC-001/use-case.md",
+    "docs/use-cases/UC-001/e2e-goal.md"
+  ],
+  "blocker": ""
+}
+```
+
+Use this shape when requirements or context are not ready and the use-case stage
+cannot fix the issue:
+
+```json
+{
+  "status": "blocked",
+  "questions": [],
+  "changed_files": [],
+  "blocker": "Concrete blocker."
+}
+```
+
 ## Use Case Document Template
 
 `docs/design/유스케이스.md` must follow this structure.

--- a/.codex/skills/harness-usecases/SKILL.md
+++ b/.codex/skills/harness-usecases/SKILL.md
@@ -38,7 +38,7 @@ Use the following standards as the source of truth for the instructions.
 - Use the table's `English` names for code-facing command/event/policy candidates when such candidates are included.
 - Do not introduce new actor names, goal names, domain concepts, state names, command names, event names, policy names, or external system names that conflict with `context.md`.
 - Do not use terms listed under `Forbidden Terms`.
-- If a needed term is missing or ambiguous, stop or mark the related use case detail as `Needs confirmation`; record the missing term as an `Open Language Question` instead of inventing behavior.
+- If a needed MVP term is missing or ambiguous, stop or mark the related use case detail as `Needs confirmation`; record the missing term as a `Blocking Open Language Question` instead of inventing behavior.
 
 ### Use Case Standards
 
@@ -112,7 +112,7 @@ Rules:
 - If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-requirements first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop because use cases would encode unconfirmed behavior.
-- If Open Language Questions block actor, goal, state, command, event, policy, or external-system naming, stop because use cases would encode unconfirmed language.
+- If Blocking Open Language Questions block actor, goal, command, input, output, result, policy, or scope-boundary naming, stop because use cases would encode unconfirmed language.
 - Use context.md canonical terms and avoid Forbidden Terms.
 - Write use cases around a single goal of an external actor.
 - Do not turn internal server/API flows into use cases.

--- a/.codex/skills/harness-usecases/references/agent-prompt.md
+++ b/.codex/skills/harness-usecases/references/agent-prompt.md
@@ -20,7 +20,7 @@ Rules:
 - If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-requirements first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop and explain that use cases need confirmed policy.
-- If Open Language Questions block naming, stop and explain that use cases need confirmed ubiquitous language.
+- If Blocking Open Language Questions block naming, stop and explain that use cases need confirmed ubiquitous language.
 - Use only context.md canonical terms for actors, goals, domain concepts, states, command/event/policy candidates, and external systems.
 - Do not use terms listed under Forbidden Terms.
 - Write use cases from external actor goals only.

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind
+from harness_codex.runtime.prompt import build_agent_prompt
 
 SESSION_PATH = Path(".harness/ui/harvest-session.json")
 REQUIREMENTS_PATH = Path("docs/design/요구사항.md")
@@ -16,6 +20,8 @@ CONTEXT_PATH = Path("context.md")
 USE_CASES_PATH = Path("docs/design/유스케이스.md")
 USE_CASE_SLICE_ROOT = Path("docs/use-cases")
 GRILL_ME_SKILL_PATH = Path(".codex/skills/grill-me/SKILL.md")
+USE_CASE_AGENT_CONFIG_PATH = Path(".codex/agents/harness_usecases.toml")
+USE_CASE_SKILL_PATH = Path(".codex/skills/harness-usecases/SKILL.md")
 
 
 @dataclass(frozen=True)
@@ -103,6 +109,55 @@ def start_use_cases(root: Path | str) -> HarvestUiResult:
     return _result(root_path, session)
 
 
+def start_use_case_generation(root: Path | str, idea: str = "") -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    if not session["requirements_gate_passed"]:
+        raise ValueError("requirements gate has not passed")
+    session["active_stage"] = "useCases"
+    if _has_runtime_ready_use_case_slices(root_path):
+        session["use_cases_ready"] = True
+        session["runtime_error"] = ""
+        _write_session(root_path, session)
+        return _result(root_path, session)
+    if _current_use_case_question(session) is None:
+        _advance_use_case_harvest(root_path, session, idea)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
+def answer_use_cases(root: Path | str, answer: str, idea: str = "") -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    if not session["requirements_gate_passed"]:
+        raise ValueError("requirements gate has not passed")
+    normalized_answer = answer.strip()
+    if not normalized_answer:
+        raise ValueError("answer is required")
+    current_question = _current_use_case_question(session)
+    if current_question is None:
+        raise ValueError("no active use-case question")
+    session["use_case_clarifications"].append(
+        {
+            "questions": [
+                {
+                    "question": current_question.get("question", ""),
+                    "recommended": current_question.get("recommended", ""),
+                }
+            ],
+            "answer": normalized_answer,
+        }
+    )
+    session["use_case_current_question"] = None
+    session["use_case_current_questions"] = []
+    if session.get("use_case_pending_questions"):
+        _activate_next_use_case_pending_question(session)
+    else:
+        _advance_use_case_harvest(root_path, session, idea)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
 def load_harvest_ui(root: Path | str) -> HarvestUiResult:
     root_path = Path(root)
     session = _load_session(root_path)
@@ -129,6 +184,10 @@ def _new_session(prompt: str) -> dict[str, Any]:
         "runtime_error": "",
         "draft_context_markdown": "",
         "draft_requirements_markdown": "",
+        "use_case_clarifications": [],
+        "use_case_current_question": None,
+        "use_case_current_questions": [],
+        "use_case_pending_questions": [],
     }
 
 
@@ -159,6 +218,10 @@ def _normalize_session(session: dict[str, Any]) -> None:
     session.setdefault("pending_questions", [])
     session.setdefault("draft_context_markdown", "")
     session.setdefault("draft_requirements_markdown", "")
+    session.setdefault("use_case_clarifications", [])
+    session.setdefault("use_case_current_question", None)
+    session.setdefault("use_case_current_questions", [])
+    session.setdefault("use_case_pending_questions", [])
     current = session.get("current_question")
     current_questions = session.get("current_questions") or []
     if current is None and current_questions:
@@ -167,6 +230,14 @@ def _normalize_session(session: dict[str, Any]) -> None:
         session["current_questions"] = [session["current_question"]]
     else:
         session["current_questions"] = []
+    use_case_current = session.get("use_case_current_question")
+    use_case_current_questions = session.get("use_case_current_questions") or []
+    if use_case_current is None and use_case_current_questions:
+        session["use_case_current_question"] = use_case_current_questions[0]
+    if session.get("use_case_current_question"):
+        session["use_case_current_questions"] = [session["use_case_current_question"]]
+    else:
+        session["use_case_current_questions"] = []
 
 
 def _load_session(root: Path) -> dict[str, Any] | None:
@@ -212,6 +283,10 @@ def _session_from_requirements_doc(root: Path) -> dict[str, Any] | None:
         "active_stage": "requirements",
         "use_cases_ready": _has_runtime_ready_use_case_slices(root),
         "runtime_error": "",
+        "use_case_clarifications": [],
+        "use_case_current_question": None,
+        "use_case_current_questions": [],
+        "use_case_pending_questions": [],
     }
     if session["use_cases_ready"]:
         session["active_stage"] = "useCases"
@@ -296,7 +371,12 @@ def _result(root: Path, session: dict[str, Any]) -> HarvestUiResult:
             "requirements_passed" if gate_passed else "requirements_running"
         )
     )
-    current_question = _current_question(session) if session_started and not gate_passed else None
+    if session_started and not gate_passed:
+        current_question = _current_question(session)
+    elif session_started and gate_passed and not session.get("use_cases_ready"):
+        current_question = _current_use_case_question(session)
+    else:
+        current_question = None
     current_questions = (current_question,) if current_question else ()
     return HarvestUiResult(
         initial_prompt=session["initial_prompt"],
@@ -324,6 +404,16 @@ def _current_question(session: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def _current_use_case_question(session: dict[str, Any]) -> dict[str, Any] | None:
+    current = session.get("use_case_current_question")
+    if isinstance(current, dict) and current.get("question"):
+        return current
+    current_questions = session.get("use_case_current_questions") or []
+    if current_questions:
+        return current_questions[0]
+    return None
+
+
 def _activate_next_pending_question(session: dict[str, Any]) -> None:
     pending = list(session.get("pending_questions") or [])
     if not pending:
@@ -337,17 +427,39 @@ def _activate_next_pending_question(session: dict[str, Any]) -> None:
     session["pending_questions"] = pending
 
 
+def _activate_next_use_case_pending_question(session: dict[str, Any]) -> None:
+    pending = list(session.get("use_case_pending_questions") or [])
+    if not pending:
+        session["use_case_current_question"] = None
+        session["use_case_current_questions"] = []
+        session["use_case_pending_questions"] = []
+        return
+    next_question = pending.pop(0)
+    session["use_case_current_question"] = next_question
+    session["use_case_current_questions"] = [next_question]
+    session["use_case_pending_questions"] = pending
+
+
 def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
     result = _run_grill_me(root, session)
     session["draft_context_markdown"] = str(result.get("context_markdown", "") or "")
     session["draft_requirements_markdown"] = str(result.get("requirements_markdown", "") or "")
+    open_language_questions = _extract_open_language_questions(session["draft_context_markdown"])
+    filtered_questions = _filter_new_questions(result["questions"], session)
+    if open_language_questions:
+        follow_up_questions = filtered_questions or _fallback_open_language_questions(open_language_questions)
+        session["requirements_gate_passed"] = False
+        session["current_question"] = follow_up_questions[0]
+        session["current_questions"] = [follow_up_questions[0]]
+        session["pending_questions"] = follow_up_questions[1:]
+        session["runtime_error"] = ""
+        return
     if result["complete"]:
         session["requirements_gate_passed"] = True
         session["current_question"] = None
         session["current_questions"] = []
         session["pending_questions"] = []
     else:
-        filtered_questions = _filter_new_questions(result["questions"], session)
         if not filtered_questions:
             session["requirements_gate_passed"] = True
             session["current_question"] = None
@@ -358,6 +470,32 @@ def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
             session["current_question"] = filtered_questions[0]
             session["current_questions"] = [filtered_questions[0]]
             session["pending_questions"] = filtered_questions[1:]
+    session["runtime_error"] = ""
+
+
+def _advance_use_case_harvest(root: Path, session: dict[str, Any], idea: str) -> None:
+    result = _run_use_case_harvest(root, session, idea)
+    status = str(result.get("status", "")).strip().lower()
+    if status == "complete":
+        if not _has_runtime_ready_use_case_slices(root):
+            raise ValueError("use-case harvest reported complete but runtime-ready use-case docs are missing")
+        session["use_cases_ready"] = True
+        session["use_case_current_question"] = None
+        session["use_case_current_questions"] = []
+        session["use_case_pending_questions"] = []
+        session["runtime_error"] = ""
+        return
+    if status == "blocked":
+        blocker = str(result.get("blocker", "") or "use-case harvest blocked")
+        raise ValueError(blocker)
+    questions = _filter_new_use_case_questions(result.get("questions", []), session)
+    if not questions:
+        blocker = str(result.get("blocker", "") or "use-case harvest needs input but returned no new questions")
+        raise ValueError(blocker)
+    session["use_cases_ready"] = False
+    session["use_case_current_question"] = questions[0]
+    session["use_case_current_questions"] = [questions[0]]
+    session["use_case_pending_questions"] = questions[1:]
     session["runtime_error"] = ""
 
 
@@ -379,6 +517,33 @@ def _filter_new_questions(
     return filtered
 
 
+def _filter_new_use_case_questions(
+    questions: Any,
+    session: dict[str, Any],
+) -> list[dict[str, str]]:
+    if not isinstance(questions, list):
+        return []
+    seen = _asked_use_case_question_keys(session)
+    filtered: list[dict[str, str]] = []
+    for item in questions:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("question", "")).strip()
+        if not text:
+            continue
+        key = _question_key(text)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        filtered.append(
+            {
+                "question": text,
+                "recommended": str(item.get("recommended", "") or "").strip(),
+            }
+        )
+    return filtered
+
+
 def _asked_question_keys(session: dict[str, Any]) -> set[str]:
     keys: set[str] = set()
     for item in session.get("clarifications", []):
@@ -391,6 +556,25 @@ def _asked_question_keys(session: dict[str, Any]) -> set[str]:
         if key:
             keys.add(key)
     current = _current_question(session)
+    if current:
+        key = _question_key(str(current.get("question", "")))
+        if key:
+            keys.add(key)
+    return keys
+
+
+def _asked_use_case_question_keys(session: dict[str, Any]) -> set[str]:
+    keys: set[str] = set()
+    for item in session.get("use_case_clarifications", []):
+        for question in item.get("questions") or []:
+            key = _question_key(str(question.get("question", "")))
+            if key:
+                keys.add(key)
+    for question in session.get("use_case_pending_questions") or []:
+        key = _question_key(str(question.get("question", "")))
+        if key:
+            keys.add(key)
+    current = _current_use_case_question(session)
     if current:
         key = _question_key(str(current.get("question", "")))
         if key:
@@ -468,6 +652,153 @@ def _run_grill_me(root: Path, session: dict[str, Any]) -> dict[str, Any]:
     return _parse_grill_me_json(final_message)
 
 
+def _run_use_case_harvest(root: Path, session: dict[str, Any], idea: str) -> dict[str, Any]:
+    agent_config_path = root / USE_CASE_AGENT_CONFIG_PATH
+    skill_path = root / USE_CASE_SKILL_PATH
+    if not agent_config_path.exists():
+        raise ValueError(f"missing use-case agent config: {USE_CASE_AGENT_CONFIG_PATH}")
+    if not skill_path.exists():
+        raise ValueError(f"missing use-case skill config: {USE_CASE_SKILL_PATH}")
+    with agent_config_path.open("rb") as file:
+        agent_config = tomllib.load(file)
+
+    run_id = f"interactive-use-cases-{uuid4().hex[:12]}"
+    run_dir = root / ".harness/ui/use-case-runs" / run_id
+    step_dir = run_dir / "step"
+    step_dir.mkdir(parents=True, exist_ok=True)
+    final_message_path = step_dir / "final-message.md"
+    prompt_path = step_dir / "prompt.md"
+    command_path = step_dir / "command.json"
+    step = Step(
+        id="harvest-use-cases",
+        kind=StepKind.AGENT,
+        name="Derive runtime-ready use case docs",
+        agent_id="harness_usecases",
+        skill_id="harness-usecases",
+        inputs=(CONTEXT_PATH, REQUIREMENTS_PATH),
+        outputs=(USE_CASES_PATH, USE_CASE_SLICE_ROOT),
+        timeout_sec=300,
+        metadata={
+            "stage": "harvest",
+            "scope": "runtime_ready_use_cases",
+            "interactive": True,
+            "slice_outputs": {
+                "root": str(USE_CASE_SLICE_ROOT),
+                "required_per_use_case": ("use-case.md", "e2e-goal.md"),
+            },
+        },
+    )
+    context = RunContext(
+        run_id=run_id,
+        workflow_name="harvest-workflow",
+        mode=RunMode.APPLY,
+        repo_root=root,
+        workdir=root,
+        run_dir=run_dir,
+        metadata={
+            "stage": "interactive_harvest",
+            "initial_idea": idea or session.get("initial_prompt", ""),
+            "interactive_turn": "use_cases",
+        },
+    )
+    prompt = build_agent_prompt(
+        step=step,
+        context=context,
+        agent_config=agent_config,
+        agent_config_path=USE_CASE_AGENT_CONFIG_PATH,
+        skill_path=skill_path,
+        skill_body=skill_path.read_text(encoding="utf-8"),
+    )
+    prompt = f"{prompt}\n\n{_use_case_turn_contract(session)}"
+    prompt_path.write_text(prompt, encoding="utf-8")
+    command = [
+        "codex",
+        "exec",
+        "--cd",
+        str(root),
+        "--skip-git-repo-check",
+        "-c",
+        'approval_policy="never"',
+        "--sandbox",
+        "workspace-write",
+        "--output-last-message",
+        str(final_message_path),
+    ]
+    model = agent_config.get("model")
+    if isinstance(model, str) and model:
+        command.extend(["--model", model])
+    reasoning_effort = agent_config.get("model_reasoning_effort")
+    if isinstance(reasoning_effort, str) and reasoning_effort:
+        command.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
+    command.append("-")
+    command_path.write_text(json.dumps(command, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        input=prompt,
+        text=True,
+        capture_output=True,
+        timeout=300,
+        check=False,
+    )
+    (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
+    (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    if completed.returncode != 0:
+        error = completed.stderr.strip() or completed.stdout.strip()
+        raise ValueError(f"use-case harvest execution failed: {error}")
+    final_message = final_message_path.read_text(encoding="utf-8")
+    return _parse_use_case_harvest_json(final_message)
+
+
+def _use_case_turn_contract(session: dict[str, Any]) -> str:
+    return f"""## 10. Interactive Use-Case Harvest Turn
+
+Return only JSON with keys: status, questions, changed_files, blocker.
+
+Status rules:
+- Return status `needs_input` when one focused user answer is required before use-case docs can be correct.
+- Return status `complete` only after writing docs/design/유스케이스.md and every required docs/use-cases/<UC-ID>/use-case.md and docs/use-cases/<UC-ID>/e2e-goal.md file.
+- Return status `blocked` only when the existing requirements/context inputs are not ready and no user answer in this stage can resolve it.
+
+Question rules:
+- When status is `needs_input`, include one to three question objects with keys question and recommended.
+- Do not ask any question already present in Use-case answer history or Pending use-case question queue.
+- If the answer history resolves enough ambiguity, write the use-case docs and return status `complete`.
+
+Use-case answer history:
+{json.dumps(session.get("use_case_clarifications", []), ensure_ascii=False, indent=2)}
+
+Pending use-case question queue:
+{json.dumps(session.get("use_case_pending_questions", []), ensure_ascii=False, indent=2)}
+"""
+
+
+def _parse_use_case_harvest_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", stripped, flags=re.DOTALL)
+        if match is None:
+            raise ValueError(f"use-case harvest returned non-JSON output: {stripped}")
+        data = json.loads(match.group(0))
+    status = str(data.get("status", "") or "").strip().lower()
+    if status not in {"needs_input", "complete", "blocked"}:
+        raise ValueError(f"use-case harvest returned invalid status: {status or '<empty>'}")
+    questions = data.get("questions", [])
+    if not isinstance(questions, list):
+        raise ValueError("use-case harvest returned invalid questions")
+    changed_files = data.get("changed_files", [])
+    if not isinstance(changed_files, list):
+        raise ValueError("use-case harvest returned invalid changed_files")
+    return {
+        "status": status,
+        "questions": questions,
+        "changed_files": [str(item) for item in changed_files],
+        "blocker": str(data.get("blocker", "") or ""),
+    }
+
+
 def _grill_me_prompt(root: Path, session: dict[str, Any], skill_path: Path) -> str:
     requirements_skill = (root / ".codex/skills/harness-requirements/SKILL.md").read_text(
         encoding="utf-8"
@@ -488,6 +819,8 @@ Question repetition rules:
 - Do not ask semantically equivalent questions to any answered or pending question.
 - If a previous answer is partial, ask only for the missing detail and explicitly narrow the question.
 - Generate questions only from unresolved/open decisions.
+- Return complete=true only when context_markdown has no unresolved entries under `## 3. Open Language Questions`.
+- If context_markdown still has any open language question, return complete=false and ask the focused follow-up question that resolves it.
 - In requirements_markdown, never use a clarification table column named `Answer`; use `Response`.
 - context_markdown must follow the root context.md structure from harness-requirements and include the Ubiquitous Language table.
 - requirements_markdown must use canonical terms from context_markdown.
@@ -560,6 +893,40 @@ def _parse_grill_me_json(text: str) -> dict[str, Any]:
         "requirements_markdown": requirements_markdown,
         "context_markdown": context_markdown,
     }
+
+
+def _extract_open_language_questions(markdown: str) -> list[str]:
+    if not markdown.strip():
+        return []
+    match = re.search(
+        r"^## 3\. Open Language Questions\s*$([\s\S]*?)(?=^##\s|\Z)",
+        markdown,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        return []
+    questions: list[str] = []
+    for line in match.group(1).splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        question = stripped[2:].strip()
+        if not question:
+            continue
+        if question.lower() in {"none", "none."}:
+            continue
+        questions.append(question)
+    return questions
+
+
+def _fallback_open_language_questions(open_questions: list[str]) -> list[dict[str, str]]:
+    return [
+        {
+            "question": question,
+            "recommended": "Confirm the canonical term or naming decision explicitly based on the current context draft.",
+        }
+        for question in open_questions[:3]
+    ]
 
 
 def _write_context_doc(root: Path, session: dict[str, Any]) -> None:

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -22,6 +22,7 @@ USE_CASE_SLICE_ROOT = Path("docs/use-cases")
 GRILL_ME_SKILL_PATH = Path(".codex/skills/grill-me/SKILL.md")
 USE_CASE_AGENT_CONFIG_PATH = Path(".codex/agents/harness_usecases.toml")
 USE_CASE_SKILL_PATH = Path(".codex/skills/harness-usecases/SKILL.md")
+MAX_REQUIREMENTS_QUESTIONS = 10
 
 
 @dataclass(frozen=True)
@@ -444,10 +445,18 @@ def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
     result = _run_grill_me(root, session)
     session["draft_context_markdown"] = str(result.get("context_markdown", "") or "")
     session["draft_requirements_markdown"] = str(result.get("requirements_markdown", "") or "")
-    open_language_questions = _extract_open_language_questions(session["draft_context_markdown"])
+    open_language_questions = _extract_blocking_open_language_questions(session["draft_context_markdown"])
     filtered_questions = _filter_new_questions(result["questions"], session)
+    remaining_budget = _remaining_requirements_question_budget(session)
+    if _requirements_question_budget_exhausted(session):
+        session["requirements_gate_passed"] = True
+        session["current_question"] = None
+        session["current_questions"] = []
+        session["pending_questions"] = []
+        session["runtime_error"] = ""
+        return
     if open_language_questions:
-        follow_up_questions = filtered_questions or _fallback_open_language_questions(open_language_questions)
+        follow_up_questions = (filtered_questions or _fallback_open_language_questions(open_language_questions))[:remaining_budget]
         session["requirements_gate_passed"] = False
         session["current_question"] = follow_up_questions[0]
         session["current_questions"] = [follow_up_questions[0]]
@@ -466,6 +475,7 @@ def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
             session["current_questions"] = []
             session["pending_questions"] = []
         else:
+            filtered_questions = filtered_questions[:remaining_budget]
             session["requirements_gate_passed"] = False
             session["current_question"] = filtered_questions[0]
             session["current_questions"] = [filtered_questions[0]]
@@ -561,6 +571,17 @@ def _asked_question_keys(session: dict[str, Any]) -> set[str]:
         if key:
             keys.add(key)
     return keys
+
+
+def _requirements_question_budget_exhausted(session: dict[str, Any]) -> bool:
+    return _remaining_requirements_question_budget(session) <= 0
+
+
+def _remaining_requirements_question_budget(session: dict[str, Any]) -> int:
+    asked = len(session.get("clarifications", []))
+    pending = len(session.get("pending_questions", []) or [])
+    current = 1 if _current_question(session) else 0
+    return max(0, MAX_REQUIREMENTS_QUESTIONS - asked - pending - current)
 
 
 def _asked_use_case_question_keys(session: dict[str, Any]) -> set[str]:
@@ -819,8 +840,14 @@ Question repetition rules:
 - Do not ask semantically equivalent questions to any answered or pending question.
 - If a previous answer is partial, ask only for the missing detail and explicitly narrow the question.
 - Generate questions only from unresolved/open decisions.
-- Return complete=true only when context_markdown has no unresolved entries under `## 3. Open Language Questions`.
-- If context_markdown still has any open language question, return complete=false and ask the focused follow-up question that resolves it.
+- Run harvest as one MVP/use-case discovery pass. For an empty project or broad request like "build a calculator", first identify one MVP and ask only for decisions needed for that one MVP use case.
+- For an existing repository feature addition or modification, steer the draft toward one use-case-sized ChangeSet instead of a broad multi-use-case program.
+- Ask at most {MAX_REQUIREMENTS_QUESTIONS} requirements questions total. After that, draft requirements and defer non-blocking questions.
+- Blocking harvest questions are only actor, one MVP goal, primary command/action, inputs, successful result, user-visible failure policy, and hard scope boundaries for that one use case.
+- Do not ask harvest-blocking questions about event candidate names, explicit state names, DDD design, detailed NFRs, security/audit concepts, stack choices, implementation strategy, aliases, or forbidden terms unless they directly block the single MVP use case.
+- context_markdown must split unresolved language into `## 3. Blocking Open Language Questions` and `## 4. Deferred Language Questions`.
+- Return complete=true when `## 3. Blocking Open Language Questions` is empty or contains only `- None.`. Deferred language questions do not block use-case harvest.
+- If context_markdown still has blocking open language questions and the question budget is not exhausted, return complete=false and ask the focused follow-up question that resolves one blocker.
 - In requirements_markdown, never use a clarification table column named `Answer`; use `Response`.
 - context_markdown must follow the root context.md structure from harness-requirements and include the Ubiquitous Language table.
 - requirements_markdown must use canonical terms from context_markdown.
@@ -895,11 +922,18 @@ def _parse_grill_me_json(text: str) -> dict[str, Any]:
     }
 
 
-def _extract_open_language_questions(markdown: str) -> list[str]:
+def _extract_blocking_open_language_questions(markdown: str) -> list[str]:
     if not markdown.strip():
         return []
+    blocking = _extract_markdown_list_section(markdown, "3. Blocking Open Language Questions")
+    if blocking:
+        return blocking
+    return _extract_markdown_list_section(markdown, "Blocking Open Language Questions")
+
+
+def _extract_markdown_list_section(markdown: str, title: str) -> list[str]:
     match = re.search(
-        r"^## 3\. Open Language Questions\s*$([\s\S]*?)(?=^##\s|\Z)",
+        rf"^## {re.escape(title)}\s*$([\s\S]*?)(?=^##\s|\Z)",
         markdown,
         flags=re.MULTILINE,
     )
@@ -965,7 +999,7 @@ def _write_requirements_doc(root: Path, session: dict[str, Any]) -> None:
         question_text = questions[0].get("question", "") if questions else ""
         lines.append(f"| GM-{index:03d} | {question_text} | {item.get('answer', '')} |")
     if _current_question(session) or session.get("pending_questions"):
-        lines.extend(["", "## Open Language Questions", ""])
+        lines.extend(["", "## Blocking Open Language Questions", ""])
         queue = []
         current = _current_question(session)
         if current:
@@ -1010,13 +1044,14 @@ def _fallback_context_markdown(session: dict[str, Any]) -> str:
         "- `Forbidden Terms` must not be used in new documents, plans, tests, or code identifiers.",
         "- Aliases are recorded only for migration/search context and must not be introduced as new canonical language.",
         "",
-        "## 3. Open Language Questions",
+        "## 3. Blocking Open Language Questions",
         "",
     ]
     if open_questions:
         lines.extend(f"- {question}" for question in open_questions)
     else:
         lines.append("- None.")
+    lines.extend(["", "## 4. Deferred Language Questions", "", "- None."])
     return "\n".join(lines)
 
 

--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -13,9 +13,11 @@ from harness_codex.runtime.harvest_ui import (
     SESSION_PATH,
     USE_CASE_SLICE_ROOT,
     HarvestUiResult,
+    answer_use_cases,
     answer_requirements,
     load_harvest_ui,
     start_requirements,
+    start_use_case_generation,
     start_use_cases,
 )
 
@@ -70,7 +72,17 @@ def run_interactive_harvest(
         _persist_session(root, resolved_session_id)
 
     _restore_session(root, resolved_session_id)
-    _generate_runtime_ready_use_cases(root, resolved_session_id, result.initial_prompt)
+    _validate_interactive_context(root, resolved_session_id, result.initial_prompt)
+    result = start_use_case_generation(root, result.initial_prompt)
+    _persist_session(root, resolved_session_id)
+    while not result.use_cases_ready:
+        output_func(_format_questions(result))
+        answer = input_func("Answer: ").strip()
+        if not answer:
+            raise ValueError("answer is required")
+        _restore_session(root, resolved_session_id)
+        result = answer_use_cases(root, answer, result.initial_prompt)
+        _persist_session(root, resolved_session_id)
     result = start_use_cases(root)
     _persist_session(root, resolved_session_id)
     return _format_completion(root, result, resolved_session_id)
@@ -113,6 +125,28 @@ def _generate_runtime_ready_use_cases(root: Path, session_id: str, idea: str) ->
         result = runner.run(step, context)
         if result.status != StepStatus.SUCCEEDED:
             raise ValueError(f"interactive harvest step failed: {step.id}: {result.error or result.status.value}")
+
+
+def _validate_interactive_context(root: Path, session_id: str, idea: str) -> None:
+    run_id = f"interactive-harvest-{uuid4().hex[:12]}"
+    context = RunContext(
+        run_id=run_id,
+        workflow_name="harvest-workflow",
+        mode=RunMode.APPLY,
+        repo_root=root,
+        workdir=root,
+        run_dir=root / ".harness/runs" / run_id,
+        metadata={
+            "stage": "interactive_harvest",
+            "interactive_session_id": session_id,
+            "initial_idea": idea,
+            "next_runtime_step": "harvest-use-cases",
+        },
+    )
+    runner = BasicStepRunner()
+    result = runner.run(_interactive_use_case_generation_steps()[0], context)
+    if result.status != StepStatus.SUCCEEDED:
+        raise ValueError(f"interactive harvest step failed: validate-context-language: {result.error or result.status.value}")
 
 
 def _interactive_use_case_generation_steps() -> tuple[Step, ...]:

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -11,9 +11,11 @@ from typing import Any
 from urllib.parse import urlparse
 
 from harness_codex.runtime.harvest_ui import (
+    answer_use_cases,
     answer_requirements,
     load_harvest_ui,
     start_requirements,
+    start_use_case_generation,
     start_use_cases,
 )
 
@@ -51,6 +53,10 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
             elif path == "/api/requirements/answer":
                 result = answer_requirements(self.repo_root, str(body.get("answer", "")))
             elif path == "/api/use-cases/start":
+                result = start_use_case_generation(self.repo_root, str(body.get("idea", "")))
+            elif path == "/api/use-cases/answer":
+                result = answer_use_cases(self.repo_root, str(body.get("answer", "")), str(body.get("idea", "")))
+            elif path == "/api/use-cases/complete":
                 result = start_use_cases(self.repo_root)
             else:
                 self._write_json(HTTPStatus.NOT_FOUND, {"error": "not found"})

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -7,9 +7,11 @@ from harness_codex.runtime.harvest_ui import (
     CONTEXT_PATH,
     REQUIREMENTS_PATH,
     USE_CASES_PATH,
+    answer_use_cases,
     answer_requirements,
     load_harvest_ui,
     start_requirements,
+    start_use_case_generation,
     start_use_cases,
 )
 
@@ -179,6 +181,64 @@ def test_harvest_ui_filters_duplicate_grill_me_questions(
     assert result.current_question["question"] == "What is the success outcome?"
 
 
+def test_harvest_ui_keeps_grill_me_running_until_context_has_no_open_language_questions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def incomplete_context_grill_me(_root: Path, session: dict) -> dict:
+        if len(session["clarifications"]) >= 1:
+            return {
+                "complete": True,
+                "questions": [],
+                "requirements_markdown": "# Requirements Specification\n",
+                "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n| Operator | 연산자 | Operator | Domain Concept | Arithmetic selector. | Selected Operation | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- None.\n",
+            }
+        return {
+            "complete": True,
+            "questions": [],
+            "requirements_markdown": "# Requirements Specification\n",
+            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n",
+        }
+
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_grill_me",
+        incomplete_context_grill_me,
+    )
+
+    result = start_requirements(tmp_path, "build a calculator")
+
+    assert result.requirements_gate_passed is False
+    assert result.current_question is not None
+    assert result.current_question["question"] == "Confirm the canonical term for the arithmetic selector."
+
+    result = answer_requirements(tmp_path, "Use Operator.")
+
+    assert result.requirements_gate_passed is True
+    assert result.current_question is None
+
+
+def test_harvest_ui_uses_open_language_questions_when_grill_me_returns_no_follow_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_grill_me",
+        lambda _root, _session: {
+            "complete": False,
+            "questions": [],
+            "requirements_markdown": "# Requirements Specification\n",
+            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n",
+        },
+    )
+
+    result = start_requirements(tmp_path, "build a calculator")
+
+    assert result.requirements_gate_passed is False
+    assert result.current_question is not None
+    assert result.current_question["question"] == "Confirm the canonical term for the arithmetic selector."
+    assert "Confirm the canonical term" in result.current_question["recommended"]
+
+
 def test_grill_me_prompt_includes_answered_and_pending_questions(
     tmp_path: Path,
 ) -> None:
@@ -210,6 +270,7 @@ def test_grill_me_prompt_includes_answered_and_pending_questions(
     assert "Answered question history" in prompt
     assert "Pending question queue" in prompt
     assert "Do not ask semantically equivalent questions" in prompt
+    assert "Return complete=true only when context_markdown has no unresolved entries" in prompt
     assert "Who uses it?" in prompt
     assert "What is success?" in prompt
 
@@ -234,6 +295,85 @@ def test_harvest_ui_blocks_use_cases_until_requirements_pass(
 def test_harvest_ui_blocks_when_grill_me_skill_is_missing(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="missing required Grill-Me skill"):
         start_requirements(tmp_path, "build a queue system")
+
+
+def test_harvest_ui_runs_use_case_generation_one_question_at_a_time(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
+    result = start_requirements(tmp_path, "build a queue system")
+    result = answer_requirements(tmp_path, "answer 1")
+    result = answer_requirements(tmp_path, "answer 2")
+    result = answer_requirements(tmp_path, "answer 3")
+    assert result.requirements_gate_passed is True
+
+    calls = []
+
+    def fake_use_case_harvest(root: Path, session: dict, _idea: str) -> dict:
+        calls.append(len(session["use_case_clarifications"]))
+        if len(session["use_case_clarifications"]) >= 1:
+            write_runtime_ready_use_cases(root)
+            return {
+                "status": "complete",
+                "questions": [],
+                "changed_files": [
+                    "docs/design/유스케이스.md",
+                    "docs/use-cases/UC-001/use-case.md",
+                    "docs/use-cases/UC-001/e2e-goal.md",
+                ],
+                "blocker": "",
+            }
+        return {
+            "status": "needs_input",
+            "questions": [
+                {
+                    "question": "Should Clear reset the result?",
+                    "recommended": "Yes.",
+                }
+            ],
+            "changed_files": [],
+            "blocker": "",
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_use_case_harvest", fake_use_case_harvest)
+
+    result = start_use_case_generation(tmp_path, "build a queue system")
+
+    assert result.active_stage == "useCases"
+    assert result.use_cases_ready is False
+    assert result.current_question is not None
+    assert result.current_question["question"] == "Should Clear reset the result?"
+
+    result = answer_use_cases(tmp_path, "Yes, reset it.", "build a queue system")
+
+    assert calls == [0, 1]
+    assert result.use_cases_ready is True
+    assert result.current_question is None
+    assert (tmp_path / USE_CASES_PATH).is_file()
+
+
+def test_harvest_ui_blocks_when_use_case_generation_reports_complete_without_docs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
+    start_requirements(tmp_path, "build a queue system")
+    answer_requirements(tmp_path, "answer 1")
+    answer_requirements(tmp_path, "answer 2")
+    answer_requirements(tmp_path, "answer 3")
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_use_case_harvest",
+        lambda _root, _session, _idea: {
+            "status": "complete",
+            "questions": [],
+            "changed_files": [],
+            "blocker": "",
+        },
+    )
+
+    with pytest.raises(ValueError, match="runtime-ready use-case docs are missing"):
+        start_use_case_generation(tmp_path, "build a queue system")
 
 
 def test_harvest_ui_recovers_session_from_requirements_doc(

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -181,7 +181,7 @@ def test_harvest_ui_filters_duplicate_grill_me_questions(
     assert result.current_question["question"] == "What is the success outcome?"
 
 
-def test_harvest_ui_keeps_grill_me_running_until_context_has_no_open_language_questions(
+def test_harvest_ui_keeps_grill_me_running_until_context_has_no_blocking_language_questions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -191,13 +191,13 @@ def test_harvest_ui_keeps_grill_me_running_until_context_has_no_open_language_qu
                 "complete": True,
                 "questions": [],
                 "requirements_markdown": "# Requirements Specification\n",
-                "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n| Operator | 연산자 | Operator | Domain Concept | Arithmetic selector. | Selected Operation | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- None.\n",
+                "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n| Operator | 연산자 | Operator | Domain Concept | Arithmetic selector. | Selected Operation | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- None.\n\n## 4. Deferred Language Questions\n\n- None.\n",
             }
         return {
             "complete": True,
             "questions": [],
             "requirements_markdown": "# Requirements Specification\n",
-            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n",
+            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n\n## 4. Deferred Language Questions\n\n- Confirm event candidate names later.\n",
         }
 
     monkeypatch.setattr(
@@ -217,7 +217,7 @@ def test_harvest_ui_keeps_grill_me_running_until_context_has_no_open_language_qu
     assert result.current_question is None
 
 
-def test_harvest_ui_uses_open_language_questions_when_grill_me_returns_no_follow_up(
+def test_harvest_ui_uses_blocking_language_questions_when_grill_me_returns_no_follow_up(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -227,7 +227,7 @@ def test_harvest_ui_uses_open_language_questions_when_grill_me_returns_no_follow
             "complete": False,
             "questions": [],
             "requirements_markdown": "# Requirements Specification\n",
-            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n",
+            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n\n## 4. Deferred Language Questions\n\n- Confirm state names later.\n",
         },
     )
 
@@ -237,6 +237,51 @@ def test_harvest_ui_uses_open_language_questions_when_grill_me_returns_no_follow
     assert result.current_question is not None
     assert result.current_question["question"] == "Confirm the canonical term for the arithmetic selector."
     assert "Confirm the canonical term" in result.current_question["recommended"]
+
+
+def test_harvest_ui_does_not_block_on_deferred_language_questions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_grill_me",
+        lambda _root, _session: {
+            "complete": True,
+            "questions": [],
+            "requirements_markdown": "# Requirements Specification\n",
+            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- None.\n\n## 4. Deferred Language Questions\n\n- Confirm event candidate names later.\n",
+        },
+    )
+
+    result = start_requirements(tmp_path, "build a calculator")
+
+    assert result.requirements_gate_passed is True
+    assert result.current_question is None
+
+
+def test_harvest_ui_enforces_requirements_question_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def budget_grill_me(_root: Path, session: dict) -> dict:
+        return {
+            "complete": False,
+            "questions": [
+                {"question": f"Question {len(session['clarifications'])}.{index}?", "recommended": "Answer"}
+                for index in range(3)
+            ],
+            "requirements_markdown": "# Requirements Specification\n",
+            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- None.\n\n## 4. Deferred Language Questions\n\n- None.\n",
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", budget_grill_me)
+
+    result = start_requirements(tmp_path, "build a calculator")
+    while result.current_question is not None:
+        result = answer_requirements(tmp_path, "answer")
+
+    assert result.requirements_gate_passed is True
+    assert len(result.clarifications) == 10
 
 
 def test_grill_me_prompt_includes_answered_and_pending_questions(
@@ -270,7 +315,8 @@ def test_grill_me_prompt_includes_answered_and_pending_questions(
     assert "Answered question history" in prompt
     assert "Pending question queue" in prompt
     assert "Do not ask semantically equivalent questions" in prompt
-    assert "Return complete=true only when context_markdown has no unresolved entries" in prompt
+    assert "Ask at most 10 requirements questions total" in prompt
+    assert "one MVP/use-case discovery pass" in prompt
     assert "Who uses it?" in prompt
     assert "What is success?" in prompt
 

--- a/tests/runtime/test_interactive_harvest.py
+++ b/tests/runtime/test_interactive_harvest.py
@@ -66,6 +66,20 @@ def _write_generated_use_cases(root: Path, _session_id: str, _idea: str) -> None
     )
 
 
+def _complete_use_case_harvest(root: Path, _session: dict, _idea: str) -> dict:
+    _write_generated_use_cases(root, "", _idea)
+    return {
+        "status": "complete",
+        "questions": [],
+        "changed_files": [
+            "docs/design/유스케이스.md",
+            "docs/use-cases/UC-001/use-case.md",
+            "docs/use-cases/UC-001/e2e-goal.md",
+        ],
+        "blocker": "",
+    }
+
+
 def test_interactive_harvest_reuses_harvest_ui_gate(
     tmp_path: Path,
     monkeypatch,
@@ -88,10 +102,8 @@ def test_interactive_harvest_reuses_harvest_ui_gate(
         }
 
     monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
-    monkeypatch.setattr(
-        "harness_codex.runtime.interactive_harvest._generate_runtime_ready_use_cases",
-        _write_generated_use_cases,
-    )
+    monkeypatch.setattr("harness_codex.runtime.interactive_harvest._validate_interactive_context", lambda *_args: None)
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_use_case_harvest", _complete_use_case_harvest)
     output_lines: list[str] = []
 
     result = run_interactive_harvest(
@@ -162,10 +174,8 @@ def test_interactive_harvest_resumes_saved_session(
         }
 
     monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
-    monkeypatch.setattr(
-        "harness_codex.runtime.interactive_harvest._generate_runtime_ready_use_cases",
-        _write_generated_use_cases,
-    )
+    monkeypatch.setattr("harness_codex.runtime.interactive_harvest._validate_interactive_context", lambda *_args: None)
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_use_case_harvest", _complete_use_case_harvest)
 
     with pytest.raises(StopInput):
         run_interactive_harvest(
@@ -201,10 +211,8 @@ def test_list_harvest_sessions_outputs_saved_sessions(
         "harness_codex.runtime.harvest_ui._run_grill_me",
         lambda _root, session: {"complete": True, "questions": [], **_draft_documents(session)},
     )
-    monkeypatch.setattr(
-        "harness_codex.runtime.interactive_harvest._generate_runtime_ready_use_cases",
-        _write_generated_use_cases,
-    )
+    monkeypatch.setattr("harness_codex.runtime.interactive_harvest._validate_interactive_context", lambda *_args: None)
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_use_case_harvest", _complete_use_case_harvest)
 
     run_interactive_harvest(
         tmp_path,
@@ -252,10 +260,8 @@ def test_interactive_harvest_blocks_completed_session_resume(
         "harness_codex.runtime.harvest_ui._run_grill_me",
         lambda _root, session: {"complete": True, "questions": [], **_draft_documents(session)},
     )
-    monkeypatch.setattr(
-        "harness_codex.runtime.interactive_harvest._generate_runtime_ready_use_cases",
-        _write_generated_use_cases,
-    )
+    monkeypatch.setattr("harness_codex.runtime.interactive_harvest._validate_interactive_context", lambda *_args: None)
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_use_case_harvest", _complete_use_case_harvest)
 
     run_interactive_harvest(
         tmp_path,


### PR DESCRIPTION
Closes #138

## 구현 의도

Harvest가 빈 프로젝트나 큰 범위의 구현 요청을 받을 때 도메인 전체를 질문하지 않고, 먼저 MVP 1개와 그 MVP의 단일 유스케이스 경계만 확정하도록 제한한다. 기존 리포지토리의 기능 추가/수정 요청도 유스케이스 단위 ChangeSet으로 좁히도록 유도한다.

## 구현 접근

- requirements Grill-Me 프롬프트를 MVP/use-case discovery pass로 재정의하고 총 질문 예산을 10개로 제한했다.
- `context.md`의 언어 질문을 `Blocking Open Language Questions`와 `Deferred Language Questions`로 분리하도록 요구사항 agent/skill 지침을 갱신했다.
- Harvest UI 런타임에서 차단 언어 질문만 gate로 취급하고, 지연 질문은 use-case 생성 진행을 막지 않도록 처리했다.
- use-case agent/skill 지침도 차단 언어 질문만 use-case 작성 blocker로 보도록 정렬했다.
- 테스트에 질문 예산, 지연 언어 질문 non-blocking 동작, 프롬프트 문구 검증을 추가했다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_harvest_ui.py tests/runtime/test_interactive_harvest.py tests/runtime/test_workflow_loader.py tests/runtime/test_models.py tests/runtime/test_agent_runner.py tests/test_context_language.py tests/test_cli_commands.py tests/test_harvester_skill_instructions.py`
- 결과: `85 passed`
- `git diff --check`

## 위험 및 롤백

질문 예산이 너무 작으면 일부 복잡한 초기 아이디어에서 요구사항 초안이 더 많은 가정을 포함할 수 있다. 문제가 발생하면 이 커밋을 되돌리거나 질문 예산과 blocking/deferred 분류 조건만 조정하면 된다.
