### PR TITLE
[codex] 대시보드 실행 방법 README 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,24 @@ Start the local UI server:
 ./harness ui-server
 ```
 
+Open the workflow dashboard in a browser:
+
+```text
+http://127.0.0.1:8765/dashboard
+```
+
+The dashboard shows active and completed ChangeSets. Documents associated with an active
+ChangeSet can be edited from the dashboard. Completed ChangeSets are available for
+read-only review.
+
+Use a different bind address or port when needed:
+
+```bash
+./harness ui-server --host 127.0.0.1 --port 9000
+```
+
+Then open `http://127.0.0.1:9000/dashboard`.
+
 ## Shell Completion
 
 Generate shell completion from the installed runtime:


### PR DESCRIPTION
## 구현 의도

로컬 워크플로 대시보드를 실행하고 접속하는 방법을 README에서 바로 확인할 수 있도록 문서화합니다.

## 구현 접근 방식

- `README.md`의 런타임 유틸리티 안내에 `./harness ui-server` 실행 후 접속할 `/dashboard` URL을 추가합니다.
- 기본 주소/포트와 `--host`, `--port`를 사용한 변경 예시를 기록합니다.
- 활성 ChangeSet 문서는 편집 가능하고 완료된 ChangeSet은 읽기 전용으로 확인된다는 대시보드 동작을 명시합니다.

## 검증 방법

- `git diff --check origin/main...HEAD` 실행 성공
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` 실행: `7 passed`

## 위험 및 롤백

- 문서만 변경하므로 런타임 동작 위험은 없습니다.
- 롤백이 필요하면 이 문서 커밋을 되돌려 실행 안내를 제거할 수 있습니다.