### PR TITLE
Reduce harvest questioning and simplify harvest CLI

### DIFF
--- a/.codex/agents/harness_requirements.toml
+++ b/.codex/agents/harness_requirements.toml
@@ -55,9 +55,8 @@ Requirements rules:
 - Split functional requirements and non-functional requirements.
 - Classify unresolved decisions as either Business Policy Decisions or Foundational Technical Decisions.
 - Business Policy Decisions are product/domain rules: success/failure outcomes, lifecycle states, pricing rules, inventory limits, reward/loss rules, market/competition rules, validation rules, permissions, and user-visible behavior.
-- Foundational Technical Decisions are large technology choices that shape the whole program: development language, main framework, DB/storage family, cache/distributed-state infrastructure such as Redis, messaging broker/framework use, major runtime/deployment constraints, and build tool.
+- Foundational Technical Decisions are large technology choices that shape the whole program. During harvest, defer them by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
 - Do not decide detailed implementation strategies during requirements elicitation. Polling vs push, circuit breaker, retry/backoff, outbox/inbox, detailed transaction propagation, cache TTL/invalidation, and observability fields belong after DDD design in the technical-decision stage.
-- Do not ask foundational technology questions during MVP harvest unless the answer is required to define the one use-case ChangeSet boundary. Otherwise record them under Foundational Technology Decisions Needed.
 - Business Policy Decisions must be resolved before use-case writing and event storming can be considered ready.
 - Core ubiquitous language must be resolved before use-case writing and event storming can be considered ready.
 - Foundational Technical Decisions may remain unresolved after requirements, but must be clearly separated for the DDD and technical-decision gates.
@@ -65,16 +64,16 @@ Requirements rules:
 - Non-functional requirements must check performance, concurrency control, data consistency, scalability, fault isolation/availability, security, failure recovery, and auditability/operability.
 - Do not finalize non-functional requirements from your own assumptions.
 - If the user did not explicitly decide a non-functional requirement, write it as a candidate or mark it 확인 필요.
-- Ask the user about performance targets, persistence/consistency, failure recovery, security, and operability before treating them as confirmed requirements.
-- Ask the user about the foundational technology stack before treating foundational technical decisions as complete.
+- Do not ask technical questions by default about authentication, authorization, cache, Redis, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the user's MVP use case explicitly depends on that decision.
+- Prefer to record unresolved technical items under `Foundational Technology Decisions Needed` or `Post-DDD Technical Decision Candidates` instead of asking about them during harvest.
 - If a measurable target is missing, mark it as 확인 필요 instead of inventing it.
 - Do not write use cases.
 
 Question loop:
 - Ask exactly one focused question at a time.
-- Treat one round as up to 7 focused questions that target the current priority area.
-- Run at most 3 rounds and at most 7 total questions per round.
-- Ask at most 10 questions total in runtime harvest.
+- Ask only the single highest-priority blocker for the current turn.
+- Do not queue non-blocking follow-up questions.
+- Run at most 3 rounds.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
 - Stop asking once the information is sufficient to produce a draft.
@@ -82,13 +81,11 @@ Question loop:
 - If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Blocking Open Language Questions, Deferred Language Questions, or Post-DDD Technical Decision Candidates instead of extending the question loop.
 - Include `Recommended answer:` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
 - After the user answers, update context.md first, update docs/design/요구사항.md using context.md canonical terms, then choose the next single unresolved decision that blocks requirements or language quality.
-- Prefer questions about one MVP use case: actor, goal, primary command/action, inputs, successful result, user-visible failure policy, and hard out-of-scope boundaries.
-- Defer event candidate names, state names, DDD details, implementation strategy, detailed NFRs, security/audit concepts, aliases, forbidden terms, and technology stack unless they directly block the MVP use case.
+- Prefer questions about actor, one MVP goal, primary action, required input, successful result, user-visible failure policy, hard out-of-scope boundary, one-ChangeSet scope fit, and core domain language.
 - Include ubiquitous language questions before finalizing the requirements document.
