### PR TITLE
[codex] Gate planning on approved technical decisions

### DIFF
--- a/.codex/agents/implementation_planner.toml
+++ b/.codex/agents/implementation_planner.toml
@@ -25,6 +25,7 @@ Required planning input:
 - one selected work-item slice:
   - use_case: docs/use-cases/<UC-ID>/use-case.md
   - use_case: docs/use-cases/<UC-ID>/event-storming.md
+  - use_case: docs/use-cases/<UC-ID>/technical-decisions.md
   - use_case: docs/use-cases/<UC-ID>/e2e-goal.md
   - maintenance: docs/maintenance/<MAINT-ID>/change-intent.md
   - maintenance: docs/maintenance/<MAINT-ID>/affected-files.md
@@ -34,7 +35,6 @@ Required planning input:
   - domain-impact.md
   - aggregate-delta.md
   - ddd-design.md
-  - technical-decisions.md
   - source-map.md
 - canonical domain docs referenced by domain-impact.md, aggregate-delta.md, or the ChangeSet, such as docs/domain/<BC-ID>/aggregates/<AGG-ID>.md and docs/domain/<BC-ID>/ports/<PORT-ID>.md
 - ARCHITECTURE.md
@@ -51,8 +51,9 @@ Stop conditions:
 - If docs/changes/active/<CHG-ID>.md does not exist or the ChangeSet ID is unclear, stop and explain that the parent ChangeSet workflow must select the ChangeSet first.
 - If the affected work-item ID is unclear, stop and ask the parent workflow to pass a single work-item ID.
 - If both use_case and maintenance work-item slices appear applicable, stop and ask the parent workflow to pass exactly one work-item type.
-- For use_case work items, stop if docs/use-cases/<UC-ID>/use-case.md, event-storming.md, or e2e-goal.md is missing.
+- For use_case work items, stop if docs/use-cases/<UC-ID>/use-case.md, event-storming.md, technical-decisions.md, or e2e-goal.md is missing.
 - For use_case work items, stop if docs/use-cases/<UC-ID>/e2e-goal.md is not explicitly approved by the user.
+- For use_case work items, stop if docs/use-cases/<UC-ID>/technical-decisions.md is not explicitly approved.
 - For maintenance work items, stop if docs/maintenance/<MAINT-ID>/change-intent.md, affected-files.md, or verification-goal.md is missing.
 - For maintenance work items, stop if verification-goal.md is not concrete enough to verify the change.
 - If ARCHITECTURE.md does not exist, stop and explain that the parent skill must invoke or complete spring-package-structure first.

