### PR TITLE
Add explicit harness reset command

### DIFF
--- a/docs/runtime-reset-command.md
+++ b/docs/runtime-reset-command.md
@@ -1,0 +1,53 @@
+# Harness Reset Command
+
+Use `harness reset` to explicitly reset local harness runtime artifacts.
+
+Reset is separate from `harness update`. Update must preserve workflow-generated artifacts; reset is the command that intentionally targets them.
+
+## Dry run by default
+
+Reset does not change files unless `--apply` is provided.
+
+```bash
+./harness reset --runs
+./harness reset --workflow-artifacts
+./harness reset --all
+```
+
+To apply a reset:
+
+```bash
+./harness reset --runs --apply
+./harness reset --workflow-artifacts --apply
+./harness reset --all --apply
+```
+
+## Scopes
+
+### `--runs`
+
+Targets local runtime state only:
+
+- `.harness/runs/`
+- `.harness/sessions/`
+- `.harness/state/`
+- `.harness/checkpoints/`
+
+Use this when you want to clear execution state but keep ChangeSets, work-item documents, plans, and harvested design docs.
+
+### `--workflow-artifacts`
+
+Targets workflow-generated artifacts:
+
+- `.harness/ui/grill-me-runs/`
+- `docs/changes/`
+- `docs/use-cases/`
+- `docs/maintenance/`
+- `docs/plans/`
+- `context.md`
+
+Use this when you want to restart the workflow artifact set.
+
+### `--all`
+
+Targets both run state and workflow artifacts.

--- a/harness_codex/__main__.py
+++ b/harness_codex/__main__.py
@@ -6,10 +6,14 @@ import sys
 from pathlib import Path
 
 from harness_codex.cli import main as cli_main
+from harness_codex.runtime.reset import main as reset_main
 from harness_codex.runtime.self_update import main as update_main
 
 
 if len(sys.argv) > 1 and sys.argv[1] == "update":
     raise SystemExit(update_main(sys.argv[2:], repo_root=Path.cwd()))
+
+if len(sys.argv) > 1 and sys.argv[1] == "reset":
+    raise SystemExit(reset_main(sys.argv[2:], repo_root=Path.cwd()))
 
 raise SystemExit(cli_main())

