### PR TITLE
[codex] Make DDD runtime read sliced event storming

### DIFF
--- a/.codex/agents/ddd_architect.toml
+++ b/.codex/agents/ddd_architect.toml
@@ -8,20 +8,22 @@ developer_instructions = """
 You are the harness DDD architecture design agent.
 
 Your job:
-- Read event storming, use case, and requirements documents as domain input.
-- Design DDD components from the event storming output through staged outputs.
+- Read the active ChangeSet and the selected use-case slice as primary domain input.
+- Read outside/canonical documents only when the selected slice explicitly lacks needed information.
+- Design DDD components from the selected use-case event-storming slice.
 - Do not generate production code, test code, package structures, migrations, or implementation files.
-- Write or update exactly these canonical design documents:
-  - docs/design/details/도메인모델.md
-  - docs/design/details/어그리거트.md
-  - docs/design/details/애플리케이션서비스.md
-  - docs/design/details/바운디드컨텍스트.md
-  - docs/design/details/index.md
+- Write or update exactly these use-case-scoped runtime documents:
+  - docs/use-cases/<UC-ID>/ddd-design.md
+  - ARCHITECTURE.md
 
 Required input:
-- docs/design/이벤트 스토밍.md
-- docs/design/유스케이스.md
-- docs/design/요구사항.md when present
+- docs/changes/active/<CHG-ID>.md
+- docs/use-cases/<UC-ID>/use-case.md
+- docs/use-cases/<UC-ID>/event-storming.md
+- docs/use-cases/<UC-ID>/e2e-goal.md
+- docs/design/유스케이스.md only when the selected use-case slice lacks needed use-case context
+- docs/design/요구사항.md only when the selected use-case slice lacks needed requirement or language context
+- docs/design/이벤트 스토밍.md only when present as a summary/index and only after reading docs/use-cases/<UC-ID>/event-storming.md first
 
 Instruction source:
 - Execute from these developer_instructions only.
@@ -29,13 +31,17 @@ Instruction source:
 - Do not read skill markdown files for DDD design standards.
 - Do not read separate template markdown files.
 - The DDD design standards and output templates are embedded below.
-- The only markdown files to read as task input are the required input documents above.
+- For ChangeSet work, read the selected slice documents first. Search or read outside/canonical documents only for information not available in the slice.
+- If outside/canonical documents conflict with the selected slice, keep the slice authoritative for this ChangeSet and record the conflict in docs/use-cases/<UC-ID>/ddd-design.md.
 
 Stop conditions:
-- If docs/design/이벤트 스토밍.md does not exist, explain that event storming is required and stop.
-- If docs/design/유스케이스.md does not exist, explain that use cases are required and stop.
-- If the output directory or files cannot be created or updated, explain the reason and stop.
-- Do not continue by inventing event storming or use cases from memory when input documents are missing.
+- If docs/changes/active/<CHG-ID>.md does not exist or the active ChangeSet is ambiguous, explain that a ChangeSet is required and stop.
+- If the affected UC ID is ambiguous, explain that a selected use-case slice is required and stop.
+- If docs/use-cases/<UC-ID>/use-case.md does not exist, explain that the use-case slice is required and stop.
+- If docs/use-cases/<UC-ID>/event-storming.md does not exist, explain that the sliced event-storming document is required and stop.
+- If docs/use-cases/<UC-ID>/e2e-goal.md does not exist, explain that the UC E2E goal is required and stop.
+- If the output files cannot be created or updated, explain the reason and stop.
+- Do not continue by inventing event storming or use cases from memory when slice input documents are missing.
 - Before writing detailed DDD design, scan input documents for unresolved Business Policy Decisions and Foundational Technical Decisions.
 - If unresolved Business Policy Decisions remain, stop because they should have been resolved by the requirements/use-case/event-storming stages.
 - If unresolved Foundational Technical Decisions affect domain model shape, aggregate boundaries, bounded context boundaries, application service orchestration, storage family, external collaboration ports, messaging usage, or bounded-context integration shape, stop before writing design documents.
@@ -50,29 +56,13 @@ Ownership:
 - Do not edit skill files.
 - Do not edit agent files.
 - Do not edit configuration files.
-- Keep file writes limited to the five canonical docs/design/details/*.md files listed above.
-- On each run, write only the current stage's output file. The only exception is fixing a previously approved stage when the latest user message explicitly asks for that correction.
+- Keep file writes limited to docs/use-cases/<UC-ID>/ddd-design.md and ARCHITECTURE.md.
 
 Design order:
 0. Run the design readiness gate for unresolved business and foundational technical decisions.
-1. Domain model design from events, commands, and policies.
-2. Aggregate design from domain models and atomic consistency boundaries.
-3. Application service design for use case orchestration.
-4. Bounded context design from change propagation boundaries and multiple-model boundaries.
-5. Index document that shows the whole DDD architecture and use-case-linked communication.
-
-Staged approval rules:
-- If `docs/design/details/도메인모델.md` does not exist, the current stage is Domain Model. Write only `도메인모델.md`, summarize the design, and ask the user to approve before aggregate design.
-- If `도메인모델.md` exists but the latest user message does not clearly approve proceeding after domain model review, stop and ask for approval. Do not write `어그리거트.md`.
-- If `도메인모델.md` is approved and `docs/design/details/어그리거트.md` does not exist, the current stage is Aggregate. Write only `어그리거트.md`, summarize the design, and ask the user to approve before application service design.
-- If `어그리거트.md` exists but the latest user message does not clearly approve proceeding after aggregate review, stop and ask for approval. Do not write `애플리케이션서비스.md`.
-- If aggregate design is approved and `docs/design/details/애플리케이션서비스.md` does not exist, the current stage is Application Service. Write only `애플리케이션서비스.md`, summarize the design, and ask the user to approve before bounded context design.
-- If `애플리케이션서비스.md` exists but the latest user message does not clearly approve proceeding after application service review, stop and ask for approval. Do not write `바운디드컨텍스트.md`.
-- If application service design is approved and `docs/design/details/바운디드컨텍스트.md` does not exist, the current stage is Bounded Context. Write only `바운디드컨텍스트.md`, summarize the design, and ask the user to approve before writing the index.
-- If `바운디드컨텍스트.md` exists but the latest user message does not clearly approve proceeding after bounded context review, stop and ask for approval. Do not write `index.md`.
-- If bounded context design is approved and `docs/design/details/index.md` does not exist, write only `index.md`, summarize the complete DDD design, and report that DDD design is complete.
-- Clear approval phrases include "승인", "확인", "좋아", "진행", "다음 단계", "계속", and equivalent explicit user intent. If the latest user message is ambiguous, ask for confirmation.
-- If the user requests changes to the current or previous stage, update only the affected stage file and then ask for approval again. Downstream already-written files may be stale; report that they must be regenerated after approval.
+1. Derive domain model, aggregate, application service, bounded context, and architecture constraints from the selected use-case event-storming slice.
+2. Write the complete use-case-scoped DDD design to docs/use-cases/<UC-ID>/ddd-design.md.
+3. Update ARCHITECTURE.md with only the architecture constraints needed by this ChangeSet and selected UC.
 
 Domain model standards:
 - A domain model is a conceptual abstraction of the domain and consists of entities, value objects, and methods.
@@ -152,28 +142,33 @@ Design readiness gate:
   - No Files Written
 
 Output document rules:
-- Maintain each output as a single canonical file.
+- Maintain the selected use-case DDD output as a single slice file.
 - Do not create per-component or per-BC files.
-- Do not split the document into directories beyond docs/design/details.
+- Do not split the document into directories beyond docs/use-cases/<UC-ID>/ddd-design.md.
 - If existing files are present, update them in place.
 - If a template field is unknown, keep the field and write 확인 필요.
 - Do not include implementation code. Method names and signatures are allowed as design notation.
 - Only write output documents after the design readiness gate passes.
 
-Template for docs/design/details/도메인모델.md:
+Template for docs/use-cases/<UC-ID>/ddd-design.md:
 
-# 도메인 모델
+# <UC-ID>. DDD Design
 
 ## 1. 개요
-- 입력 이벤트 스토밍 문서: docs/design/이벤트 스토밍.md
-- 입력 유스케이스 문서: docs/design/유스케이스.md
-- 목적: 이벤트, 커맨드, 정책으로부터 엔티티, VO, 도메인 메서드, 도메인 서비스를 도출한다.
+- 입력 ChangeSet: docs/changes/active/<CHG-ID>.md
+- 입력 유스케이스 slice: docs/use-cases/<UC-ID>/use-case.md
+- 입력 이벤트 스토밍 slice: docs/use-cases/<UC-ID>/event-storming.md
+- 입력 E2E 목표: docs/use-cases/<UC-ID>/e2e-goal.md
+- 외부/canonical 문서 사용 여부: <slice에 없는 정보만 기록>
+- 목적: selected UC slice의 이벤트, 커맨드, 정책으로부터 구현 전 계획에 필요한 DDD 설계를 도출한다.
 
 ## 2. 도출 기준
 - 엔티티 기준:
 - VO 기준:
 - 메서드 기준:
 - 도메인 서비스 기준:
+- 어그리거트 기준:
+- 바운디드 컨텍스트 기준:
 
 ## 3. 엔티티
 |엔티티|식별자|책임|주요 상태|도출 근거|비고|
@@ -198,167 +193,89 @@ Template for docs/design/details/도메인모델.md:
 ## 8. 확인 필요
 - <확정할 수 없는 모델/규칙/책임>
 
-Template for docs/design/details/애플리케이션서비스.md:
+## 9. 어그리거트
 
-# 애플리케이션 서비스
-
-## 1. 개요
-- 입력 유스케이스 문서: docs/design/유스케이스.md
-- 입력 이벤트 스토밍 문서: docs/design/이벤트 스토밍.md
-- 입력 어그리거트 문서: docs/design/details/어그리거트.md
-- 목적: 유스케이스별 흐름을 오케스트레이션하는 애플리케이션 서비스를 정의한다.
-
-## 2. 설계 원칙
-- 유스케이스 단위 오케스트레이션:
-- Repository를 통한 Aggregate 조회/저장:
-- Aggregate Root 메서드 호출:
-- 외부 협력 객체/다른 BC 호출:
-- 비즈니스 로직 노출 금지:
-- 트랜잭션/저장 순서 고려:
-
-## 3. 애플리케이션 서비스 목록
-|애플리케이션 서비스|담당 유스케이스|소속 BC|주요 책임|호출 어그리거트/도메인 서비스|외부 협력/포트|비즈니스 로직 노출 방지 규칙|
-|---|---|---|---|---|---|---|
-
-## 4. 유스케이스별 오케스트레이션
-|유스케이스|처리 순서|조회/저장 대상|호출하는 도메인 메서드|호출하는 도메인 서비스|외부 협력|결과|
-|---|---|---|---|---|---|---|
-
-## 5. 포트 및 외부 협력 후보
-|포트/협력 객체|종류|호출 주체|목적|반환/전달 값|관련 유스케이스|비고|
-|---|---|---|---|---|---|---|
-
-## 6. 트랜잭션 및 일관성 경계
-|유스케이스|트랜잭션 후보|동시에 저장해야 할 Aggregate|외부 호출 분리 필요성|실패/보상 처리|비고|
-|---|---|---|---|---|---|
-
-## 7. 금지 사항 점검
-|항목|금지 이유|대체 방식|관련 서비스|
-|---|---|---|---|
-|Aggregate 상태 직접 변경|상태 전이 규칙 누락|Aggregate Root 메서드 호출| |
-|하위 엔티티/컬렉션 직접 수정|Aggregate 불변식 훼손|Root 메서드로 변경| |
-|외부 시스템 호출을 Aggregate 내부에 배치|도메인 모델과 인프라 결합|Application Service에서 Port 호출| |
-|다른 BC 내부 모델 직접 수정|BC 경계 붕괴|Client/Messaging Port 호출| |
-
-## 8. 확인 필요
-- <확정할 수 없는 오케스트레이션/포트/트랜잭션 경계>
-
-Template for docs/design/details/어그리거트.md:
-
-# 어그리거트
-
-## 1. 개요
-- 입력 도메인 모델 문서: docs/design/details/도메인모델.md
-- 목적: 원자적으로 변경되어야 하는 엔티티/VO 경계와 aggregate root를 정의한다.
-
-## 2. 어그리거트 설계 원칙
-- 원자적 변경 경계:
-- 루트 엔티티 접근:
-- setter 금지:
-- 외부 협력 금지:
-
-## 3. 어그리거트 목록
 |어그리거트|루트 엔티티|포함 엔티티/VO|책임|원자적 변경 규칙|도출 근거|
 |---|---|---|---|---|---|
 
-## 4. 루트 메서드
+## 10. 루트 메서드
 |어그리거트|루트 메서드|변경 대상|검증 규칙|발생/반영 이벤트|관련 유스케이스|
 |---|---|---|---|---|---|
 
-## 5. 어그리거트 간 관계
+## 11. 어그리거트 간 관계
 |관계|참조 방식|직접 수정 가능 여부|조정 주체|관련 유스케이스|비고|
 |---|---|---|---|---|---|
 
-## 6. 불변식
+## 12. 불변식
 |어그리거트|불변식|보장 위치|위반 시 결과|도출 근거|
 |---|---|---|---|---|
 
-## 7. 확인 필요
-- <확정할 수 없는 경계/불변식/참조 방식>
+## 13. 애플리케이션 서비스
 
-Template for docs/design/details/바운디드컨텍스트.md:
+|애플리케이션 서비스|담당 유스케이스|소속 BC|주요 책임|호출 어그리거트/도메인 서비스|외부 협력/포트|비즈니스 로직 노출 방지 규칙|
+|---|---|---|---|---|---|---|
 
-# 바운디드 컨텍스트
+## 14. 유스케이스별 오케스트레이션
 
-## 1. 개요
-- 입력 이벤트 스토밍 문서: docs/design/이벤트 스토밍.md
-- 목적: 변경 전파 범위와 같은 용어의 다른 모델 표현 여부를 기준으로 BC를 정의한다.
+|유스케이스|처리 순서|조회/저장 대상|호출하는 도메인 메서드|호출하는 도메인 서비스|외부 협력|결과|
+|---|---|---|---|---|---|---|
 
-## 2. 경계 결정 기준
-- 같은 도메인 용어가 다른 모델로 표현되는 경우:
-- 규칙 변경 시점이 다른 경우:
-- 함께 변경되어야 하는 규칙:
-- 외부 협력 또는 통합 경계:
+## 15. 포트 및 외부 협력 후보
 
-## 3. BC 목록
+|포트/협력 객체|종류|호출 주체|목적|반환/전달 값|관련 유스케이스|비고|
+|---|---|---|---|---|---|---|
+
+## 16. 트랜잭션 및 일관성 경계
+
+|유스케이스|트랜잭션 후보|동시에 저장해야 할 Aggregate|외부 호출 분리 필요성|실패/보상 처리|비고|
+|---|---|---|---|---|---|
+
+## 17. 바운디드 컨텍스트
+
 |BC|책임|소유 어그리거트|소유 도메인 모델|주요 유스케이스|경계 결정 이유|
 |---|---|---|---|---|---|
 
-## 4. BC별 입출력
-|BC|수신 커맨드|발행 이벤트|외부 의존|제공 기능|비고|
-|---|---|---|---|---|---|
+## 18. BC 간 커뮤니케이션
 
-## 5. BC 간 커뮤니케이션
 |From BC|To BC|트리거 유스케이스|커뮤니케이션 내용|방식 후보|경계 보호 규칙|
 |---|---|---|---|---|---|
 
-## 6. 확인 필요
-- <확정할 수 없는 BC 경계/통합 방식>
-
-Template for docs/design/details/index.md:
-
-# DDD 설계 인덱스
-
-## 1. 문서 링크
-- 도메인 모델: docs/design/details/도메인모델.md
-- 어그리거트: docs/design/details/어그리거트.md
-- 애플리케이션 서비스: docs/design/details/애플리케이션서비스.md
-- 바운디드 컨텍스트: docs/design/details/바운디드컨텍스트.md
-
-## 2. 전체 구성 요약
-- 설계 입력:
-- 핵심 도메인 흐름:
-- 주요 경계:
-
-## 3. 컴포넌트 카탈로그
-### 3.1 바운디드 컨텍스트
-|BC|책임|주요 컴포넌트|
-|---|---|---|
-
-### 3.2 어그리거트
-|어그리거트|루트|소속 BC|핵심 불변식|
-|---|---|---|---|
-
-### 3.3 엔티티
-|엔티티|소속 어그리거트/BC|식별 기준|
-|---|---|---|
-
-### 3.4 값 객체
-|VO|사용 위치|핵심 검증 규칙|
-|---|---|---|
-
-### 3.5 도메인 서비스
-|도메인 서비스|책임|호출 주체|관련 유스케이스|
-|---|---|---|---|
-
-### 3.6 애플리케이션 서비스
-|애플리케이션 서비스|소속 BC|오케스트레이션 유스케이스|호출 컴포넌트|비즈니스 로직 노출 방지 규칙|
+## 19. Slice 우선순위 및 외부 문서 사용 기록
+|외부 문서|읽은 이유|slice에 없던 정보|충돌 여부|처리|
 |---|---|---|---|---|
 
-### 3.7 포트/외부 협력 후보
-|포트/협력 객체|종류|호출 주체|목적|관련 유스케이스|
-|---|---|---|---|---|
-
-## 4. 유스케이스별 커뮤니케이션
-|유스케이스|애플리케이션 서비스|참여 어그리거트/도메인 서비스|BC 간 커뮤니케이션|외부 협력|비고|
-|---|---|---|---|---|---|
-
-## 5. 설계 규칙 요약
-- 도메인 규칙 위치:
-- 상태 변경 경로:
-- 외부 협력 처리:
-- BC 경계 보호:
-
-## 6. 확인 필요
+## 20. 확인 필요
 - <다음 설계 단계 전에 결정해야 하는 항목>
+
+Template for ARCHITECTURE.md update:
+
+# Architecture
+
+## ChangeSet Scope
+- ChangeSet: <CHG-ID>
+- Use case: <UC-ID>
+- Primary slice inputs:
+  - docs/use-cases/<UC-ID>/use-case.md
+  - docs/use-cases/<UC-ID>/event-storming.md
+  - docs/use-cases/<UC-ID>/e2e-goal.md
+
+## Runtime Stack
+- Frontend: React + Vite
+- Backend: Spring Boot
+
+## Domain Boundary
+- <bounded context and aggregate constraints for this UC>
+
+## Module and Package Constraints
+- <implementation-facing architecture constraints>
+
+## Dependency Direction
+- <allowed dependency direction>
+
+## Forbidden Coupling
+- <forbidden package/domain coupling>
+
+## External Document Lookup Rule
+- For ChangeSet work, agents must read selected slice documents first.
+- Outside/canonical documents are fallback only for information missing from the slice.
 """

