### PR TITLE
Fallback to harvested use-case slices in design bridge

### DIFF
--- a/.codex/skills/harness-usecases/SKILL.md
+++ b/.codex/skills/harness-usecases/SKILL.md
@@ -68,6 +68,8 @@ docs/use-cases/<UC-ID>/
 Rules:
 - Use stable three-digit UC IDs such as `UC-001`, `UC-002`, and `UC-003`.
 - The canonical `docs/design/유스케이스.md` list and every slice directory must use the same UC ID and title.
+- `docs/design/유스케이스.md` must include at least one parser-friendly line per use case in either `- UC-001. <Actor performs goal>` or `## UC-001. <Actor performs goal>` form.
+- Do not express the only canonical use-case list as a markdown table, bold label, or metadata field.
 - `docs/use-cases/<UC-ID>/use-case.md` must contain the detailed use case for exactly one use case.
 - `docs/use-cases/<UC-ID>/e2e-goal.md` must define the end-to-end verification goal for that same use case.
 - If the use case is not fully confirmed, still create both slice documents and mark ambiguous sections as `Needs confirmation`.
@@ -119,6 +121,7 @@ Rules:
 - Separate commands, events, and policies by meaning and sentence form.
 - Write deliverables only to the owned files.
 - Every harvested UC must have docs/use-cases/<UC-ID>/use-case.md and docs/use-cases/<UC-ID>/e2e-goal.md.
+- docs/design/유스케이스.md must include parser-friendly use-case entries such as `- UC-001. <Actor performs goal>` and matching detail headings such as `## UC-001. <Actor performs goal>`.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```
 
@@ -142,6 +145,8 @@ Rules:
 
 6. **Write canonical use cases**
    Write or update `docs/design/유스케이스.md`, using one external actor goal per use case and the canonical language from `context.md`.
+   The high-level list must contain parseable bullet entries in the form `- UC-001. <Actor performs goal>`.
+   The detailed section for each use case must contain a parseable heading in the form `## UC-001. <Actor performs goal>`.
 
 7. **Write runtime slice docs**
    For every canonical use case, write or update:
@@ -217,7 +222,7 @@ cannot fix the issue:
 
 ## 2. High-Level Use Case List
 ### <Actor Group>
-- UC-001. ...
+- UC-001. <Actor performs goal>
 
 ## 3. Use Case Details
 ## UC-001. <Actor performs goal>

--- a/harness_codex/runtime/changes/design_bridge.py
+++ b/harness_codex/runtime/changes/design_bridge.py
@@ -13,6 +13,7 @@ USE_CASE_RE = re.compile(
     re.MULTILINE,
 )
 SECTION_RE = re.compile(r"^##\s+.+?\s*$", re.MULTILINE)
+SLICE_HEADING_RE = re.compile(r"^#\s+(?P<title>.+?)\s*$", re.MULTILINE)
 
 
 class DesignBridgeError(RuntimeError):
