### PR TITLE
[codex] Add editable document workflow dashboard UI

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -1,0 +1,53 @@
+:root {
+  --ink: #19221c;
+  --muted: #627066;
+  --line: #d9ddcf;
+  --surface: #f7f6ef;
+  --paper: #fffef9;
+  --accent: #234c3c;
+  --active: #e2efe5;
+  --command: #cfe7ff;
+  --event: #ffd5aa;
+  --policy: #ead7ff;
+  --system: #d8dce0;
+  --external: #d5efd5;
+  --stale: #fff1c2;
+}
+* { box-sizing: border-box; }
+body { margin: 0; color: var(--ink); background: var(--surface); font: 14px/1.45 Inter, Arial, sans-serif; }
+.masthead { display: flex; justify-content: space-between; align-items: end; padding: 28px 36px 20px; border-bottom: 1px solid var(--line); }
+.eyebrow { margin: 0 0 5px; color: var(--muted); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; }
+h1, h2, h3, p { margin-top: 0; }
+h1 { margin-bottom: 0; font-size: 31px; }
+#refresh-status { color: var(--muted); margin: 0; }
+.layout { display: grid; grid-template-columns: 280px minmax(600px, 1fr); min-height: calc(100vh - 100px); }
+.sidebar { border-right: 1px solid var(--line); padding: 26px 20px; }
+.detail { padding: 27px 34px; max-width: 1240px; }
+.change-button { background: transparent; border: 1px solid var(--line); border-radius: 10px; display: block; margin-bottom: 10px; padding: 12px; text-align: left; width: 100%; }
+.change-button.selected { background: var(--active); border-color: #acc4b0; }
+.pill { border-radius: 14px; display: inline-block; font-size: 11px; padding: 2px 9px; text-transform: uppercase; }
+.pill.active { background: var(--active); }
+.pill.completed { background: #e3e5e0; }
+.pill.stale { background: var(--stale); }
+.panel { background: var(--paper); border: 1px solid var(--line); border-radius: 14px; margin: 18px 0; padding: 18px; }
+.timeline { display: grid; gap: 9px; grid-template-columns: repeat(auto-fit, minmax(142px, 1fr)); }
+.stage { background: #f1f2ec; border-radius: 9px; min-height: 84px; padding: 10px; }
+.stage.stale { background: var(--stale); }
+.stage strong { display: block; font-size: 12px; }
+.small { color: var(--muted); font-size: 12px; }
+.artifact { color: var(--accent); display: block; margin: 4px 0; }
+.flow-lane { display: flex; gap: 10px; margin: 14px 0 22px; overflow-x: auto; padding-bottom: 8px; }
+.sticky { border-radius: 3px; box-shadow: 0 2px 5px rgba(0,0,0,.10); flex: 0 0 172px; min-height: 94px; padding: 11px; }
+.sticky.command { background: var(--command); }
+.sticky.event { background: var(--event); }
+.sticky.policy { background: var(--policy); }
+.sticky.system { background: var(--system); }
+.sticky.external_system { background: var(--external); }
+.sticky-type { color: #455148; font-size: 10px; text-transform: uppercase; }
+.doc-actions { display: flex; gap: 8px; margin-bottom: 13px; }
+button { border: 1px solid var(--line); border-radius: 7px; cursor: pointer; padding: 7px 12px; }
+.primary { background: var(--accent); border-color: var(--accent); color: white; }
+textarea { border: 1px solid var(--line); border-radius: 7px; font: 13px/1.48 "SFMono-Regular", Consolas, monospace; min-height: 420px; padding: 12px; resize: vertical; width: 100%; }
+.markdown-preview { background: #fbfbf7; border-radius: 8px; padding: 15px; white-space: pre-wrap; }
+.error { color: #9c2d20; }
+details { margin-top: 10px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.html
+++ b/harness_codex/runtime/dashboard_assets/dashboard.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Harness Workflow Dashboard</title>
+    <link rel="stylesheet" href="/assets/dashboard.css">
+  </head>
+  <body>
+    <header class="masthead">
+      <div>
+        <p class="eyebrow">Harness workflow</p>
+        <h1>Document Dashboard</h1>
+      </div>
+      <p id="refresh-status">Loading workflow data...</p>
+    </header>
+    <main class="layout">
+      <aside class="sidebar">
+        <h2>ChangeSets</h2>
+        <div id="change-sets"></div>
+      </aside>
+      <section id="detail" class="detail"></section>
+    </main>
+    <script type="module" src="/assets/dashboard.js"></script>
+  </body>
+</html>

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -1,0 +1,141 @@
+const app = {
+  state: { change_sets: [] },
+  selectedChangeSet: null,
+  openDocument: null,
+  editorMode: "preview",
+};
+
+const escapeHtml = (value) => String(value ?? "")
+  .replaceAll("&", "&amp;")
+  .replaceAll("<", "&lt;")
+  .replaceAll(">", "&gt;")
+  .replaceAll('"', "&quot;");
+
+function markdownPreview(content) {
+  return escapeHtml(content)
+    .replace(/^### (.+)$/gm, "<h4>$1</h4>")
+    .replace(/^## (.+)$/gm, "<h3>$1</h3>")
+    .replace(/^# (.+)$/gm, "<h2>$1</h2>");
+}
+
+async function loadDashboard() {
+  const response = await fetch("/api/dashboard");
+  app.state = await response.json();
+  if (!app.selectedChangeSet && app.state.change_sets.length) {
+    app.selectedChangeSet = app.state.change_sets[0].id;
+  }
+  render();
+  document.querySelector("#refresh-status").textContent = `Refreshed ${new Date().toLocaleTimeString()}`;
+}
+
+function render() {
+  const changes = app.state.change_sets;
+  const selected = changes.find((item) => item.id === app.selectedChangeSet) || changes[0];
+  document.querySelector("#change-sets").innerHTML = changes.map((item) => `
+    <button class="change-button ${selected?.id === item.id ? "selected" : ""}" data-change="${escapeHtml(item.id)}">
+      <span class="pill ${item.lifecycle}">${escapeHtml(item.lifecycle)}</span>
+      <strong>${escapeHtml(item.id)}</strong><br>
+      <span class="small">${escapeHtml(item.title)}</span>
+    </button>`).join("");
+  document.querySelectorAll("[data-change]").forEach((node) => node.onclick = () => {
+    app.selectedChangeSet = node.dataset.change;
+    app.openDocument = null;
+    render();
+  });
+  document.querySelector("#detail").innerHTML = selected ? renderDetail(selected) : "<p>No ChangeSets found.</p>";
+  bindDetail(selected);
+}
+
+function renderDetail(change) {
+  const stages = change.stages.map((stage) => `
+    <div class="stage ${stage.status}">
+      <strong>${escapeHtml(stage.procedure)}</strong>
+      <span class="pill ${stage.status}">${escapeHtml(stage.status)}</span>
+      <div class="small">${escapeHtml(stage.verified_at)}</div>
+    </div>`).join("");
+  const workItems = change.work_items.map((item) => `
+    <div class="panel">
+      <h3>${escapeHtml(item.id)}: ${escapeHtml(item.name)}</h3>
+      ${item.artifacts.map((artifact) => `<span class="artifact">${escapeHtml(artifact.path)}</span>`).join("")}
+      ${renderBoard(item.event_storming)}
+    </div>`).join("");
+  const documents = change.documents.map((document) => `
+    <button data-document="${escapeHtml(document.id)}">${escapeHtml(document.label)}</button>`).join("");
+  const runs = change.run_history.map((run) => `<li>${escapeHtml(run.run_id)}: ${escapeHtml(run.status)}</li>`).join("");
+  return `
+    <span class="pill ${change.lifecycle}">${escapeHtml(change.lifecycle)}</span>
+    <h2>${escapeHtml(change.id)} ${escapeHtml(change.title)}</h2>
+    <p>${escapeHtml(change.intent)}</p>
+    <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div></section>
+    ${documents ? `<section class="panel"><h3>Editable Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
+    ${workItems}
+    <details class="panel"><summary>Runtime history</summary><ul>${runs || "<li>No recorded runs.</li>"}</ul></details>`;
+}
+
+function renderBoard(board) {
+  if (!board || !board.flows.length) return "";
+  return `<h3>Event Storming Board</h3>${board.flows.map((flow) => `
+    <h4>${escapeHtml(flow.name)}</h4>
+    <div class="flow-lane">${flow.notes.map((note) => `
+      <article class="sticky ${escapeHtml(note.type)}">
+        <div class="sticky-type">${escapeHtml(note.type.replace("_", " "))}</div>
+        ${escapeHtml(note.text)}
+      </article>`).join("")}</div>`).join("")}`;
+}
+
+function bindDetail(change) {
+  document.querySelectorAll("[data-document]").forEach((node) => node.onclick = () => openDocument(node.dataset.document));
+  if (app.openDocument && change.documents.some((item) => item.id === app.openDocument.id)) {
+    renderEditor();
+  }
+}
+
+async function openDocument(id) {
+  const response = await fetch(`/api/dashboard/documents/${encodeURIComponent(id)}`);
+  app.openDocument = await response.json();
+  app.editorMode = "preview";
+  renderEditor();
+}
+
+function renderEditor(message = "") {
+  const target = document.querySelector("#editor");
+  if (!target || !app.openDocument) return;
+  const editing = app.editorMode === "edit";
+  target.innerHTML = `
+    <div class="doc-actions">
+      <button id="preview-mode">Preview</button>
+      <button id="edit-mode">Edit</button>
+      ${editing ? '<button class="primary" id="save-doc">Save</button>' : ""}
+    </div>
+    ${message ? `<p class="error">${escapeHtml(message)}</p>` : ""}
+    ${editing
+      ? `<textarea id="doc-content">${escapeHtml(app.openDocument.content)}</textarea>`
+      : `<div class="markdown-preview">${markdownPreview(app.openDocument.content)}</div>`}`;
+  document.querySelector("#preview-mode").onclick = () => { app.editorMode = "preview"; renderEditor(); };
+  document.querySelector("#edit-mode").onclick = () => { app.editorMode = "edit"; renderEditor(); };
+  if (editing) document.querySelector("#save-doc").onclick = saveDocument;
+}
+
+async function saveDocument() {
+  const content = document.querySelector("#doc-content").value;
+  const response = await fetch(`/api/dashboard/documents/${encodeURIComponent(app.openDocument.id)}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ content, revision: app.openDocument.revision }),
+  });
+  const result = await response.json();
+  if (!response.ok) {
+    if (response.status === 409) await openDocument(app.openDocument.id);
+    renderEditor(result.error);
+    return;
+  }
+  app.openDocument = result;
+  app.editorMode = "preview";
+  await loadDashboard();
+  renderEditor();
+}
+
+loadDashboard().catch((error) => {
+  document.querySelector("#refresh-status").textContent = error.message;
+});
+setInterval(() => loadDashboard().catch(() => {}), 5000);

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -1,0 +1,372 @@
+"""Document-backed browser dashboard state and editable document operations."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any
+
+from harness_codex.runtime.changes.models import WorkItemType
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.dashboard import DashboardRun, load_dashboard_runs
+from harness_codex.runtime.procedure_stages import procedure_stage, update_changeset_stage_status
+
+
+class DashboardDocumentError(ValueError):
+    """Base error for dashboard document operations."""
+
+
+class DashboardDocumentNotFound(DashboardDocumentError):
+    """Raised when a dashboard document identifier is not editable."""
+
+
+class DashboardDocumentConflict(DashboardDocumentError):
+    """Raised when disk content changed since an editor loaded it."""
+
+
+class DashboardDocumentValidationError(DashboardDocumentError):
+    """Raised when edited Markdown would break workflow parsing."""
+
+
+def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
+    """Project docs and runtime history into browser dashboard data."""
+
+    root = Path(repo_root)
+    runs_by_change_set: dict[str, list[DashboardRun]] = {}
+    for run in load_dashboard_runs(root):
+        runs_by_change_set.setdefault(run.change_set_id, []).append(run)
+
+    change_sets: list[dict[str, Any]] = []
+    for lifecycle in ("active", "completed"):
+        change_dir = root / "docs/changes" / lifecycle
+        for path in sorted(change_dir.glob("*.md")):
+            text = path.read_text(encoding="utf-8")
+            change_set = parse_changeset_markdown(text, path=path)
+            runs = sorted(
+                runs_by_change_set.get(change_set.change_set_id, []),
+                key=lambda run: _run_recency(root, run),
+                reverse=True,
+            )
+            run_payloads = [_run_payload(run) for run in runs]
+            change_sets.append(
+                {
+                    "id": change_set.change_set_id,
+                    "title": change_set.title,
+                    "lifecycle": lifecycle,
+                    "intent": change_set.intent_summary,
+                    "path": _relative_path(root, path),
+                    "stages": _parse_procedure_stages(text),
+                    "work_items": [
+                        _work_item_payload(root, change_set.change_set_id, lifecycle, item)
+                        for item in change_set.ordered_work_items()
+                    ],
+                    "documents": _editable_document_summaries(root, change_set, lifecycle),
+                    "latest_run": run_payloads[0] if run_payloads else None,
+                    "run_history": run_payloads,
+                }
+            )
+    return {"change_sets": change_sets}
+
+
+def read_dashboard_document(repo_root: Path | str, document_id: str) -> dict[str, Any]:
+    """Read one allow-listed editable document from an active ChangeSet."""
+
+    root = Path(repo_root)
+    document = _resolve_editable_document(root, document_id)
+    content = document["path"].read_text(encoding="utf-8")
+    return _document_payload(root, document, content)
+
+
+def save_dashboard_document(
+    repo_root: Path | str,
+    document_id: str,
+    *,
+    content: str,
+    revision: str,
+) -> dict[str, Any]:
+    """Save valid Markdown if the caller still holds the disk revision."""
+
+    root = Path(repo_root)
+    document = _resolve_editable_document(root, document_id)
+    path = document["path"]
+    current = path.read_text(encoding="utf-8")
+    if revision != _revision(current):
+        raise DashboardDocumentConflict(
+            "Document changed on disk. Reload latest content before saving."
+        )
+    normalized = content.rstrip() + "\n"
+    _validate_document(document, normalized)
+
+    change_path = document["change_path"]
+    change_text = change_path.read_text(encoding="utf-8")
+    for stage_id in _stale_stage_ids(document["kind"]):
+        change_text = update_changeset_stage_status(
+            change_text,
+            stage=procedure_stage(stage_id),
+            status="stale",
+            notes=f"stale after dashboard edit of {document['kind']}",
+        )
+
+    path.write_text(normalized, encoding="utf-8")
+    change_path.write_text(change_text, encoding="utf-8")
+    return _document_payload(root, document, normalized)
+
+
+def _work_item_payload(
+    root: Path,
+    change_set_id: str,
+    lifecycle: str,
+    item: Any,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": item.work_item_id,
+        "type": item.work_item_type.value,
+        "name": item.name,
+        "status": item.status,
+        "artifacts": [],
+    }
+    if item.work_item_type is not WorkItemType.USE_CASE:
+        return payload
+
+    slice_path = root / "docs/use-cases" / item.work_item_id
+    artifact_paths = [
+        slice_path / "use-case.md",
+        slice_path / "event-storming.md",
+        slice_path / "ddd-design.md",
+        slice_path / "technical-decisions.md",
+        slice_path / "e2e-goal.md",
+        root / "docs/plans/active" / item.work_item_id / "plan.md",
+        root / "docs/plans/completed" / item.work_item_id / "plan.md",
+    ]
+    payload["artifacts"] = [
+        {"path": _relative_path(root, path), "exists": True}
+        for path in artifact_paths
+        if path.exists()
+    ]
+    event_path = slice_path / "event-storming.md"
+    payload["event_storming"] = (
+        _parse_event_storming(event_path.read_text(encoding="utf-8"))
+        if event_path.exists()
+        else {"flows": []}
+    )
+    if lifecycle == "active":
+        payload["editable_document_id"] = f"use-case:{change_set_id}:{item.work_item_id}"
+    return payload
+
+
+def _editable_document_summaries(root: Path, change_set: Any, lifecycle: str) -> list[dict[str, str]]:
+    if lifecycle != "active":
+        return []
+    summaries: list[dict[str, str]] = []
+    requirements = root / "docs/design/요구사항.md"
+    if requirements.exists():
+        summaries.append(
+            {
+                "id": f"requirements:{change_set.change_set_id}",
+                "kind": "requirements",
+                "label": "Requirements",
+                "path": _relative_path(root, requirements),
+            }
+        )
+    for item in change_set.ordered_work_items():
+        if item.work_item_type is WorkItemType.USE_CASE:
+            path = root / "docs/use-cases" / item.work_item_id / "use-case.md"
+            if path.exists():
+                summaries.append(
+                    {
+                        "id": f"use-case:{change_set.change_set_id}:{item.work_item_id}",
+                        "kind": "use-case",
+                        "label": f"{item.work_item_id} Use Case",
+                        "path": _relative_path(root, path),
+                    }
+                )
+    return summaries
+
+
+def _resolve_editable_document(root: Path, document_id: str) -> dict[str, Any]:
+    parts = document_id.split(":")
+    if len(parts) not in (2, 3):
+        raise DashboardDocumentNotFound("Unknown editable document.")
+    kind, change_set_id = parts[:2]
+    change_path = root / "docs/changes/active" / f"{change_set_id}.md"
+    if not change_path.exists():
+        raise DashboardDocumentNotFound("Only active ChangeSet documents can be edited.")
+    change_set = parse_changeset_markdown(
+        change_path.read_text(encoding="utf-8"), path=change_path
+    )
+    if kind == "requirements" and len(parts) == 2:
+        path = root / "docs/design/요구사항.md"
+        label = "Requirements"
+    elif kind == "use-case" and len(parts) == 3:
+        uc_id = parts[2]
+        if not any(
+            item.work_item_type is WorkItemType.USE_CASE and item.work_item_id == uc_id
+            for item in change_set.ordered_work_items()
+        ):
+            raise DashboardDocumentNotFound("Use case is not part of the active ChangeSet.")
+        path = root / "docs/use-cases" / uc_id / "use-case.md"
+        label = f"{uc_id} Use Case"
+    else:
+        raise DashboardDocumentNotFound("Unknown editable document.")
+    if not path.exists():
+        raise DashboardDocumentNotFound("Editable document does not exist.")
+    return {
+        "id": document_id,
+        "kind": kind,
+        "label": label,
+        "path": path,
+        "change_path": change_path,
+    }
+
+
+def _document_payload(root: Path, document: dict[str, Any], content: str) -> dict[str, Any]:
+    return {
+        "id": document["id"],
+        "kind": document["kind"],
+        "label": document["label"],
+        "path": _relative_path(root, document["path"]),
+        "content": content,
+        "revision": _revision(content),
+    }
+
+
+def _validate_document(document: dict[str, Any], content: str) -> None:
+    placeholder_terms = ("TBD from confirmed requirements", "has not been derived yet", "<UC-ID>")
+    for term in placeholder_terms:
+        if term in content:
+            raise DashboardDocumentValidationError(
+                f"Document contains unresolved placeholder: {term}"
+            )
+    if document["kind"] == "requirements":
+        required_groups = (
+            ("# Requirements", "# 요구사항"),
+            ("## 1. Overview", "## 1. 개요"),
+            ("## 3. Functional Requirements", "## 3. 기능 요구사항"),
+        )
+    else:
+        uc_id = document["id"].split(":")[-1]
+        required_groups = (
+            (f"# {uc_id}.",),
+            ("## Actor", "- Actor:", "**Actor**"),
+            ("## Goal", "- Goal:", "**Goal**"),
+            ("## Main Flow", "## 3. Basic Flow", "**Main Flow**"),
+            ("## Result", "## 5. Outcomes", "**Result**"),
+        )
+    missing = ["/".join(group) for group in required_groups if not any(term in content for term in group)]
+    if missing:
+        raise DashboardDocumentValidationError(
+            "Document is missing required structure: " + ", ".join(missing)
+        )
+
+
+def _stale_stage_ids(kind: str) -> tuple[str, ...]:
+    if kind == "requirements":
+        return (
+            "use-case-definition",
+            "event-storming",
+            "ddd-architecture-definition",
+            "technical-decisions",
+            "plan-writing",
+            "implementation",
+        )
+    return (
+        "event-storming",
+        "ddd-architecture-definition",
+        "technical-decisions",
+        "plan-writing",
+        "implementation",
+    )
+
+
+def _parse_procedure_stages(text: str) -> list[dict[str, str]]:
+    section = _section_text(text, "## 3. Runtime Procedure State")
+    stages: list[dict[str, str]] = []
+    for line in section.splitlines():
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) >= 5 and cells[0] not in ("Stage ID", "---"):
+            stages.append(
+                {
+                    "id": cells[0],
+                    "procedure": cells[1],
+                    "status": cells[2],
+                    "verified_at": cells[3],
+                    "notes": cells[4].replace("\\|", "|"),
+                }
+            )
+    return stages
+
+
+def _parse_event_storming(text: str) -> dict[str, Any]:
+    flows: list[dict[str, Any]] = []
+    matches = list(re.finditer(r"^### \[Flow: ([^\]]+)\]\s*$", text, re.MULTILINE))
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        block = text[match.end():end].split("---", 1)[0]
+        source_name = match.group(1).strip()
+        kind = "main" if "기본" in source_name or "main" in source_name.lower() else "exception"
+        notes: list[dict[str, str]] = []
+        for line in block.splitlines():
+            value = line.strip().removeprefix("→").strip()
+            note_type = _sticky_type(value)
+            if note_type:
+                notes.append({"type": note_type, "text": value[2:].strip()})
+        if notes:
+            ordinal = sum(1 for flow in flows if flow["kind"] == kind) + 1
+            label = "Main Flow" if kind == "main" else f"Exception Flow {ordinal}"
+            flows.append(
+                {"name": label, "source_name": source_name, "kind": kind, "notes": notes}
+            )
+    return {"flows": flows}
+
+
+def _sticky_type(value: str) -> str | None:
+    return {
+        "🟦": "command",
+        "🟧": "event",
+        "🟪": "policy",
+        "⬛": "system",
+        "🟩": "external_system",
+    }.get(value[:1])
+
+
+def _run_payload(run: DashboardRun) -> dict[str, Any]:
+    return {
+        "run_id": run.run_id,
+        "status": run.status.value,
+        "report_path": str(run.report_path),
+        "work_items": [
+            {
+                "id": item.work_item_id,
+                "type": item.work_item_type.value,
+                "current_stage": item.current_stage,
+                "status": item.status.value,
+                "blocker": item.blocker,
+                "verification_result": item.verification_result,
+            }
+            for item in run.work_items
+        ],
+    }
+
+
+def _run_recency(root: Path, run: DashboardRun) -> tuple[int, str]:
+    state_path = root / ".harness/runs" / run.run_id / "state.json"
+    return ((state_path.stat().st_mtime_ns if state_path.exists() else 0), run.run_id)
+
+
+def _section_text(text: str, heading: str) -> str:
+    start = text.find(heading)
+    if start < 0:
+        return ""
+    body_start = start + len(heading)
+    next_heading = re.search(r"^## ", text[body_start:], re.MULTILINE)
+    end = body_start + next_heading.start() if next_heading else len(text)
+    return text[body_start:end]
+
+
+def _revision(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _relative_path(root: Path, path: Path) -> str:
+    return str(path.relative_to(root))

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -8,8 +8,16 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
+from harness_codex.runtime.document_dashboard import (
+    DashboardDocumentConflict,
+    DashboardDocumentNotFound,
+    DashboardDocumentValidationError,
+    document_dashboard_state,
+    read_dashboard_document,
+    save_dashboard_document,
+)
 from harness_codex.runtime.harvest_ui import (
     answer_use_cases,
     answer_requirements,
@@ -39,8 +47,27 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
     repo_root: Path
 
     def do_GET(self) -> None:
-        if self._path() == "/api/harvest":
+        path = self._path()
+        if path == "/api/harvest":
             self._write_json(HTTPStatus.OK, load_harvest_ui(self.repo_root).as_dict())
+            return
+        if path == "/api/dashboard":
+            self._write_json(HTTPStatus.OK, document_dashboard_state(self.repo_root))
+            return
+        if path.startswith("/api/dashboard/documents/"):
+            document_id = unquote(path.removeprefix("/api/dashboard/documents/"))
+            try:
+                self._write_json(HTTPStatus.OK, read_dashboard_document(self.repo_root, document_id))
+            except DashboardDocumentNotFound as exc:
+                self._write_json(HTTPStatus.NOT_FOUND, {"error": str(exc)})
+            return
+        asset = {
+            "/dashboard": ("dashboard.html", "text/html; charset=utf-8"),
+            "/assets/dashboard.css": ("dashboard.css", "text/css; charset=utf-8"),
+            "/assets/dashboard.js": ("dashboard.js", "text/javascript; charset=utf-8"),
+        }.get(path)
+        if asset:
+            self._write_asset(*asset)
             return
         self._write_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
 
@@ -67,6 +94,31 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
 
         self._write_json(HTTPStatus.OK, result.as_dict())
 
+    def do_PUT(self) -> None:
+        path = self._path()
+        if not path.startswith("/api/dashboard/documents/"):
+            self._write_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+        document_id = unquote(path.removeprefix("/api/dashboard/documents/"))
+        try:
+            body = self._read_body()
+            result = save_dashboard_document(
+                self.repo_root,
+                document_id,
+                content=str(body.get("content", "")),
+                revision=str(body.get("revision", "")),
+            )
+        except DashboardDocumentConflict as exc:
+            self._write_json(HTTPStatus.CONFLICT, {"error": str(exc)})
+            return
+        except DashboardDocumentNotFound as exc:
+            self._write_json(HTTPStatus.NOT_FOUND, {"error": str(exc)})
+            return
+        except DashboardDocumentValidationError as exc:
+            self._write_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        self._write_json(HTTPStatus.OK, result)
+
     def log_message(self, format: str, *args: object) -> None:
         return
 
@@ -86,6 +138,18 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
         self.send_header("content-type", "application/json; charset=utf-8")
         self.send_header("content-length", str(len(data)))
         self.send_header("access-control-allow-origin", "*")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _write_asset(self, filename: str, content_type: str) -> None:
+        path = Path(__file__).with_name("dashboard_assets") / filename
+        if not path.exists():
+            self._write_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+        data = path.read_bytes()
+        self.send_response(HTTPStatus.OK.value)
+        self.send_header("content-type", content_type)
+        self.send_header("content-length", str(len(data)))
         self.end_headers()
         self.wfile.write(data)
 

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+import pytest
+
+from harness_codex.runtime import document_dashboard
+from harness_codex.runtime.changes.models import WorkItemType
+from harness_codex.runtime.dashboard import DashboardRun, DashboardWorkItem
+from harness_codex.runtime.document_dashboard import (
+    DashboardDocumentConflict,
+    DashboardDocumentNotFound,
+    DashboardDocumentValidationError,
+    document_dashboard_state,
+    read_dashboard_document,
+    save_dashboard_document,
+)
+from harness_codex.runtime.models import RunStatus
+from harness_codex.runtime.procedure_stages import render_initial_changeset
+from harness_codex.runtime.ui_server import HarvestUiRequestHandler
+
+
+REQUIREMENTS_MARKDOWN = """# Requirements Specification
+
+## 1. Overview
+- Goal: Save one note.
+
+## 3. Functional Requirements
+- FR-001. Save one note.
+"""
+
+USE_CASE_MARKDOWN = """# UC-001. Local Note Author saves one Fleeting Note
+
+## Actor
+- Local Note Author
+
+## Goal
+- Save one note.
+
+## Main Flow
+1. Save note.
+
+## Result
+- Note is saved.
+"""
+
+GENERATED_USE_CASE_MARKDOWN = """# UC-001. Local Note Author saves one Fleeting Note
+
+## 1. Overview
+- Actor: Local Note Author
+- Goal: Save one note.
+
+## 2. Preconditions
+- The UI is open.
+
+## 3. Basic Flow
+1. Save note.
+
+## 5. Outcomes
+- Note is saved.
+"""
+
+EVENT_STORMING_MARKDOWN = """# UC-001 Event Storming
+
+## Flow
+### [Flow: Main Flow]
+🟦 Save Fleeting Note
+→ 🟧 Fleeting Note was saved
+→ 🟪 Show saved note
+
+---
+### [Flow: Exception Flow]
+🟦 Save Fleeting Note
+→ 🟧 Save failed
+"""
+
+
+def _write_change_set(root: Path, lifecycle: str = "active") -> Path:
+    path = root / "docs/changes" / lifecycle / "CHG-001.md"
+    path.parent.mkdir(parents=True)
+    content = render_initial_changeset(
+        change_set_id="CHG-001",
+        title="Save Fleeting Note",
+        request_summary="Create note flow.",
+    )
+    content += """\
+
+## 5. Affected Use Cases
+
+|UC ID|Use Case Name|Impact Type|Slice Path|Status|
+|---|---|---|---|---|
+|`UC-001`|Save Fleeting Note|add|`docs/use-cases/UC-001`|ready|
+"""
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _write_documents(root: Path) -> None:
+    for path, content in (
+        (root / "docs/design/요구사항.md", REQUIREMENTS_MARKDOWN),
+        (root / "docs/use-cases/UC-001/use-case.md", USE_CASE_MARKDOWN),
+        (root / "docs/use-cases/UC-001/event-storming.md", EVENT_STORMING_MARKDOWN),
+        (root / "docs/plans/completed/UC-001/plan.md", "# Plan\n"),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def test_document_dashboard_projects_docs_board_and_folder_lifecycle(tmp_path: Path) -> None:
+    _write_change_set(tmp_path, "completed")
+    _write_documents(tmp_path)
+
+    change_set = document_dashboard_state(tmp_path)["change_sets"][0]
+
+    assert change_set["lifecycle"] == "completed"
+    assert change_set["documents"] == []
+    assert change_set["stages"][0]["id"] == "requirements-definition"
+    work_item = change_set["work_items"][0]
+    assert "docs/plans/completed/UC-001/plan.md" in {
+        artifact["path"] for artifact in work_item["artifacts"]
+    }
+    flows = work_item["event_storming"]["flows"]
+    assert [flow["kind"] for flow in flows] == ["main", "exception"]
+    assert flows[0]["notes"][0] == {"type": "command", "text": "Save Fleeting Note"}
+    assert flows[0]["notes"][1] == {"type": "event", "text": "Fleeting Note was saved"}
+
+
+def test_document_dashboard_attaches_latest_runtime_summary_and_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    item = DashboardWorkItem(
+        work_item_id="UC-001",
+        work_item_type=WorkItemType.USE_CASE,
+        plan_path=Path("docs/plans/active/UC-001/plan.md"),
+        current_stage="implementation",
+        status=RunStatus.RUNNING,
+    )
+    runs = (
+        DashboardRun("run-old", "CHG-001", RunStatus.FAILED, (item,), Path("old.md")),
+        DashboardRun("run-new", "CHG-001", RunStatus.RUNNING, (item,), Path("new.md")),
+    )
+    monkeypatch.setattr(document_dashboard, "load_dashboard_runs", lambda _root: runs)
+    monkeypatch.setattr(
+        document_dashboard,
+        "_run_recency",
+        lambda _root, run: (2 if run.run_id == "run-new" else 1, run.run_id),
+    )
+
+    change_set = document_dashboard_state(tmp_path)["change_sets"][0]
+
+    assert change_set["latest_run"]["run_id"] == "run-new"
+    assert [run["run_id"] for run in change_set["run_history"]] == ["run-new", "run-old"]
+
+
+def test_save_requirements_requires_current_revision_and_stales_downstream_stages(
+    tmp_path: Path,
+) -> None:
+    change_path = _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    loaded = read_dashboard_document(tmp_path, "requirements:CHG-001")
+
+    saved = save_dashboard_document(
+        tmp_path,
+        "requirements:CHG-001",
+        content=REQUIREMENTS_MARKDOWN.replace("Save one note.", "Save a durable note."),
+        revision=loaded["revision"],
+    )
+
+    assert "Save a durable note." in saved["content"]
+    change_text = change_path.read_text(encoding="utf-8")
+    assert "|requirements-definition|Requirements Definition|pending|" in change_text
+    assert "|use-case-definition|Use Case Definition|stale|" in change_text
+    assert "|implementation|Implementation|stale|" in change_text
+    assert (tmp_path / "docs/use-cases/UC-001/event-storming.md").exists()
+    with pytest.raises(DashboardDocumentConflict):
+        save_dashboard_document(
+            tmp_path,
+            "requirements:CHG-001",
+            content=REQUIREMENTS_MARKDOWN,
+            revision=loaded["revision"],
+        )
+
+
+def test_save_use_case_validates_structure_and_stales_only_later_stages(tmp_path: Path) -> None:
+    change_path = _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    loaded = read_dashboard_document(tmp_path, "use-case:CHG-001:UC-001")
+
+    with pytest.raises(DashboardDocumentValidationError):
+        save_dashboard_document(
+            tmp_path,
+            "use-case:CHG-001:UC-001",
+            content="# UC-001. Broken\n",
+            revision=loaded["revision"],
+        )
+    save_dashboard_document(
+        tmp_path,
+        "use-case:CHG-001:UC-001",
+        content=USE_CASE_MARKDOWN.replace("Save one note.", "Save revised note."),
+        revision=loaded["revision"],
+    )
+    change_text = change_path.read_text(encoding="utf-8")
+    assert "|use-case-definition|Use Case Definition|pending|" in change_text
+    assert "|event-storming|Event Storming|stale|" in change_text
+    assert "|implementation|Implementation|stale|" in change_text
+
+
+def test_save_use_case_accepts_generated_slice_structure(tmp_path: Path) -> None:
+    _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    loaded = read_dashboard_document(tmp_path, "use-case:CHG-001:UC-001")
+
+    saved = save_dashboard_document(
+        tmp_path,
+        "use-case:CHG-001:UC-001",
+        content=GENERATED_USE_CASE_MARKDOWN,
+        revision=loaded["revision"],
+    )
+
+    assert "## 3. Basic Flow" in saved["content"]
+
+
+def test_completed_change_set_documents_are_not_editable(tmp_path: Path) -> None:
+    _write_change_set(tmp_path, "completed")
+    _write_documents(tmp_path)
+
+    with pytest.raises(DashboardDocumentNotFound):
+        read_dashboard_document(tmp_path, "requirements:CHG-001")
+
+
+def test_ui_server_serves_dashboard_and_edit_api(tmp_path: Path) -> None:
+    _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+
+    class Handler(HarvestUiRequestHandler):
+        repo_root = tmp_path
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        with urlopen(f"{base}/dashboard") as response:
+            assert "Document Dashboard" in response.read().decode("utf-8")
+        with urlopen(f"{base}/assets/dashboard.js") as response:
+            assert "loadDashboard" in response.read().decode("utf-8")
+        with urlopen(f"{base}/api/dashboard") as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["change_sets"][0]["id"] == "CHG-001"
+        document_url = f"{base}/api/dashboard/documents/requirements%3ACHG-001"
+        with urlopen(document_url) as response:
+            loaded = json.loads(response.read().decode("utf-8"))
+        request = Request(
+            document_url,
+            method="PUT",
+            headers={"content-type": "application/json"},
+            data=json.dumps(
+                {
+                    "content": REQUIREMENTS_MARKDOWN.replace("Save one note.", "Save edited note."),
+                    "revision": loaded["revision"],
+                }
+            ).encode("utf-8"),
+        )
+        with urlopen(request) as response:
+            saved = json.loads(response.read().decode("utf-8"))
+        assert "Save edited note." in saved["content"]
+        with urlopen(f"{base}/api/dashboard") as response:
+            refreshed = json.loads(response.read().decode("utf-8"))
+        statuses = {stage["id"]: stage["status"] for stage in refreshed["change_sets"][0]["stages"]}
+        assert statuses["use-case-definition"] == "stale"
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()


### PR DESCRIPTION
Closes #196

## Implementation intent
Provide a separate harness developer dashboard that shows staged workflow progress from repository documents and lets users revise active requirements and use-case slice Markdown between workflow stages.

## Implementation approach
- Add `document_dashboard.py` as a document-backed projection beside the existing runtime-run dashboard. It reads active/completed ChangeSets, parses procedure stage tables, resolves existing UC artifacts, attaches newest runtime telemetry plus prior run history, and parses event-storming flows into sticky-note lane data.
- Extend the existing Python UI server with `/dashboard`, static assets, `GET /api/dashboard`, and allow-listed document GET/PUT endpoints. The product frontend remains untouched.
- Expose Markdown preview/edit only for active ChangeSet requirements and UC slice files. Saves carry a SHA-256 revision; a changed disk document returns a conflict rather than being overwritten.
- On accepted requirements edits, retain current files but mark use-case and downstream procedure stages `stale`. On accepted use-case slice edits, mark event-storming and downstream stages `stale`.
- Render event-storming documents as read-only command/event/policy sticky lanes; editing the board and reverse slice-to-canonical sync remain follow-up work.

## Verification method
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` -> `7 passed in 3.01s`.
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime` -> `211 passed in 40.21s`.
- `git diff --cached --check` passed before commit.

## Risks and rollback
- Raw Markdown editing can change semantic content; structure validation, allow-listed paths, active-only writes, revision checking, and stale-stage invalidation constrain this risk.
- Event-storming rendering currently recognizes documented flow headings and sticky-note emoji markers; unsupported document layouts render no board lanes while leaving source files untouched.
- Rollback is a revert of this commit; existing CLI run dashboard and harvest endpoints remain preserved.