### PR TITLE
Add ChangeSet contents query interface

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -130,6 +130,14 @@ def build_parser() -> argparse.ArgumentParser:
     changes_show = changes_subparsers.add_parser("show")
     changes_show.add_argument("change_set_id")
     changes_show.set_defaults(func=changes_show_command)
+    changes_contents = changes_subparsers.add_parser("contents")
+    changes_contents.add_argument("change_set_id")
+    changes_contents.add_argument(
+        "--raw",
+        action="store_true",
+        help="Print the raw ChangeSet markdown file instead of the structured summary.",
+    )
+    changes_contents.set_defaults(func=changes_contents_command)
     changes_create_from_design = changes_subparsers.add_parser("create-from-design")
     changes_create_from_design.add_argument("--title", default="")
     changes_create_from_design.add_argument("--change-set-id")
@@ -278,6 +286,71 @@ def changes_show_command(args: argparse.Namespace, repo_root: Path) -> str:
             f"Work items: {work_items}",
         ]
     )
+
+
+def changes_contents_command(args: argparse.Namespace, repo_root: Path) -> str:
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    if args.raw:
+        path = _change_set_file_path(change_set)
+        absolute_path = repo_root / path
+        if not absolute_path.exists():
+            raise ValueError(f"ChangeSet file not found: {path}")
+        return absolute_path.read_text(encoding="utf-8").strip()
+    return _format_change_set_contents(change_set)
+
+
+def _format_change_set_contents(change_set: ChangeSet) -> str:
+    lines = [
+        f"ChangeSet contents: {change_set.change_set_id}",
+        f"Path: {_change_set_file_path(change_set)}",
+        f"Title: {change_set.title or '-'}",
+        f"Status: {change_set.status or '-'}",
+        f"Related issue: {change_set.related_issue or '-'}",
+        f"Intent: {change_set.intent_summary or '-'}",
+        "Before / After:",
+        f"- Before: {change_set.before_summary or '-'}",
+        f"- After: {change_set.after_summary or '-'}",
+    ]
+
+    _extend_lines(
+        lines,
+        "Changed documents:",
+        (
+            f"- {item.path} [{item.change_type or '-'}] status={item.status or '-'} reason={item.reason or '-'}"
+            for item in change_set.changed_documents
+        ),
+    )
+    _extend_lines(
+        lines,
+        "Work items:",
+        (
+            "\n".join(
+                [
+                    f"- {item.work_item_id} ({item.work_item_type.value})",
+                    f"  name: {item.name or '-'}",
+                    f"  impact: {item.impact_type or '-'}",
+                    f"  slice: {item.slice_path}",
+                    f"  status: {item.status or '-'}",
+                ]
+            )
+            for item in change_set.ordered_work_items()
+        ),
+    )
+    _extend_lines(lines, "Planner inputs:", (f"- {path}" for path in change_set.planner_inputs))
+    _extend_lines(lines, "Included scope:", (f"- {item}" for item in change_set.included_scope))
+    _extend_lines(lines, "Excluded scope:", (f"- {item}" for item in change_set.excluded_scope))
+    _extend_lines(lines, "Forbidden changes:", (f"- {item}" for item in change_set.forbidden_changes))
+    return "\n".join(lines)
+
+
+def _extend_lines(lines: list[str], heading: str, items: object) -> None:
+    materialized = list(items)
+    lines.append(heading)
+    lines.extend(materialized or ["- none"])
+
+
+def _change_set_file_path(change_set: ChangeSet) -> Path:
+    return change_set.path or Path("docs/changes/active") / f"{change_set.change_set_id}.md"
 
 
 def changes_create_from_design_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/tests/runtime/test_changeset_contents_cli.py
