### PR TITLE
Validate staged workflow agent and skill registry

### DIFF
--- a/harness_codex/runtime/procedure_stages.py
+++ b/harness_codex/runtime/procedure_stages.py
@@ -167,6 +167,58 @@ def verify_procedure_stage(
     return not problems, tuple(problems)
 
 
+def validate_procedure_stage_registry(
+    repo_root: Path,
+    stages: tuple[ProcedureStage, ...] = PROCEDURE_STAGES,
+) -> tuple[str, ...]:
+    """Validate that every procedure stage can resolve its agent and skill files."""
+
+    problems: list[str] = []
+    for stage in stages:
+        if stage.agent_id:
+            agent_path = Path(".codex/agents") / f"{stage.agent_id}.toml"
+            if not (repo_root / agent_path).is_file():
+                problems.append(
+                    f"{stage.stage_id}: missing agent config: {agent_path}"
+                )
+
+        if stage.skill_id:
+            skill_path = Path(".codex/skills") / stage.skill_id / "SKILL.md"
+            absolute_skill_path = repo_root / skill_path
+            if not absolute_skill_path.is_file():
+                problems.append(
+                    f"{stage.stage_id}: missing skill config: {skill_path}"
+                )
+                continue
+
+            declared_name = _skill_frontmatter_name(absolute_skill_path)
+            if declared_name is None:
+                problems.append(
+                    f"{stage.stage_id}: missing skill frontmatter name: {skill_path}"
+                )
+            elif declared_name != stage.skill_id:
+                problems.append(
+                    f"{stage.stage_id}: skill name mismatch: {skill_path} "
+                    f"declares {declared_name}, expected {stage.skill_id}"
+                )
+
+    return tuple(problems)
+
+
+def _skill_frontmatter_name(path: Path) -> str | None:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            return None
+        if stripped.startswith("name:"):
+            return stripped.removeprefix("name:").strip().strip('"\'') or None
+    return None
+
+
 def render_initial_changeset(
     *,
     change_set_id: str,

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -169,5 +169,6 @@ def test_readme_staged_workflow_commands_match_procedure_stage_ids() -> None:
     }
     stage_ids = {stage.stage_id for stage in PROCEDURE_STAGES}
 
-    assert documented <= set(readme)
+    for command in documented:
+        assert f"./harness {command}" in readme
     assert stage_ids == documented

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -2,11 +2,18 @@ from pathlib import Path
 
 from harness_codex.cli import main
 from harness_codex.runtime.procedure_stages import (
+    PROCEDURE_STAGES,
+    ProcedureStage,
     procedure_stage,
     render_initial_changeset,
     update_changeset_stage_status,
+    validate_procedure_stage_registry,
     verify_procedure_stage,
 )
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
 
 
 def test_procedure_stage_plan_uses_explicit_process_name(
@@ -92,3 +99,75 @@ def test_changeset_stage_status_is_durable_in_changeset_markdown() -> None:
 
     assert "|requirements-definition|Requirements Definition|verified|" in updated
     assert "outputs verified" in updated
+
+
+def test_all_procedure_stage_agents_and_skills_exist() -> None:
+    problems = validate_procedure_stage_registry(_repo_root())
+
+    assert problems == ()
+
+
+def test_procedure_stage_registry_reports_missing_agent_and_skill(
+    tmp_path: Path,
+) -> None:
+    stage = ProcedureStage(
+        stage_id="sample-stage",
+        display_name="Sample Stage",
+        agent_id="missing_agent",
+        skill_id="missing-skill",
+        inputs=(),
+        outputs=(),
+    )
+
+    problems = validate_procedure_stage_registry(tmp_path, (stage,))
+
+    assert problems == (
+        "sample-stage: missing agent config: .codex/agents/missing_agent.toml",
+        "sample-stage: missing skill config: .codex/skills/missing-skill/SKILL.md",
+    )
+
+
+def test_procedure_stage_registry_reports_skill_name_mismatch(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".codex/agents").mkdir(parents=True)
+    (tmp_path / ".codex/agents/sample_agent.toml").write_text(
+        "name = \"sample_agent\"\n",
+        encoding="utf-8",
+    )
+    skill_dir = tmp_path / ".codex/skills/sample-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: other-skill\n---\n",
+        encoding="utf-8",
+    )
+    stage = ProcedureStage(
+        stage_id="sample-stage",
+        display_name="Sample Stage",
+        agent_id="sample_agent",
+        skill_id="sample-skill",
+        inputs=(),
+        outputs=(),
+    )
+
+    problems = validate_procedure_stage_registry(tmp_path, (stage,))
+
+    assert problems == (
+        "sample-stage: skill name mismatch: .codex/skills/sample-skill/SKILL.md declares other-skill, expected sample-skill",
+    )
+
+
+def test_readme_staged_workflow_commands_match_procedure_stage_ids() -> None:
+    readme = (_repo_root() / "README.md").read_text(encoding="utf-8")
+    documented = {
+        "requirements-definition",
+        "use-case-definition",
+        "event-storming",
+        "ddd-architecture-definition",
+        "plan-writing",
+        "implementation",
+    }
+    stage_ids = {stage.stage_id for stage in PROCEDURE_STAGES}
+
+    assert documented <= set(readme)
+    assert stage_ids == documented


### PR DESCRIPTION
## 구현 의도
#173의 staged workflow agent/skill registry 검증을 구현합니다.

PR #172에서 `PROCEDURE_STAGES`가 도입되면서 각 stage가 `agent_id`와 `skill_id`를 요구하게 되었지만, 모든 stage의 agent/skill 파일 존재 여부와 skill frontmatter 일치 여부를 검증하는 회귀 테스트가 없었습니다.

## 구현 방법
- `validate_procedure_stage_registry(repo_root, stages=PROCEDURE_STAGES)` 추가
  - `.codex/agents/<agent_id>.toml` 존재 검증
  - `.codex/skills/<skill_id>/SKILL.md` 존재 검증
  - skill frontmatter `name:`과 `skill_id` 일치 검증
  - stage 단위로 명확한 문제 메시지 반환
- `_skill_frontmatter_name()` 추가
  - 간단한 YAML frontmatter의 `name:` 필드를 읽어 registry mismatch를 잡습니다.
- runtime test 보강
  - 현재 repo의 모든 staged workflow agent/skill registry가 유효한지 검증
  - missing agent/skill 메시지 검증
  - skill name mismatch 메시지 검증
  - README의 staged workflow command 목록과 `PROCEDURE_STAGES.stage_id`가 일치하는지 검증

## 검증 방법
- 추가/수정 테스트 파일:
  - `tests/runtime/test_procedure_stage_runtime.py`
- 이 환경에서는 로컬 pytest를 직접 실행하지 못했고, GitHub diff 기준으로 변경 범위를 확인했습니다.

## 관련 이슈
Closes #173