### PR TITLE
Install shell completion from harness update

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -42,6 +42,7 @@ from harness_codex.runtime.interactive_harvest import (
     list_harvest_sessions,
     run_interactive_harvest,
 )
+from harness_codex.runtime.shell_completion import install_completion
 from harness_codex.runtime.ui_server import run_ui_server
 from harness_codex.runtime.workflows import (
     WorkflowMaterializationError,
@@ -114,6 +115,15 @@ def build_parser() -> argparse.ArgumentParser:
     _add_harvest_mode_options(harvest)
     harvest.set_defaults(func=harvest_command)
 
+    update = subparsers.add_parser("update")
+    update.add_argument(
+        "--shell",
+        choices=("auto", "zsh", "bash", "all"),
+        default="auto",
+        help="Shell completion target to update. Defaults to the current shell.",
+    )
+    update.set_defaults(func=update_command)
+
     agent_context = subparsers.add_parser("agent-context")
     agent_context_subparsers = agent_context.add_subparsers(required=True)
     agent_context_init = agent_context_subparsers.add_parser("init")
@@ -130,14 +140,6 @@ def build_parser() -> argparse.ArgumentParser:
     changes_show = changes_subparsers.add_parser("show")
     changes_show.add_argument("change_set_id")
     changes_show.set_defaults(func=changes_show_command)
-    changes_contents = changes_subparsers.add_parser("contents")
-    changes_contents.add_argument("change_set_id")
-    changes_contents.add_argument(
-        "--raw",
-        action="store_true",
-        help="Print the raw ChangeSet markdown file instead of the structured summary.",
-    )
-    changes_contents.set_defaults(func=changes_contents_command)
     changes_create_from_design = changes_subparsers.add_parser("create-from-design")
     changes_create_from_design.add_argument("--title", default="")
     changes_create_from_design.add_argument("--change-set-id")
@@ -242,6 +244,16 @@ def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
     )
 
 
+def update_command(args: argparse.Namespace, repo_root: Path) -> str:
+    results = install_completion(repo_root, shell=args.shell)
+    lines = ["UPDATED: harness local assets", "Shell completion:"]
+    for result in results:
+        lines.append(f"- {result.shell}: {result.target}")
+        lines.append(f"  {result.note}")
+    lines.append("Restart the shell or reload completion to use updated candidates.")
+    return "\n".join(lines)
+
+
 def agent_context_init_command(args: argparse.Namespace, repo_root: Path) -> str:
     result = bootstrap_agent_context(
         repo_root,
@@ -286,71 +298,6 @@ def changes_show_command(args: argparse.Namespace, repo_root: Path) -> str:
             f"Work items: {work_items}",
         ]
     )
-
-
-def changes_contents_command(args: argparse.Namespace, repo_root: Path) -> str:
-    change_set = _load_change_set(repo_root, args.change_set_id)
-    if args.raw:
-        path = _change_set_file_path(change_set)
-        absolute_path = repo_root / path
-        if not absolute_path.exists():
-            raise ValueError(f"ChangeSet file not found: {path}")
-        return absolute_path.read_text(encoding="utf-8").strip()
-    return _format_change_set_contents(change_set)
-
-
-def _format_change_set_contents(change_set: ChangeSet) -> str:
-    lines = [
-        f"ChangeSet contents: {change_set.change_set_id}",
-        f"Path: {_change_set_file_path(change_set)}",
-        f"Title: {change_set.title or '-'}",
-        f"Status: {change_set.status or '-'}",
-        f"Related issue: {change_set.related_issue or '-'}",
-        f"Intent: {change_set.intent_summary or '-'}",
-        "Before / After:",
-        f"- Before: {change_set.before_summary or '-'}",
-        f"- After: {change_set.after_summary or '-'}",
-    ]
-
-    _extend_lines(
-        lines,
-        "Changed documents:",
-        (
-            f"- {item.path} [{item.change_type or '-'}] status={item.status or '-'} reason={item.reason or '-'}"
-            for item in change_set.changed_documents
-        ),
-    )
-    _extend_lines(
-        lines,
-        "Work items:",
-        (
-            "\n".join(
-                [
-                    f"- {item.work_item_id} ({item.work_item_type.value})",
-                    f"  name: {item.name or '-'}",
-                    f"  impact: {item.impact_type or '-'}",
-                    f"  slice: {item.slice_path}",
-                    f"  status: {item.status or '-'}",
-                ]
-            )
-            for item in change_set.ordered_work_items()
-        ),
-    )
-    _extend_lines(lines, "Planner inputs:", (f"- {path}" for path in change_set.planner_inputs))
-    _extend_lines(lines, "Included scope:", (f"- {item}" for item in change_set.included_scope))
-    _extend_lines(lines, "Excluded scope:", (f"- {item}" for item in change_set.excluded_scope))
-    _extend_lines(lines, "Forbidden changes:", (f"- {item}" for item in change_set.forbidden_changes))
-    return "\n".join(lines)
-
-
-def _extend_lines(lines: list[str], heading: str, items: object) -> None:
-    materialized = list(items)
-    lines.append(heading)
-    lines.extend(materialized or ["- none"])
-
-
-def _change_set_file_path(change_set: ChangeSet) -> Path:
-    return change_set.path or Path("docs/changes/active") / f"{change_set.change_set_id}.md"
 
 
 def changes_create_from_design_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -140,6 +140,14 @@ def build_parser() -> argparse.ArgumentParser:
     changes_show = changes_subparsers.add_parser("show")
     changes_show.add_argument("change_set_id")
     changes_show.set_defaults(func=changes_show_command)
