### PR TITLE
Add run-change ChangeSet ID shell completion

### DIFF
--- a/completions/_harness
+++ b/completions/_harness
@@ -1,0 +1,57 @@
+#compdef harness ./harness
+
+# Zsh completion for harness.
+# Install:
+#   mkdir -p ~/.zfunc
+#   cp completions/_harness ~/.zfunc/_harness
+#   fpath=(~/.zfunc $fpath)
+#   autoload -Uz compinit && compinit
+
+_harness_run_change_ids() {
+  local -a candidates
+  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion run-change --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  if (( ${#candidates[@]} )); then
+    _describe 'active ChangeSet' candidates
+  fi
+}
+
+_harness() {
+  local -a commands modes
+  commands=(
+    'harvest:Harvest a product idea into design documents'
+    'agent-context:Initialize agent context files'
+    'changes:List and create ChangeSets'
+    'run-change:Run every work item in a ChangeSet'
+    'run-use-case:Run one use case from a ChangeSet'
+    'run-work-item:Run one work item from a ChangeSet'
+    'stages:Inspect stage artifacts'
+    'artifacts:Show or accept stage artifacts'
+    'run-stage:Apply a stage transition'
+    'resume:Inspect resume target for a run'
+    'report:Print a run report'
+    'dashboard:Print dashboard state JSON'
+    'ui-server:Run the local UI server'
+  )
+  modes=(
+    '--plan:show execution plan without side effects'
+    '--preview:show preview without side effects'
+    '--apply:run and apply side effects'
+  )
+
+  case $words[2] in
+    run-change)
+      if (( CURRENT == 3 )); then
+        _harness_run_change_ids
+      elif (( CURRENT == 4 )); then
+        _describe 'mode' modes
+      fi
+      ;;
+    *)
+      if (( CURRENT == 2 )); then
+        _describe 'command' commands
+      fi
+      ;;
+  esac
+}
+
+_harness "$@"

--- a/completions/harness.bash
+++ b/completions/harness.bash
@@ -1,0 +1,37 @@
+# Bash completion for harness.
+# Install:
+#   source completions/harness.bash
+# or add that line to ~/.bashrc.
+
+_harness_complete_run_change_ids() {
+  local current_word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+  while IFS= read -r candidate; do
+    COMPREPLY+=("$candidate")
+  done < <(python3 -m harness_codex.runtime.shell_completion run-change --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+}
+
+_harness_completion() {
+  local command="${COMP_WORDS[1]:-}"
+  local current_word="${COMP_WORDS[COMP_CWORD]}"
+
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "harvest agent-context changes run-change run-use-case run-work-item stages artifacts run-stage resume report dashboard ui-server" -- "$current_word") )
+    return 0
+  fi
+
+  if [[ "$command" == "run-change" && $COMP_CWORD -eq 2 ]]; then
+    _harness_complete_run_change_ids
+    return 0
+  fi
+
+  if [[ "$command" == "run-change" && $COMP_CWORD -eq 3 ]]; then
+    COMPREPLY=( $(compgen -W "--plan --preview --apply" -- "$current_word") )
+    return 0
+  fi
+
+  COMPREPLY=()
+}
+
+complete -F _harness_completion harness
+complete -F _harness_completion ./harness

