### PR TITLE
[codex] 마크다운 미리보기 표 렌더링 지원

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -49,5 +49,10 @@ button { border: 1px solid var(--line); border-radius: 7px; cursor: pointer; pad
 .primary { background: var(--accent); border-color: var(--accent); color: white; }
 textarea { border: 1px solid var(--line); border-radius: 7px; font: 13px/1.48 "SFMono-Regular", Consolas, monospace; min-height: 420px; padding: 12px; resize: vertical; width: 100%; }
 .markdown-preview { background: #fbfbf7; border-radius: 8px; padding: 15px; white-space: pre-wrap; }
+.markdown-table { margin: 12px 0; overflow-x: auto; white-space: normal; }
+.markdown-table table { border-collapse: collapse; min-width: 100%; }
+.markdown-table th, .markdown-table td { border: 1px solid var(--line); padding: 7px 10px; text-align: left; vertical-align: top; }
+.markdown-table th { background: #eef1e8; font-weight: 600; }
+.markdown-table tbody tr:nth-child(even) { background: #f6f7f1; }
 .error { color: #9c2d20; }
 details { margin-top: 10px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -12,10 +12,73 @@ const escapeHtml = (value) => String(value ?? "")
   .replaceAll('"', "&quot;");
 
 function markdownPreview(content) {
-  return escapeHtml(content)
-    .replace(/^### (.+)$/gm, "<h4>$1</h4>")
-    .replace(/^## (.+)$/gm, "<h3>$1</h3>")
-    .replace(/^# (.+)$/gm, "<h2>$1</h2>");
+  const lines = String(content ?? "").split(/\r?\n/);
+  const html = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = renderHeading(lines[index]);
+    if (heading) {
+      html.push(heading);
+      continue;
+    }
+    const headers = splitTableRow(lines[index]);
+    if (headers && isTableDivider(lines[index + 1], headers.length)) {
+      const rows = [];
+      index += 2;
+      while (index < lines.length) {
+        const cells = splitTableRow(lines[index]);
+        if (!cells || cells.length !== headers.length) break;
+        rows.push(cells);
+        index += 1;
+      }
+      index -= 1;
+      html.push(renderTable(headers, rows));
+      continue;
+    }
+    html.push(escapeHtml(lines[index]));
+  }
+  return html.join("\n");
+}
+
+function renderHeading(line) {
+  const heading = line.match(/^(#{1,3}) (.+)$/);
+  if (!heading) return "";
+  const level = Number(heading[1].length) + 1;
+  return `<h${level}>${escapeHtml(heading[2])}</h${level}>`;
+}
+
+function splitTableRow(line) {
+  if (typeof line !== "string" || !line.includes("|")) return null;
+  let value = line.trim();
+  if (value.startsWith("|")) value = value.slice(1);
+  if (value.endsWith("|") && !value.endsWith("\\|")) value = value.slice(0, -1);
+  const cells = [];
+  let cell = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "\\" && value[index + 1] === "|") {
+      cell += "|";
+      index += 1;
+    } else if (character === "|") {
+      cells.push(cell.trim());
+      cell = "";
+    } else {
+      cell += character;
+    }
+  }
+  cells.push(cell.trim());
+  return cells.length > 1 ? cells : null;
+}
+
+function isTableDivider(line, columnCount) {
+  const cells = splitTableRow(line);
+  return cells?.length === columnCount
+    && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function renderTable(headers, rows) {
+  const head = headers.map((cell) => `<th>${escapeHtml(cell)}</th>`).join("");
+  const body = rows.map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join("")}</tr>`).join("");
+  return `<div class="markdown-table"><table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>`;
 }
 
 async function loadDashboard() {


### PR DESCRIPTION
## 구현 의도

대시보드 문서 미리보기에서 Markdown 표가 원문 텍스트로 보이는 문제를 해결하고, ChangeSet 표를 읽을 수 있는 표 형태로 표시합니다.

## 구현 접근 방식

- Markdown 미리보기 렌더러가 파이프 표의 헤더 행, 구분 행, 본문 행을 감지해 `<table>` 구조로 출력하도록 확장합니다.
- 셀 내 이스케이프된 파이프(`\|`)를 데이터로 처리하고, 모든 셀 콘텐츠는 기존과 같이 HTML 이스케이프하여 미리보기 삽입 시 스크립트/마크업 실행을 막습니다.
- 표를 읽기 쉽도록 테두리, 헤더 배경, 교차 행 배경, 가로 스크롤 스타일을 추가합니다.

## 검증 방법

- Node 기반 렌더링 확인으로 표 HTML 생성, 이스케이프된 파이프 처리, HTML 이스케이프 처리를 검증했습니다.
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` 실행 성공
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` 실행: `7 passed`
- `./venv/bin/python3 -m pytest -q -s` 실행: `269 passed`
- `git diff --check` 실행 성공

## 위험 및 롤백

- 위험: 파이프와 구분 행 형식을 갖춘 일반 텍스트 블록은 Markdown 표로 표시됩니다. 이는 GFM 표 표기와 일치하는 동작입니다.
- 데이터 변경 위험은 없습니다. 브라우저 미리보기 렌더링만 변경합니다.
- 롤백: 이 커밋을 되돌리면 기존 텍스트 기반 미리보기 동작으로 복구됩니다.