+    changes_contents = changes_subparsers.add_parser("contents")
+    changes_contents.add_argument("change_set_id")
+    changes_contents.add_argument(
+        "--raw",
+        action="store_true",
+        help="Print the raw ChangeSet markdown file instead of the structured summary.",
+    )
+    changes_contents.set_defaults(func=changes_contents_command)
     changes_create_from_design = changes_subparsers.add_parser("create-from-design")
     changes_create_from_design.add_argument("--title", default="")
     changes_create_from_design.add_argument("--change-set-id")
@@ -298,6 +306,71 @@ def changes_show_command(args: argparse.Namespace, repo_root: Path) -> str:
             f"Work items: {work_items}",
         ]
     )
+
+
+def changes_contents_command(args: argparse.Namespace, repo_root: Path) -> str:
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    if args.raw:
+        path = _change_set_file_path(change_set)
+        absolute_path = repo_root / path
+        if not absolute_path.exists():
+            raise ValueError(f"ChangeSet file not found: {path}")
+        return absolute_path.read_text(encoding="utf-8").strip()
+    return _format_change_set_contents(change_set)
+
+
+def _format_change_set_contents(change_set: ChangeSet) -> str:
+    lines = [
+        f"ChangeSet contents: {change_set.change_set_id}",
+        f"Path: {_change_set_file_path(change_set)}",
+        f"Title: {change_set.title or '-'}",
+        f"Status: {change_set.status or '-'}",
+        f"Related issue: {change_set.related_issue or '-'}",
+        f"Intent: {change_set.intent_summary or '-'}",
+        "Before / After:",
+        f"- Before: {change_set.before_summary or '-'}",
+        f"- After: {change_set.after_summary or '-'}",
+    ]
+
+    _extend_lines(
+        lines,
+        "Changed documents:",
+        (
+            f"- {item.path} [{item.change_type or '-'}] status={item.status or '-'} reason={item.reason or '-'}"
+            for item in change_set.changed_documents
+        ),
+    )
+    _extend_lines(
+        lines,
+        "Work items:",
+        (
+            "\n".join(
+                [
+                    f"- {item.work_item_id} ({item.work_item_type.value})",
+                    f"  name: {item.name or '-'}",
+                    f"  impact: {item.impact_type or '-'}",
+                    f"  slice: {item.slice_path}",
+                    f"  status: {item.status or '-'}",
+                ]
+            )
+            for item in change_set.ordered_work_items()
+        ),
+    )
+    _extend_lines(lines, "Planner inputs:", (f"- {path}" for path in change_set.planner_inputs))
+    _extend_lines(lines, "Included scope:", (f"- {item}" for item in change_set.included_scope))
+    _extend_lines(lines, "Excluded scope:", (f"- {item}" for item in change_set.excluded_scope))
+    _extend_lines(lines, "Forbidden changes:", (f"- {item}" for item in change_set.forbidden_changes))
+    return "\n".join(lines)
+
+
+def _extend_lines(lines: list[str], heading: str, items: object) -> None:
+    materialized = list(items)
+    lines.append(heading)
+    lines.extend(materialized or ["- none"])
+
+
+def _change_set_file_path(change_set: ChangeSet) -> Path:
+    return change_set.path or Path("docs/changes/active") / f"{change_set.change_set_id}.md"
 
 
 def changes_create_from_design_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/harness_codex/runtime/shell_completion.py
