### PR TITLE
Preserve workflow artifacts during harness update

### DIFF
--- a/docs/runtime-update-command.md
+++ b/docs/runtime-update-command.md
@@ -22,14 +22,35 @@ The command downloads the installer from the configured harness-codex repository
 - `--repo`: GitHub repository URL. Defaults to `https://github.com/omegafrog/harness-codex`.
 - `--skip-venv`: skip venv creation and dependency installation.
 
-## Warning
+## Preservation policy
 
-`./harness update` runs the installer with `--force`. It may overwrite:
+`./harness update` refreshes runtime-managed files while preserving workflow-generated artifacts and project-local configuration.
+
+Update may replace:
 
 - `harness_codex/`
-- `.harness/`
-- `.codex/`
+- bundled `.harness/` runtime/workflow files
+- bundled `.codex/` agents and skills
 - `tests/runtime/`
 - `./harness`
 
-Back up local changes to harness runtime files before updating.
+Update must preserve existing workflow outputs and local project state, including:
+
+- `.harness/runs/`
+- `.harness/sessions/`
+- `.harness/state/`
+- `.harness/checkpoints/`
+- `.harness/ui/grill-me-runs/`
+- `docs/changes/`
+- `docs/use-cases/`
+- `docs/maintenance/`
+- `docs/plans/`
+- `docs/design/요구사항.md`
+- `docs/design/유스케이스.md`
+- `context.md`
+- `.codex/repository-settings.md`
+- `.codex/stack-profile.yaml`
+- `.codex/test-gate.yaml`
+- `AGENTS.md`
+
+Destructive state cleanup should be implemented as an explicit reset command or flag, not as part of update.

