### PR TITLE
수확 유스케이스 문서 준비 상태 검증 강화

### DIFF
--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -97,10 +97,9 @@ def start_use_cases(root: Path | str) -> HarvestUiResult:
     session = _load_or_recover_session(root_path)
     if not session["requirements_gate_passed"]:
         raise ValueError("requirements gate has not passed")
-    if not _has_runtime_ready_use_case_slices(root_path):
-        raise ValueError(
-            "runtime-ready use case docs are missing; run agent-backed harvest use-case generation"
-        )
+    ready, error = _validate_runtime_ready_use_case_slices(root_path)
+    if not ready:
+        raise ValueError(error)
     session["active_stage"] = "useCases"
     session["use_cases_ready"] = True
     session["runtime_error"] = ""
@@ -114,7 +113,8 @@ def start_use_case_generation(root: Path | str, idea: str = "") -> HarvestUiResu
     if not session["requirements_gate_passed"]:
         raise ValueError("requirements gate has not passed")
     session["active_stage"] = "useCases"
-    if _has_runtime_ready_use_case_slices(root_path):
+    ready, _ = _validate_runtime_ready_use_case_slices(root_path)
+    if ready:
         session["use_cases_ready"] = True
         session["runtime_error"] = ""
         _write_session(root_path, session)
@@ -164,6 +164,7 @@ def load_harvest_ui(root: Path | str) -> HarvestUiResult:
         session = _new_session("")
     else:
         _normalize_session(session)
+        _sync_use_case_readiness(root_path, session)
         _resume_if_needed(root_path, session)
     return _result(root_path, session)
 
@@ -204,6 +205,7 @@ def _load_or_recover_session(root: Path) -> dict[str, Any]:
     if session is None:
         raise ValueError("harvest session has not started")
     _normalize_session(session)
+    _sync_use_case_readiness(root, session)
     return session
 
 
@@ -270,6 +272,7 @@ def _session_from_requirements_doc(root: Path) -> dict[str, Any] | None:
         return None
     clarifications = tuple(_parse_grill_me_rows(text))
     gate_passed = "Current gate: Passed" in text