-- Include non-functional requirement questions before finalizing the requirements document.
-- Include foundational technology stack questions before finalizing the requirements document.
-- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions and MVP-blocking language questions within the question budget.
-- Keep unresolved items separated into `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Blocking Open Language Questions`, and `Deferred Language Questions`.
+- Do not block finalizing the harvest draft on deep non-functional or foundational technology details that do not directly block MVP scoping.
+- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions and core Open Language Questions within the question budget.
+- Keep unresolved items separated into `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, and `Open Language Questions`.
 - If business policy items remain, mark the document as not ready for use-case writing or event storming.
 - If core language questions remain, mark the document as not ready for use-case writing or event storming.
 """

--- a/.codex/skills/harness-requirements/SKILL.md
+++ b/.codex/skills/harness-requirements/SKILL.md
@@ -84,9 +84,10 @@ Use the following standards as the source of truth for the instructions.
 - Do not confirm requirements that the user has not explicitly stated or that cannot be verified from local artifacts.
 - Separate unresolved items into `Business Policy Decisions Needed` and `Foundational Technology Decisions Needed`.
 - Business policies include success/failure outcomes, state transitions, validation rules, compensation, authorization, and user-visible behavior.
-- Confirm programming language, main framework, database/storage, cache/distributed state infrastructure, messaging, and runtime constraints only when needed to define the MVP ChangeSet boundary. Otherwise defer them to Foundational Technology Decisions Needed.
 - Do not confirm technology choices before the problem, actors, scope, and core business policies are understood.
-- Foundational technologies should usually be left under `Foundational Technology Decisions Needed` during broad MVP harvest unless the repository already answers them.
+- Do not ask technology-specific questions by default. Ask them only when they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
+- Foundational technologies may remain unresolved after harvest and should usually be recorded under `Foundational Technology Decisions Needed`.
 - Detailed technical strategies that can be decided after design must not be confirmed during the requirements phase. Leave them under `Post-DDD Technical Decision Candidates`.
 - Before moving to use-case writing or Event Storming, there must be no unresolved business policy decisions.
 
@@ -116,11 +117,10 @@ must not continue asking until the domain is perfect.
 
 Rules:
 
-- Ask at most 10 questions total.
-- Run at most 2 rounds.
-- Treat one round as up to 5 focused questions that target the current priority area.
+- Run at most 3 rounds.
 - Ask one focused question at a time when interacting with the user.
-- Ask at most 5 total questions per round.
+- Ask only the single highest-priority blocker for the current turn.
+- Do not queue non-blocking follow-up questions.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Stop once one actor, one MVP goal, the primary action, inputs, success result, failure policy, and hard scope boundary are clear enough to produce a draft.
 - If the question budget is exhausted, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
@@ -135,8 +135,9 @@ You are conducting an interview to clarify requirements and confirm ubiquitous l
 Questioning method:
 - Use a time-boxed questioning loop, not an unbounded interview.
 - Run at most 3 rounds.
-- Ask at most 7 total questions per round.
 - Ask one focused question at a time when interacting with the user.
+- Ask only the single highest-priority blocker for the current turn.
+- Do not queue non-blocking follow-up questions.
 - Include `Recommended answer:` with each question.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
@@ -155,14 +156,22 @@ Judgment standards:
 - Do not write use cases in this phase.
 
 Question priority:
-1. MVP candidate and one external actor goal
-2. Main actor
-3. Primary command/action
-4. Inputs and output
-5. Successful result
-6. User-visible failure policy
-7. Hard out-of-scope boundaries
-8. Existing repository evidence that constrains the ChangeSet
+1. Problem situation
+2. Goal
+3. Scope
+4. Actors
+5. Goals per actor
+6. Core domain terms and concept names
+7. State names
+8. Command/event/policy candidate terms
+9. Alias and forbidden-term cleanup
+10. Core features
+11. Success/failure outcomes
+12. Business policies
+13. Hard out-of-scope boundary
+14. External systems only when user-visible behavior depends on them
+15. Non-functional requirements only when they block MVP scoping
+16. Foundational technologies only when they block MVP scoping
 
 Ubiquitous language confirmation criteria:
 - Same concept has exactly one canonical term.
@@ -173,11 +182,11 @@ Ubiquitous language confirmation criteria:
 - Non-blocking missing terms are recorded in `Deferred Language Questions`.
 
 Completion criteria:
-- One MVP actor and one MVP goal are clear enough for a single use-case document.
-- Functional requirement candidates for that use case can be written.
-- There are no unresolved MVP-blocking business policies, or the remaining items are explicitly recorded as not-ready blockers.
-- Foundational technologies are confirmed only when already known or needed for the ChangeSet boundary; otherwise they are separated as needing confirmation.
-- MVP-blocking ubiquitous language is confirmed and can be written to `context.md`, or unresolved terms are explicitly recorded under `Blocking Open Language Questions`.
+- Main actors and their goals are separated enough for functional requirements.
+- Functional and non-functional requirement candidates can be written.
+- There are no unresolved core business policies, or the remaining items are explicitly recorded as not-ready blockers.
+- Foundational technologies are either unnecessary for MVP scoping or separated as needing confirmation.
+- Core ubiquitous language is confirmed and can be written to `context.md`, or unresolved terms are explicitly recorded under `Open Language Questions`.
 
 Output format:
 ## Confirmed Decisions
@@ -333,7 +342,7 @@ Execution rules:
 - ...
 
 ## 6. Foundational Technology Decisions
-> In the requirements phase, confirm only foundational stack and infrastructure choices. Detailed implementation strategies are decided after DDD design.
+> In the requirements phase, record only foundational stack or infrastructure choices that directly block MVP scoping. Otherwise defer them.
 
 - Programming language:
 - Main framework:

--- a/.codex/skills/harness-requirements/references/agent-prompt.md
+++ b/.codex/skills/harness-requirements/references/agent-prompt.md
@@ -20,9 +20,10 @@ Rules:
 - Do not guess unclear decisions.
 - Do not finalize non-functional requirements from assumptions.
 - Use a time-boxed grill-me loop rather than an unbounded interview.
-- Run at most 2 rounds for the MVP pass; this remains inside the legacy guardrail of at most 3 rounds.
-- Ask at most 10 total requirements questions for the MVP pass; this remains inside the legacy guardrail of at most 7 total questions per round.
+- Run at most 3 rounds.
 - Ask one focused question at a time when interacting with the user.
+- Ask only the single highest-priority blocker for the current turn.
+- Do not queue non-blocking follow-up questions.
 - Include `Recommended answer:` with every question.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
@@ -30,12 +31,13 @@ Rules:
 - After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
 - If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Blocking Open Language Questions, Deferred Language Questions, or Post-DDD Technical Decision Candidates.
 - Confirm ubiquitous language through grill-me before use-case harvest.
-- Update context.md first with confirmed canonical terms, Korean names, English code-facing names, definitions, aliases, Forbidden Terms, Blocking Open Language Questions, and Deferred Language Questions.
+- Update context.md first with confirmed canonical terms, Korean names, English code-facing names, definitions, aliases, Forbidden Terms, and open language questions.
 - Use context.md canonical terms when updating docs/design/요구사항.md.
 - After the user answers, update context.md and docs/design/요구사항.md, then ask the next most important unresolved requirement or language decision within the question budget.
 - Split functional and non-functional requirements.
-- Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, Blocking Open Language Questions, and Deferred Language Questions.
-- Defer technology stack questions unless they directly block the first use-case-sized ChangeSet boundary.
+- Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, and Open Language Questions.
+- Do not ask technology-specific questions by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
 - Do not write use cases.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```

