### PR TITLE
[codex] 완료된 ChangeSet 읽기 전용 대시보드 조회 지원

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -67,7 +67,7 @@ function renderDetail(change) {
     <h2>${escapeHtml(change.id)} ${escapeHtml(change.title)}</h2>
     <p>${escapeHtml(change.intent)}</p>
     <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div></section>
-    ${documents ? `<section class="panel"><h3>Editable Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
+    ${documents ? `<section class="panel"><h3>Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
     ${workItems}
     <details class="panel"><summary>Runtime history</summary><ul>${runs || "<li>No recorded runs.</li>"}</ul></details>`;
 }
@@ -100,11 +100,12 @@ async function openDocument(id) {
 function renderEditor(message = "") {
   const target = document.querySelector("#editor");
   if (!target || !app.openDocument) return;
-  const editing = app.editorMode === "edit";
+  const editable = app.openDocument.editable !== false;
+  const editing = editable && app.editorMode === "edit";
   target.innerHTML = `
     <div class="doc-actions">
       <button id="preview-mode">Preview</button>
-      <button id="edit-mode">Edit</button>
+      ${editable ? '<button id="edit-mode">Edit</button>' : ""}
       ${editing ? '<button class="primary" id="save-doc">Save</button>' : ""}
     </div>
     ${message ? `<p class="error">${escapeHtml(message)}</p>` : ""}
@@ -112,7 +113,7 @@ function renderEditor(message = "") {
       ? `<textarea id="doc-content">${escapeHtml(app.openDocument.content)}</textarea>`
       : `<div class="markdown-preview">${markdownPreview(app.openDocument.content)}</div>`}`;
   document.querySelector("#preview-mode").onclick = () => { app.editorMode = "preview"; renderEditor(); };
-  document.querySelector("#edit-mode").onclick = () => { app.editorMode = "edit"; renderEditor(); };
+  if (editable) document.querySelector("#edit-mode").onclick = () => { app.editorMode = "edit"; renderEditor(); };
   if (editing) document.querySelector("#save-doc").onclick = saveDocument;
 }
 

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -61,7 +61,7 @@ def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
                         _work_item_payload(root, change_set.change_set_id, lifecycle, item)
                         for item in change_set.ordered_work_items()
                     ],
-                    "documents": _editable_document_summaries(root, change_set, lifecycle),
+                    "documents": _document_summaries(root, change_set, lifecycle, path),
                     "latest_run": run_payloads[0] if run_payloads else None,
                     "run_history": run_payloads,
                 }
@@ -70,10 +70,10 @@ def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
 
 
 def read_dashboard_document(repo_root: Path | str, document_id: str) -> dict[str, Any]:
-    """Read one allow-listed editable document from an active ChangeSet."""
+    """Read one document exposed by the dashboard."""
 
     root = Path(repo_root)
-    document = _resolve_editable_document(root, document_id)
+    document = _resolve_readable_document(root, document_id)
     content = document["path"].read_text(encoding="utf-8")
     return _document_payload(root, document, content)
 
@@ -155,10 +155,23 @@ def _work_item_payload(
     return payload
 
 
-def _editable_document_summaries(root: Path, change_set: Any, lifecycle: str) -> list[dict[str, str]]:
+def _document_summaries(
+    root: Path,
+    change_set: Any,
+    lifecycle: str,
+    change_path: Path,
+) -> list[dict[str, str | bool]]:
     if lifecycle != "active":
-        return []
-    summaries: list[dict[str, str]] = []
+        return [
+            {
+                "id": f"change-set:{change_set.change_set_id}",
+                "kind": "change-set",
+                "label": "ChangeSet (Read only)",
+                "path": _relative_path(root, change_path),
+                "editable": False,
+            }
+        ]
+    summaries: list[dict[str, str | bool]] = []
     requirements = root / "docs/design/요구사항.md"
     if requirements.exists():
         summaries.append(
@@ -167,6 +180,7 @@ def _editable_document_summaries(root: Path, change_set: Any, lifecycle: str) ->
                 "kind": "requirements",
                 "label": "Requirements",
                 "path": _relative_path(root, requirements),
+                "editable": True,
             }
         )
     for item in change_set.ordered_work_items():
@@ -179,9 +193,28 @@ def _editable_document_summaries(root: Path, change_set: Any, lifecycle: str) ->
                         "kind": "use-case",
                         "label": f"{item.work_item_id} Use Case",
                         "path": _relative_path(root, path),
+                        "editable": True,
                     }
                 )
     return summaries
+
+
+def _resolve_readable_document(root: Path, document_id: str) -> dict[str, Any]:
+    if document_id.startswith("change-set:"):
+        change_set_id = document_id.removeprefix("change-set:")
+        if not re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id):
+            raise DashboardDocumentNotFound("Unknown completed ChangeSet document.")
+        path = root / "docs/changes/completed" / f"{change_set_id}.md"
+        if not change_set_id or not path.exists():
+            raise DashboardDocumentNotFound("Completed ChangeSet document does not exist.")
+        return {
+            "id": document_id,
+            "kind": "change-set",
+            "label": "ChangeSet (Read only)",
+            "path": path,
+            "editable": False,
+        }
+    return _resolve_editable_document(root, document_id)
 
 
 def _resolve_editable_document(root: Path, document_id: str) -> dict[str, Any]:
@@ -217,6 +250,7 @@ def _resolve_editable_document(root: Path, document_id: str) -> dict[str, Any]:
         "label": label,
         "path": path,
         "change_path": change_path,
+        "editable": True,
     }
 
 
@@ -228,6 +262,7 @@ def _document_payload(root: Path, document: dict[str, Any], content: str) -> dic
         "path": _relative_path(root, document["path"]),
         "content": content,
         "revision": _revision(content),
+        "editable": document["editable"],
     }
 
 

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -117,7 +117,15 @@ def test_document_dashboard_projects_docs_board_and_folder_lifecycle(tmp_path: P
     change_set = document_dashboard_state(tmp_path)["change_sets"][0]
 
     assert change_set["lifecycle"] == "completed"
-    assert change_set["documents"] == []
+    assert change_set["documents"] == [
+        {
+            "id": "change-set:CHG-001",
+            "kind": "change-set",
+            "label": "ChangeSet (Read only)",
+            "path": "docs/changes/completed/CHG-001.md",
+            "editable": False,
+        }
+    ]
     assert change_set["stages"][0]["id"] == "requirements-definition"
     work_item = change_set["work_items"][0]
     assert "docs/plans/completed/UC-001/plan.md" in {
@@ -230,8 +238,20 @@ def test_completed_change_set_documents_are_not_editable(tmp_path: Path) -> None
     _write_change_set(tmp_path, "completed")
     _write_documents(tmp_path)
 
+    loaded = read_dashboard_document(tmp_path, "change-set:CHG-001")
+
+    assert loaded["editable"] is False
+    assert loaded["path"] == "docs/changes/completed/CHG-001.md"
+    assert "# ChangeSet CHG-001" in loaded["content"]
     with pytest.raises(DashboardDocumentNotFound):
         read_dashboard_document(tmp_path, "requirements:CHG-001")
+    with pytest.raises(DashboardDocumentNotFound):
+        save_dashboard_document(
+            tmp_path,
+            "change-set:CHG-001",
+            content=loaded["content"],
+            revision=loaded["revision"],
+        )
 
 
 def test_ui_server_serves_dashboard_and_edit_api(tmp_path: Path) -> None:


### PR DESCRIPTION
## 구현 의도

완료된 ChangeSet도 대시보드에서 조회할 수 있도록 하되, 완료된 워크플로 기록은 변경되지 않도록 읽기 전용으로 노출합니다.

## 구현 접근 방식

- 대시보드 상태 생성 시 `docs/changes/completed/<CHG-ID>.md`를 읽기 전용 문서 항목으로 포함합니다.
- 문서 GET 경로는 완료된 ChangeSet 문서를 읽을 수 있게 확장하고, 응답에 `editable: false`를 전달합니다.
- 완료된 ChangeSet 문서 ID는 `CHG-*` 형식을 검증하여 문서 경로 밖의 값을 허용하지 않습니다.
- PUT 저장 경로는 기존 active ChangeSet 문서 해석만 사용하므로 완료된 ChangeSet에 대한 저장 요청을 거부합니다.
- 브라우저 UI는 `editable: false` 문서를 미리보기로 표시하고 Edit/Save 버튼을 렌더링하지 않습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` 실행: `7 passed`
- `./venv/bin/python3 -m pytest -q -s` 실행: `269 passed`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` 실행 성공
- `git diff --check` 실행 성공

## 위험 및 롤백

- 위험: 완료된 ChangeSet 목록에 읽기 전용 문서 버튼이 추가되므로 대시보드 표시 영역이 늘어납니다.
- 데이터 변경 위험은 낮습니다. 완료 문서 저장 API는 계속 거부됩니다.
- 롤백: 이 PR의 커밋을 되돌리면 완료 ChangeSet 문서 노출과 UI 읽기 전용 렌더링이 함께 제거됩니다.