### PR TITLE
[codex] 좁은 문서 델타 적용 경로 추가

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -173,6 +173,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     changes_create_from_design.add_argument("--force", action="store_true")
     changes_create_from_design.set_defaults(func=changes_create_from_design_command)
+    changes_document_delta = changes_subparsers.add_parser("document-delta")
+    changes_document_delta.add_argument("change_set_id")
+    changes_document_delta.add_argument("--uc", required=True)
+    changes_document_delta.add_argument(
+        "--target",
+        choices=("technical-decisions",),
+        default="technical-decisions",
+    )
+    changes_document_delta.add_argument("--summary", required=True)
+    changes_document_delta.add_argument("--plan-note", default="")
+    _add_mode_options(changes_document_delta)
+    changes_document_delta.set_defaults(func=changes_document_delta_command)
 
     for stage in PROCEDURE_STAGES:
         _add_procedure_stage_parser(subparsers, stage)
@@ -346,6 +358,101 @@ def changes_contents_command(args: argparse.Namespace, repo_root: Path) -> str:
             raise ValueError(f"ChangeSet file not found: {path}")
         return absolute_path.read_text(encoding="utf-8").strip()
     return _format_change_set_contents(change_set)
+
+
+def changes_document_delta_command(args: argparse.Namespace, repo_root: Path) -> str:
+    mode = _selected_mode(args)
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    use_case = next((uc for uc in change_set.affected_use_cases if uc.uc_id == args.uc), None)
+    if use_case is None:
+        return f"BLOCKED: {args.uc} is not affected by {change_set.change_set_id}"
+
+    target_path = use_case.slice_path / "technical-decisions.md"
+    active_plan_path = Path("docs/plans/active") / args.uc / "plan.md"
+    plan_note = args.plan_note or args.summary
+    delta_block = _document_delta_block(
+        change_set_id=change_set.change_set_id,
+        uc_id=args.uc,
+        summary=args.summary,
+        plan_note=plan_note,
+    )
+    plan_block = _plan_delta_block(
+        target_path=target_path,
+        summary=args.summary,
+        plan_note=plan_note,
+    )
+
+    if mode in (RunMode.PLAN, RunMode.PREVIEW):
+        return "\n".join(
+            [
+                f"Mode: {mode.value}",
+                f"ChangeSet: {change_set.change_set_id}",
+                f"UC: {args.uc}",
+                f"Target: {target_path}",
+                f"Plan patch: {active_plan_path if (repo_root / active_plan_path).exists() else '-'}",
+                "Side effects: false",
+            ]
+        )
+
+    target_absolute = repo_root / target_path
+    if not target_absolute.exists():
+        return f"BLOCKED: target document not found: {target_path}"
+    _append_once(target_absolute, delta_block)
+
+    plan_patched = False
+    plan_absolute = repo_root / active_plan_path
+    if plan_absolute.exists():
+        _append_once(plan_absolute, plan_block)
+        plan_patched = True
+
+    return "\n".join(
+        [
+            f"APPLIED document delta: {change_set.change_set_id}",
+            f"Target: {target_path}",
+            f"Plan patched: {active_plan_path if plan_patched else '-'}",
+        ]
+    )
+
+
+def _document_delta_block(
+    *,
+    change_set_id: str,
+    uc_id: str,
+    summary: str,
+    plan_note: str,
+) -> str:
+    return "\n".join(
+        [
+            "## Runtime Document Delta",
+            "",
+            f"- ChangeSet: `{change_set_id}`",
+            f"- UC: `{uc_id}`",
+            f"- Summary: {summary}",
+            f"- Plan impact: {plan_note}",
+            "",
+        ]
+    )
+
+
+def _plan_delta_block(*, target_path: Path, summary: str, plan_note: str) -> str:
+    return "\n".join(
+        [
+            "## Document Delta Update",
+            "",
+            f"- Source: `{target_path}`",
+            f"- Summary: {summary}",
+            f"- Plan note: {plan_note}",
+            "",
+        ]
+    )
+
+
+def _append_once(path: Path, block: str) -> None:
+    original = path.read_text(encoding="utf-8")
+    if block.strip() in original:
+        return
+    separator = "\n\n" if original.strip() else ""
+    path.write_text(original.rstrip() + separator + block, encoding="utf-8")
 
 
 def _format_change_set_contents(change_set: ChangeSet) -> str:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -444,6 +444,67 @@ def test_changes_create_from_design_reports_missing_design_doc(
     assert not (tmp_path / "docs/agent").exists()
 
 
+def test_changes_document_delta_preview_has_no_side_effects(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+    target = tmp_path / "docs/use-cases/UC-001/technical-decisions.md"
+    target.write_text("# Technical Decisions\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "document-delta",
+            "CHG-001",
+            "--uc",
+            "UC-001",
+            "--summary",
+            "Approve minimal reload read contract.",
+            "--preview",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Side effects: false" in output
+    assert "Approve minimal reload read contract." not in target.read_text(encoding="utf-8")
+
+
+def test_changes_document_delta_patches_target_doc_and_active_plan(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    write_changeset(tmp_path)
+    target = tmp_path / "docs/use-cases/UC-001/technical-decisions.md"
+    target.write_text("# Technical Decisions\n", encoding="utf-8")
+    plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "document-delta",
+            "CHG-001",
+            "--uc",
+            "UC-001",
+            "--summary",
+            "Approve minimal reload read contract.",
+            "--plan-note",
+            "Add one GET reload task.",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "APPLIED document delta" in output
+    assert "Approve minimal reload read contract." in target.read_text(encoding="utf-8")
+    assert "Add one GET reload task." in plan.read_text(encoding="utf-8")
+
+
 class FakeDateTime:
     @classmethod
     def now(cls):


### PR DESCRIPTION
## 구현 의도

Fixes #186.

작은 승인된 기술 결정 보정 때문에 전체 technical-decisions agent와 plan-writing agent를 다시 실행하지 않도록, 좁은 문서 델타 적용 경로를 추가합니다.

## 구현 방식

- `harness changes document-delta <CHG-ID> --uc <UC-ID> --summary ... --apply` 명령을 추가했습니다.
- 현재는 `technical-decisions` target만 지원합니다.
- target 문서에 `Runtime Document Delta` 블록을 append합니다.
- active plan이 있으면 `Document Delta Update` 블록도 append합니다.
- `--preview` / `--plan`은 side effect 없이 대상 경로만 보여줍니다.

## 검증 방법

- 집중 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py::test_changes_document_delta_preview_has_no_side_effects tests/test_cli_commands.py::test_changes_document_delta_patches_target_doc_and_active_plan`
  - 결과: `2 passed in 0.62s`
- 전체 테스트:
  - `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests`
  - 결과: `244 passed in 28.76s`

## 개선 검증 보고서

합성 ChangeSet/UC에서 좁은 문서 델타를 적용해 측정했습니다.

- exit code: `0`
- `.harness/runs` 생성 여부: `false`
- agent prompt files 생성 수: `0`
- target technical-decisions 문서 크기: `153 bytes`
- active plan 문서 크기: `171 bytes`

즉 작은 보정은 agent run/prompt 없이 문서와 plan만 직접 패치합니다.

## 리스크 및 롤백

리스크는 현재 명령이 technical-decisions delta append만 지원한다는 점입니다. 범위를 의도적으로 좁혀 안전하게 시작했습니다. 문제가 있으면 이 PR을 revert하면 기존 전체 stage rerun 방식으로 돌아갑니다.