--- a/docs/README-harvest-quickstart.md
+++ b/docs/README-harvest-quickstart.md
@@ -78,11 +78,6 @@ A completed session cannot be resumed as a question loop. The command reports th
 - `--plan`: show the harvest workflow plan without changing files. Treat this as debug/explain mode.
 - `--interactive`: run the Grill-Me question/answer loop in the terminal and generate design documents after the requirements gate passes.
 
-Compatibility aliases:
-
-- `--preview`: deprecated alias for `--plan`.
-- `--apply`: deprecated alias for `--interactive`.
-
 ## Help expectation
 
 `./harness harvest --help` should be enough to understand these options without opening the source code.

--- a/docs/README-harvest-quickstart.md
+++ b/docs/README-harvest-quickstart.md
@@ -66,8 +66,6 @@ A completed session cannot be resumed as a question loop. The command reports th
 
 ```bash
 ./harness harvest --idea "<feature idea>" --plan
-./harness harvest --idea "<feature idea>" --preview
-./harness harvest --idea "<feature idea>" --apply
 ./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
 ./harness harvest sessions
 ./harness harvest --interactive --session-id harvest-001 --resume
@@ -77,10 +75,13 @@ A completed session cannot be resumed as a question loop. The command reports th
 - `--session-id`: interactive harvest session id. If omitted, the runtime generates one.
 - `--resume`: resume an existing interactive harvest session instead of starting a new one.
 - `sessions`: list saved interactive harvest sessions from `.harness/ui/sessions`.
-- `--plan`: show the harvest workflow plan without changing files.
-- `--preview`: show a no-side-effect preview. It currently has the same behavior as `--plan`.
-- `--apply`: run the non-interactive harvest workflow through the agent runner.
+- `--plan`: show the harvest workflow plan without changing files. Treat this as debug/explain mode.
 - `--interactive`: run the Grill-Me question/answer loop in the terminal and generate design documents after the requirements gate passes.
+
+Compatibility aliases:
+
+- `--preview`: deprecated alias for `--plan`.
+- `--apply`: deprecated alias for `--interactive`.
 
 ## Help expectation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ The bootstrap creates a short `AGENTS.md` and cold-path context files under
 `docs/agent/`. If an existing root `AGENTS.md` is not harness-managed, the
 bootstrap preserves it and records that decision in `docs/agent/session-state.md`.
 
-`harness harvest --apply` runs this bootstrap before specialist agents. `harness
+`harness harvest --interactive` runs this bootstrap before specialist agents. `harness
 changes create-from-design` runs it after generating ChangeSet and use-case slice
 documents.
 

--- a/docs/runtime-interactive-harvest.md
+++ b/docs/runtime-interactive-harvest.md
@@ -26,15 +26,16 @@ If `docs/design/요구사항.md` and `docs/design/유스케이스.md` already ex
 
 ```bash
 ./harness harvest --idea "<feature idea>" --plan
-./harness harvest --idea "<feature idea>" --preview
-./harness harvest --idea "<feature idea>" --apply
 ./harness harvest --idea "<feature idea>" --interactive
 ```
 
-- `--plan`: show the harvest workflow plan without changing files.
-- `--preview`: show a no-side-effect preview. It currently has the same behavior as `--plan`.
-- `--apply`: run the non-interactive harvest workflow through the agent runner.
+- `--plan`: show the harvest workflow plan without changing files. Treat this as debug/explain mode.
 - `--interactive`: run the Grill-Me question/answer loop in the terminal and generate design documents after the requirements gate passes.
+
+Compatibility aliases:
+
+- `--preview`: deprecated alias for `--plan`.
+- `--apply`: deprecated alias for `--interactive`.
 
 ## Interactive behavior
 

--- a/docs/runtime-interactive-harvest.md
+++ b/docs/runtime-interactive-harvest.md
@@ -32,11 +32,6 @@ If `docs/design/요구사항.md` and `docs/design/유스케이스.md` already ex
 - `--plan`: show the harvest workflow plan without changing files. Treat this as debug/explain mode.
 - `--interactive`: run the Grill-Me question/answer loop in the terminal and generate design documents after the requirements gate passes.
 
-Compatibility aliases:
-
-- `--preview`: deprecated alias for `--plan`.
-- `--apply`: deprecated alias for `--interactive`.
-
 ## Interactive behavior
 
 `harvest --interactive` reuses the existing runtime-backed harvest UI session service.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -83,9 +83,8 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  harness harvest --idea '<feature idea>' --plan\n"
-            "  harness harvest --idea '<feature idea>' --apply --session-id harvest-001\n"
-            "  harness harvest --apply --session-id harvest-001 --resume\n"
             "  harness harvest --idea '<feature idea>' --interactive --session-id harvest-001\n"
