### PR TITLE
[codex] 성공 에이전트 stderr 저장량 축소

### DIFF
--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -21,6 +21,9 @@ from harness_codex.runtime.models import (
 from harness_codex.runtime.prompt import build_agent_prompt
 
 
+SUCCESS_STDERR_TAIL_BYTES = 16_384
+
+
 @dataclass(frozen=True)
 class AgentRunRequest:
     """전담 에이전트 호출에 필요한 입력."""
@@ -153,11 +156,11 @@ class ConfigurableCliAgentAdapter:
         stdout_path = request.step_dir / "stdout.txt"
         stderr_path = request.step_dir / "stderr.txt"
         stdout_path.write_text(completed.stdout, encoding="utf-8")
-        stderr_path.write_text(completed.stderr, encoding="utf-8")
         if provider_metadata["provider"] == "custom_cli":
             final_message_path.write_text(completed.stdout, encoding="utf-8")
 
         if completed.returncode != 0:
+            stderr_path.write_text(completed.stderr, encoding="utf-8")
             error = completed.stderr.strip() or completed.stdout.strip()
             blocker = _agent_process_blocker_error(error)
             status = StepStatus.BLOCKED if blocker is not None else StepStatus.FAILED
@@ -173,6 +176,7 @@ class ConfigurableCliAgentAdapter:
             _mirror_agent_artifacts(request, stdout_path, stderr_path, final_message_path, result)
             return result
 
+        stderr_path.write_text(_successful_stderr_artifact(completed.stderr), encoding="utf-8")
         result = AgentRunResult(
             status=StepStatus.SUCCEEDED,
             exit_code=0,
@@ -493,6 +497,23 @@ def _decode_process_output(value: str | bytes | None) -> str:
     if isinstance(value, bytes):
         return value.decode(errors="replace")
     return value
+
+
+def _successful_stderr_artifact(stderr: str) -> str:
+    if len(stderr.encode("utf-8")) <= SUCCESS_STDERR_TAIL_BYTES:
+        return stderr
+
+    encoded = stderr.encode("utf-8")
+    tail = encoded[-SUCCESS_STDERR_TAIL_BYTES:].decode("utf-8", errors="replace")
+    return "\n".join(
+        [
+            "[harness-codex] successful agent stderr truncated",
+            f"original_bytes={len(encoded)}",
+            f"retained_tail_bytes={SUCCESS_STDERR_TAIL_BYTES}",
+            "",
+            tail,
+        ]
+    )
 
 
 def _agent_process_blocker_error(output: str) -> str | None:

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -310,6 +310,75 @@ def test_configurable_agent_adapter_uses_codex_provider_by_default(
     assert calls[0][1]["timeout"] == 30
 
 
+def test_configurable_agent_adapter_trims_large_successful_stderr(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    request = agent_request(
+        tmp_path,
+        {
+            "name": "implementation_executor",
+            "description": "test agent",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+    stderr = "start\n" + ("x" * 30_000) + "\nend"
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="agent stdout",
+            stderr=stderr,
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(request)
+
+    stored = (request.step_dir / "stderr.txt").read_text(encoding="utf-8")
+    assert result.status == StepStatus.SUCCEEDED
+    assert "successful agent stderr truncated" in stored
+    assert "original_bytes=" in stored
+    assert "retained_tail_bytes=16384" in stored
+    assert "end" in stored
+    assert "start" not in stored
+    assert len(stored.encode("utf-8")) < len(stderr.encode("utf-8"))
+
+
+def test_configurable_agent_adapter_keeps_large_failed_stderr(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    request = agent_request(
+        tmp_path,
+        {
+            "name": "implementation_executor",
+            "description": "test agent",
+            "developer_instructions": "테스트 지시문",
+        },
+    )
+    request.step_dir.mkdir(parents=True)
+    stderr = "start\n" + ("x" * 30_000) + "\nend"
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=1,
+            stdout="",
+            stderr=stderr,
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(request)
+
+    stored = (request.step_dir / "stderr.txt").read_text(encoding="utf-8")
+    assert result.status == StepStatus.FAILED
+    assert stored == stderr
+
+
 def test_configurable_agent_adapter_uses_explicit_codex_binary(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## 구현 의도

Fixes #182.

성공한 agent 실행의 stderr가 수백 KB~MB 단위로 저장되는 문제를 줄입니다. 실패한 실행은 디버깅을 위해 stderr 전체를 유지하고, 성공한 실행만 큰 stderr를 tail 중심 요약으로 저장합니다.

## 구현 방식

- 성공한 agent 실행에서 stderr가 `16,384 bytes`를 넘으면 truncation 헤더와 마지막 tail만 저장합니다.
- 작은 stderr는 기존처럼 그대로 저장해 호환성을 유지합니다.
- 실패/blocked 실행은 기존처럼 전체 stderr를 저장합니다.
- 성공 stderr trim과 실패 stderr 보존을 각각 테스트로 고정했습니다.

## 검증 방법

- 집중 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py`
  - 결과: `17 passed in 4.25s`
- 전체 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests`
  - 결과: `244 passed in 36.85s`

## 개선 검증 보고서

합성 성공 agent 실행에서 stderr `300,001 bytes`를 생성해 비교했습니다.

- 기존 방식 추정 stderr 저장량: `300,001 bytes`
- 변경 후 stderr 저장량: `16,483 bytes`
- 절감량: `283,518 bytes`
- 절감률: `94.51%`
- 저장 첫 줄: `[harness-codex] successful agent stderr truncated`

실패 실행은 테스트에서 전체 stderr가 그대로 저장됨을 확인했습니다.

## 리스크 및 롤백

리스크는 성공 실행의 stderr 전체가 기본 artifact에 남지 않는 점입니다. 실패 stderr는 그대로 보존되며, 성공 stderr에는 tail과 원본 byte 수가 남습니다. 문제가 있으면 이 PR을 revert해 전체 stderr 저장 방식으로 되돌릴 수 있습니다.