+    use_cases_ready, _ = _validate_runtime_ready_use_case_slices(root)
     session = {
         "initial_prompt": initial_prompt,
         "clarifications": list(clarifications),
@@ -278,7 +281,7 @@ def _session_from_requirements_doc(root: Path) -> dict[str, Any] | None:
         "pending_questions": [],
         "requirements_gate_passed": gate_passed,
         "active_stage": "requirements",
-        "use_cases_ready": _has_runtime_ready_use_case_slices(root),
+        "use_cases_ready": use_cases_ready,
         "runtime_error": "",
         "use_case_clarifications": [],
         "use_case_current_question": None,
@@ -478,8 +481,9 @@ def _advance_use_case_harvest(root: Path, session: dict[str, Any], idea: str) ->
     result = _run_use_case_harvest(root, session, idea)
     status = str(result.get("status", "")).strip().lower()
     if status == "complete":
-        if not _has_runtime_ready_use_case_slices(root):
-            raise ValueError("use-case harvest reported complete but runtime-ready use-case docs are missing")
+        ready, error = _validate_runtime_ready_use_case_slices(root)
+        if not ready:
+            raise ValueError(f"use-case harvest reported complete but {error}")
         session["use_cases_ready"] = True
         session["use_case_current_question"] = None
         session["use_case_current_questions"] = []
@@ -1110,22 +1114,68 @@ def _fallback_context_markdown(session: dict[str, Any]) -> str:
 
 
 def _has_runtime_ready_use_case_slices(root: Path) -> bool:
-    if not (root / USE_CASES_PATH).is_file():
-        return False
-    slice_root = root / USE_CASE_SLICE_ROOT
-    if not slice_root.exists():
-        return False
-    for directory in sorted(slice_root.glob("UC-*")):
-        use_case_path = directory / "use-case.md"
-        e2e_path = directory / "e2e-goal.md"
-        if not use_case_path.is_file() or not e2e_path.is_file():
+    ready, _ = _validate_runtime_ready_use_case_slices(root)
+    return ready
+
+
+def _sync_use_case_readiness(root: Path, session: dict[str, Any]) -> None:
+    if not session.get("requirements_gate_passed"):
+        session["use_cases_ready"] = False
+        return
+    ready, _ = _validate_runtime_ready_use_case_slices(root)
+    was_ready = bool(session.get("use_cases_ready"))
+    session["use_cases_ready"] = ready
+    if ready:
+        session["active_stage"] = "useCases"
+    elif was_ready:
+        session["active_stage"] = "requirements"
+
+
+def _validate_runtime_ready_use_case_slices(root: Path) -> tuple[bool, str]:
+    canonical_path = root / USE_CASES_PATH
+    if not canonical_path.is_file():
+        return False, (
+            "docs/design/유스케이스.md is missing, empty, or has no parseable UC entries. "
+            "Expected '- UC-001. ...' or '## UC-001. ...'."
+        )
+
+    canonical_text = canonical_path.read_text(encoding="utf-8")
+    if not canonical_text.strip():
+        return False, (
+            "docs/design/유스케이스.md is missing, empty, or has no parseable UC entries. "
+            "Expected '- UC-001. ...' or '## UC-001. ...'."
+        )
+
+    uc_ids = _parse_canonical_use_case_ids(canonical_text)
+    if not uc_ids:
+        return False, (
+            "docs/design/유스케이스.md is missing, empty, or has no parseable UC entries. "
+            "Expected '- UC-001. ...' or '## UC-001. ...'."
+        )
+
+    missing_files: list[str] = []
+    for uc_id in uc_ids:
+        use_case_path = root / USE_CASE_SLICE_ROOT / uc_id / "use-case.md"
+        e2e_path = root / USE_CASE_SLICE_ROOT / uc_id / "e2e-goal.md"
+        if not use_case_path.is_file():
+            missing_files.append(str(USE_CASE_SLICE_ROOT / uc_id / "use-case.md"))
+        if not e2e_path.is_file():
+            missing_files.append(str(USE_CASE_SLICE_ROOT / uc_id / "e2e-goal.md"))
+        if missing_files:
             continue
         if _looks_like_placeholder(use_case_path.read_text(encoding="utf-8")):
-            continue
+            missing_files.append(str(USE_CASE_SLICE_ROOT / uc_id / "use-case.md"))
         if _looks_like_placeholder(e2e_path.read_text(encoding="utf-8")):
-            continue
-        return True
-    return False
+            missing_files.append(str(USE_CASE_SLICE_ROOT / uc_id / "e2e-goal.md"))
+    if missing_files:
+        missing_list = ", ".join(sorted(dict.fromkeys(missing_files)))
+        return False, f"runtime-ready use-case docs are missing: {missing_list}"
+    return True, ""
+
+
+def _parse_canonical_use_case_ids(text: str) -> list[str]:
+    matches = re.findall(r"^(?:- |## )(UC-\d+)\.\s+.+$", text, flags=re.MULTILINE)
+    return list(dict.fromkeys(match.strip() for match in matches))
 
 
 def _looks_like_placeholder(text: str) -> bool:

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import json
+import re
 import pytest
 
 from harness_codex.runtime.harvest_ui import (
@@ -96,6 +97,46 @@ def write_runtime_ready_use_cases(root: Path) -> None:
     )
 
 
+def write_passed_requirements(root: Path, initial_idea: str = "calculator") -> None:
+    (root / REQUIREMENTS_PATH).parent.mkdir(parents=True, exist_ok=True)
+    (root / REQUIREMENTS_PATH).write_text(
+        "\n".join(
+            [
+                "# Requirements Specification",
+                "",
+                "## 1. Overview",
+                f"- Initial idea: {initial_idea}",
+                "- Current gate: Passed",
+                "",
+                "## 5. Grill-Me Loop",
+                "| ID | Question | Response |",
+                "|---|---|---|",
+                "| GM-1 | Who uses it? | me |",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_canonical_use_cases(root: Path, content: str) -> None:
+    (root / USE_CASES_PATH).parent.mkdir(parents=True, exist_ok=True)
+    (root / USE_CASES_PATH).write_text(content, encoding="utf-8")
+
+
+def write_use_case_slice(root: Path, uc_id: str = "UC-001") -> None:
+    use_case_dir = root / f"docs/use-cases/{uc_id}"
+    use_case_dir.mkdir(parents=True, exist_ok=True)
+    (use_case_dir / "use-case.md").write_text(
+        f"# {uc_id}. User performs goal\n\n## Goal\n- Perform goal.\n",
+        encoding="utf-8",
+    )
+    (use_case_dir / "e2e-goal.md").write_text(
+        f"# {uc_id} E2E Goal\n\n## Given\n- Ready.\n\n## When\n- User acts.\n\n## Then\n- Goal succeeds.\n",
+        encoding="utf-8",
+    )
+
+
 def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -142,6 +183,98 @@ def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
     assert result.active_stage == "useCases"
     assert result.use_cases_ready is True
     assert (tmp_path / USE_CASES_PATH).is_file()
+
+
+def test_harvest_ui_requires_canonical_use_case_doc_before_ready(tmp_path: Path) -> None:
+    write_passed_requirements(tmp_path)
+
+    result = load_harvest_ui(tmp_path)
+
+    assert result.use_cases_ready is False
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "docs/design/유스케이스.md is missing, empty, or has no parseable UC entries. Expected '- UC-001. ...' or '## UC-001. ...'."
+        ),
+    ):
+        start_use_cases(tmp_path)
+
+
+def test_harvest_ui_rejects_empty_canonical_use_case_doc(tmp_path: Path) -> None:
+    write_passed_requirements(tmp_path)
+    write_canonical_use_cases(tmp_path, " \n")
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "docs/design/유스케이스.md is missing, empty, or has no parseable UC entries. Expected '- UC-001. ...' or '## UC-001. ...'."
+        ),
+    ):
+        start_use_cases(tmp_path)
+
+
+def test_harvest_ui_rejects_unparseable_canonical_use_case_doc(tmp_path: Path) -> None:
+    write_passed_requirements(tmp_path)
+    write_canonical_use_cases(
+        tmp_path,
+        "# Use Case Document\n\n## 2. High-Level Use Case List\n- User performs goal\n",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "docs/design/유스케이스.md is missing, empty, or has no parseable UC entries. Expected '- UC-001. ...' or '## UC-001. ...'."
+        ),
+    ):
+        start_use_cases(tmp_path)
+
+
+def test_harvest_ui_accepts_bullet_canonical_use_case_entries(tmp_path: Path) -> None:
+    write_passed_requirements(tmp_path)
+    write_canonical_use_cases(
+        tmp_path,
+        "# Use Case Document\n\n## 2. High-Level Use Case List\n- UC-001. User performs goal\n",
+    )
+    write_use_case_slice(tmp_path, "UC-001")
+
+    result = start_use_cases(tmp_path)
+
+    assert result.use_cases_ready is True
+    assert result.active_stage == "useCases"
+
+
+def test_harvest_ui_accepts_heading_canonical_use_case_entries(tmp_path: Path) -> None:
+    write_passed_requirements(tmp_path)
+    write_canonical_use_cases(
+        tmp_path,
+        "# Use Case Document\n\n## UC-001. User performs goal\n",
+    )
+    write_use_case_slice(tmp_path, "UC-001")
+
+    result = start_use_case_generation(tmp_path, "build a queue system")
+
+    assert result.use_cases_ready is True
+    assert result.active_stage == "useCases"
+
+
+def test_harvest_ui_names_missing_matching_use_case_slice_files(tmp_path: Path) -> None:
+    write_passed_requirements(tmp_path)
+    write_canonical_use_cases(
+        tmp_path,
+        "# Use Case Document\n\n## 2. High-Level Use Case List\n- UC-001. User performs goal\n",
+    )
+    use_case_dir = tmp_path / "docs/use-cases/UC-001"
+    use_case_dir.mkdir(parents=True, exist_ok=True)
+    (use_case_dir / "use-case.md").write_text(
+        "# UC-001. User performs goal\n\n## Goal\n- Perform goal.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"docs/use-cases/UC-001/e2e-goal\.md",
+    ):
+        start_use_cases(tmp_path)
 
 
 def test_harvest_ui_filters_duplicate_grill_me_questions(
@@ -397,7 +530,12 @@ def test_harvest_ui_blocks_when_use_case_generation_reports_complete_without_doc
         },
     )
 