+++ b/tests/runtime/test_changeset_contents_cli.py
@@ -1,0 +1,102 @@
+from argparse import Namespace
+from pathlib import Path
+
+from harness_codex.cli import changes_contents_command
+
+
+CHANGESET_MARKDOWN = """# Add note analysis
+
+## 1. Metadata
+
+| Item | Value |
+|---|---|
+| ChangeSet ID | `CHG-20260522-001` |
+| Status | active |
+| Related issue/request | #123 |
+
+## 2. Implementation Intent
+
+- Request summary: Add the first note analysis flow.
+
+## 3. Before / After
+
+| Before | After |
+|---|---|
+| No analysis. | End User can request NoteAnalysis. |
+
+## 4. Changed Documents
+
+| Document | Change Type | Reason | Status |
+|---|---|---|---|
+| `docs/design/요구사항.md` | update | Add confirmed MVP behavior. | ready |
+
+## 5. Affected Work Items
+
+| Work Item ID | Type | Name | Impact Type | Slice Path | Status |
+|---|---|---|---|---|---|
+| UC-001 | use_case | Analyze Fleeting Note | add | docs/use-cases/UC-001 | ready |
+| MAINT-001 | maintenance | Update runtime docs | update | docs/maintenance/MAINT-001 | ready |
+
+## 7. Planner Input Scope
+
+- `docs/design/요구사항.md`
+- `docs/use-cases/UC-001/use-case.md`
+
+## 8. Scope Boundary
+
+### Included
+- NoteAnalysis application flow
+
+### Excluded
+- Authentication
+
+### Forbidden Changes
+- Do not add multi-user workspace support
+"""
+
+
+def test_changes_contents_command_prints_structured_changeset(tmp_path: Path):
+    changes_dir = tmp_path / "docs/changes/active"
+    changes_dir.mkdir(parents=True)
+    (changes_dir / "CHG-20260522-001.md").write_text(CHANGESET_MARKDOWN, encoding="utf-8")
+
+    output = changes_contents_command(
+        Namespace(change_set_id="CHG-20260522-001", raw=False),
+        tmp_path,
+    )
+
+    assert "ChangeSet contents: CHG-20260522-001" in output
+    assert "Path: docs/changes/active/CHG-20260522-001.md" in output
+    assert "Title: Add note analysis" in output
+    assert "Status: active" in output
+    assert "Related issue: #123" in output
+    assert "Intent: Add the first note analysis flow." in output
+    assert "- Before: No analysis." in output
+    assert "- After: End User can request NoteAnalysis." in output
+    assert "Changed documents:" in output
+    assert "- docs/design/요구사항.md [update] status=ready reason=Add confirmed MVP behavior." in output
+    assert "Work items:" in output
+    assert "- UC-001 (use_case)" in output
+    assert "  name: Analyze Fleeting Note" in output
+    assert "- MAINT-001 (maintenance)" in output
+    assert "Planner inputs:" in output
+    assert "- docs/use-cases/UC-001/use-case.md" in output
+    assert "Included scope:" in output
+    assert "- NoteAnalysis application flow" in output
+    assert "Excluded scope:" in output
+    assert "- Authentication" in output
+    assert "Forbidden changes:" in output
+    assert "- Do not add multi-user workspace support" in output
+
+
+def test_changes_contents_command_raw_prints_changeset_markdown(tmp_path: Path):
+    changes_dir = tmp_path / "docs/changes/active"
+    changes_dir.mkdir(parents=True)
+    (changes_dir / "CHG-20260522-001.md").write_text(CHANGESET_MARKDOWN, encoding="utf-8")
+
+    output = changes_contents_command(
+        Namespace(change_set_id="CHG-20260522-001", raw=True),
+        tmp_path,
+    )
+
+    assert output == CHANGESET_MARKDOWN.strip()


### PR DESCRIPTION
## 구현 의도

ChangeSet 생성 이후 사용자가 ChangeSet의 실제 내용물을 빠르게 조회할 수 있는 CLI 인터페이스를 추가합니다.

기존 `changes show`는 제목, 상태, Before/After, 영향 UC 정도만 보여줘서 다음 정보를 확인하기 어려웠습니다.

- 변경 문서 목록
- work item 상세
- planner input scope
- included / excluded / forbidden scope boundary
- 원본 ChangeSet markdown

## 구현 방법

- `./harness changes contents <CHANGE_SET_ID>` 명령을 추가했습니다.
- 기본 출력은 파싱된 ChangeSet 모델을 구조화해서 보여줍니다.
  - metadata
  - before / after
  - changed documents
  - work items
  - planner inputs
  - included scope
  - excluded scope
  - forbidden changes
- `./harness changes contents <CHANGE_SET_ID> --raw`를 추가했습니다.
  - `docs/changes/active/<CHANGE_SET_ID>.md` 원문을 그대로 출력합니다.
- ChangeSet 파일 경로를 계산하는 `_change_set_file_path()` helper를 추가했습니다.
- 빈 섹션은 `- none`으로 표시하도록 `_extend_lines()` helper를 추가했습니다.

## 검증 방법

- `tests/runtime/test_changeset_contents_cli.py` 추가
- 검증 항목:
  - 구조화된 ChangeSet contents 출력에 metadata, changed documents, work items, scope boundary가 포함되는지
  - `--raw` 출력이 ChangeSet markdown 원문과 동일한지