+            "  harness harvest --interactive --session-id harvest-001 --resume\n"
             "  harness harvest sessions"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -98,7 +97,7 @@ def build_parser() -> argparse.ArgumentParser:
     harvest.add_argument(
         "--session-id",
         default="",
-        help="Harvest session id. Use with --apply or --interactive to start or resume a named session.",
+        help="Harvest session id. Use with --interactive to start or resume a named session.",
     )
     harvest.add_argument(
         "--resume",
@@ -208,9 +207,11 @@ def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
 
     if not any((args.plan, args.preview, args.apply, args.interactive)):
         raise ValueError(
-            "harvest requires one of --plan, --preview, --apply, --interactive, "
+            "harvest requires one of --plan or --interactive, "
             "or the sessions subcommand"
         )
+
+    _warn_harvest_mode_aliases(args)
 
     workflow_dir = repo_root / ".harness/workflows"
     if not (workflow_dir / "harvest-workflow.yaml").exists():
@@ -478,10 +479,31 @@ def _add_mode_options(parser: argparse.ArgumentParser) -> None:
 
 def _add_harvest_mode_options(parser: argparse.ArgumentParser) -> None:
     mode = parser.add_mutually_exclusive_group(required=False)
-    mode.add_argument("--plan", action="store_true", help="Show the harvest workflow plan without changing files.")
-    mode.add_argument("--preview", action="store_true", help="Preview the harvest workflow without changing files; currently equivalent to --plan.")
-    mode.add_argument("--apply", action="store_true", help="Run the interactive harvest flow through runtime-ready use-case slice generation.")
-    mode.add_argument("--interactive", action="store_true", help="Compatibility alias for the interactive harvest flow used by --apply.")
+    mode.add_argument(
+        "--plan",
+        action="store_true",
+        help="Show the harvest workflow plan without changing files. Debug/explain mode only.",
+    )
+    mode.add_argument("--preview", action="store_true", help=argparse.SUPPRESS)
+    mode.add_argument("--apply", action="store_true", help=argparse.SUPPRESS)
+    mode.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Run the interactive Grill-Me loop and generate design documents.",
+    )
+
+
+def _warn_harvest_mode_aliases(args: argparse.Namespace) -> None:
+    if args.preview:
+        print(
+            "warning: `harvest --preview` is deprecated; use `harvest --plan`.",
+            file=sys.stderr,
+        )
+    if args.apply:
+        print(
+            "warning: `harvest --apply` is deprecated; use `harvest --interactive`.",
+            file=sys.stderr,
+        )
 
 
 def _format_scopes(change_set: ChangeSet, scopes: tuple, mode: RunMode) -> str:

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -205,22 +205,19 @@ def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
     if getattr(args, "harvest_subcommand", "") == "sessions":
         return list_harvest_sessions(repo_root)
 
-    if not any((args.plan, args.preview, args.apply, args.interactive)):
+    if not any((args.plan, args.interactive)):
         raise ValueError(
             "harvest requires one of --plan or --interactive, "
             "or the sessions subcommand"
         )
-
-    _warn_harvest_mode_aliases(args)
 
     workflow_dir = repo_root / ".harness/workflows"
     if not (workflow_dir / "harvest-workflow.yaml").exists():
         workflow_dir = Path(__file__).resolve().parents[1] / ".harness/workflows"
     workflow = load_named_workflow("harvest-workflow", workflows_dir=workflow_dir)
 
-    mode = _selected_mode(args)
-    if mode in (RunMode.PLAN, RunMode.PREVIEW):
-        return _format_harvest_plan(workflow, mode, args.idea)
+    if args.plan:
+        return _format_harvest_plan(workflow, RunMode.PLAN, args.idea)
 
     agent_context = bootstrap_agent_context(repo_root, _repo_description(args.idea))
     return "\n".join(
@@ -484,26 +481,11 @@ def _add_harvest_mode_options(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Show the harvest workflow plan without changing files. Debug/explain mode only.",
     )
-    mode.add_argument("--preview", action="store_true", help=argparse.SUPPRESS)
-    mode.add_argument("--apply", action="store_true", help=argparse.SUPPRESS)
     mode.add_argument(
         "--interactive",
         action="store_true",
         help="Run the interactive Grill-Me loop and generate design documents.",
     )
-
-
-def _warn_harvest_mode_aliases(args: argparse.Namespace) -> None:
-    if args.preview:
-        print(
-            "warning: `harvest --preview` is deprecated; use `harvest --plan`.",
-            file=sys.stderr,
-        )
-    if args.apply:
-        print(
-            "warning: `harvest --apply` is deprecated; use `harvest --interactive`.",
-            file=sys.stderr,
-        )
 
 
 def _format_scopes(change_set: ChangeSet, scopes: tuple, mode: RunMode) -> str:

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -22,7 +22,6 @@ USE_CASE_SLICE_ROOT = Path("docs/use-cases")
 GRILL_ME_SKILL_PATH = Path(".codex/skills/grill-me/SKILL.md")
 USE_CASE_AGENT_CONFIG_PATH = Path(".codex/agents/harness_usecases.toml")
 USE_CASE_SKILL_PATH = Path(".codex/skills/harness-usecases/SKILL.md")
-MAX_REQUIREMENTS_QUESTIONS = 10
 
 
 @dataclass(frozen=True)
@@ -76,10 +75,8 @@ def answer_requirements(root: Path | str, answer: str) -> HarvestUiResult:
     )
     session["current_questions"] = []
     session["current_question"] = None
-    if session.get("pending_questions"):
-        _activate_next_pending_question(session)
-    else:
-        _advance_grill_me(root_path, session)
+    session["pending_questions"] = []
+    _advance_grill_me(root_path, session)
     _write_context_doc(root_path, session)
     _write_requirements_doc(root_path, session)
     _write_session(root_path, session)
@@ -151,10 +148,8 @@ def answer_use_cases(root: Path | str, answer: str, idea: str = "") -> HarvestUi
     )
     session["use_case_current_question"] = None
     session["use_case_current_questions"] = []
-    if session.get("use_case_pending_questions"):
-        _activate_next_use_case_pending_question(session)
-    else:
-        _advance_use_case_harvest(root_path, session, idea)
+    session["use_case_pending_questions"] = []
+    _advance_use_case_harvest(root_path, session, idea)
     _write_session(root_path, session)
     return _result(root_path, session)
 
