### PR TITLE
[codex] 프롬프트 안정 컨텍스트 캐시 추가

### DIFF
--- a/harness_codex/runtime/prompt.py
+++ b/harness_codex/runtime/prompt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -47,7 +48,7 @@ def build_agent_prompt(
     sections = [
         _section("1. Runtime Instruction", RUNTIME_INSTRUCTION),
         _section("2. Repository Source of Truth", _source_of_truth(context.repo_root)),
-        _section("3. Agent Instruction", _agent_instruction(agent_config, agent_config_path)),
+        _section("3. Agent Instruction", _agent_instruction(agent_config, agent_config_path, context.repo_root)),
         _section("4. Skill Body", _skill_body(skill_path, skill_body, context.repo_root)),
         _section("5. Workflow Definition", _workflow_definition(context)),
         _section("6. Repository Settings", _repository_settings(context.repo_root)),
@@ -81,24 +82,17 @@ def _fixed_file_block(repo_root: Path, paths: tuple[Path, ...]) -> str:
     for path in sorted(paths, key=lambda value: str(value)):
         absolute = repo_root / path
         if absolute.exists():
-            blocks.append(_file_block(path, absolute.read_text(encoding="utf-8")))
+            blocks.append(_file_block(path, absolute.read_text(encoding="utf-8"), repo_root))
         else:
-            blocks.append(_file_block(path, "<not found>"))
+            blocks.append(_file_block(path, "<not found>", repo_root))
     return "\n\n".join(blocks)
 
 
-def _file_block(path: Path, content: str) -> str:
-    return "\n".join(
-        [
-            f"### `{path}`",
-            "```text",
-            content.strip(),
-            "```",
-        ]
-    )
+def _file_block(path: Path, content: str, repo_root: Path) -> str:
+    return _cached_context_block(path, content, "text", repo_root=repo_root)
 
 
-def _agent_instruction(agent_config: Mapping[str, Any], agent_config_path: Path) -> str:
+def _agent_instruction(agent_config: Mapping[str, Any], agent_config_path: Path, repo_root: Path) -> str:
     stable_agent_view = {
         "name": agent_config.get("name", ""),
         "description": agent_config.get("description", ""),
@@ -109,7 +103,7 @@ def _agent_instruction(agent_config: Mapping[str, Any], agent_config_path: Path)
         "agent_config_path": str(agent_config_path),
     }
     developer_instructions = str(agent_config.get("developer_instructions", "")).strip()
-    return "\n".join(
+    content = "\n".join(
         [
             "```json",
             _stable_json(stable_agent_view),
@@ -119,6 +113,7 @@ def _agent_instruction(agent_config: Mapping[str, Any], agent_config_path: Path)
             developer_instructions or "<empty>",
         ]
     )
+    return _cached_context_block(Path(agent_config_path), content, "markdown", repo_root=repo_root)
 
 
 def _skill_body(
@@ -134,7 +129,7 @@ def _skill_body(
     except ValueError:
         display_path = skill_path
 
-    return "\n".join(
+    content = "\n".join(
         [
             f"### `{display_path}`",
             "```markdown",
@@ -142,6 +137,7 @@ def _skill_body(
             "```",
         ]
     )
+    return _cached_context_block(display_path, content, "markdown", repo_root=repo_root)
 
 
 def _workflow_definition(context: RunContext) -> str:
@@ -150,10 +146,12 @@ def _workflow_definition(context: RunContext) -> str:
         return _file_block(
             Path(".harness/workflows") / f"{context.workflow_name}.yaml",
             workflow_path.read_text(encoding="utf-8"),
+            context.repo_root,
         )
     return _file_block(
         Path(".harness/workflows") / f"{context.workflow_name}.yaml",
         "<not found>",
+        context.repo_root,
     )
 
 
@@ -178,6 +176,7 @@ def _changeset_summary(context: RunContext) -> str:
                 _file_block(
                     change_set_path,
                     absolute.read_text(encoding="utf-8") if absolute.exists() else "<not found>",
+                    context.repo_root,
                 ),
             ]
         )
@@ -239,6 +238,59 @@ def _current_execution_payload(step: Step, context: RunContext) -> str:
 
 def _stable_json(value: Any) -> str:
     return json.dumps(_jsonable(value), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _cached_context_block(
+    source_path: Path,
+    content: str,
+    language: str,
+    *,
+    repo_root: Path | None = None,
+) -> str:
+    normalized = content.strip()
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    cache_path = Path(".harness/cache/prompt-context") / f"{digest}.md"
+    if repo_root is not None:
+        absolute_cache_path = repo_root / cache_path
+        absolute_cache_path.parent.mkdir(parents=True, exist_ok=True)
+        if not absolute_cache_path.exists():
+            absolute_cache_path.write_text(
+                "\n".join(
+                    [
+                        f"# Prompt Context Cache {digest}",
+                        "",
+                        f"- Source: `{source_path}`",
+                        f"- Language: `{language}`",
+                        f"- Bytes: {len(normalized.encode('utf-8'))}",
+                        "",
+                        f"```{language}",
+                        normalized,
+                        "```",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+    return "\n".join(
+        [
+            f"### `{source_path}`",
+            f"- Cache: `{cache_path}`",
+            f"- SHA-256: `{digest}`",
+            f"- Bytes: {len(normalized.encode('utf-8'))}",
+            "- Instruction: read the cache file if this context is needed.",
+            "",
+            "Preview:",
+            "```text",
+            _preview(normalized),
+            "```",
+        ]
+    )
+
+
+def _preview(content: str, max_chars: int = 1000) -> str:
+    if len(content) <= max_chars:
+        return content
+    return content[:max_chars].rstrip() + "\n..."
 
 
 def _jsonable(value: Any) -> Any:

--- a/tests/runtime/test_prompt_builder.py
+++ b/tests/runtime/test_prompt_builder.py
@@ -148,8 +148,32 @@ def test_missing_optional_context_keeps_stable_section_order(tmp_path: Path) -> 
     )
 
     assert "### `.codex/repository-settings.md`" in prompt
-    assert "<not found>" in prompt
+    assert ".harness/cache/prompt-context/" in prompt
+    assert any(
+        "<not found>" in path.read_text(encoding="utf-8")
+        for path in (tmp_path / ".harness/cache/prompt-context").glob("*.md")
+    )
     assert prompt.index("## 6. Repository Settings") < prompt.index("## 7. ChangeSet Summary")
+
+
+def test_stable_context_is_written_to_prompt_cache(tmp_path: Path) -> None:
+    write_stable_context(tmp_path)
+
+    prompt = build_agent_prompt(
+        step=step(),
+        context=context(tmp_path, run_id="run-001", work_item="UC-001"),
+        agent_config=agent_config(),
+        agent_config_path=Path(".codex/agents/implementation_executor.toml"),
+        skill_path=tmp_path / ".codex/skills/harness-plan-executor/SKILL.md",
+        skill_body="# Skill\nexecute plan\n",
+    )
+
+    cache_dir = tmp_path / ".harness/cache/prompt-context"
+    cache_files = tuple(cache_dir.glob("*.md"))
+    assert cache_files
+    assert "Cache: `.harness/cache/prompt-context/" in prompt
+    assert any("source of truth" in path.read_text(encoding="utf-8") for path in cache_files)
+    assert any("execute plan" in path.read_text(encoding="utf-8") for path in cache_files)
 
 
 def test_agent_adapter_writes_run_root_invocation_artifacts(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## 구현 의도

Fixes #183.

반복 agent 실행에서 안정적인 문맥(AGENTS, agent instruction, skill body, workflow, repository settings 등)을 매번 전체 prompt에 넣는 비용을 줄입니다.

## 구현 방식

- 안정 컨텍스트 블록을 SHA-256으로 해시합니다.
- 전체 내용은 `.harness/cache/prompt-context/<sha>.md`에 저장합니다.
- prompt에는 cache path, checksum, byte 수, 짧은 preview만 포함합니다.
- agent는 필요한 경우 cache file을 읽을 수 있습니다.
- volatile sections(ChangeSet, work item, current payload)는 기존처럼 prompt에 남깁니다.

## 검증 방법

- 집중 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_prompt_builder.py tests/runtime/test_agent_runner.py::test_configurable_agent_adapter_uses_codex_provider_by_default`
  - 결과: `6 passed in 3.93s`
- 전체 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests`
  - 결과: `243 passed in 37.43s`

## 개선 검증 보고서

합성 prompt에서 안정 컨텍스트 약 `55,000 bytes`를 사용해 측정했습니다.

- 변경 후 prompt 크기: `9,125 bytes`
- 안정 컨텍스트 원문 추정 크기: `55,000 bytes`
- cache file 수: `6`
- prompt 절감 추정: `45,875 bytes`
- prompt 절감률 추정: `83.41%`

원문은 cache file에 남고, prompt에는 checksum/path/preview만 남습니다.

## 리스크 및 롤백

리스크는 agent가 안정 컨텍스트 전문이 필요할 때 cache file을 읽어야 한다는 점입니다. prompt에 cache path와 instruction을 명시했고, preview를 남겨 기본 식별성은 유지했습니다. 문제가 있으면 이 PR을 revert하면 inline prompt 방식으로 돌아갑니다.