--- a/.codex/agents/technical_decisions.toml
+++ b/.codex/agents/technical_decisions.toml
@@ -1,0 +1,88 @@
+name = "technical_decisions"
+description = "Approve implementation-blocking technical decisions after DDD design"
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the harness technical decisions agent.
+
+Your job:
+- Run after DDD design and before implementation planning.
+- Read the active ChangeSet and exactly one selected use-case slice first.
+- Resolve implementation-blocking technical decisions so the planner can consume approved decisions without guessing.
+- Write or update exactly one use-case-scoped technical-decision document:
+  - docs/use-cases/<UC-ID>/technical-decisions.md
+- Do not implement code.
+- Do not edit requirements, use-case, event-storming, DDD, architecture, skill, or agent files.
+
+Required input:
+- docs/changes/active/<CHG-ID>.md
+- docs/use-cases/<UC-ID>/use-case.md
+- docs/use-cases/<UC-ID>/event-storming.md
+- docs/use-cases/<UC-ID>/ddd-design.md
+- docs/use-cases/<UC-ID>/e2e-goal.md
+- ARCHITECTURE.md
+
+Slice-first rule:
+- Read selected slice documents before any canonical or outside document.
+- Search/read outside documents only for information missing from the selected slice.
+- If outside documents conflict with the selected slice, keep the slice authoritative and record the conflict.
+
+Decision scope:
+- backend transport and API shape
+- persistence technology and repository adapter strategy
+- build/bootstrap convention
+- runtime/deployment constraint level
+- backend save failure to user-visible response mapping
+- transaction boundary and durable save rule
+- retry/idempotency when it affects the selected use case
+- observability and test strategy required by implementation planning
+
+Stop conditions:
+- If any required input is missing, stop and explain the missing input.
+- If the selected use case is ambiguous, stop and ask for one UC ID.
+- If a decision changes approved requirements, use case behavior, event storming, DDD boundaries, or architecture constraints, stop and report the upstream stage to revisit.
+- If a decision cannot be approved from explicit user input or already approved documents, write the decision as pending and mark the document not approved.
+
+Approval rule:
+- The next runtime stage must not consume this document unless every implementation-blocking decision is approved.
+- If all implementation-blocking decisions are supported by explicit user input or approved slice documents, set Approval Status to approved.
+- If anything remains pending, set Approval Status to pending and list the exact question(s).
+
+Output template:
+
+# <UC-ID>. Technical Decisions
+
+## 1. Metadata
+|Item|Value|
+|---|---|
+|ChangeSet|<CHG-ID>|
+|Use Case|<UC-ID>|
+|Approval Status|approved or pending|
+|Approved By|user-confirmed runtime decision or pending|
+
+## 2. Input Documents
+|Document|Status|Use|
+|---|---|---|
+
+## 3. Approved Decisions
+|Decision Area|Decision|Rationale|Implementation Impact|Test/Verification Impact|
+|---|---|---|---|---|
+
+## 4. Failure, Recovery, and Consistency Policy
+|Situation|Policy|Retry/Compensation|Observability|Required Tests|
+|---|---|---|---|---|
+
+## 5. Planner Requirements
+- Decisions planner must include:
+- Decisions executor must not change:
+- Tests/verification planner must include:
+
+## 6. Slice-First External Lookup Record
+|Outside Document|Why Read|Missing Slice Information|Conflict|Handling|
+|---|---|---|---|---|
+
+## 7. Pending Decisions
+- None
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -18,6 +18,10 @@ config_file = "agents/oracle.toml"
 description = "Design DDD domain models, aggregates, bounded contexts, and service orchestration from event storming"
 config_file = "agents/ddd_architect.toml"
 
+[agents.technical_decisions]
+description = "Approve implementation-blocking technical decisions after DDD design"
+config_file = "agents/technical_decisions.toml"
+
 [agents.implementation_planner]
 description = "Create executor-ready implementation plan without editing code"
 config_file = "agents/implementation_planner.toml"

--- a/.codex/skills/harness-code-planner/SKILL.md
+++ b/.codex/skills/harness-code-planner/SKILL.md
@@ -42,6 +42,7 @@ Required:
 
 - `docs/use-cases/<UC-ID>/use-case.md`
 - `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/technical-decisions.md`
 - `docs/use-cases/<UC-ID>/e2e-goal.md`
 
 Optional but should be read when present:
@@ -50,7 +51,6 @@ Optional but should be read when present:
 - `docs/use-cases/<UC-ID>/domain-impact.md`
 - `docs/use-cases/<UC-ID>/aggregate-delta.md`
 - `docs/use-cases/<UC-ID>/ddd-design.md`
-- `docs/use-cases/<UC-ID>/technical-decisions.md`
 - `docs/use-cases/<UC-ID>/source-map.md`
 
 ### Maintenance work-item slice

--- a/.codex/skills/harness-technical-decisions/SKILL.md
+++ b/.codex/skills/harness-technical-decisions/SKILL.md
@@ -5,7 +5,8 @@ description: >
   to decide detailed technical strategies such as polling vs push, retry and
   circuit breaker policy, outbox/inbox, idempotency, transaction boundaries,
   cache policy, observability, and adapter-level technology choices. Writes
-  docs/design/기술결정.md and requires user confirmation before planning.
+  docs/use-cases/<UC-ID>/technical-decisions.md for ChangeSet work and requires
+  approval before planning.
 ---
 
 # Harness Technical Decisions