@@ -445,22 +440,14 @@ def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
     result = _run_grill_me(root, session)
     session["draft_context_markdown"] = str(result.get("context_markdown", "") or "")
     session["draft_requirements_markdown"] = str(result.get("requirements_markdown", "") or "")
-    open_language_questions = _extract_blocking_open_language_questions(session["draft_context_markdown"])
+    open_language_questions = _extract_open_language_questions(session["draft_context_markdown"])
     filtered_questions = _filter_new_questions(result["questions"], session)
-    remaining_budget = _remaining_requirements_question_budget(session)
-    if _requirements_question_budget_exhausted(session):
-        session["requirements_gate_passed"] = True
-        session["current_question"] = None
-        session["current_questions"] = []
-        session["pending_questions"] = []
-        session["runtime_error"] = ""
-        return
     if open_language_questions:
-        follow_up_questions = (filtered_questions or _fallback_open_language_questions(open_language_questions))[:remaining_budget]
+        follow_up_questions = filtered_questions or _fallback_open_language_questions(open_language_questions)
         session["requirements_gate_passed"] = False
         session["current_question"] = follow_up_questions[0]
         session["current_questions"] = [follow_up_questions[0]]
-        session["pending_questions"] = follow_up_questions[1:]
+        session["pending_questions"] = []
         session["runtime_error"] = ""
         return
     if result["complete"]:
@@ -475,11 +462,10 @@ def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
             session["current_questions"] = []
             session["pending_questions"] = []
         else:
-            filtered_questions = filtered_questions[:remaining_budget]
             session["requirements_gate_passed"] = False
             session["current_question"] = filtered_questions[0]
             session["current_questions"] = [filtered_questions[0]]
-            session["pending_questions"] = filtered_questions[1:]
+            session["pending_questions"] = []
     session["runtime_error"] = ""
 
 
@@ -505,7 +491,7 @@ def _advance_use_case_harvest(root: Path, session: dict[str, Any], idea: str) ->
     session["use_cases_ready"] = False
     session["use_case_current_question"] = questions[0]
     session["use_case_current_questions"] = [questions[0]]
-    session["use_case_pending_questions"] = questions[1:]
+    session["use_case_pending_questions"] = []
     session["runtime_error"] = ""
 
 
@@ -571,17 +557,6 @@ def _asked_question_keys(session: dict[str, Any]) -> set[str]:
         if key:
             keys.add(key)
     return keys
-
-
-def _requirements_question_budget_exhausted(session: dict[str, Any]) -> bool:
-    return _remaining_requirements_question_budget(session) <= 0
-
-
-def _remaining_requirements_question_budget(session: dict[str, Any]) -> int:
-    asked = len(session.get("clarifications", []))
-    pending = len(session.get("pending_questions", []) or [])
-    current = 1 if _current_question(session) else 0
-    return max(0, MAX_REQUIREMENTS_QUESTIONS - asked - pending - current)
 
 
 def _asked_use_case_question_keys(session: dict[str, Any]) -> set[str]:
@@ -782,15 +757,14 @@ Status rules:
 - Return status `blocked` only when the existing requirements/context inputs are not ready and no user answer in this stage can resolve it.
 
 Question rules:
-- When status is `needs_input`, include one to three question objects with keys question and recommended.
-- Do not ask any question already present in Use-case answer history or Pending use-case question queue.
+- When status is `needs_input`, include exactly one question object with keys question and recommended.
+- Ask only the single highest-priority blocker for this turn.
+- Do not queue non-blocking follow-up questions.
+- Do not ask any question already present in Use-case answer history.
 - If the answer history resolves enough ambiguity, write the use-case docs and return status `complete`.
 
 Use-case answer history:
 {json.dumps(session.get("use_case_clarifications", []), ensure_ascii=False, indent=2)}
-
-Pending use-case question queue:
-{json.dumps(session.get("use_case_pending_questions", []), ensure_ascii=False, indent=2)}
 """
 
 
@@ -826,28 +800,22 @@ def _grill_me_prompt(root: Path, session: dict[str, Any], skill_path: Path) -> s
     )
     grill_me_skill = skill_path.read_text(encoding="utf-8")
     asked_questions = _asked_questions(session)
-    pending_questions = session.get("pending_questions") or []
     return f"""Use $grill-me to clarify requirements.
 
 Return only JSON with keys: complete, questions, requirements_markdown, context_markdown.
 Always include draft requirements_markdown and context_markdown that reflect the current confirmed state.
-When incomplete, return up to exactly 3 questions in questions[].
+When incomplete, return exactly 1 question in questions[].
 Each question object must have keys: question, recommended.
 
 Question repetition rules:
 - Do not ask any question already present in Answered question history.
-- Do not ask any question already present in Pending question queue.
-- Do not ask semantically equivalent questions to any answered or pending question.
+- Do not ask semantically equivalent questions to any answered or active question.
 - If a previous answer is partial, ask only for the missing detail and explicitly narrow the question.
 - Generate questions only from unresolved/open decisions.
