### PR TITLE
Block use-case planning until E2E goal approval

### DIFF
--- a/harness_codex/runtime/changes/__init__.py
+++ b/harness_codex/runtime/changes/__init__.py
@@ -8,6 +8,7 @@ from harness_codex.runtime.changes.models import (
     ChangeSetDocument,
     PlanningBlocked,
     PlanningInputScope,
+    VerificationGoalApproval,
     WorkItemType,
 )
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
@@ -35,6 +36,7 @@ __all__ = [
     "NoActiveChangeSetsError",
     "PlanningBlocked",
     "PlanningInputScope",
+    "VerificationGoalApproval",
     "WorkItemType",
     "create_changeset_from_design",
     "parse_changeset_markdown",

--- a/harness_codex/runtime/changes/__init__.py
+++ b/harness_codex/runtime/changes/__init__.py
@@ -6,9 +6,9 @@ from harness_codex.runtime.changes.models import (
     AffectedWorkItem,
     ChangeSet,
     ChangeSetDocument,
+    GoalApproval,
     PlanningBlocked,
     PlanningInputScope,
-    VerificationGoalApproval,
     WorkItemType,
 )
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
@@ -33,10 +33,10 @@ __all__ = [
     "DesignBridgeError",
     "DesignBridgeResult",
     "DesignUseCase",
+    "GoalApproval",
     "NoActiveChangeSetsError",
     "PlanningBlocked",
     "PlanningInputScope",
-    "VerificationGoalApproval",
     "WorkItemType",
     "create_changeset_from_design",
     "parse_changeset_markdown",

--- a/harness_codex/runtime/changes/models.py
+++ b/harness_codex/runtime/changes/models.py
@@ -59,6 +59,17 @@ class AffectedWorkItem:
 
 
 @dataclass(frozen=True)
+class GoalApproval:
+    """Approval status for a work item's verification or E2E goal."""
+
+    work_item_id: str
+    path: Path
+    change_status: str = ""
+    approval_status: str = ""
+    notes: str = ""
+
+
+@dataclass(frozen=True)
 class ChangeSet:
     """Structured representation of `docs/changes/active/<CHG-ID>.md`."""
 
@@ -74,6 +85,7 @@ class ChangeSet:
     affected_use_cases: tuple[AffectedUseCase, ...] = ()
     affected_maintenance_items: tuple[AffectedMaintenanceItem, ...] = ()
     affected_work_items: tuple[AffectedWorkItem, ...] = ()
+    goal_approvals: tuple[GoalApproval, ...] = ()
     planner_inputs: tuple[Path, ...] = ()
     included_scope: tuple[str, ...] = ()
     excluded_scope: tuple[str, ...] = ()

--- a/harness_codex/runtime/changes/parser.py
+++ b/harness_codex/runtime/changes/parser.py
@@ -11,6 +11,7 @@ from harness_codex.runtime.changes.models import (
     AffectedWorkItem,
     ChangeSet,
     ChangeSetDocument,
+    GoalApproval,
     WorkItemType,
 )
 
@@ -94,6 +95,15 @@ def parse_changeset_markdown(
         affected_use_cases=affected_use_cases,
         affected_maintenance_items=affected_maintenance_items,
         affected_work_items=affected_work_items,
+        goal_approvals=_parse_goal_approvals(
+            _section(
+                sections,
+                "7. Verification Goal Changes",
+                "7. Verification goal changes",
+                "7. 검증 목표 변경",
+                "7. 검증 목표 변경사항",
+            )
+        ),
         planner_inputs=_parse_bulleted_paths(
             _section(
                 sections,
@@ -262,6 +272,24 @@ def _parse_affected_work_items(section: str) -> tuple[AffectedWorkItem, ...]:
             )
 
     return tuple(items)
+
+
+def _parse_goal_approvals(section: str) -> tuple[GoalApproval, ...]:
+    approvals: list[GoalApproval] = []
+
+    for cells in _table_rows(section):
+        if len(cells) >= 4:
+            approvals.append(
+                GoalApproval(
+                    work_item_id=_strip_code(cells[0]),
+                    path=Path(_strip_code(cells[1])),
+                    change_status=_strip_code(cells[2]),
+                    approval_status=_strip_code(cells[3]),
+                    notes=_strip_code(cells[4]) if len(cells) >= 5 else "",
+                )
+            )
+
+    return tuple(approvals)
 
 
 def _legacy_work_items(

--- a/harness_codex/runtime/changes/resolver.py
+++ b/harness_codex/runtime/changes/resolver.py
@@ -14,6 +14,9 @@ from harness_codex.runtime.changes.models import (
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
 
 
+APPROVED_STATUS = "approved"
+
+
 class NoActiveChangeSetsError(FileNotFoundError):
     """Raised when the active ChangeSet directory contains no markdown files."""
 
@@ -106,6 +109,21 @@ class ChangeSetResolver:
                             f"Use case work item {work_item.work_item_id} "
                             "is missing required documents: "
                             + ", ".join(str(path) for path in missing)
+                        ),
+                    )
+                approval_status = _use_case_approval_status(
+                    self.repo_root,
+                    use_case.slice_path / "e2e-goal.md",
+                )
+                if approval_status and approval_status.lower() != APPROVED_STATUS:
+                    return PlanningBlocked(
+                        change_set_id=change_set.change_set_id,
+                        reason=(
+                            f"Use case work item {work_item.work_item_id} "
+                            "is waiting for E2E goal approval: "
+                            f"status={approval_status} "
+                            f"path={use_case.slice_path / 'e2e-goal.md'}. "
+                            "Approve or refine the E2E goal before planning."
                         ),
                     )
                 continue
@@ -285,6 +303,25 @@ def _missing_maintenance_documents(
         slice_path / "verification-goal.md",
     )
     return tuple(path for path in required if not (repo_root / path).exists())
+
+
+def _use_case_approval_status(repo_root: Path, e2e_goal_path: Path) -> str:
+    absolute_path = repo_root / e2e_goal_path
+    if not absolute_path.exists():
+        return ""
+
+    return _approval_status_from_markdown(absolute_path.read_text(encoding="utf-8"))
+
+
+def _approval_status_from_markdown(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|") or "---" in stripped:
+            continue
+        cells = [cell.strip().strip("`") for cell in stripped.strip("|").split("|")]
+        if len(cells) >= 2 and cells[0] in {"Approval Status", "승인 상태"}:
+            return cells[1]
+    return ""
 
 
 def _replace_uc_placeholders(

--- a/harness_codex/runtime/changes/resolver.py
+++ b/harness_codex/runtime/changes/resolver.py
@@ -111,18 +111,19 @@ class ChangeSetResolver:
                             + ", ".join(str(path) for path in missing)
                         ),
                     )
-                approval_status = _use_case_approval_status(
+                approval_found, approval_status, approval_path = _approval_status_for_use_case(
                     self.repo_root,
-                    use_case.slice_path / "e2e-goal.md",
+                    change_set,
+                    use_case,
                 )
-                if approval_status and approval_status.lower() != APPROVED_STATUS:
+                if approval_found and approval_status.lower() != APPROVED_STATUS:
                     return PlanningBlocked(
                         change_set_id=change_set.change_set_id,
                         reason=(
                             f"Use case work item {work_item.work_item_id} "
                             "is waiting for E2E goal approval: "
-                            f"status={approval_status} "
-                            f"path={use_case.slice_path / 'e2e-goal.md'}. "
+                            f"status={approval_status or '<blank>'} "
+                            f"path={approval_path}. "
                             "Approve or refine the E2E goal before planning."
                         ),
                     )
@@ -305,23 +306,37 @@ def _missing_maintenance_documents(
     return tuple(path for path in required if not (repo_root / path).exists())
 
 
-def _use_case_approval_status(repo_root: Path, e2e_goal_path: Path) -> str:
+def _approval_status_for_use_case(
+    repo_root: Path,
+    change_set: ChangeSet,
+    use_case: AffectedUseCase,
+) -> tuple[bool, str, Path]:
+    e2e_goal_path = use_case.slice_path / "e2e-goal.md"
+    for approval in change_set.goal_approvals:
+        if approval.work_item_id == use_case.uc_id:
+            return True, approval.approval_status, approval.path
+
+    found, status = _use_case_approval_status(repo_root, e2e_goal_path)
+    return found, status, e2e_goal_path
+
+
+def _use_case_approval_status(repo_root: Path, e2e_goal_path: Path) -> tuple[bool, str]:
     absolute_path = repo_root / e2e_goal_path
     if not absolute_path.exists():
-        return ""
+        return False, ""
 
     return _approval_status_from_markdown(absolute_path.read_text(encoding="utf-8"))
 
 
-def _approval_status_from_markdown(text: str) -> str:
+def _approval_status_from_markdown(text: str) -> tuple[bool, str]:
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped.startswith("|") or "---" in stripped:
             continue
         cells = [cell.strip().strip("`") for cell in stripped.strip("|").split("|")]
         if len(cells) >= 2 and cells[0] in {"Approval Status", "승인 상태"}:
-            return cells[1]
-    return ""
+            return True, cells[1]
+    return False, ""
 
 
 def _replace_uc_placeholders(

--- a/tests/runtime/test_affected_use_case_resolver.py
+++ b/tests/runtime/test_affected_use_case_resolver.py
@@ -19,11 +19,27 @@ def write_changeset(tmp_path: Path, body: str) -> Path:
     return path
 
 
-def write_use_case_slice(tmp_path: Path, uc_id: str = "UC-001") -> None:
+def write_use_case_slice(
+    tmp_path: Path,
+    uc_id: str = "UC-001",
+    *,
+    approval_status: str = "",
+) -> None:
     slice_dir = tmp_path / "docs/use-cases" / uc_id
     slice_dir.mkdir(parents=True)
     (slice_dir / "use-case.md").write_text("# use case\n", encoding="utf-8")
-    (slice_dir / "e2e-goal.md").write_text("# e2e goal\n", encoding="utf-8")
+    if approval_status:
+        e2e_goal = f"""# e2e goal
+
+## 1. Metadata
+
+|Item|Value|
+|---|---|
+|Approval Status|{approval_status}|
+"""
+    else:
+        e2e_goal = "# e2e goal\n"
+    (slice_dir / "e2e-goal.md").write_text(e2e_goal, encoding="utf-8")
 
 
 CHANGESET = """# ChangeSet CHG-001
@@ -113,6 +129,30 @@ def test_resolver_blocks_missing_use_case_documents(tmp_path: Path) -> None:
 
     assert isinstance(result, PlanningBlocked)
     assert "Use case work item UC-001 is missing required documents" in result.reason
+
+
+def test_resolver_blocks_pending_e2e_approval_before_planning(tmp_path: Path) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(tmp_path, approval_status="pending")
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "Use case work item UC-001 is waiting for E2E goal approval" in result.reason
+    assert "status=pending" in result.reason
+    assert "docs/use-cases/UC-001/e2e-goal.md" in result.reason
+
+
+def test_resolver_allows_approved_e2e_goal(tmp_path: Path) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(tmp_path, approval_status="approved")
+    resolver = ChangeSetResolver(tmp_path)
+
+    scopes = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert not isinstance(scopes, PlanningBlocked)
+    assert scopes[0].display_id == "UC-001"
 
 
 def test_resolver_builds_maintenance_planning_scope(tmp_path: Path) -> None:

--- a/tests/runtime/test_affected_use_case_resolver.py
+++ b/tests/runtime/test_affected_use_case_resolver.py
@@ -23,12 +23,12 @@ def write_use_case_slice(
     tmp_path: Path,
     uc_id: str = "UC-001",
     *,
-    approval_status: str = "",
+    approval_status: str | None = None,
 ) -> None:
     slice_dir = tmp_path / "docs/use-cases" / uc_id
     slice_dir.mkdir(parents=True)
     (slice_dir / "use-case.md").write_text("# use case\n", encoding="utf-8")
-    if approval_status:
+    if approval_status is not None:
         e2e_goal = f"""# e2e goal
 
 ## 1. Metadata
@@ -62,6 +62,45 @@ CHANGESET = """# ChangeSet CHG-001
 - `docs/use-cases/<UC-ID>/e2e-goal.md`
 - `.codex/repository-settings.md`
 """
+
+
+CHANGESET_WITH_PENDING_APPROVAL = """# ChangeSet CHG-001
+
+## 1. 메타데이터
+|항목|값|
+|---|---|
+|ChangeSet ID|`CHG-001`|
+|상태|active|
+
+## 5. 영향 유스케이스
+|UC ID|유스케이스 이름|영향 유형|Slice 경로|상태|
+|---|---|---|---|---|
+|`UC-001`|결제 승인|update|`docs/use-cases/UC-001/`|planned|
+
+## 7. Verification Goal Changes
+|Work Item ID|Verification Goal Path|Change Status|Approval Status|Notes|
+|---|---|---|---|---|
+|`UC-001`|`docs/use-cases/UC-001/e2e-goal.md`|new|pending|Generated from design intake|
+
+## 8. Planner Input Scope
+- `docs/changes/active/<CHG-ID>.md`
+- `docs/use-cases/<UC-ID>/use-case.md`
+- `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/e2e-goal.md`
+- `.codex/repository-settings.md`
+"""
+
+
+CHANGESET_WITH_APPROVED_APPROVAL = CHANGESET_WITH_PENDING_APPROVAL.replace(
+    "|`UC-001`|`docs/use-cases/UC-001/e2e-goal.md`|new|pending|Generated from design intake|",
+    "|`UC-001`|`docs/use-cases/UC-001/e2e-goal.md`|new|approved|Generated from design intake|",
+)
+
+
+CHANGESET_WITH_BLANK_APPROVAL = CHANGESET_WITH_PENDING_APPROVAL.replace(
+    "|`UC-001`|`docs/use-cases/UC-001/e2e-goal.md`|new|pending|Generated from design intake|",
+    "|`UC-001`|`docs/use-cases/UC-001/e2e-goal.md`|new||Generated from design intake|",
+)
 
 
 def test_resolver_lists_active_changesets(tmp_path: Path) -> None:
@@ -142,6 +181,40 @@ def test_resolver_blocks_pending_e2e_approval_before_planning(tmp_path: Path) ->
     assert "Use case work item UC-001 is waiting for E2E goal approval" in result.reason
     assert "status=pending" in result.reason
     assert "docs/use-cases/UC-001/e2e-goal.md" in result.reason
+
+
+def test_resolver_blocks_pending_changeset_approval_before_planning(tmp_path: Path) -> None:
+    path = write_changeset(tmp_path, CHANGESET_WITH_PENDING_APPROVAL)
+    write_use_case_slice(tmp_path, approval_status="approved")
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "Use case work item UC-001 is waiting for E2E goal approval" in result.reason
+    assert "status=pending" in result.reason
+
+
+def test_resolver_blocks_blank_changeset_approval_before_planning(tmp_path: Path) -> None:
+    path = write_changeset(tmp_path, CHANGESET_WITH_BLANK_APPROVAL)
+    write_use_case_slice(tmp_path, approval_status="approved")
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "status=<blank>" in result.reason
+
+
+def test_resolver_allows_approved_changeset_approval(tmp_path: Path) -> None:
+    path = write_changeset(tmp_path, CHANGESET_WITH_APPROVED_APPROVAL)
+    write_use_case_slice(tmp_path, approval_status="pending")
+    resolver = ChangeSetResolver(tmp_path)
+
+    scopes = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert not isinstance(scopes, PlanningBlocked)
+    assert scopes[0].display_id == "UC-001"
 
 
 def test_resolver_allows_approved_e2e_goal(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add a resolver-level pre-plan gate that reads each generated use-case `e2e-goal.md` approval metadata.
- Block ChangeSet planning before `plan-work-item` when `Approval Status` is present and not `approved`.
- Surface the root blocker directly instead of letting planner fail later with a missing `plan.md` output.
- Add regression coverage for pending and approved E2E goal statuses.

## Behavior

When a generated use-case goal still has:

```markdown
|Approval Status|pending|
```

`run-change`, `run-use-case`, and `run-work-item` now resolve to `BLOCKED` before planner execution:

```text
Use case work item UC-001 is waiting for E2E goal approval: status=pending path=docs/use-cases/UC-001/e2e-goal.md. Approve or refine the E2E goal before planning.
```

Legacy slices without an approval metadata row continue to resolve as before.

## Verification

- Added resolver tests for pending approval blocking and approved approval pass-through.
- Performed local Python syntax compilation of the patched files before pushing the branch.

Refs #166