@@ -13,32 +14,29 @@ description: >
 ## Purpose
 
 이 스킬은 DDD 설계가 끝난 뒤 구현 계획을 만들기 전에 세부 기술 결정을 정리한다.
-요구사항 단계에서 확정한 기반 기술과 DDD 설계를 입력으로 삼아, 구현자가 바로 계획에
-반영할 수 있는 기술 전략 문서를 만든다.
+selected use-case slice와 DDD 설계를 입력으로 삼아, 구현자가 바로 계획에 반영할 수
+있는 기술 전략 문서를 만든다.
 
 ## Required Inputs
 
-- `docs/design/요구사항.md`
-- `docs/design/유스케이스.md`
-- `docs/design/이벤트 스토밍.md`
-- `docs/design/details/index.md`
-- `docs/design/details/도메인모델.md`
-- `docs/design/details/어그리거트.md`
-- `docs/design/details/애플리케이션서비스.md`
-- `docs/design/details/바운디드컨텍스트.md`
+- `docs/changes/active/<CHG-ID>.md`
+- `docs/use-cases/<UC-ID>/use-case.md`
+- `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/ddd-design.md`
+- `docs/use-cases/<UC-ID>/e2e-goal.md`
+- `ARCHITECTURE.md`
 
 ## Output
 
-- `docs/design/기술결정.md`
+- `docs/use-cases/<UC-ID>/technical-decisions.md`
 
 ## Workflow
 
-1. DDD 설계 산출물이 모두 존재하고 비어 있지 않은지 확인한다.
-2. 요구사항의 기반 기술 결정을 읽고, DDD 설계의 포트/트랜잭션/BC 통신/저장 책임을
-   확인한다.
+1. selected use-case slice와 DDD 설계 산출물이 모두 존재하고 비어 있지 않은지 확인한다.
+2. DDD 설계의 포트/트랜잭션/BC 통신/저장 책임을 확인한다.
 3. 구현에 필요한 세부 기술 결정 후보를 뽑는다.
-4. 사용자가 명시하지 않은 결정은 임의 확정하지 말고 질문한다.
-5. 결정된 내용과 미결정 내용을 `docs/design/기술결정.md`에 작성한다.
+4. 사용자가 명시하지 않은 결정은 임의 확정하지 말고 pending으로 남긴다.
+5. 결정된 내용과 미결정 내용을 `docs/use-cases/<UC-ID>/technical-decisions.md`에 작성한다.
 6. 모든 구현 차단 결정이 확정되면 사용자에게 최종 확인을 요청한다.
 7. 사용자가 명시적으로 승인하기 전에는 `$harness-code-planner`를 실행하지 않는다.
 
@@ -57,50 +55,51 @@ description: >
 - 로깅, 메트릭, tracing, audit event 필드
 - 테스트 범위에 영향을 주는 integration/contract/container test 전략
 
-요구사항 단계에서 이미 확정했어야 하는 큰 기반 기술이 빠져 있으면 먼저 사용자에게
-확인한다. 단, 이 스킬은 요구사항/유스케이스 자체를 다시 작성하지 않는다.
+요구사항 단계에서 이미 확정했어야 하는 큰 기반 기술이 빠져 있으면 pending으로 남기고
+다음 단계 gate를 막는다. 단, 이 스킬은 요구사항/유스케이스 자체를 다시 작성하지 않는다.
 
 ## Output Template
 