-- Run harvest as one MVP/use-case discovery pass. For an empty project or broad request like "build a calculator", first identify one MVP and ask only for decisions needed for that one MVP use case.
-- For an existing repository feature addition or modification, steer the draft toward one use-case-sized ChangeSet instead of a broad multi-use-case program.
-- Ask at most {MAX_REQUIREMENTS_QUESTIONS} requirements questions total. After that, draft requirements and defer non-blocking questions.
-- Blocking harvest questions are only actor, one MVP goal, primary command/action, inputs, successful result, user-visible failure policy, and hard scope boundaries for that one use case.
-- Do not ask harvest-blocking questions about event candidate names, explicit state names, DDD design, detailed NFRs, security/audit concepts, stack choices, implementation strategy, aliases, or forbidden terms unless they directly block the single MVP use case.
-- context_markdown must split unresolved language into `## 3. Blocking Open Language Questions` and `## 4. Deferred Language Questions`.
-- Return complete=true when `## 3. Blocking Open Language Questions` is empty or contains only `- None.`. Deferred language questions do not block use-case harvest.
-- If context_markdown still has blocking open language questions and the question budget is not exhausted, return complete=false and ask the focused follow-up question that resolves one blocker.
+- Ask only the single highest-priority blocker for a single MVP/use-case-sized ChangeSet.
+- Do not queue non-blocking follow-up questions.
+- Return complete=true only when context_markdown has no unresolved entries under `## 3. Open Language Questions`.
+- If context_markdown still has any open language question, return complete=false and ask the focused follow-up question that resolves it.
 - In requirements_markdown, never use a clarification table column named `Answer`; use `Response`.
 - context_markdown must follow the root context.md structure from harness-requirements and include the Ubiquitous Language table.
 - requirements_markdown must use canonical terms from context_markdown.
@@ -861,8 +829,8 @@ Answered question history:
 Clarification history:
 {json.dumps(session["clarifications"], ensure_ascii=False, indent=2)}
 
-Pending question queue:
-{json.dumps(pending_questions, ensure_ascii=False, indent=2)}
+Active question:
+{json.dumps([_current_question(session)] if _current_question(session) else [], ensure_ascii=False, indent=2)}
 
 Harness requirements standards:
 {requirements_skill}
@@ -902,7 +870,7 @@ def _parse_grill_me_json(text: str) -> dict[str, Any]:
     if not isinstance(raw_questions, list):
         raise ValueError("Grill-Me returned invalid questions")
     questions = []
-    for item in raw_questions[:3]:
+    for item in raw_questions[:1]:
         if not isinstance(item, dict):
             continue
         question = str(item.get("question", "")).strip()
@@ -922,18 +890,11 @@ def _parse_grill_me_json(text: str) -> dict[str, Any]:
     }
 
 
-def _extract_blocking_open_language_questions(markdown: str) -> list[str]:
+def _extract_open_language_questions(markdown: str) -> list[str]:
     if not markdown.strip():
         return []
-    blocking = _extract_markdown_list_section(markdown, "3. Blocking Open Language Questions")
-    if blocking:
-        return blocking
-    return _extract_markdown_list_section(markdown, "Blocking Open Language Questions")
-
-
-def _extract_markdown_list_section(markdown: str, title: str) -> list[str]:
     match = re.search(
-        rf"^## {re.escape(title)}\s*$([\s\S]*?)(?=^##\s|\Z)",
+        r"^## 3\. Open Language Questions\s*$([\s\S]*?)(?=^##\s|\Z)",
         markdown,
         flags=re.MULTILINE,
     )

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -69,10 +69,9 @@ def fake_grill_me(_root: Path, session: dict) -> dict:
         "complete": False,
         "questions": [
             {
-                "question": f"Question {index + 1}.{question_index + 1}?",
-                "recommended": f"Answer {index + 1}.{question_index + 1}",
+                "question": f"Question {index + 1}?",
+                "recommended": f"Answer {index + 1}",
             }
-            for question_index in range(3)
         ],
         "requirements_markdown": requirements_markdown,
         "context_markdown": context_markdown,
@@ -109,27 +108,27 @@ def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
     assert result.requirements_gate_passed is False
     assert result.current_question is not None
     assert len(result.current_questions) == 1
-    assert result.current_question["question"] == "Question 1.1?"
+    assert result.current_question["question"] == "Question 1?"
     assert (tmp_path / REQUIREMENTS_PATH).is_file()
     assert (tmp_path / CONTEXT_PATH).is_file()
     assert (tmp_path / ".harness/ui/harvest-session.json").is_file()
     assert not (tmp_path / USE_CASES_PATH).exists()
 
     session = json.loads((tmp_path / ".harness/ui/harvest-session.json").read_text(encoding="utf-8"))
-    assert len(session["pending_questions"]) == 2
+    assert session["pending_questions"] == []
 
     result = answer_requirements(tmp_path, "answer 1")
 
     assert result.requirements_gate_passed is False
     assert result.current_question is not None
-    assert result.current_question["question"] == "Question 1.2?"
+    assert result.current_question["question"] == "Question 2?"
     assert len(result.clarifications) == 1
     assert len(result.clarifications[0]["questions"]) == 1
-    assert result.clarifications[0]["questions"][0]["question"] == "Question 1.1?"
+    assert result.clarifications[0]["questions"][0]["question"] == "Question 1?"
 
     result = answer_requirements(tmp_path, "answer 2")
     assert result.current_question is not None
-    assert result.current_question["question"] == "Question 1.3?"
+    assert result.current_question["question"] == "Question 3?"
 
     result = answer_requirements(tmp_path, "answer 3")
     assert result.requirements_gate_passed is True