@@ -54,6 +55,8 @@ def create_changeset_from_design(
     requirements = _read_required(repo, requirements_path)
     use_cases_text = _read_required(repo, use_cases_path)
     use_cases = _parse_design_use_cases(use_cases_text)
+    if not use_cases:
+        use_cases = _parse_use_case_slices(repo)
 
     if selected_use_cases:
         selected = {_normalize_uc_id(uc_id) for uc_id in selected_use_cases}
@@ -61,14 +64,15 @@ def create_changeset_from_design(
 
     if not use_cases:
         raise DesignBridgeError(
-            f"No use cases found in {use_cases_path}. Expected entries like 'UC-01. User performs a goal'."
+            "No use cases found. Checked docs/design/유스케이스.md and "
+            "docs/use-cases/UC-*/use-case.md. Expected '- UC-001. ...' "
+            "or generated runtime slice docs."
         )
 
     if change_set_id is None:
         change_set_id = _next_change_set_id(repo)
 
     change_set_path = Path("docs/changes/active") / f"{change_set_id}.md"
-    created_paths = [change_set_path]
     documents: dict[Path, str] = {}
     documents[change_set_path] = _render_change_set(
         change_set_id=change_set_id,
@@ -79,24 +83,16 @@ def create_changeset_from_design(
         requirements=requirements,
         use_cases=use_cases,
     )
+    created_paths = [change_set_path]
 
     for use_case in use_cases:
-        documents.update(
-            _render_use_case_slice(
-                change_set_id=change_set_id,
-                use_case=use_case,
-            )
-        )
-        created_paths.extend(
-            use_case.slice_path / name
-            for name in (
-                "index.md",
-                "use-case.md",
-                "event-storming.md",
-                "e2e-goal.md",
-                "affected-files.md",
-            )
-        )
+        for path, text in _render_use_case_slice(
+            change_set_id=change_set_id,
+            use_case=use_case,
+        ).items():
+            if force or not (repo / path).exists():
+                documents[path] = text
+                created_paths.append(path)
 
     _write_documents(repo, documents, force=force)
     return DesignBridgeResult(
@@ -135,6 +131,40 @@ def _parse_design_use_cases(text: str) -> tuple[DesignUseCase, ...]:
     return tuple(by_id.values())
 
 
+def _parse_use_case_slices(repo: Path) -> tuple[DesignUseCase, ...]:
+    slice_root = repo / "docs/use-cases"
+    if not slice_root.exists():
+        return ()
+
+    use_cases: list[DesignUseCase] = []
+    for directory in sorted(slice_root.glob("UC-*")):
+        if not directory.is_dir():
+            continue
+        use_case_path = directory / "use-case.md"
+        if not use_case_path.exists():
+            continue
+        text = use_case_path.read_text(encoding="utf-8")
+        uc_id = _normalize_uc_id(directory.name)
+        use_cases.append(
+            DesignUseCase(
+                uc_id=uc_id,
+                source_id=directory.name,
+                name=_slice_use_case_name(text, uc_id),
+                source_block=text.strip(),
+            )
+        )
+    return tuple(use_cases)
+
+
+def _slice_use_case_name(text: str, uc_id: str) -> str:
+    match = SLICE_HEADING_RE.search(text)
+    if match is None:
+        return uc_id
+    title = match.group("title").strip()
+    title = re.sub(rf"^{re.escape(uc_id)}\.?\s*", "", title, flags=re.IGNORECASE).strip()
+    return title or uc_id
+
+
 def _source_block(text: str, start: int, sections: list[re.Match[str]]) -> str:
     end = len(text)
     for section in sections:
@@ -145,7 +175,10 @@ def _source_block(text: str, start: int, sections: list[re.Match[str]]) -> str:
 
 
 def _normalize_uc_id(raw_id: str) -> str:
-    number = int(re.search(r"\d+", raw_id).group(0))
+    match = re.search(r"\d+", raw_id)
+    if match is None:
+        raise DesignBridgeError(f"Invalid use-case id: {raw_id}")
+    number = int(match.group(0))
     return f"UC-{number:03d}"
 
 

--- a/tests/runtime/test_design_bridge_use_case_fallback.py
+++ b/tests/runtime/test_design_bridge_use_case_fallback.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+import pytest
+
+from harness_codex.runtime.changes.design_bridge import (
+    DesignBridgeError,
+    create_changeset_from_design,
+)
+
+
+def write_requirements(repo: Path) -> None:
+    design_dir = repo / "docs/design"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    (design_dir / "요구사항.md").write_text(
+        "# Requirements Specification\n\n## 1. Overview\n- Goal: Build a calculator.\n",
+        encoding="utf-8",
+    )
+
+
+def write_unparsable_use_case_doc(repo: Path) -> None:
+    design_dir = repo / "docs/design"
+    design_dir.mkdir(parents=True, exist_ok=True)
+    (design_dir / "유스케이스.md").write_text(
+        """# Use Case Document
+
+## 2. High-Level Use Case List
+
+| Use Case ID | Name |
+|---|---|
+| `UC-001` | 사용자가 계산 결과를 확인한다 |
+""",
+        encoding="utf-8",
+    )
+
+
+def write_use_case_slice(repo: Path, uc_id: str = "UC-001") -> None:
+    use_case_dir = repo / "docs/use-cases" / uc_id
+    use_case_dir.mkdir(parents=True, exist_ok=True)
+    (use_case_dir / "use-case.md").write_text(
+        f"""# {uc_id}. 사용자가 계산 결과를 확인한다
+
+## Goal
+- 사용자는 계산 결과를 확인한다.
+
+## Main Flow
+1. 사용자가 숫자와 연산자를 입력한다.
+2. 시스템이 계산 결과를 보여준다.
+""",
+        encoding="utf-8",
+    )
+    (use_case_dir / "e2e-goal.md").write_text(
+        f"# {uc_id} E2E Goal\n\n## Then\n- 계산 결과가 표시된다.\n",
+        encoding="utf-8",
+    )
+
+
+def test_create_from_design_falls_back_to_generated_use_case_slices(tmp_path: Path) -> None:
+    write_requirements(tmp_path)
+    write_unparsable_use_case_doc(tmp_path)
+    write_use_case_slice(tmp_path)
+
+    result = create_changeset_from_design(
+        tmp_path,
+        title="계산기",
+        change_set_id="CHG-20260521-001",
+    )
+
+    assert result.change_set_id == "CHG-20260521-001"
+    assert len(result.use_cases) == 1
+    assert result.use_cases[0].uc_id == "UC-001"
+    assert result.use_cases[0].name == "사용자가 계산 결과를 확인한다"
+    assert (tmp_path / "docs/changes/active/CHG-20260521-001.md").is_file()
+    assert (tmp_path / "docs/use-cases/UC-001/use-case.md").read_text(encoding="utf-8").startswith(
+        "# UC-001. 사용자가 계산 결과를 확인한다"
+    )
+    assert (tmp_path / "docs/use-cases/UC-001/event-storming.md").is_file()
+    assert (tmp_path / "docs/use-cases/UC-001/affected-files.md").is_file()
+
+
+def test_create_from_design_filters_slice_fallback_by_selected_use_case(tmp_path: Path) -> None:
+    write_requirements(tmp_path)
+    write_unparsable_use_case_doc(tmp_path)
+    write_use_case_slice(tmp_path, "UC-001")
+    write_use_case_slice(tmp_path, "UC-002")
+
+    result = create_changeset_from_design(
+        tmp_path,
+        title="계산기",
+        change_set_id="CHG-20260521-002",
+        selected_use_cases=("UC-002",),
+    )
+
+    assert [use_case.uc_id for use_case in result.use_cases] == ["UC-002"]
+
+
+def test_create_from_design_reports_both_sources_when_no_use_cases_exist(tmp_path: Path) -> None:
+    write_requirements(tmp_path)
+    write_unparsable_use_case_doc(tmp_path)
+
+    with pytest.raises(DesignBridgeError, match="docs/use-cases/UC-.*/use-case.md"):
+        create_changeset_from_design(
+            tmp_path,
+            title="계산기",
+            change_set_id="CHG-20260521-003",
+        )


### PR DESCRIPTION
## 구현 의도

Fixes #148.

`changes create-from-design`가 canonical `docs/design/유스케이스.md`에서 UC 목록을 못 찾더라도, harvest가 이미 만든 `docs/use-cases/UC-*` slice를 읽어서 ChangeSet을 만들 수 있게 합니다.

## 구현 방법

- 기존 canonical use-case 문서 파싱은 유지했습니다.
- canonical 문서에서 UC를 찾지 못하면 `docs/use-cases/UC-*/use-case.md`를 fallback으로 읽습니다.
- fallback에서는 UC ID를 디렉토리 이름에서 가져오고, 이름은 slice 문서의 첫 heading에서 추출합니다.
- 기존 slice 문서는 덮어쓰지 않고 부족한 보조 문서만 생성합니다.
- `harness-usecases` skill에 parser-friendly UC entry 형식을 명시했습니다.

## 검증 방법

테스트를 추가했습니다.

- canonical 문서가 table-only여도 slice fallback으로 ChangeSet 생성
- selected UC 필터가 fallback에도 적용됨
- canonical 문서와 slice가 모두 없으면 명확한 에러 발생

전체 테스트는 이 환경에서 실행하지 못했습니다.
