### PR TITLE
[codex] 검증 quick full 티어 추가

### DIFF
--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -78,6 +78,7 @@ from harness_codex.runtime.verifier import (
     UseCaseVerificationResult,
     UseCaseVerifier,
     VerificationStatus,
+    VerificationTier,
 )
 
 __all__ = [
@@ -132,6 +133,7 @@ __all__ = [
     "UseCaseVerificationResult",
     "UseCaseVerifier",
     "VerificationStatus",
+    "VerificationTier",
     "Workflow",
     "WorkflowValidationError",
     "bootstrap_agent_context",

--- a/harness_codex/runtime/verifier.py
+++ b/harness_codex/runtime/verifier.py
@@ -27,6 +27,13 @@ class VerificationStatus(str, Enum):
     ENVIRONMENT_BLOCKER = "ENVIRONMENT_BLOCKER"
 
 
+class VerificationTier(str, Enum):
+    """Verification breadth for iterative vs final checks."""
+
+    QUICK = "quick"
+    FULL = "full"
+
+
 @dataclass(frozen=True)
 class UseCaseVerificationInput:
     """Inputs required to verify a single implemented use-case plan."""
@@ -36,6 +43,7 @@ class UseCaseVerificationInput:
     e2e_goal_path: Path
     repository_settings_path: Path = Path(".codex/repository-settings.md")
     test_gate_path: Path = Path(".codex/test-gate.yaml")
+    tier: VerificationTier = VerificationTier.FULL
     required_commands: tuple[str, ...] = (
         "./gradlew test",
         "./gradlew e2eTest",
@@ -136,15 +144,23 @@ class UseCaseVerifier:
             return verification_input.required_commands
 
         document = yaml.safe_load(gate_path.read_text(encoding="utf-8")) or {}
-        required = document.get("required") or document.get("required_stages") or []
-        commands: list[str] = []
-        for item in required:
-            if isinstance(item, str):
-                commands.append(item)
-            elif isinstance(item, Mapping) and isinstance(item.get("command"), str):
-                commands.append(item["command"])
+        tier_commands = _commands_from_gate_items(document.get(verification_input.tier.value))
+        if tier_commands:
+            return tier_commands
 
-        return tuple(commands) or verification_input.required_commands
+        required = document.get("required") or document.get("required_stages") or []
+        if verification_input.tier == VerificationTier.QUICK:
+            quick_required = [
+                item
+                for item in required
+                if isinstance(item, Mapping) and item.get("tier") == VerificationTier.QUICK.value
+            ]
+            quick_commands = _commands_from_gate_items(quick_required)
+            if quick_commands:
+                return quick_commands
+
+        commands = _commands_from_gate_items(required)
+        return commands or verification_input.required_commands
 
     def _run_command(self, command: str) -> CommandCheck:
         completed = subprocess.run(
@@ -162,3 +178,16 @@ class UseCaseVerifier:
             passed=completed.returncode == 0,
             evidence=evidence or f"exit_code={completed.returncode}",
         )
+
+
+def _commands_from_gate_items(items: object) -> tuple[str, ...]:
+    if not isinstance(items, list):
+        return ()
+
+    commands: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            commands.append(item)
+        elif isinstance(item, Mapping) and isinstance(item.get("command"), str):
+            commands.append(item["command"])
+    return tuple(commands)

--- a/tests/runtime/test_verifier_contract.py
+++ b/tests/runtime/test_verifier_contract.py
@@ -8,6 +8,7 @@ from harness_codex.runtime import (
     UseCaseVerificationResult,
     UseCaseVerifier,
     VerificationStatus,
+    VerificationTier,
 )
 
 
@@ -26,6 +27,7 @@ def test_use_case_verification_input_targets_one_plan_and_e2e_goal() -> None:
         ".codex/repository-settings.md"
     )
     assert verification_input.test_gate_path == Path(".codex/test-gate.yaml")
+    assert verification_input.tier == VerificationTier.FULL
     assert "./gradlew test" in verification_input.required_commands
     assert "./gradlew e2eTest" in verification_input.required_commands
 
@@ -108,6 +110,83 @@ def test_use_case_verifier_runs_test_gate_commands(tmp_path: Path) -> None:
 
     assert result.status == VerificationStatus.PASS
     assert result.command_checks[0].command.startswith("python3 -c")
+
+
+def test_use_case_verifier_uses_quick_tier_commands_when_requested(tmp_path: Path) -> None:
+    gate_dir = tmp_path / ".codex"
+    gate_dir.mkdir()
+    (gate_dir / "test-gate.yaml").write_text(
+        "quick:\n"
+        "  - command: python3 -c \"open('quick-marker', 'w').write('quick')\"\n"
+        "full:\n"
+        "  - command: python3 -c 'raise SystemExit(1)'\n",
+        encoding="utf-8",
+    )
+
+    result = UseCaseVerifier(tmp_path).verify(
+        UseCaseVerificationInput(
+            change_set_path=Path("docs/changes/active/CHG-1.md"),
+            plan_path=Path("docs/plans/active/UC-1/plan.md"),
+            e2e_goal_path=Path("docs/use-cases/UC-1/e2e-goal.md"),
+            tier=VerificationTier.QUICK,
+            required_commands=(),
+        )
+    )
+
+    assert result.status == VerificationStatus.PASS
+    assert (tmp_path / "quick-marker").read_text(encoding="utf-8") == "quick"
+    assert len(result.command_checks) == 1
+
+
+def test_use_case_verifier_defaults_to_full_tier_commands(tmp_path: Path) -> None:
+    gate_dir = tmp_path / ".codex"
+    gate_dir.mkdir()
+    (gate_dir / "test-gate.yaml").write_text(
+        "quick:\n"
+        "  - command: python3 -c 'print(\"quick\")'\n"
+        "full:\n"
+        "  - command: python3 -c 'print(\"full\")'\n",
+        encoding="utf-8",
+    )
+
+    result = UseCaseVerifier(tmp_path).verify(
+        UseCaseVerificationInput(
+            change_set_path=Path("docs/changes/active/CHG-1.md"),
+            plan_path=Path("docs/plans/active/UC-1/plan.md"),
+            e2e_goal_path=Path("docs/use-cases/UC-1/e2e-goal.md"),
+            required_commands=(),
+        )
+    )
+
+    assert result.status == VerificationStatus.PASS
+    assert result.command_checks[0].evidence == "full"
+
+
+def test_use_case_verifier_can_select_quick_required_items(tmp_path: Path) -> None:
+    gate_dir = tmp_path / ".codex"
+    gate_dir.mkdir()
+    (gate_dir / "test-gate.yaml").write_text(
+        "required:\n"
+        "  - stage: quick-unit\n"
+        "    tier: quick\n"
+        "    command: python3 -c 'print(\"quick\")'\n"
+        "  - stage: full-e2e\n"
+        "    command: python3 -c 'raise SystemExit(1)'\n",
+        encoding="utf-8",
+    )
+
+    result = UseCaseVerifier(tmp_path).verify(
+        UseCaseVerificationInput(
+            change_set_path=Path("docs/changes/active/CHG-1.md"),
+            plan_path=Path("docs/plans/active/UC-1/plan.md"),
+            e2e_goal_path=Path("docs/use-cases/UC-1/e2e-goal.md"),
+            tier=VerificationTier.QUICK,
+            required_commands=(),
+        )
+    )
+
+    assert result.status == VerificationStatus.PASS
+    assert result.command_checks[0].evidence == "quick"
 
 
 def test_use_case_verifier_classifies_command_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
## 구현 의도

Fixes #185.

반복 구현 중에는 빠른 검증만 실행하고, 완료 직전에는 전체 검증을 실행할 수 있도록 verifier 계약에 `quick` / `full` 티어를 추가합니다.

## 구현 방식

- `VerificationTier` enum을 추가했습니다: `quick`, `full`.
- `UseCaseVerificationInput`에 `tier`를 추가하고 기본값은 `full`로 유지했습니다.
- `.codex/test-gate.yaml`에서 `quick:` / `full:` 섹션을 읽을 수 있게 했습니다.
- 기존 `required:` 형식은 그대로 지원합니다.
- `required:` 항목에 `tier: quick`이 있으면 quick 요청에서 해당 명령만 선택합니다.

## 검증 방법

- 집중 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_verifier_contract.py`
  - 결과: `10 passed in 0.69s`
- 전체 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests`
  - 결과: `245 passed in 33.63s`

## 개선 검증 보고서

합성 test-gate에서 quick 1개, full 2개 명령을 정의하고 비교했습니다.

- quick tier 실행 명령 수: `1`
- full tier 실행 명령 수: `2`
- quick tier에서 회피한 명령 수: `1`
- quick evidence: `quick`
- full evidence: `full1`, `full2`

즉 반복 remediation에서는 빠른 검증만 선택할 수 있고, 최종 완료에서는 기존처럼 full 검증을 기본값으로 유지합니다.

## 리스크 및 롤백

기본 tier가 `full`이므로 기존 호출은 동일한 의미를 유지합니다. 새 quick tier는 명시적으로 요청될 때만 적용됩니다. 문제가 있으면 이 PR을 revert하면 단일 required 검증 방식으로 돌아갑니다.
