### PR TITLE
Make harness update refresh from origin/main

### DIFF
--- a/docs/runtime-update-command.md
+++ b/docs/runtime-update-command.md
@@ -1,24 +1,24 @@
 # Harness Update Command
 
-Installed projects can update their embedded harness-codex runtime with:
+Installed projects can update their embedded harness-codex runtime from `origin/main` with:
 
 ```bash
 ./harness update
 ```
 
-The command downloads the installer from the configured harness-codex repository and reruns it with `--force --target <repo-root>`.
+The command downloads the installer from the configured harness-codex repository and reruns it with `--force --target <repo-root>`. By default, the user-facing source ref is `origin/main`; for GitHub archive/download URLs this is normalized to the downloadable branch ref `main`.
 
 ## Options
 
 ```bash
 ./harness update --dry-run
-./harness update --ref main
+./harness update --ref origin/main
 ./harness update --ref <branch-or-commit> --skip-venv
 ./harness update --repo https://github.com/omegafrog/harness-codex
 ```
 
 - `--dry-run`: print the installer command without running it.
-- `--ref`: branch, tag, or commit to install. Defaults to `main`.
+- `--ref`: branch, tag, or commit to install. Defaults to `origin/main`. Remote-tracking refs such as `origin/main` and `refs/remotes/origin/main` are normalized to GitHub-downloadable refs such as `main`.
 - `--repo`: GitHub repository URL. Defaults to `https://github.com/omegafrog/harness-codex`.
 - `--skip-venv`: skip venv creation and dependency installation.
 

--- a/harness_codex/runtime/self_update.py
+++ b/harness_codex/runtime/self_update.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Protocol
 
 DEFAULT_REPO = "https://github.com/omegafrog/harness-codex"
-DEFAULT_REF = "main"
+DEFAULT_REF = "origin/main"
 INSTALLER_PATH = "scripts/install-harness-codex.sh"
 
 