--- a/harness_codex/runtime/reset.py
+++ b/harness_codex/runtime/reset.py
@@ -1,0 +1,135 @@
+"""Explicit reset helper for local harness runtime artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+RUN_STATE_PATHS = (
+    Path(".harness/runs"),
+    Path(".harness/sessions"),
+    Path(".harness/state"),
+    Path(".harness/checkpoints"),
+)
+
+WORKFLOW_ARTIFACT_PATHS = (
+    Path(".harness/ui/grill-me-runs"),
+    Path("docs/changes"),
+    Path("docs/use-cases"),
+    Path("docs/maintenance"),
+    Path("docs/plans"),
+    Path("context.md"),
+)
+
+
+@dataclass(frozen=True)
+class ResetResult:
+    mode: str
+    applied: bool
+    targets: tuple[Path, ...]
+    affected: tuple[Path, ...]
+
+
+def main(argv: list[str] | None = None, *, repo_root: Path | str = ".") -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = run_reset(Path(repo_root), args)
+    except ValueError as exc:
+        print(str(exc))
+        return 2
+    print(format_result(result))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="harness reset",
+        description="Reset local harness runtime artifacts explicitly.",
+        epilog=(
+            "Reset is intentionally separate from `harness update`. "
+            "By default it only prints the target paths. Pass --apply to change files."
+        ),
+    )
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument(
+        "--runs",
+        action="store_true",
+        help="Target local run/session/checkpoint state only.",
+    )
+    scope.add_argument(
+        "--workflow-artifacts",
+        action="store_true",
+        help="Target workflow output artifacts such as ChangeSets, work-item slices, plans, and harvest UI runs.",
+    )
+    scope.add_argument(
+        "--all",
+        action="store_true",
+        help="Target both local run state and workflow output artifacts.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the reset. Without this flag, reset runs as a dry run.",
+    )
+    return parser
+
+
+def run_reset(repo_root: Path, args: argparse.Namespace) -> ResetResult:
+    targets = selected_targets(args)
+    affected = tuple(path for path in targets if (repo_root / path).exists())
+    if args.apply:
+        for path in affected:
+            _remove_path(repo_root / path)
+    return ResetResult(
+        mode=selected_mode(args),
+        applied=bool(args.apply),
+        targets=targets,
+        affected=affected,
+    )
+
+
+def selected_targets(args: argparse.Namespace) -> tuple[Path, ...]:
+    if args.runs:
+        return RUN_STATE_PATHS
+    if args.workflow_artifacts:
+        return WORKFLOW_ARTIFACT_PATHS
+    if args.all:
+        return RUN_STATE_PATHS + WORKFLOW_ARTIFACT_PATHS
+    raise ValueError("select one reset scope: --runs, --workflow-artifacts, or --all")
+
+
+def selected_mode(args: argparse.Namespace) -> str:
+    if args.runs:
+        return "runs"
+    if args.workflow_artifacts:
+        return "workflow-artifacts"
+    if args.all:
+        return "all"
+    return "unknown"
+
+
+def format_result(result: ResetResult) -> str:
+    header = "APPLIED" if result.applied else "DRY RUN"
+    lines = [
+        f"{header}: harness reset --{result.mode}",
+        "Targets:",
+        *[f"- {path}" for path in result.targets],
+        "Existing targets:",
+    ]
+    if result.affected:
+        lines.extend(f"- {path}" for path in result.affected)
+    else:
+        lines.append("- none")
+    if not result.applied:
+        lines.append("Pass --apply to apply this reset.")
+    return "\n".join(lines)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        path.unlink()

--- a/tests/runtime/test_reset_command.py
+++ b/tests/runtime/test_reset_command.py
@@ -1,0 +1,66 @@
+import argparse
+from pathlib import Path
+
+from harness_codex.runtime.reset import (
+    RUN_STATE_PATHS,
+    WORKFLOW_ARTIFACT_PATHS,
+    build_parser,
+    run_reset,
+)
+
+
+def parse_args(*args: str) -> argparse.Namespace:
+    return build_parser().parse_args(list(args))
+
+
+def test_reset_runs_is_dry_run_by_default(tmp_path: Path):
+    target = tmp_path / ".harness/runs/run-1"
+    target.mkdir(parents=True)
+    marker = target / "state.json"
+    marker.write_text("{}", encoding="utf-8")
+
+    result = run_reset(tmp_path, parse_args("--runs"))
+
+    assert result.applied is False
+    assert result.targets == RUN_STATE_PATHS
+    assert Path(".harness/runs") in result.affected
+    assert marker.exists()
+
+
+def test_reset_runs_apply_removes_only_run_state(tmp_path: Path):
+    run_state = tmp_path / ".harness/runs/run-1"
+    run_state.mkdir(parents=True)
+    run_state.joinpath("state.json").write_text("{}", encoding="utf-8")
+
+    change_set = tmp_path / "docs/changes/active/CHG-001.md"
+    change_set.parent.mkdir(parents=True)
+    change_set.write_text("# change", encoding="utf-8")
+
+    result = run_reset(tmp_path, parse_args("--runs", "--apply"))
+
+    assert result.applied is True
+    assert not (tmp_path / ".harness/runs").exists()
+    assert change_set.exists()
+
+
+def test_reset_workflow_artifacts_apply_preserves_run_state(tmp_path: Path):
+    run_state = tmp_path / ".harness/runs/run-1/state.json"
+    run_state.parent.mkdir(parents=True)
+    run_state.write_text("{}", encoding="utf-8")
+
+    plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# plan", encoding="utf-8")
+
+    result = run_reset(tmp_path, parse_args("--workflow-artifacts", "--apply"))
+
+    assert result.applied is True
+    assert result.targets == WORKFLOW_ARTIFACT_PATHS
+    assert run_state.exists()
+    assert not (tmp_path / "docs/plans").exists()
+
+
+def test_reset_all_targets_both_groups(tmp_path: Path):
+    result = run_reset(tmp_path, parse_args("--all"))
+
+    assert result.targets == RUN_STATE_PATHS + WORKFLOW_ARTIFACT_PATHS


### PR DESCRIPTION
## 구현 의도

`harness update`와 분리된 명시적 reset 명령을 추가합니다. update는 워크플로우 산출물을 보존하고, reset은 사용자가 명시적으로 선택한 범위만 정리하는 역할로 분리합니다.

관련 이슈: #154

## 구현 방법

- `harness reset`을 `__main__.py`에서 `harness update`와 같은 방식으로 직접 라우팅했습니다.
- `harness_codex/runtime/reset.py`를 추가했습니다.
- reset scope를 세 가지로 나눴습니다.
  - `--runs`: `.harness/runs`, `.harness/sessions`, `.harness/state`, `.harness/checkpoints`
  - `--workflow-artifacts`: `.harness/ui/grill-me-runs`, `docs/changes`, `docs/use-cases`, `docs/maintenance`, `docs/plans`, `context.md`
  - `--all`: 위 두 그룹 전체
- 기본 동작은 dry-run입니다.
- 실제 적용은 `--apply`가 있을 때만 수행합니다.
- `docs/runtime-reset-command.md`에 사용법을 문서화했습니다.

## 검증 방법

- `tests/runtime/test_reset_command.py` 추가
- 검증 항목:
  - `--runs`는 기본적으로 dry-run이고 파일을 변경하지 않음
  - `--runs --apply`는 run state만 대상으로 하고 ChangeSet 문서는 유지함
  - `--workflow-artifacts --apply`는 workflow artifact만 대상으로 하고 run state는 유지함
  - `--all`은 두 그룹을 모두 대상으로 함

## 참고

현재 브랜치는 PR 생성 시점 기준 main보다 1 commit behind로 표시됩니다. 필요하면 병합 전 branch update가 필요할 수 있습니다.