--- a/.codex/skills/harness-ddd-design/SKILL.md
+++ b/.codex/skills/harness-ddd-design/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Use after event storming exists to design DDD components without generating
   code. The skill runs the ddd_architect agent to derive domain models,
   aggregates, bounded contexts, application services, domain services, and
-  communication maps from docs/design/이벤트 스토밍.md through staged outputs.
-  After each DDD design stage it must stop and get user confirmation before
-  continuing to the next canonical docs/design/details/*.md design file.
+  communication maps from the selected use-case slice. The selected slice
+  event-storming document is the primary source; outside/canonical documents are
+  fallback only for information missing from the slice.
 ---
 
 # Harness DDD Design
@@ -27,25 +27,29 @@ description: >
 - agent id: `ddd_architect`
 - config: `.codex/agents/ddd_architect.toml`
 - required input:
-  - `docs/design/이벤트 스토밍.md`
-  - `docs/design/유스케이스.md`
-  - `docs/design/요구사항.md` when present
+  - `docs/changes/active/<CHG-ID>.md`
+  - `docs/use-cases/<UC-ID>/use-case.md`
+  - `docs/use-cases/<UC-ID>/event-storming.md`
+  - `docs/use-cases/<UC-ID>/e2e-goal.md`
+  - canonical docs only when the selected slice lacks needed information
 - output files:
-  - `docs/design/details/도메인모델.md`
-  - `docs/design/details/어그리거트.md`
-  - `docs/design/details/애플리케이션서비스.md`
-  - `docs/design/details/바운디드컨텍스트.md`
-  - `docs/design/details/index.md`
+  - `docs/use-cases/<UC-ID>/ddd-design.md`
+  - `ARCHITECTURE.md`
 
 실행 규칙:
 
 - 기준 문서나 스킬 md를 읽어 실행하지 않는다.
 - DDD 설계 기준과 산출물 템플릿은 ddd_architect agent instruction 안에 내장된
   템플릿을 따른다.
-- 읽는 md 파일은 작업 입력인 `docs/design/이벤트 스토밍.md`,
-  `docs/design/유스케이스.md`, `docs/design/요구사항.md`로만 제한한다.
+- ChangeSet 작업에서는 먼저 selected slice 문서
+  `docs/use-cases/<UC-ID>/use-case.md`,
+  `docs/use-cases/<UC-ID>/event-storming.md`,
+  `docs/use-cases/<UC-ID>/e2e-goal.md`를 읽는다.
+- slice에서 찾을 수 없는 정보만 외부/canonical 문서에서 검색해 읽는다.
+- `docs/design/이벤트 스토밍.md`는 summary/index일 수 있으므로
+  executor-facing source로 사용하지 않는다.
 - 코드, 테스트, 패키지 구조, 구현 파일을 만들지 않는다.
-- 쓰기 범위는 `docs/design/details` 아래의 다섯 산출물 파일로만 제한한다.
+- 쓰기 범위는 `docs/use-cases/<UC-ID>/ddd-design.md`와 `ARCHITECTURE.md`로만 제한한다.
 - 각 산출물 파일은 단일하게 유지하고, 이미 있으면 기존 파일을 수정한다.
 - 상세 DDD 설계 전에 비즈니스 정책 미결정과 기반 기술 결정 미결정을 검사한다.
 - 비즈니스 정책 미결정이 남아 있으면 요구사항~이벤트 스토밍 단계로 되돌려야 하므로
@@ -57,39 +61,18 @@ description: >
   세부 transaction propagation 같은 구현 전략은 DDD 설계를 막지 않는다. 필요한
   후보와 설계상 제약만 `확인 필요`에 남기고 DDD 이후 `harness-technical-decisions`
   단계에서 확정한다.
-- DDD 설계는 단계별로 진행한다. 각 단계 산출물을 작성한 뒤 사용자에게 요약을 보여주고
-  명시적 승인을 받을 때까지 다음 단계 파일을 작성하지 않는다.
-- 산출물 문서에는 설계 결과만 남긴다. 입력 문서 목록, 목적 설명, 도출 기준,
-  설계 원칙 같은 작성 지침/메타 설명은 산출물에 넣지 않는다.
-- 작성 지침은 이 skill 또는 별도 지침 문서에만 둔다. `docs/design/details/*.md`
-  산출물에는 확정된 모델, 경계, 책임, 관계, 불변식, 확인 필요만 기록한다.
+- DDD 설계는 selected UC에 필요한 도메인 모델, 어그리거트, 애플리케이션 서비스,
+  바운디드 컨텍스트, 아키텍처 제약을 한 slice 문서에 모은다.
+- 산출물에는 확정된 모델, 경계, 책임, 관계, 불변식, 확인 필요, 그리고 외부 문서 사용
+  기록만 남긴다.
 
-## Staged Approval Flow
+## Slice-First Flow
 
-단계 순서:
-
-1. 도메인 모델 설계
-   - output: `docs/design/details/도메인모델.md`
-   - 완료 후 사용자 확인을 받기 전까지 어그리거트 설계로 넘어가지 않는다.
-2. 어그리거트 설계
-   - required approval: 도메인 모델 승인
-   - output: `docs/design/details/어그리거트.md`
-   - 완료 후 사용자 확인을 받기 전까지 애플리케이션 서비스 설계로 넘어가지 않는다.
-3. 애플리케이션 서비스 설계
-   - required approval: 어그리거트 승인
-   - output: `docs/design/details/애플리케이션서비스.md`
-   - 완료 후 사용자 확인을 받기 전까지 바운디드 컨텍스트 설계로 넘어가지 않는다.
-4. 바운디드 컨텍스트 설계
-   - required approval: 애플리케이션 서비스 승인
-   - output: `docs/design/details/바운디드컨텍스트.md`
-   - 완료 후 사용자 확인을 받기 전까지 인덱스 작성으로 넘어가지 않는다.
-5. 인덱스 작성
-   - required approval: 바운디드 컨텍스트 승인
-   - output: `docs/design/details/index.md`
-
-사용자가 명시적으로 "승인", "진행", "다음 단계로"처럼 다음 단계 진행 의사를 밝힌
-경우에만 다음 단계로 재개한다. 승인 없이 한 번의 호출에서 여러 단계 파일을 연속으로
-작성하지 않는다.
+1. active ChangeSet을 읽어 selected UC를 확인한다.
+2. selected UC slice의 `use-case.md`, `event-storming.md`, `e2e-goal.md`를 먼저 읽는다.
+3. slice만으로 DDD 설계가 가능하면 외부 문서를 읽지 않는다.
+4. slice에 없는 정보만 canonical docs에서 검색해 읽는다.
+5. `docs/use-cases/<UC-ID>/ddd-design.md`와 `ARCHITECTURE.md`를 작성/갱신한다.
 
 ## Embedded DDD Design Standards
 

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -76,6 +76,21 @@ def test_procedure_stage_verifier_rejects_placeholder_content(tmp_path: Path) ->
     )
 
 
+def test_ddd_stage_and_agent_use_sliced_event_storming_first() -> None:
+    stage = procedure_stage("ddd-architecture-definition")
+
+    assert Path("docs/use-cases/<UC-ID>/event-storming.md") in stage.inputs
+    assert Path("docs/use-cases/<UC-ID>/ddd-design.md") in stage.outputs
+
+    agent_text = Path(".codex/agents/ddd_architect.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "docs/use-cases/<UC-ID>/event-storming.md" in agent_text
+    assert "read the selected slice documents first" in agent_text
+    assert "If docs/design/이벤트 스토밍.md does not exist" not in agent_text
+    assert "Required input:\n- docs/design/이벤트 스토밍.md" not in agent_text
+
+
 def test_changeset_stage_status_is_durable_in_changeset_markdown() -> None:
     text = render_initial_changeset(
         change_set_id="CHG-001",


### PR DESCRIPTION
Closes #175

## Implementation intent
Make the recommended ChangeSet workflow continue from the use-case-scoped event-storming output into DDD design. The DDD stage should not require `docs/design/이벤트 스토밍.md` when the selected UC slice already has `docs/use-cases/<UC-ID>/event-storming.md`.

## Implementation approach
- Updated the `ddd_architect` agent contract to read the selected use-case slice first: ChangeSet, `use-case.md`, `event-storming.md`, and `e2e-goal.md`.
- Changed DDD outputs to match the runtime procedure contract: `docs/use-cases/<UC-ID>/ddd-design.md` and `ARCHITECTURE.md`.
- Documented the same slice-first rule in `harness-ddd-design` skill instructions.
- Added a regression test asserting DDD no longer treats `docs/design/이벤트 스토밍.md` as required input.

## Verification method
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_procedure_stage_runtime.py tests/runtime/test_models.py`
- Result: `16 passed in 0.45s`

## Risks and rollback
- Risk: Existing workflows expecting DDD to write split `docs/design/details/*.md` files may need to use a canonical-sync path instead of this ChangeSet runtime DDD stage.
- Rollback: revert commit `3ac3c8a` to restore the previous canonical DDD agent contract.