@@ -36,9 +36,9 @@ def build_parser() -> argparse.ArgumentParser:
         prog="harness update",
         description="Update the installed harness-codex runtime in this project.",
         epilog=(
-            "Update refreshes runtime-managed files while preserving workflow-generated "
-            "artifacts such as runs, sessions, ChangeSets, plans, harvested docs, and "
-            "project-local config."
+            "Update refreshes runtime-managed files from origin/main by default "
+            "while preserving workflow-generated artifacts such as runs, sessions, "
+            "ChangeSets, plans, harvested docs, and project-local config."
         ),
     )
     parser.add_argument(
@@ -49,7 +49,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--ref",
         default=DEFAULT_REF,
-        help=f"branch, tag, or commit to install. Default: {DEFAULT_REF}",
+        help=(
+            "branch, tag, or commit to install. Defaults to origin/main. "
+            "GitHub archive/download URLs normalize origin/<branch> to <branch>."
+        ),
     )
     parser.add_argument(
         "--skip-venv",
@@ -76,7 +79,7 @@ def run_self_update(
         ref=args.ref,
         skip_venv=args.skip_venv,
     )
-    warning = _warning()
+    warning = _warning(args.repo, args.ref)
     if args.dry_run:
         return "\n".join([warning, "Dry run. Command:", command])
 
@@ -108,7 +111,8 @@ def build_update_command(
     ref: str = DEFAULT_REF,
     skip_venv: bool = False,
 ) -> str:
-    installer_url = _installer_url(repo, ref)
+    install_ref = _downloadable_ref(ref)
+    installer_url = _installer_url(repo, install_ref)
     parts = [
         "curl",
         "-fsSL",
@@ -121,7 +125,7 @@ def build_update_command(
         "--target",
         shlex.quote(str(repo_root)),
         "--ref",
-        shlex.quote(ref),
+        shlex.quote(install_ref),
     ]
     if skip_venv:
         parts.append("--skip-venv")
@@ -141,8 +145,26 @@ def _installer_url(repo: str, ref: str) -> str:
     return f"https://raw.githubusercontent.com/{owner_repo}/{ref}/{INSTALLER_PATH}"
 
 
-def _warning() -> str:
+def _downloadable_ref(ref: str) -> str:
+    """Convert a local remote-tracking ref label into a GitHub-downloadable ref."""
+
+    normalized = ref.strip()
+    if not normalized:
+        raise ValueError("--ref must not be empty")
+    if normalized.startswith("refs/remotes/origin/"):
+        return normalized.removeprefix("refs/remotes/origin/")
+    if normalized.startswith("origin/"):
+        return normalized.removeprefix("origin/")
+    return normalized
+
+
+def _warning(repo: str, ref: str) -> str:
+    install_ref = _downloadable_ref(ref)
+    source = f"{repo.rstrip('/')}@{ref}"
+    if install_ref != ref:
+        source = f"{source} (download ref: {install_ref})"
     return (
+        f"Update source: {source}\n"
         "Update will refresh runtime-managed files but preserves workflow-generated "
         "artifacts: .harness runs/sessions/state, ChangeSets, work-item docs, plans, "
         "harvested docs, and project-local config."

--- a/tests/runtime/test_self_update.py
+++ b/tests/runtime/test_self_update.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from harness_codex.runtime.self_update import build_update_command, run_self_update
 
 
-def test_build_update_command_defaults_to_force_target_and_ref(tmp_path: Path) -> None:
-    command = build_update_command(tmp_path, repo="https://github.com/omegafrog/harness-codex", ref="main")
+def test_build_update_command_defaults_to_origin_main_download_ref(tmp_path: Path) -> None:
+    command = build_update_command(tmp_path, repo="https://github.com/omegafrog/harness-codex")
 
     assert "curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh" in command
     assert "bash -s -- --force" in command
@@ -14,9 +14,10 @@ def test_build_update_command_defaults_to_force_target_and_ref(tmp_path: Path) -
     assert "--ref main" in command
 
 
-def test_build_update_command_supports_skip_venv(tmp_path: Path) -> None:
-    command = build_update_command(tmp_path, ref="feature-x", skip_venv=True)
+def test_build_update_command_normalizes_origin_ref_for_github_download(tmp_path: Path) -> None:
+    command = build_update_command(tmp_path, ref="origin/feature-x", skip_venv=True)
 
+    assert "origin/feature-x" not in command
     assert "--ref feature-x" in command
     assert "--skip-venv" in command
 
@@ -33,7 +34,7 @@ def test_run_self_update_dry_run_does_not_call_runner(tmp_path: Path) -> None:
         tmp_path,
         Namespace(
             repo="https://github.com/omegafrog/harness-codex",
-            ref="main",
+            ref="origin/main",
             skip_venv=True,
             dry_run=True,
         ),
@@ -41,9 +42,11 @@ def test_run_self_update_dry_run_does_not_call_runner(tmp_path: Path) -> None:
     )
 
     assert called is False
+    assert "Update source: https://github.com/omegafrog/harness-codex@origin/main" in output
+    assert "download ref: main" in output
     assert "Dry run. Command:" in output
     assert "--skip-venv" in output
-    assert "may overwrite" in output
+    assert "preserves workflow-generated artifacts" in output
 
 
 def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
@@ -57,7 +60,7 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
         tmp_path,
         Namespace(
             repo="https://github.com/omegafrog/harness-codex",
-            ref="main",
+            ref="origin/main",
             skip_venv=True,
             dry_run=False,
         ),
@@ -68,6 +71,7 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
     command = calls[0][0][0]
     assert "--force" in command
     assert f"--target {tmp_path}" in command
+    assert "--ref main" in command
     assert calls[0][1]["cwd"] == tmp_path
     assert calls[0][1]["shell"] is True
     assert output.endswith("harness-codex update completed.")
@@ -82,7 +86,7 @@ def test_run_self_update_reports_failed_installer(tmp_path: Path) -> None:
             tmp_path,
             Namespace(
                 repo="https://github.com/omegafrog/harness-codex",
-                ref="main",
+                ref="origin/main",
                 skip_venv=False,
                 dry_run=False,
             ),


### PR DESCRIPTION
## 구현 의도
`./harness update`가 단순 completion 갱신이 아니라 설치된 harness-codex runtime을 기본적으로 `origin/main` 기준 최신 상태로 갱신하도록 의미를 명확히 합니다.

## 구현 방법
- self-update 기본 ref를 `origin/main`으로 변경했습니다.
- GitHub raw/archive 다운로드에 사용할 수 있도록 `origin/<branch>` 및 `refs/remotes/origin/<branch>`를 `<branch>`로 정규화합니다.
- dry-run/실행 출력에 사용자 기준 source ref와 실제 download ref를 함께 표시합니다.
- update 문서의 기본 동작과 preservation policy를 갱신했습니다.

## 검증 방법
- `tests/runtime/test_self_update.py`를 갱신해 기본 ref가 `origin/main` 의미를 갖고, 실제 installer command는 `main` download ref를 사용하는지 검증하도록 했습니다.
- 이 환경에서는 네트워크/로컬 테스트 실행은 수행하지 못했고, GitHub diff 기준으로 변경 파일 범위를 확인했습니다.