--- a/harness_codex/runtime/shell_completion.py
+++ b/harness_codex/runtime/shell_completion.py
@@ -1,0 +1,96 @@
+"""Shell completion candidate helpers for the harness CLI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from harness_codex.runtime.changes import ChangeSetResolver, NoActiveChangeSetsError
+
+
+@dataclass(frozen=True)
+class CompletionCandidate:
+    """One shell completion candidate with an optional display description."""
+
+    value: str
+    description: str = ""
+
+
+def run_change_candidates(repo_root: Path | str, prefix: str = "") -> tuple[CompletionCandidate, ...]:
+    """Return active ChangeSet IDs for `run-change` completion."""
+
+    normalized_prefix = prefix.strip()
+    try:
+        change_sets = ChangeSetResolver(Path(repo_root)).list_active()
+    except NoActiveChangeSetsError:
+        return ()
+
+    return tuple(
+        CompletionCandidate(change_set.change_set_id, change_set.title)
+        for change_set in change_sets
+        if not normalized_prefix or change_set.change_set_id.startswith(normalized_prefix)
+    )
+
+
+def format_candidates(
+    candidates: Iterable[CompletionCandidate],
+    *,
+    shell_format: str,
+) -> str:
+    """Format candidates for completion scripts."""
+
+    if shell_format == "zsh":
+        return "\n".join(
+            f"{candidate.value}:{_zsh_description(candidate.description)}"
+            for candidate in candidates
+        )
+    if shell_format == "bash":
+        return "\n".join(candidate.value for candidate in candidates)
+    if shell_format == "tsv":
+        return "\n".join(
+            f"{candidate.value}\t{candidate.description}" for candidate in candidates
+        )
+    raise ValueError(f"unsupported completion format: {shell_format}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python3 -m harness_codex.runtime.shell_completion")
+    subparsers = parser.add_subparsers(required=True)
+
+    run_change = subparsers.add_parser("run-change")
+    run_change.add_argument("--repo-root", default=".")
+    run_change.add_argument("--prefix", default="")
+    run_change.add_argument(
+        "--format",
+        choices=("bash", "zsh", "tsv"),
+        default="tsv",
+    )
+    run_change.set_defaults(func=run_change_completion_command)
+    return parser
+
+
+def run_change_completion_command(args: argparse.Namespace) -> str:
+    return format_candidates(
+        run_change_candidates(args.repo_root, args.prefix),
+        shell_format=args.format,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    output = args.func(args)
+    if output:
+        print(output)
+    return 0
+
+
+def _zsh_description(value: str) -> str:
+    return value.replace(":", " -") if value else "-"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from harness_codex.runtime.shell_completion import format_candidates, run_change_candidates
+
+
+CHANGESET_A = """# Add note analysis
+
+## 1. Metadata
+
+| Item | Value |
+|---|---|
+| ChangeSet ID | `CHG-20260522-001` |
+| Status | active |
+
+## 2. Implementation Intent
+
+- Request summary: Add note analysis.
+
+## 3. Before / After
+
+| Before | After |
+|---|---|
+| Before A | After A |
+"""
+
+CHANGESET_B = """# Improve runtime completion
+
+## 1. Metadata
+
+| Item | Value |
+|---|---|
+| ChangeSet ID | `CHG-20260522-002` |
+| Status | active |
+
+## 2. Implementation Intent
+
+- Request summary: Improve completion.
+
+## 3. Before / After
+
+| Before | After |
+|---|---|
+| Before B | After B |
+"""
+
+
+def test_run_change_candidates_returns_active_changeset_ids_and_titles(tmp_path: Path):
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-20260522-001.md").write_text(CHANGESET_A, encoding="utf-8")
+    (active_dir / "CHG-20260522-002.md").write_text(CHANGESET_B, encoding="utf-8")
+
+    candidates = run_change_candidates(tmp_path)
+
+    assert [(item.value, item.description) for item in candidates] == [
+        ("CHG-20260522-001", "Add note analysis"),
+        ("CHG-20260522-002", "Improve runtime completion"),
+    ]
+
+
+def test_run_change_candidates_filters_by_prefix(tmp_path: Path):
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-20260522-001.md").write_text(CHANGESET_A, encoding="utf-8")
+    (active_dir / "CHG-20260522-002.md").write_text(CHANGESET_B, encoding="utf-8")
+
+    candidates = run_change_candidates(tmp_path, "CHG-20260522-002")
+
+    assert [(item.value, item.description) for item in candidates] == [
+        ("CHG-20260522-002", "Improve runtime completion"),
+    ]
+
+
+def test_run_change_candidates_returns_empty_when_no_active_changesets(tmp_path: Path):
+    assert run_change_candidates(tmp_path) == ()
+
+
+def test_format_candidates_supports_bash_zsh_and_tsv(tmp_path: Path):
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-20260522-001.md").write_text(CHANGESET_A, encoding="utf-8")
+    candidates = run_change_candidates(tmp_path)
+
+    assert format_candidates(candidates, shell_format="bash") == "CHG-20260522-001"
+    assert format_candidates(candidates, shell_format="zsh") == "CHG-20260522-001:Add note analysis"
+    assert format_candidates(candidates, shell_format="tsv") == "CHG-20260522-001\tAdd note analysis"


### PR DESCRIPTION
## 구현 의도

`./harness run-change <TAB>`에서 active ChangeSet ID를 바로 고를 수 있게 shell completion을 추가합니다.

목표:

- `run-change` 첫 번째 인자 위치에서 `docs/changes/active/*.md`의 ChangeSet ID 후보를 표시
- 후보에는 ChangeSet title도 함께 제공
- 선택/삽입되는 값은 title이 아니라 ChangeSet ID 유지

## 구현 방법

- `harness_codex/runtime/shell_completion.py` 추가
  - `run_change_candidates(repo_root, prefix)`에서 active ChangeSet을 읽어 `ChangeSet ID + title` 후보를 반환
  - `--format bash|zsh|tsv` 포맷 지원
- `completions/harness.bash` 추가
  - `run-change` 첫 번째 인자 위치에서 active ChangeSet ID를 완성
  - bash는 안정성을 위해 삽입 후보를 ID만 제공
- `completions/_harness` 추가
  - zsh에서 `CHG-ID: title` 형태로 설명을 표시
  - `run-change <TAB>` 시 active ChangeSet ID와 title을 함께 보여줌
- `tests/runtime/test_shell_completion.py` 추가
  - active ChangeSet ID/title 후보 생성
  - prefix filtering
  - active ChangeSet이 없는 경우
  - bash/zsh/tsv 포맷 검증

## 사용 방법

### bash

```bash
source completions/harness.bash
./harness run-change <TAB>
```

### zsh

```zsh
mkdir -p ~/.zfunc
cp completions/_harness ~/.zfunc/_harness
fpath=(~/.zfunc $fpath)
autoload -Uz compinit && compinit
./harness run-change <TAB>
```

## 검증 방법

- `tests/runtime/test_shell_completion.py`로 후보 생성과 포맷을 검증했습니다.