--- a/harness_codex/runtime/self_update.py
+++ b/harness_codex/runtime/self_update.py
@@ -36,8 +36,9 @@ def build_parser() -> argparse.ArgumentParser:
         prog="harness update",
         description="Update the installed harness-codex runtime in this project.",
         epilog=(
-            "Warning: update runs the installer with --force and may overwrite "
-            "harness_codex/, .harness/, .codex/, tests/runtime, and the harness launcher."
+            "Update refreshes runtime-managed files while preserving workflow-generated "
+            "artifacts such as runs, sessions, ChangeSets, plans, harvested docs, and "
+            "project-local config."
         ),
     )
     parser.add_argument(
@@ -142,8 +143,9 @@ def _installer_url(repo: str, ref: str) -> str:
 
 def _warning() -> str:
     return (
-        "Warning: update uses installer --force and may overwrite "
-        "harness_codex/, .harness/, .codex/, tests/runtime, and ./harness."
+        "Update will refresh runtime-managed files but preserves workflow-generated "
+        "artifacts: .harness runs/sessions/state, ChangeSets, work-item docs, plans, "
+        "harvested docs, and project-local config."
     )
 
 

--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -70,6 +70,55 @@ mkdir -p "$TARGET_DIR"
 TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+PRESERVE_DIR="$TMP_DIR/preserved"
+
+# Files below are produced or edited by project workflows and must survive
+# `harness update`, even though update refreshes .harness/ and .codex/ with --force.
+PRESERVED_PATHS=(
+  ".harness/runs"
+  ".harness/sessions"
+  ".harness/state"
+  ".harness/checkpoints"
+  ".harness/ui/grill-me-runs"
+  "docs/changes"
+  "docs/use-cases"
+  "docs/maintenance"
+  "docs/plans"
+  "docs/design/요구사항.md"
+  "docs/design/유스케이스.md"
+  "context.md"
+  ".codex/repository-settings.md"
+  ".codex/stack-profile.yaml"
+  ".codex/test-gate.yaml"
+  "AGENTS.md"
+)
+
+backup_preserved_paths() {
+  local rel src dst
+  for rel in "${PRESERVED_PATHS[@]}"; do
+    src="$TARGET_DIR/$rel"
+    if [[ -e "$src" ]]; then
+      dst="$PRESERVE_DIR/$rel"
+      mkdir -p "$(dirname "$dst")"
+      cp -a "$src" "$dst"
+      echo "preserved: $rel"
+    fi
+  done
+}
+
+restore_preserved_paths() {
+  local rel src dst
+  for rel in "${PRESERVED_PATHS[@]}"; do
+    src="$PRESERVE_DIR/$rel"
+    if [[ -e "$src" ]]; then
+      dst="$TARGET_DIR/$rel"
+      rm -rf "$dst"
+      mkdir -p "$(dirname "$dst")"
+      cp -a "$src" "$dst"
+      echo "restored: $rel"
+    fi
+  done
+}
 
 ARCHIVE_URL="$HARNESS_REPO/archive/${HARNESS_REF}.tar.gz"
 echo "Downloading harness-codex from $ARCHIVE_URL"
@@ -81,6 +130,8 @@ if [[ -z "${SRC_DIR:-}" || ! -d "$SRC_DIR" ]]; then
   echo "Failed to locate extracted harness-codex source directory" >&2
   exit 1
 fi
+
+backup_preserved_paths
 
 copy_dir() {
   local src="$1"
@@ -98,7 +149,7 @@ copy_dir() {
 copy_file_if_missing() {
   local dst="$1"
   local content="$2"
-  if [[ -e "$dst" && "$FORCE" -ne 1 ]]; then
+  if [[ -e "$dst" ]]; then
     echo "skip existing: ${dst#$TARGET_DIR/}"
     return
   fi
@@ -173,6 +224,8 @@ copy_file_if_missing "$TARGET_DIR/.codex/test-gate.yaml" 'required:
   - name: runtime
     command: ./venv/bin/python3 -m pytest -q -s tests/runtime
 '
+
+restore_preserved_paths
 
 if [[ "$SKIP_VENV" -ne 1 ]]; then
   if [[ ! -d "$TARGET_DIR/venv" ]]; then

--- a/tests/runtime/test_install_update_preservation.py
+++ b/tests/runtime/test_install_update_preservation.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/install-harness-codex.sh").read_text(encoding="utf-8")
+
+
+def test_installer_defines_workflow_artifacts_as_preserved_paths():
+    for path in [
+        ".harness/runs",
+        ".harness/sessions",
+        ".harness/state",
+        ".harness/checkpoints",
+        ".harness/ui/grill-me-runs",
+        "docs/changes",
+        "docs/use-cases",
+        "docs/maintenance",
+        "docs/plans",
+        "docs/design/요구사항.md",
+        "docs/design/유스케이스.md",
+        "context.md",
+        ".codex/repository-settings.md",
+        ".codex/stack-profile.yaml",
+        ".codex/test-gate.yaml",
+        "AGENTS.md",
+    ]:
+        assert f'"{path}"' in SCRIPT
+
+
+def test_installer_restores_preserved_paths_after_forced_runtime_copy():
+    backup_index = SCRIPT.index("backup_preserved_paths")
+    runtime_copy_index = SCRIPT.index('copy_dir "$SRC_DIR/.harness"')
+    codex_copy_index = SCRIPT.index('copy_dir "$SRC_DIR/.codex"')
+    restore_index = SCRIPT.index("restore_preserved_paths")
+
+    assert backup_index < runtime_copy_index
+    assert backup_index < codex_copy_index
+    assert runtime_copy_index < restore_index
+    assert codex_copy_index < restore_index
+
+
+def test_default_project_files_are_not_overwritten_by_force_update():
+    function_start = SCRIPT.index("copy_file_if_missing() {")
+    function_end = SCRIPT.index("create_launcher() {")
+    body = SCRIPT[function_start:function_end]
+
+    assert 'if [[ -e "$dst" ]]' in body
+    assert '"$FORCE"' not in body


### PR DESCRIPTION
## 구현 의도

`harness update`가 런타임을 갱신하더라도 워크플로우가 생성한 산출물과 프로젝트별 설정은 삭제되지 않도록 보호합니다. 관련 이슈: #152

## 구현 방법

- installer에 `PRESERVED_PATHS` 목록을 추가했습니다.
- 강제 복사 전에 보존 대상 파일/디렉터리를 임시 위치에 백업합니다.
- `harness_codex/`, `.harness/`, `.codex/`, `tests/runtime/`, launcher를 갱신한 뒤 보존 대상을 다시 복원합니다.
- `copy_file_if_missing`는 이름 그대로 `--force` 여부와 상관없이 기존 파일을 덮어쓰지 않도록 변경했습니다.
- `harness update` 도움말/문서의 경고를 보존 정책 중심으로 갱신했습니다.

## 검증 방법

- `tests/runtime/test_install_update_preservation.py`를 추가해 다음을 검증합니다.
  - workflow artifact 보존 경로가 installer에 등록되어 있는지
  - 보존 백업이 런타임 강제 복사보다 먼저 실행되고, 복원이 그 이후 실행되는지
  - 기본 프로젝트 파일 생성 함수가 `--force`에서도 기존 파일을 덮어쓰지 않는지

## 병합 상태

GitHub 기준 현재 PR은 병합 가능 상태입니다.