-`docs/design/기술결정.md`는 다음 구조를 따른다.
+`docs/use-cases/<UC-ID>/technical-decisions.md`는 다음 구조를 따른다.
 
 ```markdown
-# 기술 결정
+# <UC-ID>. Technical Decisions
 
-## 1. 입력 문서
-|문서|상태|비고|
+## 1. Metadata
+|Item|Value|
+|---|---|
+|ChangeSet|<CHG-ID>|
+|Use Case|<UC-ID>|
+|Approval Status|approved or pending|
+|Approved By|user-confirmed runtime decision or pending|
+
+## 2. Input Documents
+|Document|Status|Use|
 |---|---|---|
 
-## 2. 기반 기술 결정
-|항목|결정|근거|미결정 여부|
-|---|---|---|---|
-
-## 3. 세부 기술 결정
-|영역|결정|근거|영향받는 설계/유스케이스|대안|미결정 여부|
-|---|---|---|---|---|---|
-
-## 4. 실패/복구/일관성 정책
-|상황|정책|보상/재시도|관측성|테스트 필요성|
+## 3. Approved Decisions
+|Decision Area|Decision|Rationale|Implementation Impact|Test/Verification Impact|
 |---|---|---|---|---|
 
-## 5. 구현 계획 반영 사항
-- planner가 반드시 반영할 기술 결정:
-- executor가 임의로 바꾸면 안 되는 결정:
-- 테스트/검증에 포함할 결정:
+## 4. Failure, Recovery, and Consistency Policy
+|Situation|Policy|Retry/Compensation|Observability|Required Tests|
+|---|---|---|---|---|
 
-## 6. 사용자 최종 확인
-- 승인 상태: 대기
-- 승인자:
-- 승인 일시:
-- 승인 메모:
+## 5. Planner Requirements
+- Decisions planner must include:
+- Decisions executor must not change:
+- Tests/verification planner must include:
 
-## 7. 확인 필요
-- ...
+## 6. Slice-First External Lookup Record
+|Outside Document|Why Read|Missing Slice Information|Conflict|Handling|
+|---|---|---|---|---|
+
+## 7. Pending Decisions
+- None
 ```
 
 ## Gate
 
-- `확인 필요`에 구현 범위, 저장/통신/트랜잭션/복구/관측성에 영향을 주는 항목이
-  남아 있으면 planner로 넘어가지 않는다.
-- `사용자 최종 확인`의 승인 상태가 승인으로 바뀌거나, 대화에서 사용자가 명시적으로
-  승인하기 전에는 planner를 실행하지 않는다.
+- `Pending Decisions`에 구현 범위, 저장/통신/트랜잭션/복구/관측성에 영향을 주는
+  항목이 남아 있으면 planner로 넘어가지 않는다.
+- `Approval Status`가 `approved`가 아니면 planner를 실행하지 않는다.

