### PR TITLE
Print ubiquitous language summary after harvest

### DIFF
--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from collections.abc import Callable
 from pathlib import Path
@@ -24,6 +25,7 @@ from harness_codex.runtime.harvest_ui import (
 InputFunc = Callable[[str], str]
 OutputFunc = Callable[[str], None]
 INTERACTIVE_SESSION_DIR = Path(".harness/ui/sessions")
+CONTEXT_PATH = Path("context.md")
 LANGUAGE_RECOVERY_STAGE = "ubiquitous_language"
 
 
@@ -84,6 +86,9 @@ def run_interactive_harvest(
             result = _open_language_validation_recovery(root, resolved_session_id, str(exc))
             _persist_session(root, resolved_session_id)
             continue
+        language_summary = _format_ubiquitous_language_summary(root)
+        if language_summary:
+            output_func(language_summary)
         break
 
     result = start_use_case_generation(root, result.initial_prompt)
@@ -275,6 +280,86 @@ def _format_questions(result: HarvestUiResult) -> str:
         if recommended:
             lines.append(f"   Recommended answer: {recommended}")
     return "\n".join(lines)
+
+
+def _format_ubiquitous_language_summary(root: Path) -> str:
+    context_path = root / CONTEXT_PATH
+    if not context_path.exists():
+        return ""
+    rows = _parse_ubiquitous_language_rows(context_path.read_text(encoding="utf-8"))
+    if not rows:
+        return ""
+
+    lines = ["", "Confirmed Ubiquitous Language:"]
+    for row in rows:
+        canonical = row.get("canonical term", "") or row.get("canonical", "")
+        korean = row.get("korean", "")
+        english = row.get("english", "")
+        term_parts = [part for part in (korean, english) if part and part != "-"]
+        suffix = f" ({' / '.join(term_parts)})" if term_parts else ""
+        lines.append(f"- {canonical}{suffix}")
+
+    forbidden_lines: list[str] = []
+    for row in rows:
+        canonical = row.get("canonical term", "") or row.get("canonical", "")
+        for forbidden in _split_language_cell(row.get("forbidden terms", "")):
+            forbidden_lines.append(f"- {forbidden} -> {canonical}")
+    lines.append("Forbidden Language:")
+    lines.extend(forbidden_lines or ["- none"])
+    return "\n".join(lines)
+
+
+def _parse_ubiquitous_language_rows(markdown: str) -> list[dict[str, str]]:
+    lines = markdown.splitlines()
+    in_section = False
+    table_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            in_section = "ubiquitous language" in stripped.lower()
+            if table_lines and not in_section:
+                break
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("|"):
+            table_lines.append(stripped)
+        elif table_lines:
+            break
+
+    if len(table_lines) < 2:
+        return []
+    header = [_normalize_header(cell) for cell in _split_markdown_table_row(table_lines[0])]
+    rows: list[dict[str, str]] = []
+    for line in table_lines[2:]:
+        cells = _split_markdown_table_row(line)
+        if not cells or len(cells) < 2:
+            continue
+        row = {
+            header[index]: cells[index].strip()
+            for index in range(min(len(header), len(cells)))
+            if header[index]
+        }
+        canonical = row.get("canonical term", "") or row.get("canonical", "")
+        if canonical and canonical != "-":
+            rows.append(row)
+    return rows
+
+
+def _split_markdown_table_row(line: str) -> list[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _normalize_header(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _split_language_cell(value: str) -> list[str]:
+    text = value.strip()
+    if not text or text.lower() in {"-", "none", "none."}:
+        return []
+    parts = re.split(r"\s*(?:,|;|<br>|/)\s*", text)
+    return [part.strip() for part in parts if part.strip() and part.strip() != "-"]
 
 
 def _open_language_validation_recovery(

--- a/tests/runtime/test_interactive_harvest_language_summary.py
+++ b/tests/runtime/test_interactive_harvest_language_summary.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from harness_codex.runtime.interactive_harvest import (
+    _format_ubiquitous_language_summary,
+    _parse_ubiquitous_language_rows,
+)
+
+
+def test_parse_ubiquitous_language_rows_from_context_markdown():
+    markdown = """# Project Context
+
+## 1. Ubiquitous Language
+
+| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
+|---|---|---|---|---|---|---|---|
+| Zettel Note | 제텔 노트 | Zettel Note | Entity | Atomic note. | Note | memo, page | grill-me |
+| Rewrite Suggestion | 재작성 제안 | Rewrite Suggestion | Concept | Agent proposal. | - | rewrite result<br>fixed note | grill-me |
+
+## 2. Naming Rules
+"""
+
+    rows = _parse_ubiquitous_language_rows(markdown)
+
+    assert rows == [
+        {
+            "canonical term": "Zettel Note",
+            "korean": "제텔 노트",
+            "english": "Zettel Note",
+            "type": "Entity",
+            "definition": "Atomic note.",
+            "aliases": "Note",
+            "forbidden terms": "memo, page",
+            "source": "grill-me",
+        },
+        {
+            "canonical term": "Rewrite Suggestion",
+            "korean": "재작성 제안",
+            "english": "Rewrite Suggestion",
+            "type": "Concept",
+            "definition": "Agent proposal.",
+            "aliases": "-",
+            "forbidden terms": "rewrite result<br>fixed note",
+            "source": "grill-me",
+        },
+    ]
+
+
+def test_format_ubiquitous_language_summary_lists_confirmed_and_forbidden_terms(tmp_path: Path):
+    (tmp_path / "context.md").write_text(
+        """# Project Context
+
+## 1. Ubiquitous Language
+
+| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
+|---|---|---|---|---|---|---|---|
+| Zettel Note | 제텔 노트 | Zettel Note | Entity | Atomic note. | Note | memo, page | grill-me |
+| Rewrite Suggestion | 재작성 제안 | Rewrite Suggestion | Concept | Agent proposal. | - | rewrite result<br>fixed note | grill-me |
+
+## 2. Naming Rules
+""",
+        encoding="utf-8",
+    )
+
+    summary = _format_ubiquitous_language_summary(tmp_path)
+
+    assert "Confirmed Ubiquitous Language:" in summary
+    assert "- Zettel Note (제텔 노트 / Zettel Note)" in summary
+    assert "- Rewrite Suggestion (재작성 제안 / Rewrite Suggestion)" in summary
+    assert "Forbidden Language:" in summary
+    assert "- memo -> Zettel Note" in summary
+    assert "- page -> Zettel Note" in summary
+    assert "- rewrite result -> Rewrite Suggestion" in summary
+    assert "- fixed note -> Rewrite Suggestion" in summary
+
+
+def test_format_ubiquitous_language_summary_prints_none_when_no_forbidden_terms(tmp_path: Path):
+    (tmp_path / "context.md").write_text(
+        """# Project Context
+
+## 1. Ubiquitous Language
+
+| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
+|---|---|---|---|---|---|---|---|
+| User | 사용자 | User | Actor | Primary actor. | - | - | grill-me |
+
+## 2. Naming Rules
+""",
+        encoding="utf-8",
+    )
+
+    summary = _format_ubiquitous_language_summary(tmp_path)
+
+    assert "- User (사용자 / User)" in summary
+    assert "Forbidden Language:\n- none" in summary


### PR DESCRIPTION
## 구현 의도

Interactive harvest에서 `context.md`가 생성되고 Ubiquitous Language 검증이 통과하면, 사용자가 바로 확인할 수 있도록 확정된 언어와 금지된 언어를 터미널에 출력합니다.

관련 이슈: #158

## 구현 방법

- `interactive_harvest.py`에 `CONTEXT_PATH`와 Ubiquitous Language summary formatter를 추가했습니다.
- requirements gate 통과 후 `validate-context-language`가 성공한 시점에 `context.md`를 읽어 요약을 출력합니다.
- `context.md`의 `## Ubiquitous Language` 섹션 안 Markdown table을 파싱합니다.
- 각 row에서 다음을 출력합니다.
  - 확정된 canonical term
  - Korean / English 용어
  - forbidden terms가 있으면 `금지어 -> canonical term` 형태로 출력
- 금지어가 없으면 `Forbidden Language: - none`으로 출력합니다.

## 검증 방법

- `tests/runtime/test_interactive_harvest_language_summary.py` 추가
- 검증 항목:
  - context.md의 Ubiquitous Language table을 파싱하는지
  - confirmed canonical terms와 Korean/English terms를 출력하는지
  - comma, `<br>`로 구분된 forbidden terms를 각각 출력하는지
  - forbidden term이 없을 때 `none`으로 출력하는지

## 참고

현재 브랜치는 PR 생성 시점 기준 main보다 1 commit behind로 표시됩니다. 필요하면 병합 전 branch update가 필요할 수 있습니다.