-    with pytest.raises(ValueError, match="runtime-ready use-case docs are missing"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "use-case harvest reported complete but docs/design/유스케이스.md is missing, empty, or has no parseable UC entries. Expected '- UC-001. ...' or '## UC-001. ...'."
+        ),
+    ):
         start_use_case_generation(tmp_path, "build a queue system")
 
 
@@ -435,3 +573,38 @@ def test_harvest_ui_recovers_session_from_requirements_doc(
     assert result.current_questions
     assert len(result.current_questions) == 1
     assert (tmp_path / ".harness/ui/harvest-session.json").is_file()
+
+
+def test_harvest_ui_clears_stale_ready_flag_when_canonical_use_cases_invalid(tmp_path: Path) -> None:
+    write_passed_requirements(tmp_path)
+    write_canonical_use_cases(tmp_path, " \n")
+    session_path = tmp_path / ".harness/ui/harvest-session.json"
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    session_path.write_text(
+        json.dumps(
+            {
+                "initial_prompt": "calculator",
+                "clarifications": [],
+                "current_question": None,
+                "current_questions": [],
+                "pending_questions": [],
+                "requirements_gate_passed": True,
+                "active_stage": "useCases",
+                "use_cases_ready": True,
+                "runtime_error": "",
+                "draft_context_markdown": "",
+                "draft_requirements_markdown": "",
+                "use_case_clarifications": [],
+                "use_case_current_question": None,
+                "use_case_current_questions": [],
+                "use_case_pending_questions": [],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = load_harvest_ui(tmp_path)
+
+    assert result.use_cases_ready is False
+    assert result.active_stage == "requirements"


### PR DESCRIPTION
## 구현 의도

Fixes #150.

인터랙티브 하베스트가 `docs/use-cases/UC-*` slice 파일만 보고 use-case 단계를 완료 처리하지 않도록, canonical `docs/design/유스케이스.md`의 내용까지 검증합니다.

## 구현 방식

- 기존 slice 존재 여부만 확인하던 준비 상태 확인을 canonical 문서 검증까지 포함하는 흐름으로 강화했습니다.
- `docs/design/유스케이스.md`가 없거나 비어 있거나 parse 가능한 `- UC-001. ...` / `## UC-001. ...` 항목이 없으면 준비 완료로 보지 않습니다.
- canonical 문서에서 추출한 모든 UC ID에 대해 `docs/use-cases/<UC-ID>/use-case.md`와 `e2e-goal.md`가 존재하고 placeholder가 아닌지 확인합니다.
- `start_use_cases`, `start_use_case_generation`, session 복구, use-case harvest 완료 처리 경로가 같은 검증 함수를 사용하도록 정리했습니다.
- stale session의 `use_cases_ready=true`도 canonical 문서가 유효하지 않으면 다시 해제되도록 했습니다.

## 검증 방법

다음 테스트를 실행했습니다.

```bash
/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_harvest_ui.py tests/runtime/test_interactive_harvest.py tests/runtime/test_interactive_harvest_cli.py tests/test_cli_commands.py
```

결과: `47 passed in 10.77s`

## 위험 및 롤백

기존에는 slice 파일만 있어도 완료로 처리되던 일부 불완전한 harvest 상태가 이제 실패합니다. 이는 의도된 동작이지만, 과거에 생성된 불완전한 세션은 use-case 문서를 다시 생성해야 할 수 있습니다. 문제가 생기면 이 커밋을 되돌려 기존 slice-only 준비 상태 확인으로 롤백할 수 있습니다.