+++ b/harness_codex/runtime/shell_completion.py
@@ -1,8 +1,10 @@
-"""Shell completion candidate helpers for the harness CLI."""
+"""Shell completion candidate and install helpers for the harness CLI."""
 
 from __future__ import annotations
 
 import argparse
+import os
+import shutil
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -17,6 +19,16 @@ class CompletionCandidate:
 
     value: str
     description: str = ""
+
+
+@dataclass(frozen=True)
+class CompletionInstallResult:
+    """Installed completion file path and user-facing follow-up note."""
+
+    shell: str
+    source: Path
+    target: Path
+    note: str
 
 
 def run_change_candidates(repo_root: Path | str, prefix: str = "") -> tuple[CompletionCandidate, ...]:
@@ -56,6 +68,29 @@ def format_candidates(
     raise ValueError(f"unsupported completion format: {shell_format}")
 
 
+def install_completion(
+    repo_root: Path | str,
+    *,
+    shell: str = "auto",
+    home: Path | None = None,
+) -> tuple[CompletionInstallResult, ...]:
+    """Install bundled shell completion files into the user's home directory."""
+
+    root = Path(repo_root)
+    selected = _detect_shell(shell)
+    install_home = home or Path.home()
+    if selected == "zsh":
+        return (_install_zsh_completion(root, install_home),)
+    if selected == "bash":
+        return (_install_bash_completion(root, install_home),)
+    if selected == "all":
+        return (
+            _install_zsh_completion(root, install_home),
+            _install_bash_completion(root, install_home),
+        )
+    raise ValueError(f"unsupported shell for completion install: {shell}")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python3 -m harness_codex.runtime.shell_completion")
     subparsers = parser.add_subparsers(required=True)
@@ -69,6 +104,11 @@ def build_parser() -> argparse.ArgumentParser:
         default="tsv",
     )
     run_change.set_defaults(func=run_change_completion_command)
+
+    install = subparsers.add_parser("install")
+    install.add_argument("--repo-root", default=".")
+    install.add_argument("--shell", choices=("auto", "zsh", "bash", "all"), default="auto")
+    install.set_defaults(func=install_completion_command)
     return parser
 
 
@@ -79,6 +119,15 @@ def run_change_completion_command(args: argparse.Namespace) -> str:
     )
 
 
+def install_completion_command(args: argparse.Namespace) -> str:
+    results = install_completion(args.repo_root, shell=args.shell)
+    lines = ["Installed harness shell completion:"]
+    for result in results:
+        lines.append(f"- {result.shell}: {result.source} -> {result.target}")
+        lines.append(f"  {result.note}")
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -86,6 +135,47 @@ def main(argv: list[str] | None = None) -> int:
     if output:
         print(output)
     return 0
