### PR TITLE
[codex] 런타임 버전 확인 및 병합 후 자동 증가

### DIFF
--- a/.github/workflows/bump-runtime-version.yml
+++ b/.github/workflows/bump-runtime-version.yml
@@ -1,0 +1,35 @@
+name: Bump runtime version after merged PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: bump-runtime-version-main
+  cancel-in-progress: false
+
+jobs:
+  bump-version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out merged main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Bump runtime patch version
+        run: python3 scripts/bump_runtime_version.py
+
+      - name: Commit bumped version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add harness_codex/__init__.py
+          git commit -m "chore: 런타임 패치 버전 자동 증가"
+          git push origin HEAD:main

--- a/docs/runtime-update-command.md
+++ b/docs/runtime-update-command.md
@@ -8,6 +8,14 @@ Installed projects can update their embedded harness-codex runtime from `origin/
 
 The command downloads the installer from the configured harness-codex repository and reruns it with `--force --target <repo-root>`. By default, the user-facing source ref is `origin/main`; for GitHub archive/download URLs this is normalized to the downloadable branch ref `main`.
 
+The runtime has its own semantic version in `harness_codex/__init__.py`. A completed update prints the installed version transition, for example `Runtime version: 0.1.0 -> 0.1.1`. A dry run prints the currently installed runtime version without claiming a target version.
+
+## Version automation
+
+When a pull request is merged into `main`, `.github/workflows/bump-runtime-version.yml` increases the runtime patch version and pushes a follow-up bot commit to `main`. A bot push does not retrigger the workflow because the workflow listens only for merged pull requests.
+
+The workflow requires `contents: write` permission for `GITHUB_TOKEN`. If repository branch rules prevent GitHub Actions from pushing directly to `main`, those rules must allow this workflow or the automated version commit will fail.
+
 ## Options
 
 ```bash

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/harness_codex/runtime/self_update.py
+++ b/harness_codex/runtime/self_update.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import shlex
 import subprocess
 from pathlib import Path
 from typing import Protocol
+
+from harness_codex import __version__
 
 DEFAULT_REPO = "https://github.com/omegafrog/harness-codex"
 DEFAULT_REF = "origin/main"
@@ -73,6 +76,7 @@ def run_self_update(
     *,
     runner: Runner = subprocess.run,
 ) -> str:
+    version_before = _installed_runtime_version(repo_root)
     command = build_update_command(
         repo_root.resolve(),
         repo=args.repo,
@@ -81,7 +85,9 @@ def run_self_update(
     )
     warning = _warning(args.repo, args.ref)
     if args.dry_run:
-        return "\n".join([warning, "Dry run. Command:", command])
+        return "\n".join(
+            [warning, f"Installed runtime version: {version_before}", "Dry run. Command:", command]
+        )
 
     completed = runner(
         command,
@@ -101,7 +107,15 @@ def run_self_update(
             "harness update failed"
             + (f":\n{output}" if output else f" with exit code {completed.returncode}")
         )
-    return "\n".join([warning, output, "harness-codex update completed."]).strip()
+    version_after = _installed_runtime_version(repo_root)
+    return "\n".join(
+        [
+            warning,
+            f"Runtime version: {version_before} -> {version_after}",
+            output,
+            "harness-codex update completed.",
+        ]
+    ).strip()
 
 
 def build_update_command(
@@ -169,6 +183,24 @@ def _warning(repo: str, ref: str) -> str:
         "artifacts: .harness runs/sessions/state, ChangeSets, work-item docs, plans, "
         "harvested docs, and project-local config."
     )
+
+
+def _installed_runtime_version(repo_root: Path) -> str:
+    init_file = repo_root / "harness_codex" / "__init__.py"
+    if not init_file.exists():
+        return __version__
+    try:
+        tree = ast.parse(init_file.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return "unknown"
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "__version__" for target in node.targets):
+            continue
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            return node.value.value
+    return "unknown"
 
 
 if __name__ == "__main__":

--- a/scripts/bump_runtime_version.py
+++ b/scripts/bump_runtime_version.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+VERSION_PATTERN = re.compile(
+    r'^(?P<prefix>__version__\s*=\s*")'
+    r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r'(?P<suffix>"\s*)$',
+    re.MULTILINE,
+)
+
+
+def bump_patch_version(text: str) -> tuple[str, str, str]:
+    matches = list(VERSION_PATTERN.finditer(text))
+    if len(matches) != 1:
+        raise ValueError("expected exactly one semantic __version__ assignment")
+    match = matches[0]
+    before = ".".join(match.group(name) for name in ("major", "minor", "patch"))
+    after = ".".join(
+        [match.group("major"), match.group("minor"), str(int(match.group("patch")) + 1)]
+    )
+    replacement = f"{match.group('prefix')}{after}{match.group('suffix')}"
+    updated = text[: match.start()] + replacement + text[match.end() :]
+    return updated, before, after
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Increase the harness runtime patch version.")
+    parser.add_argument(
+        "--file",
+        default="harness_codex/__init__.py",
+        type=Path,
+        help="Runtime version file to update.",
+    )
+    args = parser.parse_args(argv)
+    try:
+        original = args.file.read_text(encoding="utf-8")
+        updated, before, after = bump_patch_version(original)
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+    args.file.write_text(updated, encoding="utf-8")
+    print(f"{before} -> {after}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_self_update.py
+++ b/tests/runtime/test_self_update.py
@@ -2,6 +2,7 @@ import subprocess
 from argparse import Namespace
 from pathlib import Path
 
+from harness_codex import __version__
 from harness_codex.runtime.self_update import build_update_command, run_self_update
 
 
@@ -47,13 +48,18 @@ def test_run_self_update_dry_run_does_not_call_runner(tmp_path: Path) -> None:
     assert "Dry run. Command:" in output
     assert "--skip-venv" in output
     assert "preserves workflow-generated artifacts" in output
+    assert f"Installed runtime version: {__version__}" in output
 
 
 def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
     calls = []
+    runtime_package = tmp_path / "harness_codex"
+    runtime_package.mkdir()
+    (runtime_package / "__init__.py").write_text('__version__ = "0.1.0"\n', encoding="utf-8")
 
     def runner(*args, **kwargs):
         calls.append((args, kwargs))
+        (runtime_package / "__init__.py").write_text('__version__ = "0.1.1"\n', encoding="utf-8")
         return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="installed", stderr="")
 
     output = run_self_update(
@@ -74,6 +80,7 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
     assert "--ref main" in command
     assert calls[0][1]["cwd"] == tmp_path
     assert calls[0][1]["shell"] is True
+    assert "Runtime version: 0.1.0 -> 0.1.1" in output
     assert output.endswith("harness-codex update completed.")
 
 

--- a/tests/runtime/test_version_bump.py
+++ b/tests/runtime/test_version_bump.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "bump_runtime_version.py"
+
+
+def test_bump_runtime_version_increases_patch_version(tmp_path: Path) -> None:
+    version_file = tmp_path / "__init__.py"
+    version_file.write_text('__all__ = ["__version__"]\n\n__version__ = "0.1.1"\n', encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--file", str(version_file)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout.strip() == "0.1.1 -> 0.1.2"
+    assert '__version__ = "0.1.2"' in version_file.read_text(encoding="utf-8")
+
+
+def test_bump_runtime_version_rejects_non_semantic_version(tmp_path: Path) -> None:
+    version_file = tmp_path / "__init__.py"
+    version_file.write_text('__version__ = "dev"\n', encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--file", str(version_file)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "expected exactly one semantic __version__ assignment" in completed.stderr
+    assert version_file.read_text(encoding="utf-8") == '__version__ = "dev"\n'


### PR DESCRIPTION
## 구현 의도 (Implementation intent)

`harness update` 실행 시 설치된 런타임 버전을 확인할 수 있게 하고, 이후 `main`으로 PR이 병합될 때마다 런타임 패치 버전을 자동 증가시킵니다.

## 구현 접근 (Implementation approach)

- 런타임 버전을 `harness_codex/__init__.py`의 `__version__`으로 관리하며 현재 변경 버전을 `0.1.1`로 올렸습니다.
- `harness_codex/runtime/self_update.py`가 업데이트 전후 `__version__` 파일을 읽어 dry-run에서는 현재 설치 버전, 성공한 설치에서는 `이전 -> 이후` 전이를 출력합니다.
- `scripts/bump_runtime_version.py`는 정확히 하나의 semantic version 할당을 찾아 patch 숫자만 증가시킵니다.
- `.github/workflows/bump-runtime-version.yml`은 `main` 대상 PR의 병합 완료 이벤트에서만 실행되어 스크립트를 실행하고 bot 커밋을 `main`에 푸시합니다. bot push는 PR 병합 이벤트가 아니므로 자기 재실행 루프가 없습니다.

## 검증 방법 (Verification method)

- `git diff --check`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_version_bump.py tests/runtime/test_self_update.py` (`7 passed`)
- `./venv/bin/python3 -m pytest -q -s` (`254 passed`)
- workflow YAML parse 확인 및 임시 파일 대상 버전 증가 실행 확인 (`0.1.1 -> 0.1.2`)

## 위험 및 롤백 (Risks and rollback)

- 저장소 branch rule이 GitHub Actions의 `main` 직접 push를 막으면 병합 후 버전 증가 커밋이 실패합니다. 이 경우 workflow push 권한을 허용하거나 별도 PR 생성 방식으로 변경해야 합니다.
- 롤백은 workflow와 버전 증가 스크립트를 되돌리고, 필요 시 `__version__`을 이전 값으로 복원하는 revert PR로 수행합니다.