### PR TITLE
Fix Markdown-aware forbidden term validation

### DIFF
--- a/.codex/agents/harness_usecases.toml
+++ b/.codex/agents/harness_usecases.toml
@@ -62,7 +62,7 @@ Use case rules:
 - Commands must be written in imperative form.
 - Events must be written in past tense.
 - Policies must be written as conditions or decision criteria.
-- Every detailed use case must include Actor, Supporting Actor, Goal, Preconditions, Main Flow, Exception Flow, Result, Non-Functional Requirements.
+- Every detailed use case must include Actor, Supporting Actor, Goal, Preconditions, Main Flow, Failure Flow, Result, Non-Functional Requirements.
 - If a section has no content yet, write None or Needs confirmation.
 - Do not mark use cases complete unless all use case, language, and event-storming-readiness rules above are satisfied.
 - Do not write requirements.

--- a/.codex/skills/harness-usecases/SKILL.md
+++ b/.codex/skills/harness-usecases/SKILL.md
@@ -236,7 +236,7 @@ cannot fix the issue:
 **Main Flow**
 1. ...
 
-**Exception Flow**
+**Failure Flow**
 - ...
 
 **Result**
@@ -298,7 +298,7 @@ cannot fix the issue:
 ## Main Flow
 1. ...
 
-## Exception Flow
+## Failure Flow
 - ...
 
 ## Result