@@ -181,7 +180,7 @@ def test_harvest_ui_filters_duplicate_grill_me_questions(
     assert result.current_question["question"] == "What is the success outcome?"
 
 
-def test_harvest_ui_keeps_grill_me_running_until_context_has_no_blocking_language_questions(
+def test_harvest_ui_keeps_grill_me_running_until_context_has_no_open_language_questions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -191,13 +190,13 @@ def test_harvest_ui_keeps_grill_me_running_until_context_has_no_blocking_languag
                 "complete": True,
                 "questions": [],
                 "requirements_markdown": "# Requirements Specification\n",
-                "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n| Operator | 연산자 | Operator | Domain Concept | Arithmetic selector. | Selected Operation | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- None.\n\n## 4. Deferred Language Questions\n\n- None.\n",
+                "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n| Operator | 연산자 | Operator | Domain Concept | Arithmetic selector. | Selected Operation | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- None.\n",
             }
         return {
             "complete": True,
             "questions": [],
             "requirements_markdown": "# Requirements Specification\n",
-            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n\n## 4. Deferred Language Questions\n\n- Confirm event candidate names later.\n",
+            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n",
         }
 
     monkeypatch.setattr(
@@ -217,7 +216,7 @@ def test_harvest_ui_keeps_grill_me_running_until_context_has_no_blocking_languag
     assert result.current_question is None
 
 
-def test_harvest_ui_uses_blocking_language_questions_when_grill_me_returns_no_follow_up(
+def test_harvest_ui_uses_open_language_questions_when_grill_me_returns_no_follow_up(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -227,7 +226,7 @@ def test_harvest_ui_uses_blocking_language_questions_when_grill_me_returns_no_fo
             "complete": False,
             "questions": [],
             "requirements_markdown": "# Requirements Specification\n",
-            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n\n## 4. Deferred Language Questions\n\n- Confirm state names later.\n",
+            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Open Language Questions\n\n- Confirm the canonical term for the arithmetic selector.\n",
         },
     )
 
@@ -239,52 +238,7 @@ def test_harvest_ui_uses_blocking_language_questions_when_grill_me_returns_no_fo
     assert "Confirm the canonical term" in result.current_question["recommended"]
 
 
-def test_harvest_ui_does_not_block_on_deferred_language_questions(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "harness_codex.runtime.harvest_ui._run_grill_me",
-        lambda _root, _session: {
-            "complete": True,
-            "questions": [],
-            "requirements_markdown": "# Requirements Specification\n",
-            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- None.\n\n## 4. Deferred Language Questions\n\n- Confirm event candidate names later.\n",
-        },
-    )
-
-    result = start_requirements(tmp_path, "build a calculator")
-
-    assert result.requirements_gate_passed is True
-    assert result.current_question is None
-
-
-def test_harvest_ui_enforces_requirements_question_budget(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def budget_grill_me(_root: Path, session: dict) -> dict:
-        return {
-            "complete": False,
-            "questions": [
-                {"question": f"Question {len(session['clarifications'])}.{index}?", "recommended": "Answer"}
-                for index in range(3)
-            ],
-            "requirements_markdown": "# Requirements Specification\n",
-            "context_markdown": "# Project Context\n\n## 1. Ubiquitous Language\n\n| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |\n|---|---|---|---|---|---|---|---|\n| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |\n\n## 2. Naming Rules\n\n- Documents must use `Canonical Term`.\n\n## 3. Blocking Open Language Questions\n\n- None.\n\n## 4. Deferred Language Questions\n\n- None.\n",
-        }
-
-    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", budget_grill_me)
-
-    result = start_requirements(tmp_path, "build a calculator")
-    while result.current_question is not None:
-        result = answer_requirements(tmp_path, "answer")
-
-    assert result.requirements_gate_passed is True
-    assert len(result.clarifications) == 10
-
-
-def test_grill_me_prompt_includes_answered_and_pending_questions(
+def test_grill_me_prompt_includes_answered_and_active_questions(
     tmp_path: Path,
 ) -> None:
     skill_dir = tmp_path / ".codex/skills"
@@ -305,18 +259,17 @@ def test_grill_me_prompt_includes_answered_and_pending_questions(
                     "answer": "Customer",
                 }
             ],
-            "current_question": None,
-            "current_questions": [],
-            "pending_questions": [{"question": "What is success?", "recommended": "Entry"}],
+            "current_question": {"question": "What is success?", "recommended": "Entry"},
+            "current_questions": [{"question": "What is success?", "recommended": "Entry"}],
+            "pending_questions": [],
         },
         skill_dir / "grill-me/SKILL.md",
     )
 
     assert "Answered question history" in prompt
-    assert "Pending question queue" in prompt
+    assert "Active question" in prompt
     assert "Do not ask semantically equivalent questions" in prompt
-    assert "Ask at most 10 requirements questions total" in prompt
-    assert "one MVP/use-case discovery pass" in prompt
+    assert "Return complete=true only when context_markdown has no unresolved entries" in prompt
     assert "Who uses it?" in prompt
     assert "What is success?" in prompt
 

--- a/tests/runtime/test_interactive_harvest_cli.py
+++ b/tests/runtime/test_interactive_harvest_cli.py
@@ -10,7 +10,9 @@ def test_harvest_help_includes_interactive_option(capsys) -> None:
 
     output = capsys.readouterr().out
     assert "--interactive" in output
-    assert "Grill-Me question/answer loop" in output
+    assert "interactive Grill-Me loop" in output
+    assert "--apply" not in output
+    assert "--preview" not in output
 
 
 def test_harvest_interactive_requires_idea(tmp_path, capsys) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -311,31 +311,11 @@ def test_harvest_apply_warns_and_uses_interactive_runtime(
         },
     )
 
-    exit_code = main(
-        [
-            "--repo-root",
-            str(tmp_path),
-            "harvest",
-            "--idea",
-            "simple calculator app",
-            "--apply",
-        ]
-    )
+    exit_code = main(["--repo-root", str(tmp_path), "harvest", "--idea", "simple calculator app"])
 
     captured = capsys.readouterr()
-    output = captured.out
-    error = captured.err
     assert exit_code == 2
