### PR TITLE
[codex] 구현 실행 전 환경 프리플라이트 추가

### DIFF
--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tomllib
@@ -224,6 +225,10 @@ class BasicStepRunner:
             )
 
         agent_config = _load_agent_config(agent_config_path)
+        preflight_error = _implementation_environment_preflight(step, context, step_dir, agent_config)
+        if preflight_error is not None:
+            return _blocked_agent_result(step, context, step_dir, preflight_error)
+
         skill_id = _step_skill_id(step)
         skill_path: Path | None = None
         skill_body: str | None = None
@@ -370,6 +375,53 @@ def _relative_to_repo(path: Path | None, context: RunContext) -> Path:
 def _load_agent_config(path: Path) -> Mapping[str, Any]:
     with path.open("rb") as file:
         return tomllib.load(file)
+
+
+def _implementation_environment_preflight(
+    step: Step,
+    context: RunContext,
+    step_dir: Path,
+    agent_config: Mapping[str, Any],
+) -> str | None:
+    if step.agent_id != "implementation_executor":
+        return None
+
+    problems: list[str] = []
+    gradlew = context.repo_root / "gradlew"
+    sandbox_mode = str(agent_config.get("sandbox_mode", "") or "")
+    if gradlew.exists() and sandbox_mode != "danger-full-access":
+        problems.append(
+            "Gradle wrapper detected, but implementation_executor sandbox_mode is "
+            f"{sandbox_mode or '<unset>'}. Use danger-full-access so Gradle daemon "
+            "and local runtime sockets can start before running implementation."
+        )
+
+    npm_path = shutil.which("npm")
+    if (context.repo_root / "frontend/package.json").exists() and npm_path and npm_path.startswith("/mnt/"):
+        problems.append(
+            "frontend/package.json detected, but npm resolves to a Windows-mounted path: "
+            f"{npm_path}. Put a Linux-native Node/npm path before /mnt paths in PATH."
+        )
+
+    payload = {
+        "step_id": step.id,
+        "agent_id": step.agent_id,
+        "gradlew_present": gradlew.exists(),
+        "sandbox_mode": sandbox_mode or None,
+        "gradle_user_home": os.environ.get("GRADLE_USER_HOME"),
+        "npm_path": npm_path,
+        "status": "blocked" if problems else "passed",
+        "problems": problems,
+    }
+    preflight_path = step_dir / "preflight.json"
+    preflight_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    if not problems:
+        return None
+    return "implementation environment preflight failed: " + " ".join(problems)
 
 
 def _validate_agent_outputs(step: Step, context: RunContext) -> str | None:

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -257,6 +257,69 @@ def test_basic_step_runner_fails_when_required_use_case_slices_are_missing(tmp_p
     assert result.error == "missing required use-case slices under docs/use-cases"
 
 
+def test_basic_step_runner_blocks_implementation_executor_on_gradle_workspace_sandbox(
+    tmp_path: Path,
+) -> None:
+    write_agent_config(tmp_path, agent_id="implementation_executor")
+    (tmp_path / "gradlew").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    fake_adapter = FakeAgentAdapter()
+    runner = BasicStepRunner(agent_adapter=fake_adapter)
+    step = Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute implementation",
+        agent_id="implementation_executor",
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "implementation environment preflight failed" in (result.error or "")
+    assert "sandbox_mode is workspace-write" in (result.error or "")
+    assert fake_adapter.requests == []
+    preflight = json.loads(
+        (tmp_path / ".harness/runs/run-001/steps/execute-work-item/preflight.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert preflight["status"] == "blocked"
+    assert preflight["gradlew_present"] is True
+
+
+def test_basic_step_runner_allows_implementation_executor_with_full_access(
+    tmp_path: Path,
+) -> None:
+    write_agent_config(tmp_path, agent_id="implementation_executor")
+    config_path = tmp_path / ".codex/agents/implementation_executor.toml"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            'sandbox_mode = "workspace-write"',
+            'sandbox_mode = "danger-full-access"',
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "gradlew").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    fake_adapter = FakeAgentAdapter()
+    runner = BasicStepRunner(agent_adapter=fake_adapter)
+    step = Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute implementation",
+        agent_id="implementation_executor",
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert len(fake_adapter.requests) == 1
+    preflight = json.loads(
+        (tmp_path / ".harness/runs/run-001/steps/execute-work-item/preflight.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert preflight["status"] == "passed"
+
+
 def test_configurable_agent_adapter_uses_codex_provider_by_default(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## 구현 의도

Fixes #184.

구현 executor가 명확히 실패할 환경에서 긴 agent 실행과 반복 Gradle 실패를 시작하기 전에 빠르게 차단합니다.

## 구현 방식

- `implementation_executor` agent 실행 전에 `preflight.json`을 작성합니다.
- Gradle wrapper가 있는데 agent sandbox가 `danger-full-access`가 아니면 즉시 `BLOCKED` 처리합니다.
- frontend가 있는데 `npm`이 `/mnt/...` Windows 경로로 잡히면 즉시 `BLOCKED` 처리합니다.
- 문제가 없으면 기존 agent 실행으로 진행합니다.

## 검증 방법

- 집중 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py`
  - 결과: `17 passed in 4.33s`
- 전체 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests`
  - 결과: `244 passed in 27.37s`

## 개선 검증 보고서

합성 Gradle repo + `workspace-write` implementation executor 설정에서 측정했습니다.

- 결과: `blocked`
- agent adapter 호출 수: `0`
- preflight 처리 시간: `91.05 ms`
- preflight status: `blocked`
- 문제 수: `1`

즉, 이전처럼 agent를 실행해 Gradle 실패를 반복하지 않고 실행 전에 차단합니다.

## 리스크 및 롤백

리스크는 Gradle wrapper가 있는 프로젝트에서 `workspace-write` sandbox를 계속 쓰던 기존 구성이 더 빨리 막히는 점입니다. 의도된 동작은 `implementation_executor`를 `danger-full-access`로 바꾼 뒤 실행하는 것입니다. 문제가 있으면 이 PR을 revert하면 기존 지연 실패 방식으로 돌아갑니다.