@@ -335,5 +335,5 @@ cannot fix the issue:
 - None
 ```
 
-Even when a use case has no supporting actors, exception flow, or non-functional
+Even when a use case has no supporting actors, failure flow, or non-functional
 requirements, keep the sections and write `- None` or `- Needs confirmation`.

--- a/harness_codex/context_language.py
+++ b/harness_codex/context_language.py
@@ -103,7 +103,13 @@ def validate_forbidden_terms(
     terms: Iterable[LanguageTerm],
     scan_paths: Iterable[Path] = DEFAULT_SCAN_PATHS,
 ) -> tuple[str, ...]:
-    """Return violations where a forbidden term appears in generated docs."""
+    """Return violations where a forbidden term appears in generated docs.
+
+    Markdown headings, tables, and fenced code blocks are treated as document
+    structure, not generated domain language. This prevents template headings
+    such as ``## Exception Flow`` from failing a forbidden-term gate while still
+    catching the same term in body prose.
+    """
 
     forbidden = sorted(
         {
@@ -124,7 +130,7 @@ def validate_forbidden_terms(
         if not root.exists():
             continue
         for path in sorted(root.rglob("*.md")):
-            text = path.read_text(encoding="utf-8")
+            text = _markdown_search_text(path.read_text(encoding="utf-8"))
             for forbidden_term in forbidden:
                 if _contains_term(text, forbidden_term):
                     violations.append(f"{path.relative_to(repo_root)} contains forbidden term: {forbidden_term}")
@@ -176,6 +182,31 @@ def _markdown_table_rows(text: str) -> list[list[str]]:
         elif rows:
             break
     return rows
+
+
+def _markdown_search_text(text: str) -> str:
+    lines: list[str] = []
+    in_code_block = False
+
+    for line in text.splitlines():
+        stripped = line.strip()
+
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            continue
+
+        if in_code_block:
+            continue
+
+        if stripped.startswith("#"):
+            continue
+
+        if stripped.startswith("|") and stripped.endswith("|"):
+            continue
+
+        lines.append(line)
+
+    return "\n".join(lines)
 
 
 def _split_terms(value: str) -> tuple[str, ...]:

--- a/tests/test_context_language.py
+++ b/tests/test_context_language.py
@@ -22,6 +22,19 @@ VALID_CONTEXT = """# Project Context
 - Documents must use `Canonical Term`.
 """
 
+CONTEXT_WITH_EXCEPTION_FORBIDDEN = """# Project Context
+
+## 1. Ubiquitous Language
+
+| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
+|---|---|---|---|---|---|---|---|
+| 실패 흐름 | 실패 흐름 | FailureFlow | Other | 목표 달성이 실패하거나 거절되는 흐름 | Exception Flow | Exception | grill-me |
+
+## 2. Naming Rules
+
+- Documents must use `Canonical Term`.
+"""
+
 
 def test_load_language_terms_reads_required_table(tmp_path: Path) -> None:
     context = tmp_path / "context.md"
@@ -67,5 +80,72 @@ def test_validate_context_language_allows_clean_docs(tmp_path: Path) -> None:
     docs = tmp_path / "docs" / "design"
     docs.mkdir(parents=True)
     (docs / "요구사항.md").write_text("사용자는 대기열에 들어간다.", encoding="utf-8")
+
+    assert validate_context_language(tmp_path) == ()
+
+
+def test_validate_context_language_ignores_forbidden_terms_in_markdown_headings(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "context.md").write_text(CONTEXT_WITH_EXCEPTION_FORBIDDEN, encoding="utf-8")
+    use_case = tmp_path / "docs" / "use-cases" / "UC-001"
+    use_case.mkdir(parents=True)
+    (use_case / "use-case.md").write_text(
+        """# UC-001. User performs goal
+
+## Main Flow
+1. The user performs the goal.
+
+## Exception Flow
+- None
+""",
+        encoding="utf-8",
+    )
+
+    assert validate_context_language(tmp_path) == ()
+
+
+def test_validate_context_language_rejects_forbidden_terms_in_body_prose(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "context.md").write_text(CONTEXT_WITH_EXCEPTION_FORBIDDEN, encoding="utf-8")
+    use_case = tmp_path / "docs" / "use-cases" / "UC-001"
+    use_case.mkdir(parents=True)
+    (use_case / "use-case.md").write_text(
+        """# UC-001. User performs goal
+
+## Failure Flow
+- The system handles the Exception.
+""",
+        encoding="utf-8",
+    )
+
+    assert validate_context_language(tmp_path) == (
+        "docs/use-cases/UC-001/use-case.md contains forbidden term: Exception",
+    )
+
+
+def test_validate_context_language_ignores_forbidden_terms_in_code_blocks_and_tables(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "context.md").write_text(CONTEXT_WITH_EXCEPTION_FORBIDDEN, encoding="utf-8")
+    use_case = tmp_path / "docs" / "use-cases" / "UC-001"
+    use_case.mkdir(parents=True)
+    (use_case / "use-case.md").write_text(
+        """# UC-001. User performs goal
+
+| Section | Legacy Label |
+|---|---|
+| Flow | Exception |
+
+```text
+Exception
+```
+
+## Failure Flow
+- None
+""",
+        encoding="utf-8",
+    )
 
     assert validate_context_language(tmp_path) == ()


### PR DESCRIPTION
## 구현 의도

Fixes #144.

금지어 검증이 Markdown 목차나 템플릿 구조까지 본문처럼 검사해서 `## Exception Flow` 같은 제목만으로도 실패하는 문제를 수정합니다.

## 구현 방법

- `context_language.py`에서 금지어 검사 전에 Markdown 구조 요소를 제외합니다.
  - heading
  - fenced code block
  - markdown table row
- 본문 prose에 금지어가 남아 있는 경우는 계속 실패하도록 유지합니다.
- use-case 템플릿과 agent instruction의 `Exception Flow`를 `Failure Flow`로 변경했습니다.

## 검증 방법

테스트를 추가했습니다.

- 본문에 금지어가 있으면 violation 발생
- heading에만 금지어가 있으면 통과
- table/code block에만 금지어가 있으면 통과

전체 테스트 실행은 이 환경에서 하지 못했습니다.

## 변경 파일

- `harness_codex/context_language.py`
- `tests/test_context_language.py`
- `.codex/skills/harness-usecases/SKILL.md`
- `.codex/agents/harness_usecases.toml`