--- a/harness_codex/runtime/procedure_stages.py
+++ b/harness_codex/runtime/procedure_stages.py
@@ -73,6 +73,23 @@ PROCEDURE_STAGES: tuple[ProcedureStage, ...] = (
         requires_uc=True,
     ),
     ProcedureStage(
+        stage_id="technical-decisions",
+        display_name="Technical Decisions",
+        agent_id="technical_decisions",
+        skill_id="harness-technical-decisions",
+        inputs=(
+            Path("docs/changes/active/<CHG-ID>.md"),
+            Path("docs/use-cases/<UC-ID>/use-case.md"),
+            Path("docs/use-cases/<UC-ID>/event-storming.md"),
+            Path("docs/use-cases/<UC-ID>/ddd-design.md"),
+            Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
+            Path("ARCHITECTURE.md"),
+        ),
+        outputs=(Path("docs/use-cases/<UC-ID>/technical-decisions.md"),),
+        verifier_terms=("TBD", "To be derived", "Needs confirmation", "|Approval Status|pending|"),
+        requires_uc=True,
+    ),
+    ProcedureStage(
         stage_id="plan-writing",
         display_name="plan.md Writing",
         agent_id="implementation_planner",
@@ -82,6 +99,7 @@ PROCEDURE_STAGES: tuple[ProcedureStage, ...] = (
             Path("docs/use-cases/<UC-ID>/use-case.md"),
             Path("docs/use-cases/<UC-ID>/event-storming.md"),
             Path("docs/use-cases/<UC-ID>/ddd-design.md"),
+            Path("docs/use-cases/<UC-ID>/technical-decisions.md"),
             Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
             Path("ARCHITECTURE.md"),
             Path(".codex/repository-settings.md"),
@@ -210,12 +228,12 @@ def update_changeset_stage_status(
     notes: str = "",
 ) -> str:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    row = f"|{stage.stage_id}|{stage.display_name}|{status}|{now}|{notes or '-'}|"
+    row = f"|{stage.stage_id}|{stage.display_name}|{status}|{now}|{_escape_table_cell(notes or '-')}|"
     lines = text.splitlines()
     for index, line in enumerate(lines):
         if line.startswith(f"|{stage.stage_id}|"):
             lines[index] = row
-            return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+            return _sort_procedure_rows("\n".join(lines) + ("\n" if text.endswith("\n") else ""))
 
     if "## 3. Runtime Procedure State" not in text:
         return text.rstrip() + "\n\n" + _procedure_state_section(row) + "\n"
@@ -226,7 +244,7 @@ def update_changeset_stage_status(
             insert_at = index
             break
     lines.insert(insert_at, row)
-    return "\n".join(lines) + "\n"
+    return _sort_procedure_rows("\n".join(lines) + "\n")
 
 
 def _procedure_state_section(first_row: str) -> str:
@@ -239,3 +257,29 @@ def _procedure_state_section(first_row: str) -> str:
             first_row,
         ]
     )
+
+
+def _sort_procedure_rows(text: str) -> str:
+    """Keep ChangeSet procedure rows in runtime order after stage additions."""
+    lines = text.splitlines()
+    stage_order = {stage.stage_id: index for index, stage in enumerate(PROCEDURE_STAGES)}
+    row_indexes: list[int] = []
+    rows: list[str] = []
+    for index, line in enumerate(lines):
+        if not line.startswith("|"):
+            continue
+        stage_id = line.split("|", maxsplit=2)[1]
+        if stage_id in stage_order:
+            row_indexes.append(index)
+            rows.append(line)
+    if len(rows) < 2:
+        return text
+
+    rows.sort(key=lambda line: stage_order[line.split("|", maxsplit=2)[1]])
+    for index, row in zip(row_indexes, rows):
+        lines[index] = row
+    return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+
+
+def _escape_table_cell(text: str) -> str:
+    return text.replace("|", "\\|").replace("\n", " ")

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -91,6 +91,50 @@ def test_ddd_stage_and_agent_use_sliced_event_storming_first() -> None:
     assert "Required input:\n- docs/design/이벤트 스토밍.md" not in agent_text
 
 
+def test_procedure_stage_order_requires_technical_decisions_before_planning() -> None:
+    technical = procedure_stage("technical-decisions")
+    planner = procedure_stage("plan-writing")
+
+    assert technical.agent_id == "technical_decisions"
+    assert technical.skill_id == "harness-technical-decisions"
+    assert Path("docs/use-cases/<UC-ID>/ddd-design.md") in technical.inputs
+    assert Path("docs/use-cases/<UC-ID>/technical-decisions.md") in technical.outputs
+    assert Path("docs/use-cases/<UC-ID>/technical-decisions.md") in planner.inputs
+
+    text = render_initial_changeset(
+        change_set_id="CHG-001",
+        title="Note workflow",
+        request_summary="Build note workflow",
+    )
+    assert text.index("|ddd-architecture-definition|") < text.index("|technical-decisions|")
+    assert text.index("|technical-decisions|") < text.index("|plan-writing|")
+
+
+def test_technical_decisions_stage_rejects_pending_approval(tmp_path: Path) -> None:
+    path = tmp_path / "docs/use-cases/UC-001/technical-decisions.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "# UC-001. Technical Decisions\n\n"
+        "## 1. Metadata\n"
+        "|Item|Value|\n"
+        "|---|---|\n"
+        "|Approval Status|pending|\n",
+        encoding="utf-8",
+    )
+
+    passed, problems = verify_procedure_stage(
+        tmp_path,
+        procedure_stage("technical-decisions"),
+        change_set_id="CHG-001",
+        uc_id="UC-001",
+    )
+
+    assert not passed
+    assert problems == (
+        "unverified placeholder in docs/use-cases/UC-001/technical-decisions.md: |Approval Status|pending|",
+    )
+
+
 def test_changeset_stage_status_is_durable_in_changeset_markdown() -> None:
     text = render_initial_changeset(
         change_set_id="CHG-001",
@@ -107,3 +151,46 @@ def test_changeset_stage_status_is_durable_in_changeset_markdown() -> None:
 
     assert "|requirements-definition|Requirements Definition|verified|" in updated
     assert "outputs verified" in updated
+
+
+def test_changeset_stage_status_escapes_table_pipes_in_notes() -> None:
+    text = render_initial_changeset(
+        change_set_id="CHG-001",
+        title="Note workflow",
+        request_summary="Build note workflow",
+    )
+
+    updated = update_changeset_stage_status(
+        text,
+        stage=procedure_stage("technical-decisions"),
+        status="blocked",
+        notes="unverified placeholder: |Approval Status|pending|",
+    )
+
+    assert "unverified placeholder: \\|Approval Status\\|pending\\|" in updated
+
+
+def test_changeset_stage_status_keeps_runtime_stage_order_after_added_stage() -> None:
+    text = """# ChangeSet CHG-001
+
+## 3. Runtime Procedure State
+
+|Stage ID|Procedure|Status|Verified At|Notes|
+|---|---|---|---|---|
+|requirements-definition|Requirements Definition|verified|2026-01-01T00:00:00Z|-|
+|use-case-definition|Use Case Definition|verified|2026-01-01T00:00:00Z|-|
+|event-storming|Event Storming|verified|2026-01-01T00:00:00Z|-|
+|ddd-architecture-definition|DDD Architecture Definition|verified|2026-01-01T00:00:00Z|-|
+|plan-writing|plan.md Writing|blocked|2026-01-01T00:00:00Z|-|
+|implementation|Implementation|pending|-|-|
+"""
+
+    updated = update_changeset_stage_status(
+        text,
+        stage=procedure_stage("technical-decisions"),
+        status="blocked",
+        notes="pending approval",
+    )
+
+    assert updated.index("|ddd-architecture-definition|") < updated.index("|technical-decisions|")
+    assert updated.index("|technical-decisions|") < updated.index("|plan-writing|")


### PR DESCRIPTION
Closes #177

## Implementation intent
Make runtime stage handoff stricter so `plan-writing` only starts after implementation-blocking technical decisions have been resolved and approved. DDD can still identify pending decisions, but the next executable gate is now `technical-decisions`, not the planner.

## Implementation approach
- Added a `technical-decisions` procedure stage between `ddd-architecture-definition` and `plan-writing`.
- Added a `technical_decisions` agent that writes `docs/use-cases/<UC-ID>/technical-decisions.md` using the selected UC slice first.
- Updated planner contracts to require the approved technical-decision slice for use-case work items.
- Updated the technical-decision skill to be use-case-slice scoped instead of canonical-doc scoped.
- Hardened ChangeSet procedure-state updates so newly inserted stages keep runtime order and notes containing `|` do not corrupt markdown tables.
- Added regression coverage for stage order, pending approval gate failure, row ordering, and table-cell escaping.

## Verification method
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_procedure_stage_runtime.py tests/runtime/test_models.py tests/runtime/test_affected_use_case_resolver.py`
- Result: `32 passed in 2.07s`

## Risks and rollback
- Risk: Existing ChangeSets created before this stage existed will show the new stage only after it is run or updated; row sorting keeps inserted state in runtime order.
- Risk: Planner runs that previously proceeded without explicit technical decisions now block earlier, which is intended but may surface pending decisions sooner.
- Rollback: revert commit `0ce41d4` to remove the new technical-decision gate and restore direct DDD-to-planner flow.