### PR TITLE
[codex] 중복 실행 아티팩트 저장 제거

### DIFF
--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -77,7 +77,11 @@ class ConfigurableCliAgentAdapter:
             skill_body=request.skill_body,
         )
         prompt_path.write_text(prompt, encoding="utf-8")
-        _write_run_root_text(request, f"prompt-{request.step.id}.md", prompt)
+        _write_run_root_artifact_reference(
+            request,
+            f"prompt-{request.step.id}.md",
+            prompt_path,
+        )
 
         provider_result = _resolve_provider_command(
             request,
@@ -538,10 +542,17 @@ def _agent_invocation_manifest(step: Step, context: RunContext, agent_config_pat
     }
 
 
-def _write_run_root_text(request: AgentRunRequest, filename: str, text: str) -> Path:
+def _write_run_root_artifact_reference(
+    request: AgentRunRequest,
+    filename: str,
+    target_path: Path,
+) -> Path:
     path = request.context.run_dir / filename
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    path.write_text(
+        f"See canonical artifact: {_relative_to_run_dir(target_path, request.context.run_dir)}\n",
+        encoding="utf-8",
+    )
     return path
 
 
@@ -554,8 +565,16 @@ def _mirror_agent_artifacts(
 ) -> None:
     run_dir = request.context.run_dir
     run_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(stdout_path, run_dir / f"stdout-{request.step.id}.log")
-    shutil.copyfile(stderr_path, run_dir / f"stderr-{request.step.id}.log")
+    _write_run_root_artifact_reference(
+        request,
+        f"stdout-{request.step.id}.log",
+        stdout_path,
+    )
+    _write_run_root_artifact_reference(
+        request,
+        f"stderr-{request.step.id}.log",
+        stderr_path,
+    )
     response = {
         "step_id": request.step.id,
         "status": result.status.value,
@@ -577,6 +596,13 @@ def _write_response_snapshot(context: RunContext, step_id: str, result_path: Pat
         return
     context.run_dir.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(result_path, context.run_dir / f"response-{step_id}.json")
+
+
+def _relative_to_run_dir(path: Path, run_dir: Path) -> Path:
+    try:
+        return path.relative_to(run_dir)
+    except ValueError:
+        return path
 
 
 def _write_usage_snapshot(request: AgentRunRequest, result: AgentRunResult) -> None:

--- a/tests/runtime/test_prompt_builder.py
+++ b/tests/runtime/test_prompt_builder.py
@@ -178,10 +178,22 @@ def test_agent_adapter_writes_run_root_invocation_artifacts(tmp_path: Path, monk
     result = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(request)
 
     assert result.status == StepStatus.SUCCEEDED
-    assert (ctx.run_dir / "prompt-execute-work-item.md").is_file()
+    root_prompt = ctx.run_dir / "prompt-execute-work-item.md"
+    step_prompt = request.step_dir / "prompt.md"
+    assert root_prompt.is_file()
+    assert root_prompt.read_text(encoding="utf-8") == (
+        "See canonical artifact: steps/execute-work-item/prompt.md\n"
+    )
+    assert root_prompt.stat().st_size < step_prompt.stat().st_size
     assert (ctx.run_dir / "response-execute-work-item.json").is_file()
-    assert (ctx.run_dir / "stdout-execute-work-item.log").read_text(encoding="utf-8") == "final answer"
-    assert (ctx.run_dir / "stderr-execute-work-item.log").read_text(encoding="utf-8") == "diagnostic"
+    assert (ctx.run_dir / "stdout-execute-work-item.log").read_text(encoding="utf-8") == (
+        "See canonical artifact: steps/execute-work-item/stdout.txt\n"
+    )
+    assert (ctx.run_dir / "stderr-execute-work-item.log").read_text(encoding="utf-8") == (
+        "See canonical artifact: steps/execute-work-item/stderr.txt\n"
+    )
+    assert (request.step_dir / "stdout.txt").read_text(encoding="utf-8") == "final answer"
+    assert (request.step_dir / "stderr.txt").read_text(encoding="utf-8") == "diagnostic"
     usage = json.loads((ctx.run_dir / "usage-execute-work-item.json").read_text(encoding="utf-8"))
     assert usage["step_id"] == "execute-work-item"
     assert usage["work_item_id"] == "UC-001"


### PR DESCRIPTION
## 구현 의도

Fixes #181.

실행 런 디렉터리에서 동일한 prompt/stdout/stderr 내용을 루트와 step 디렉터리에 중복 저장하던 낭비를 줄입니다. 기존 루트 경로는 유지하되 전체 내용을 복사하지 않고 canonical step artifact를 가리키는 작은 참조 파일로 바꿉니다.

## 구현 방식

- `steps/<step-id>/prompt.md`, `stdout.txt`, `stderr.txt`를 canonical artifact로 유지했습니다.
- 기존 호환 경로인 `prompt-<step>.md`, `stdout-<step>.log`, `stderr-<step>.log`는 `See canonical artifact: ...` 형태의 작은 참조 파일로 씁니다.
- `response-<step>.json`과 usage snapshot은 기존처럼 유지했습니다.
- 테스트는 루트 artifact가 존재하면서도 step canonical 파일보다 작고, 실제 stdout/stderr 내용은 step artifact에 보존되는지 검증합니다.

## 검증 방법

- 집중 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_prompt_builder.py::test_agent_adapter_writes_run_root_invocation_artifacts tests/runtime/test_agent_runner.py`
  - 결과: `16 passed in 6.22s`
- 전체 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests`
  - 결과: `242 passed in 34.94s`

## 개선 검증 보고서

합성 agent 실행으로 큰 prompt/stdout/stderr를 생성해 전후 저장량을 비교했습니다.

- canonical prompt/stdout/stderr 크기: `532,025 bytes`
- 새 루트 참조 파일 3개 합계: `146 bytes`
- 기존 방식 추정 총량: `1,465,235 bytes`
- 변경 후 실제 총량: `933,356 bytes`
- 절감량: `531,879 bytes`
- 절감률: `36.3%`

큰 Zeten 실행에서 확인했던 중복 형태, 예: `steps/.../stderr.txt`와 `stderr-....log`가 각각 1.4MB씩 저장되던 구조를 제거합니다.

## 리스크 및 롤백

리스크는 루트 artifact 경로를 직접 읽던 도구가 전체 내용 대신 참조 파일을 보게 되는 점입니다. canonical step artifact 경로는 그대로 유지되며, 루트 파일도 사라지지 않습니다. 문제가 있으면 이 PR을 revert하면 이전 복사 방식으로 돌아갑니다.