+
+
+def _install_zsh_completion(repo_root: Path, home: Path) -> CompletionInstallResult:
+    source = repo_root / "completions" / "_harness"
+    if not source.exists():
+        raise ValueError(f"completion source file not found: {source}")
+    target_dir = home / ".zfunc"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "_harness"
+    shutil.copyfile(source, target)
+    return CompletionInstallResult(
+        shell="zsh",
+        source=source,
+        target=target,
+        note="Ensure `fpath=(~/.zfunc $fpath)` and `autoload -Uz compinit && compinit` are loaded in your zsh session.",
+    )
+
+
+def _install_bash_completion(repo_root: Path, home: Path) -> CompletionInstallResult:
+    source = repo_root / "completions" / "harness.bash"
+    if not source.exists():
+        raise ValueError(f"completion source file not found: {source}")
+    target_dir = home / ".local/share/bash-completion/completions"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "harness"
+    shutil.copyfile(source, target)
+    return CompletionInstallResult(
+        shell="bash",
+        source=source,
+        target=target,
+        note="Start a new bash session or source the installed completion file to use it immediately.",
+    )
+
+
+def _detect_shell(value: str) -> str:
+    if value != "auto":
+        return value
+    shell_name = Path(os.environ.get("SHELL", "")).name
+    if shell_name in {"zsh", "bash"}:
+        return shell_name
+    return "zsh"
 
 
 def _zsh_description(value: str) -> str:

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from harness_codex.runtime.shell_completion import format_candidates, run_change_candidates
+from harness_codex.runtime.shell_completion import (
+    format_candidates,
+    install_completion,
+    run_change_candidates,
+)
 
 
 CHANGESET_A = """# Add note analysis
@@ -84,3 +88,33 @@ def test_format_candidates_supports_bash_zsh_and_tsv(tmp_path: Path):
     assert format_candidates(candidates, shell_format="bash") == "CHG-20260522-001"
     assert format_candidates(candidates, shell_format="zsh") == "CHG-20260522-001:Add note analysis"
     assert format_candidates(candidates, shell_format="tsv") == "CHG-20260522-001\tAdd note analysis"
+
+
+def test_install_completion_copies_zsh_completion(tmp_path: Path):
+    repo = tmp_path / "repo"
+    source_dir = repo / "completions"
+    source_dir.mkdir(parents=True)
+    (source_dir / "_harness").write_text("# zsh completion\n", encoding="utf-8")
+    home = tmp_path / "home"
+
+    result = install_completion(repo, shell="zsh", home=home)
+
+    target = home / ".zfunc/_harness"
+    assert target.read_text(encoding="utf-8") == "# zsh completion\n"
+    assert result[0].shell == "zsh"
+    assert result[0].target == target
+
+
+def test_install_completion_copies_bash_completion(tmp_path: Path):
+    repo = tmp_path / "repo"
+    source_dir = repo / "completions"
+    source_dir.mkdir(parents=True)
+    (source_dir / "harness.bash").write_text("# bash completion\n", encoding="utf-8")
+    home = tmp_path / "home"
+
+    result = install_completion(repo, shell="bash", home=home)
+
+    target = home / ".local/share/bash-completion/completions/harness"
+    assert target.read_text(encoding="utf-8") == "# bash completion\n"
+    assert result[0].shell == "bash"
+    assert result[0].target == target


### PR DESCRIPTION
## 구현 의도

#164에서 `run-change` ChangeSet ID shell completion은 추가됐지만, 사용자가 completion 파일을 직접 복사해야 했습니다.

사용자 입장에서는 `harness update` 이후 completion도 함께 갱신되어야 하므로, `./harness update`가 shell completion 설치/갱신까지 처리하도록 보완합니다.

## 구현 방법

- `harness update` top-level command를 추가했습니다.
- `harness update --shell auto|zsh|bash|all` 옵션을 지원합니다.
- 기본값 `auto`는 `$SHELL`을 보고 `zsh` 또는 `bash`를 선택합니다.
- zsh completion은 `completions/_harness`를 `~/.zfunc/_harness`로 설치합니다.
- bash completion은 `completions/harness.bash`를 `~/.local/share/bash-completion/completions/harness`로 설치합니다.
- 기존 `python3 -m harness_codex.runtime.shell_completion run-change ...` 후보 조회 기능은 유지했습니다.
- main에 들어간 `changes contents` 인터페이스는 보존했습니다.

## 사용 방법

```zsh
git pull
./harness update
rm -f ~/.zcompdump*
autoload -Uz compinit && compinit
```

그 다음:

```zsh
./harness run-change 
```

공백 뒤에서 Tab 키를 누르면 active ChangeSet ID 후보가 표시됩니다.

명시적으로 zsh만 갱신하려면:

```zsh
./harness update --shell zsh
```

bash만 갱신하려면:

```bash
./harness update --shell bash
```

## 검증 방법

- `tests/runtime/test_shell_completion.py`에 install helper 테스트를 추가했습니다.
- 검증 항목:
  - zsh completion 파일이 `~/.zfunc/_harness`에 복사되는지
  - bash completion 파일이 `~/.local/share/bash-completion/completions/harness`에 복사되는지
  - 기존 ChangeSet ID/title 후보 생성 및 prefix filtering 테스트 유지