-    assert "deprecated" in error
-    assert "INTERACTIVE HARVEST started" in output
-    assert (
-        "interactive harvest step failed" in error
-        or "missing agent config" in error
-        or "status=blocked" in output
-    )
-    run_dir = next((tmp_path / ".harness/runs").iterdir())
-    assert (run_dir / "steps").is_dir()
-    assert any((run_dir / "steps").iterdir())
+    assert "harvest requires one of --plan or --interactive" in captured.err
 
 
 def test_changes_create_from_design_generates_runnable_slice(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -266,7 +266,7 @@ def test_agent_context_init_creates_expected_files(
     assert (tmp_path / "docs/agent/token-reduction-report.md").is_file()
 
 
-def test_harvest_apply_uses_runtime_and_records_blocker_without_agent_config(
+def test_harvest_apply_warns_and_uses_interactive_runtime(
     tmp_path: Path,
     capsys,
     monkeypatch,
@@ -324,11 +324,13 @@ def test_harvest_apply_uses_runtime_and_records_blocker_without_agent_config(
 
     captured = capsys.readouterr()
     output = captured.out
+    error = captured.err
     assert exit_code == 2
+    assert "deprecated" in error
     assert "INTERACTIVE HARVEST started" in output
     assert (
-        "interactive harvest step failed" in captured.err
-        or "missing agent config" in captured.err
+        "interactive harvest step failed" in error
+        or "missing agent config" in error
         or "status=blocked" in output
     )
     run_dir = next((tmp_path / ".harness/runs").iterdir())

--- a/tests/test_harvester_skill_instructions.py
+++ b/tests/test_harvester_skill_instructions.py
@@ -5,7 +5,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_harvester_skills_ask_one_question_with_recommendation() -> None:
-    paths = (
+    all_paths = (
         REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
         REPO_ROOT / ".codex/agents/harness_requirements.toml",
         REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
@@ -14,11 +14,20 @@ def test_harvester_skills_ask_one_question_with_recommendation() -> None:
         REPO_ROOT / ".codex/skills/harness-usecases/references/agent-prompt.md",
     )
 
-    for path in paths:
+    requirement_paths = all_paths[:3]
+    usecase_paths = all_paths[3:]
+
+    for path in requirement_paths:
         text = path.read_text(encoding="utf-8")
         assert "one focused question at a time" in text
         assert "Recommended answer" in text
         assert "3-7" not in text
+
+        assert "single highest-priority blocker" in text
+
+    for path in usecase_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "one JSON needs_input question" in text or "one focused question at a time" in text
 
 
 def test_requirements_grill_me_questioning_is_time_boxed() -> None:
@@ -31,11 +40,26 @@ def test_requirements_grill_me_questioning_is_time_boxed() -> None:
     for path in paths:
         text = path.read_text(encoding="utf-8")
         assert "at most 3 rounds" in text
-        assert "at most 7 total questions per round" in text
         assert "After each round" in text
         assert "not continue asking until the domain is perfect" in text
         assert "produce a draft" in text
         assert "Open Language Questions" in text
+
+
+def test_requirements_harvest_defers_technology_specific_questions() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
+        REPO_ROOT / ".codex/agents/harness_requirements.toml",
+        REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
+    )
+
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert "questions by default" in text
+        assert "authentication" in text
+        assert "authorization" in text
+        assert "cache" in text
+        assert "messaging" in text
 
 
 def test_requirements_skill_explores_local_context_before_questions() -> None:


### PR DESCRIPTION
## 구현 의도
- harvest 단계가 기술 스택 설계 인터뷰처럼 동작하지 않도록 MVP 범위 확인 중심으로 질문 계약을 축소합니다.
- harvest CLI 를 `--interactive` 와 `--plan` 중심으로 단순화해 실행 흐름 혼란을 줄입니다.
- 기존 런타임이 질문을 큐잉하던 동작을 제거해 매 턴 하나의 최우선 blocker 만 묻게 만듭니다.
- Closes #140

## 구현 방식
- `harness_codex/runtime/harvest_ui.py` 에서 requirements/use-case 단계 모두 답변 후 항상 재평가하도록 바꿔 pending question queue 를 비우고, 프롬프트 계약도 `exactly 1 question` 과 `single highest-priority blocker` 로 제한했습니다.
- `harness_codex/cli.py` 에서 harvest 도움말과 파서를 `--interactive` / `--plan` 중심으로 정리하고, harvest 전용 `--apply` 와 `--preview` 옵션을 제거했습니다.
- `.codex/agents/harness_requirements.toml`, `.codex/skills/harness-requirements/**` 에서 기술 특화 질문을 기본 금지하고 actor/goal/action/input/result/failure/scope 중심으로 harvest 질문 우선순위를 재정의했습니다.
- 관련 문서와 테스트를 새 계약에 맞게 갱신해 CLI 설명, 프롬프트 wording, 단일 질문 런타임 동작을 함께 검증했습니다.

## 검증 방법
- `./venv/bin/python -m pytest -s tests/test_harvester_skill_instructions.py tests/runtime/test_harvest_ui.py tests/runtime/test_interactive_harvest_cli.py tests/test_cli_commands.py`
- `./venv/bin/python -m pytest -s tests/runtime/test_interactive_harvest_cli.py tests/test_cli_commands.py`

## 위험 및 롤백
- 위험: harvest 에서 `--apply`, `--preview` 를 호출하던 외부 스크립트는 이제 즉시 실패합니다. 호출부를 `--interactive`, `--plan` 으로 바꿔야 합니다.
- 위험: harvest 질문 수가 줄어든 만큼 일부 기술 제약이 문서의 deferred section 으로 밀릴 수 있습니다. 이후 DDD/technical-decision 단계에서 보완해야 합니다.
- 롤백: 브랜치의 관련 커밋(`a37e0aa`, `cb7111f`)을 되돌리면 기존 질문 계약과 CLI 표면으로 복귀할 수 있습니다.