### PR TITLE
Align README staged workflow commands with CLI help

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -21,6 +21,8 @@ from harness_codex.runtime import (
     RunState,
     RunStateStore,
     RunStatus,
+    Step,
+    StepKind,
     StageArtifactState,
     UseCaseLoopState,
     WorkItemLoopState,
@@ -41,6 +43,15 @@ from harness_codex.runtime.dashboard import dashboard_state_json
 from harness_codex.runtime.interactive_harvest import (
     list_harvest_sessions,
     run_interactive_harvest,
+)
+from harness_codex.runtime.procedure_stages import (
+    PROCEDURE_STAGES,
+    ProcedureStage,
+    procedure_stage,
+    render_initial_changeset,
+    replace_stage_placeholders,
+    update_changeset_stage_status,
+    verify_procedure_stage,
 )
 from harness_codex.runtime.shell_completion import install_completion
 from harness_codex.runtime.ui_server import run_ui_server
@@ -161,6 +172,9 @@ def build_parser() -> argparse.ArgumentParser:
     changes_create_from_design.add_argument("--force", action="store_true")
     changes_create_from_design.set_defaults(func=changes_create_from_design_command)
 
+    for stage in PROCEDURE_STAGES:
+        _add_procedure_stage_parser(subparsers, stage)
+
     run_change = subparsers.add_parser("run-change")
     run_change.add_argument("change_set_id")
     _add_mode_options(run_change)
@@ -218,6 +232,19 @@ def build_parser() -> argparse.ArgumentParser:
     ui_server.set_defaults(func=ui_server_command)
 
     return parser
+
+
+def _add_procedure_stage_parser(
+    subparsers: argparse._SubParsersAction,
+    stage: ProcedureStage,
+) -> None:
+    command = subparsers.add_parser(stage.stage_id)
+    command.add_argument("change_set_id")
+    command.add_argument("--uc", default="")
+    command.add_argument("--title", default="")
+    command.add_argument("--idea", default="")
+    _add_mode_options(command)
+    command.set_defaults(func=procedure_stage_command, procedure_stage_id=stage.stage_id)
 
 
 def harvest_command(args: argparse.Namespace, repo_root: Path) -> str:
@@ -450,6 +477,179 @@ def _suggest_next_change_set_id(repo_root: Path) -> str:
                 continue
             sequence = max(sequence, current)
     return f"CHG-{date}-{sequence:03d}"
+
+
+def procedure_stage_command(args: argparse.Namespace, repo_root: Path) -> str:
+    stage = procedure_stage(args.procedure_stage_id)
+    mode = _selected_mode(args)
+    uc_id = args.uc.strip() or None
+    if stage.requires_uc and not uc_id:
+        raise ValueError(f"{stage.stage_id} requires --uc")
+
+    change_set_path = Path("docs/changes/active") / f"{args.change_set_id}.md"
+    if mode == RunMode.PLAN:
+        return _format_procedure_stage_plan(stage, args.change_set_id, uc_id)
+
+    if stage.stage_id == "requirements-definition" and not (repo_root / change_set_path).exists():
+        if mode == RunMode.PREVIEW:
+            return f"BLOCKED: ChangeSet does not exist yet: {change_set_path}"
+        _create_initial_procedure_changeset(
+            repo_root,
+            change_set_path,
+            change_set_id=args.change_set_id,
+            title=args.title or args.idea or args.change_set_id,
+            idea=args.idea,
+        )
+    elif not (repo_root / change_set_path).exists():
+        return f"BLOCKED: ChangeSet does not exist: {change_set_path}"
+
+    if mode == RunMode.PREVIEW:
+        passed, problems = verify_procedure_stage(
+            repo_root,
+            stage,
+            change_set_id=args.change_set_id,
+            uc_id=uc_id,
+        )
+        return _format_procedure_stage_verification(stage, passed, problems)
+
+    run_id = f"run-{uuid4().hex[:12]}"
+    context = RunContext(
+        run_id=run_id,
+        workflow_name=f"procedure-{stage.stage_id}",
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=repo_root / ".harness/runs" / run_id,
+        metadata={
+            "change_set_id": args.change_set_id,
+            "procedure_stage": stage.stage_id,
+            "uc_id": uc_id,
+            "idea": args.idea,
+        },
+    )
+    step = Step(
+        id=stage.stage_id,
+        kind=StepKind.AGENT,
+        name=stage.display_name,
+        agent_id=stage.agent_id,
+        skill_id=stage.skill_id,
+        inputs=replace_stage_placeholders(
+            stage.inputs,
+            change_set_id=args.change_set_id,
+            uc_id=uc_id,
+        ),
+        outputs=replace_stage_placeholders(
+            stage.outputs,
+            change_set_id=args.change_set_id,
+            uc_id=uc_id,
+        ),
+        timeout_sec=3600,
+        metadata={"procedure_stage": stage.stage_id},
+    )
+    result = BasicStepRunner().run(step, context)
+    passed, problems = verify_procedure_stage(
+        repo_root,
+        stage,
+        change_set_id=args.change_set_id,
+        uc_id=uc_id,
+    )
+    status = "verified" if result.successful and passed else "blocked"
+    notes = "; ".join(problems) or result.error or "-"
+    _record_procedure_stage_status(repo_root, change_set_path, stage, status, notes)
+    return "\n".join(
+        [
+            f"Stage: {stage.stage_id}",
+            f"Run: {run_id}",
+            f"Agent status: {result.status.value}",
+            f"Verification: {'passed' if passed else 'failed'}",
+            f"ChangeSet status: {status}",
+            f"Notes: {notes}",
+        ]
+    )
+
+
+def _create_initial_procedure_changeset(
+    repo_root: Path,
+    change_set_path: Path,
+    *,
+    change_set_id: str,
+    title: str,
+    idea: str,
+) -> None:
+    target = repo_root / change_set_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        render_initial_changeset(
+            change_set_id=change_set_id,
+            title=title,
+            request_summary=idea or title,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _record_procedure_stage_status(
+    repo_root: Path,
+    change_set_path: Path,
+    stage: ProcedureStage,
+    status: str,
+    notes: str,
+) -> None:
+    target = repo_root / change_set_path
+    text = target.read_text(encoding="utf-8")
+    target.write_text(
+        update_changeset_stage_status(
+            text,
+            stage=stage,
+            status=status,
+            notes=notes,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _format_procedure_stage_plan(
+    stage: ProcedureStage,
+    change_set_id: str,
+    uc_id: str | None,
+) -> str:
+    inputs = replace_stage_placeholders(
+        stage.inputs,
+        change_set_id=change_set_id,
+        uc_id=uc_id,
+    )
+    outputs = replace_stage_placeholders(
+        stage.outputs,
+        change_set_id=change_set_id,
+        uc_id=uc_id,
+    )
+    lines = [
+        f"Stage: {stage.stage_id}",
+        f"Procedure: {stage.display_name}",
+        f"Agent: {stage.agent_id or '-'}",
+        f"Skill: {stage.skill_id or '-'}",
+        "Inputs:",
+        *[f"- {path}" for path in inputs],
+        "Outputs:",
+        *[f"- {path}" for path in outputs],
+    ]
+    return "\n".join(lines)
+
+
+def _format_procedure_stage_verification(
+    stage: ProcedureStage,
+    passed: bool,
+    problems: tuple[str, ...],
+) -> str:
+    lines = [
+        f"Stage: {stage.stage_id}",
+        f"Procedure: {stage.display_name}",
+        f"Verification: {'passed' if passed else 'failed'}",
+    ]
+    if problems:
+        lines.append("Problems:")
+        lines.extend(f"- {problem}" for problem in problems)
+    return "\n".join(lines)
 
 
 def run_change_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/harness_codex/runtime/procedure_stages.py
+++ b/harness_codex/runtime/procedure_stages.py
@@ -1,0 +1,241 @@
+"""ChangeSet-backed runtime procedure stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ProcedureStage:
+    """One explicit runtime interface in the harness delivery sequence."""
+
+    stage_id: str
+    display_name: str
+    agent_id: str | None
+    skill_id: str | None
+    inputs: tuple[Path, ...]
+    outputs: tuple[Path, ...]
+    verifier_terms: tuple[str, ...] = ()
+    requires_uc: bool = False
+
+
+PROCEDURE_STAGES: tuple[ProcedureStage, ...] = (
+    ProcedureStage(
+        stage_id="requirements-definition",
+        display_name="Requirements Definition",
+        agent_id="harness_requirements",
+        skill_id="harness-requirements",
+        inputs=(Path("docs/changes/active/<CHG-ID>.md"),),
+        outputs=(Path("context.md"), Path("docs/design/요구사항.md")),
+        verifier_terms=("TBD from confirmed requirements",),
+    ),
+    ProcedureStage(
+        stage_id="use-case-definition",
+        display_name="Use Case Definition",
+        agent_id="harness_usecases",
+        skill_id="harness-usecases",
+        inputs=(
+            Path("docs/changes/active/<CHG-ID>.md"),
+            Path("context.md"),
+            Path("docs/design/요구사항.md"),
+        ),
+        outputs=(Path("docs/design/유스케이스.md"), Path("docs/use-cases")),
+        verifier_terms=("TBD from confirmed requirements",),
+    ),
+    ProcedureStage(
+        stage_id="event-storming",
+        display_name="Event Storming",
+        agent_id="oracle",
+        skill_id="harness-event-storming",
+        inputs=(
+            Path("docs/changes/active/<CHG-ID>.md"),
+            Path("docs/use-cases/<UC-ID>/use-case.md"),
+            Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
+        ),
+        outputs=(Path("docs/use-cases/<UC-ID>/event-storming.md"),),
+        verifier_terms=("has not been derived yet", "To be derived"),
+        requires_uc=True,
+    ),
+    ProcedureStage(
+        stage_id="ddd-architecture-definition",
+        display_name="DDD Architecture Definition",
+        agent_id="ddd_architect",
+        skill_id="harness-ddd-design",
+        inputs=(
+            Path("docs/changes/active/<CHG-ID>.md"),
+            Path("docs/use-cases/<UC-ID>/use-case.md"),
+            Path("docs/use-cases/<UC-ID>/event-storming.md"),
+        ),
+        outputs=(Path("docs/use-cases/<UC-ID>/ddd-design.md"), Path("ARCHITECTURE.md")),
+        verifier_terms=("TBD", "To be derived"),
+        requires_uc=True,
+    ),
+    ProcedureStage(
+        stage_id="plan-writing",
+        display_name="plan.md Writing",
+        agent_id="implementation_planner",
+        skill_id="harness-code-planner",
+        inputs=(
+            Path("docs/changes/active/<CHG-ID>.md"),
+            Path("docs/use-cases/<UC-ID>/use-case.md"),
+            Path("docs/use-cases/<UC-ID>/event-storming.md"),
+            Path("docs/use-cases/<UC-ID>/ddd-design.md"),
+            Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
+            Path("ARCHITECTURE.md"),
+            Path(".codex/repository-settings.md"),
+        ),
+        outputs=(Path("docs/plans/active/<UC-ID>/plan.md"),),
+        verifier_terms=("TBD", "To be derived"),
+        requires_uc=True,
+    ),
+    ProcedureStage(
+        stage_id="implementation",
+        display_name="Implementation",
+        agent_id="implementation_executor",
+        skill_id="harness-plan-executor",
+        inputs=(
+            Path("docs/changes/active/<CHG-ID>.md"),
+            Path("docs/plans/active/<UC-ID>/plan.md"),
+            Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
+            Path(".codex/test-gate.yaml"),
+        ),
+        outputs=(Path("docs/plans/completed/<UC-ID>/plan.md"),),
+        requires_uc=True,
+    ),
+)
+
+
+PROCEDURE_STAGE_BY_ID = {stage.stage_id: stage for stage in PROCEDURE_STAGES}
+
+
+def procedure_stage(stage_id: str) -> ProcedureStage:
+    try:
+        return PROCEDURE_STAGE_BY_ID[stage_id]
+    except KeyError as exc:
+        known = ", ".join(stage.stage_id for stage in PROCEDURE_STAGES)
+        raise ValueError(f"unknown procedure stage: {stage_id}. Known: {known}") from exc
+
+
+def replace_stage_placeholders(
+    paths: tuple[Path, ...],
+    *,
+    change_set_id: str,
+    uc_id: str | None = None,
+) -> tuple[Path, ...]:
+    return tuple(
+        Path(
+            str(path)
+            .replace("<CHG-ID>", change_set_id)
+            .replace("<UC-ID>", uc_id or "<UC-ID>")
+        )
+        for path in paths
+    )
+
+
+def verify_procedure_stage(
+    repo_root: Path,
+    stage: ProcedureStage,
+    *,
+    change_set_id: str,
+    uc_id: str | None = None,
+) -> tuple[bool, tuple[str, ...]]:
+    if stage.requires_uc and not uc_id:
+        return False, (f"{stage.stage_id} requires --uc",)
+
+    problems: list[str] = []
+    outputs = replace_stage_placeholders(
+        stage.outputs,
+        change_set_id=change_set_id,
+        uc_id=uc_id,
+    )
+    for output in outputs:
+        absolute = repo_root / output
+        if not absolute.exists():
+            problems.append(f"missing output: {output}")
+            continue
+        if absolute.is_file() and not absolute.read_text(encoding="utf-8").strip():
+            problems.append(f"empty output: {output}")
+            continue
+        if absolute.is_file():
+            text = absolute.read_text(encoding="utf-8")
+            for term in stage.verifier_terms:
+                if term and term in text:
+                    problems.append(f"unverified placeholder in {output}: {term}")
+
+    return not problems, tuple(problems)
+
+
+def render_initial_changeset(
+    *,
+    change_set_id: str,
+    title: str,
+    request_summary: str,
+) -> str:
+    rows = "\n".join(
+        f"|{stage.stage_id}|{stage.display_name}|pending|-|-|"
+        for stage in PROCEDURE_STAGES
+    )
+    return f"""# ChangeSet {change_set_id}
+
+## 1. Metadata
+
+|Item|Value|
+|---|---|
+|ChangeSet ID|`{change_set_id}`|
+|Status|active|
+|Created date|{datetime.now().strftime("%Y-%m-%d")}|
+|Author|Codex|
+
+## 2. Implementation Intent
+
+- Request summary: {request_summary or title}
+- Expected user result: The runtime can resume each stage from this ChangeSet.
+- Reason for change: ChangeSet is the durable source of stage state from requirements through implementation.
+
+## 3. Runtime Procedure State
+
+|Stage ID|Procedure|Status|Verified At|Notes|
+|---|---|---|---|---|
+{rows}
+"""
+
+
+def update_changeset_stage_status(
+    text: str,
+    *,
+    stage: ProcedureStage,
+    status: str,
+    notes: str = "",
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    row = f"|{stage.stage_id}|{stage.display_name}|{status}|{now}|{notes or '-'}|"
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith(f"|{stage.stage_id}|"):
+            lines[index] = row
+            return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+
+    if "## 3. Runtime Procedure State" not in text:
+        return text.rstrip() + "\n\n" + _procedure_state_section(row) + "\n"
+
+    insert_at = len(lines)
+    for index, line in enumerate(lines):
+        if line.startswith("## ") and index > 0 and lines[index - 1].strip():
+            insert_at = index
+            break
+    lines.insert(insert_at, row)
+    return "\n".join(lines) + "\n"
+
+
+def _procedure_state_section(first_row: str) -> str:
+    return "\n".join(
+        [
+            "## 3. Runtime Procedure State",
+            "",
+            "|Stage ID|Procedure|Status|Verified At|Notes|",
+            "|---|---|---|---|---|",
+            first_row,
+        ]
+    )

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from harness_codex.cli import main
+from harness_codex.runtime.procedure_stages import (
+    procedure_stage,
+    render_initial_changeset,
+    update_changeset_stage_status,
+    verify_procedure_stage,
+)
+
+
+def test_procedure_stage_plan_uses_explicit_process_name(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "event-storming",
+            "CHG-001",
+            "--uc",
+            "UC-001",
+            "--plan",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Stage: event-storming" in output
+    assert "Procedure: Event Storming" in output
+    assert "docs/use-cases/UC-001/event-storming.md" in output
+
+
+def test_procedure_stage_preview_verifies_outputs(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    change_dir = tmp_path / "docs/changes/active"
+    change_dir.mkdir(parents=True)
+    (change_dir / "CHG-001.md").write_text("# ChangeSet CHG-001\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "event-storming",
+            "CHG-001",
+            "--uc",
+            "UC-001",
+            "--preview",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Verification: failed" in output
+    assert "missing output: docs/use-cases/UC-001/event-storming.md" in output
+
+
+def test_procedure_stage_verifier_rejects_placeholder_content(tmp_path: Path) -> None:
+    path = tmp_path / "docs/use-cases/UC-001/event-storming.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("- Event storming has not been derived yet.\n", encoding="utf-8")
+
+    passed, problems = verify_procedure_stage(
+        tmp_path,
+        procedure_stage("event-storming"),
+        change_set_id="CHG-001",
+        uc_id="UC-001",
+    )
+
+    assert not passed
+    assert problems == (
+        "unverified placeholder in docs/use-cases/UC-001/event-storming.md: has not been derived yet",
+    )
+
+
+def test_changeset_stage_status_is_durable_in_changeset_markdown() -> None:
+    text = render_initial_changeset(
+        change_set_id="CHG-001",
+        title="Note workflow",
+        request_summary="Build note workflow",
+    )
+
+    updated = update_changeset_stage_status(
+        text,
+        stage=procedure_stage("requirements-definition"),
+        status="verified",
+        notes="outputs verified",
+    )
+
+    assert "|requirements-definition|Requirements Definition|verified|" in updated
+    assert "outputs verified" in updated


### PR DESCRIPTION
## 구현 의도
`harness update` 이후 `./harness --help`에 README.md가 안내하는 staged workflow 명령이 보이지 않는 문제를 해결합니다.

현재 README는 `requirements-definition`, `use-case-definition`, `event-storming`, `ddd-architecture-definition`, `plan-writing`, `implementation` 명령을 안내하지만, 실제 argparse parser에는 해당 명령이 등록되어 있지 않았습니다.

## 구현 방법
- `PROCEDURE_STAGES` 기반으로 staged workflow 명령을 CLI parser에 등록했습니다.
- 각 stage command는 `CHG-ID`, `--uc`, `--title`, `--idea`, `--plan|--preview|--apply`를 받도록 했습니다.
- `requirements-definition --apply`는 ChangeSet이 없으면 초기 ChangeSet과 Runtime Procedure State 테이블을 생성합니다.
- stage preview/apply는 산출물 존재 여부와 placeholder 여부를 검증하고 ChangeSet stage 상태를 기록합니다.
- `procedure_stages.py`에 stage 정의, placeholder 치환, stage 검증, ChangeSet 상태 테이블 갱신 로직을 추가했습니다.

## 검증 방법
- `tests/runtime/test_procedure_stage_runtime.py` 추가
  - `event-storming --plan`이 README stage command로 동작하는지 확인
  - `event-storming --preview`가 누락 산출물을 보고하는지 확인
  - placeholder content를 미검증 산출물로 차단하는지 확인
  - ChangeSet stage status가 markdown에 durable하게 기록되는지 확인

로컬 pytest는 이 환경에서 직접 실행하지 못했고, GitHub diff 기준으로 변경 파일 범위를 확인했습니다.