### PR TITLE
[codex] add dashboard requirements flow and active ChangeSet deletion

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -16,15 +16,22 @@
 * { box-sizing: border-box; }
 body { margin: 0; color: var(--ink); background: var(--surface); font: 14px/1.45 Inter, Arial, sans-serif; }
 .masthead { display: flex; justify-content: space-between; align-items: end; padding: 28px 36px 20px; border-bottom: 1px solid var(--line); }
+.toolbar { align-items: center; display: flex; gap: 10px; }
+.toolbar #refresh-status { margin-left: 12px; }
 .eyebrow { margin: 0 0 5px; color: var(--muted); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; }
 h1, h2, h3, p { margin-top: 0; }
 h1 { margin-bottom: 0; font-size: 31px; }
 #refresh-status { color: var(--muted); margin: 0; }
 .layout { display: grid; grid-template-columns: 280px minmax(600px, 1fr); min-height: calc(100vh - 100px); }
+.layout.workflow-layout { display: block; }
+.layout.workflow-layout .sidebar { display: none; }
+.layout.workflow-layout .detail { margin: 0 auto; max-width: 1080px; }
 .sidebar { border-right: 1px solid var(--line); padding: 26px 20px; }
 .detail { padding: 27px 34px; max-width: 1240px; }
 .change-button { background: transparent; border: 1px solid var(--line); border-radius: 10px; display: block; margin-bottom: 10px; padding: 12px; text-align: left; width: 100%; }
 .change-button.selected { background: var(--active); border-color: #acc4b0; }
+.change-heading { align-items: start; display: flex; gap: 16px; justify-content: space-between; }
+.change-heading h2 { margin: 8px 0 0; }
 .pill { border-radius: 14px; display: inline-block; font-size: 11px; padding: 2px 9px; text-transform: uppercase; }
 .pill.active { background: var(--active); }
 .pill.completed { background: #e3e5e0; }
@@ -46,7 +53,9 @@ h1 { margin-bottom: 0; font-size: 31px; }
 .sticky-type { color: #455148; font-size: 10px; text-transform: uppercase; }
 .doc-actions { display: flex; gap: 8px; margin-bottom: 13px; }
 button { border: 1px solid var(--line); border-radius: 7px; cursor: pointer; padding: 7px 12px; }
+button:disabled { cursor: progress; opacity: .65; }
 .primary { background: var(--accent); border-color: var(--accent); color: white; }
+.danger { background: #fff3f0; border-color: #e5aaa0; color: #8d291c; }
 textarea { border: 1px solid var(--line); border-radius: 7px; font: 13px/1.48 "SFMono-Regular", Consolas, monospace; min-height: 420px; padding: 12px; resize: vertical; width: 100%; }
 .markdown-preview { background: #fbfbf7; border-radius: 8px; padding: 15px; white-space: pre-wrap; }
 .markdown-table { margin: 12px 0; overflow-x: auto; white-space: normal; }
@@ -56,3 +65,18 @@ textarea { border: 1px solid var(--line); border-radius: 7px; font: 13px/1.48 "S
 .markdown-table tbody tr:nth-child(even) { background: #f6f7f1; }
 .error { color: #9c2d20; }
 details { margin-top: 10px; }
+.workflow-page { margin: 0 auto; max-width: 1000px; }
+.workflow-page > h2 { font-size: 30px; margin-bottom: 10px; }
+.lead { color: var(--muted); font-size: 15px; }
+.prompt-form, .grill-form { display: grid; gap: 12px; }
+.prompt-form { max-width: 760px; padding: 24px; }
+.prompt-form label, .grill-form label { color: var(--muted); font-size: 12px; font-weight: 600; text-transform: uppercase; }
+.prompt-form textarea { min-height: 220px; }
+.prompt-form button, .grill-form button { justify-self: start; }
+.workspace-heading { align-items: end; display: flex; justify-content: space-between; margin-bottom: 18px; }
+.requirements-document .markdown-preview { max-height: 460px; overflow-y: auto; }
+.grill-panel { margin-top: 24px; position: sticky; bottom: 14px; box-shadow: 0 -4px 18px rgba(25,34,28,.06); }
+.question { font-size: 17px; font-weight: 600; margin-bottom: 0; }
+.recommended { background: #eef1e8; border-radius: 8px; color: var(--muted); padding: 10px 12px; }
+.grill-form textarea { min-height: 82px; }
+.completion { background: var(--active); border-radius: 8px; color: var(--accent); padding: 13px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.html
+++ b/harness_codex/runtime/dashboard_assets/dashboard.html
@@ -12,7 +12,11 @@
         <p class="eyebrow">Harness workflow</p>
         <h1>Document Dashboard</h1>
       </div>
-      <p id="refresh-status">Loading workflow data...</p>
+      <div class="toolbar">
+        <button id="dashboard-home">Dashboard</button>
+        <button id="new-change-set" class="primary">New ChangeSet</button>
+        <p id="refresh-status">Loading workflow data...</p>
+      </div>
     </header>
     <main class="layout">
       <aside class="sidebar">

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -3,6 +3,10 @@ const app = {
   selectedChangeSet: null,
   openDocument: null,
   editorMode: "preview",
+  view: "dashboard",
+  harvest: null,
+  requirementsChangeSet: null,
+  error: "",
 };
 
 const escapeHtml = (value) => String(value ?? "")
@@ -94,6 +98,7 @@ async function loadDashboard() {
 function render() {
   const changes = app.state.change_sets;
   const selected = changes.find((item) => item.id === app.selectedChangeSet) || changes[0];
+  document.querySelector(".layout").classList.toggle("workflow-layout", app.view !== "dashboard");
   document.querySelector("#change-sets").innerHTML = changes.map((item) => `
     <button class="change-button ${selected?.id === item.id ? "selected" : ""}" data-change="${escapeHtml(item.id)}">
       <span class="pill ${item.lifecycle}">${escapeHtml(item.lifecycle)}</span>
@@ -103,10 +108,116 @@ function render() {
   document.querySelectorAll("[data-change]").forEach((node) => node.onclick = () => {
     app.selectedChangeSet = node.dataset.change;
     app.openDocument = null;
+    app.view = "dashboard";
     render();
   });
-  document.querySelector("#detail").innerHTML = selected ? renderDetail(selected) : "<p>No ChangeSets found.</p>";
+  const detail = document.querySelector("#detail");
+  if (app.view === "new") {
+    detail.innerHTML = renderNewChangeSet();
+    document.querySelector("#initial-prompt-form").onsubmit = submitInitialPrompt;
+    return;
+  }
+  if (app.view === "requirements") {
+    detail.innerHTML = renderRequirementsWorkspace();
+    renderEditor();
+    const form = document.querySelector("#grill-form");
+    if (form) form.onsubmit = submitRequirementAnswer;
+    return;
+  }
+  detail.innerHTML = selected ? renderDetail(selected) : "<p>No ChangeSets found.</p>";
   bindDetail(selected);
+}
+
+function renderNewChangeSet() {
+  return `<section class="workflow-page">
+    <p class="eyebrow">New ChangeSet</p>
+    <h2>Requirements Definition</h2>
+    <p class="lead">Describe initial product change. Runtime starts requirements clarification only.</p>
+    <form id="initial-prompt-form" class="panel prompt-form">
+      <label for="initial-prompt">Initial prompt</label>
+      <textarea id="initial-prompt" placeholder="Describe one product or feature idea..." required></textarea>
+      ${app.error ? `<p class="error">${escapeHtml(app.error)}</p>` : ""}
+      <button class="primary" type="submit">Start requirements definition</button>
+    </form>
+  </section>`;
+}
+
+async function submitInitialPrompt(event) {
+  event.preventDefault();
+  const prompt = document.querySelector("#initial-prompt").value.trim();
+  const button = event.target.querySelector("button");
+  if (!prompt) return;
+  button.disabled = true;
+  button.textContent = "Starting...";
+  app.error = "";
+  try {
+    const response = await fetch("/api/change-sets/requirements/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Unable to start requirements definition.");
+    app.requirementsChangeSet = result.change_set_id;
+    app.selectedChangeSet = result.change_set_id;
+    app.harvest = result.harvest;
+    app.view = "requirements";
+    await loadDashboard();
+    await openRequirementsDocument();
+    render();
+  } catch (error) {
+    app.error = error.message;
+    render();
+  }
+}
+
+function renderRequirementsWorkspace() {
+  const question = app.harvest?.current_question;
+  const questionPanel = app.harvest?.requirements_gate_passed
+    ? '<p class="completion">Requirements clarification complete.</p>'
+    : question
+      ? `<form id="grill-form" class="grill-form">
+          <p class="question">${escapeHtml(question.question)}</p>
+          ${question.recommended ? `<p class="recommended">Recommended answer: ${escapeHtml(question.recommended)}</p>` : ""}
+          <label for="grill-answer">Your answer</label>
+          <textarea id="grill-answer" required></textarea>
+          <button class="primary" type="submit">Submit answer</button>
+        </form>`
+      : "<p>No current question.</p>";
+  return `<section class="workflow-page">
+    <div class="workspace-heading"><div><p class="eyebrow">Requirements Definition</p><h2>${escapeHtml(app.requirementsChangeSet)}</h2></div></div>
+    <section class="panel requirements-document"><h3>Requirements</h3><div id="editor"></div></section>
+    <section class="panel grill-panel"><h3>Grill-Me Questions</h3>${questionPanel}</section>
+  </section>`;
+}
+
+async function openRequirementsDocument() {
+  const id = `requirements:${app.requirementsChangeSet}`;
+  const response = await fetch(`/api/dashboard/documents/${encodeURIComponent(id)}`);
+  const result = await response.json();
+  if (!response.ok) throw new Error(result.error || "Requirements document unavailable.");
+  app.openDocument = result;
+  app.editorMode = "preview";
+}
+
+async function submitRequirementAnswer(event) {
+  event.preventDefault();
+  const answer = document.querySelector("#grill-answer").value.trim();
+  if (!answer) return;
+  try {
+    const response = await fetch("/api/change-sets/requirements/answer", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ change_set_id: app.requirementsChangeSet, answer }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Unable to submit answer.");
+    app.harvest = result.harvest;
+    await openRequirementsDocument();
+    render();
+  } catch (error) {
+    document.querySelector(".grill-panel").insertAdjacentHTML("beforeend", `<p class="error">${escapeHtml(error.message)}</p>`);
+  }
 }
 
 function renderDetail(change) {
@@ -126,8 +237,11 @@ function renderDetail(change) {
     <button data-document="${escapeHtml(document.id)}">${escapeHtml(document.label)}</button>`).join("");
   const runs = change.run_history.map((run) => `<li>${escapeHtml(run.run_id)}: ${escapeHtml(run.status)}</li>`).join("");
   return `
-    <span class="pill ${change.lifecycle}">${escapeHtml(change.lifecycle)}</span>
-    <h2>${escapeHtml(change.id)} ${escapeHtml(change.title)}</h2>
+    <div class="change-heading">
+      <div><span class="pill ${change.lifecycle}">${escapeHtml(change.lifecycle)}</span>
+      <h2>${escapeHtml(change.id)} ${escapeHtml(change.title)}</h2></div>
+      ${change.lifecycle === "active" ? '<button class="danger" data-delete-change-set>Delete active ChangeSet</button>' : ""}
+    </div>
     <p>${escapeHtml(change.intent)}</p>
     <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div></section>
     ${documents ? `<section class="panel"><h3>Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
@@ -148,9 +262,24 @@ function renderBoard(board) {
 
 function bindDetail(change) {
   document.querySelectorAll("[data-document]").forEach((node) => node.onclick = () => openDocument(node.dataset.document));
+  const deleteButton = document.querySelector("[data-delete-change-set]");
+  if (deleteButton) deleteButton.onclick = () => deleteActiveChangeSet(change);
   if (app.openDocument && change.documents.some((item) => item.id === app.openDocument.id)) {
     renderEditor();
   }
+}
+
+async function deleteActiveChangeSet(change) {
+  if (!window.confirm(`Delete active ChangeSet ${change.id}? Generated documents are preserved.`)) return;
+  const response = await fetch(`/api/dashboard/change-sets/${encodeURIComponent(change.id)}`, { method: "DELETE" });
+  const result = await response.json();
+  if (!response.ok) {
+    document.querySelector("#detail").insertAdjacentHTML("afterbegin", `<p class="error">${escapeHtml(result.error)}</p>`);
+    return;
+  }
+  app.selectedChangeSet = null;
+  app.openDocument = null;
+  await loadDashboard();
 }
 
 async function openDocument(id) {
@@ -202,4 +331,17 @@ async function saveDocument() {
 loadDashboard().catch((error) => {
   document.querySelector("#refresh-status").textContent = error.message;
 });
-setInterval(() => loadDashboard().catch(() => {}), 5000);
+document.querySelector("#new-change-set").onclick = () => {
+  app.view = "new";
+  app.openDocument = null;
+  app.error = "";
+  render();
+};
+document.querySelector("#dashboard-home").onclick = () => {
+  app.view = "dashboard";
+  app.openDocument = null;
+  render();
+};
+setInterval(() => {
+  if (app.view === "dashboard") loadDashboard().catch(() => {});
+}, 5000);

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -29,6 +29,10 @@ class DashboardDocumentValidationError(DashboardDocumentError):
     """Raised when edited Markdown would break workflow parsing."""
 
 
+class DashboardChangeSetNotFound(DashboardDocumentError):
+    """Raised when one active ChangeSet cannot be deleted."""
+
+
 def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
     """Project docs and runtime history into browser dashboard data."""
 
@@ -67,6 +71,19 @@ def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
                 }
             )
     return {"change_sets": change_sets}
+
+
+def delete_active_changeset(repo_root: Path | str, change_set_id: str) -> dict[str, str]:
+    """Delete one selected active ChangeSet; preserve separately managed artifacts."""
+
+    root = Path(repo_root)
+    if not re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id):
+        raise DashboardChangeSetNotFound("Unknown active ChangeSet.")
+    path = root / "docs/changes/active" / f"{change_set_id}.md"
+    if not path.exists():
+        raise DashboardChangeSetNotFound("Active ChangeSet does not exist.")
+    path.unlink()
+    return {"id": change_set_id, "deleted_path": _relative_path(root, path)}
 
 
 def read_dashboard_document(repo_root: Path | str, document_id: str) -> dict[str, Any]:

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -6,7 +6,7 @@ import json
 import re
 import subprocess
 import tomllib
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -39,6 +39,9 @@ class HarvestUiResult:
     use_cases_ready: bool
     runtime_error: str
     workflow: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 def start_requirements(root: Path | str, prompt: str) -> HarvestUiResult:

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -11,10 +12,12 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from harness_codex.runtime.document_dashboard import (
+    DashboardChangeSetNotFound,
     DashboardDocumentConflict,
     DashboardDocumentNotFound,
     DashboardDocumentValidationError,
     document_dashboard_state,
+    delete_active_changeset,
     read_dashboard_document,
     save_dashboard_document,
 )
@@ -26,6 +29,41 @@ from harness_codex.runtime.harvest_ui import (
     start_use_case_generation,
     start_use_cases,
 )
+from harness_codex.runtime.procedure_stages import render_initial_changeset
+
+
+def _suggest_change_set_id(repo_root: Path) -> str:
+    date = datetime.now().strftime("%Y%m%d")
+    sequence = 1
+    for directory in (repo_root / "docs/changes/active", repo_root / "docs/changes/completed"):
+        if not directory.exists():
+            continue
+        for path in directory.glob(f"CHG-{date}-*.md"):
+            try:
+                sequence = max(sequence, int(path.stem.rsplit("-", maxsplit=1)[1]) + 1)
+            except (IndexError, ValueError):
+                continue
+    return f"CHG-{date}-{sequence:03d}"
+
+
+def start_requirements_changeset(repo_root: Path | str, prompt: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    normalized_prompt = prompt.strip()
+    if not normalized_prompt:
+        raise ValueError("initial prompt is required")
+    result = start_requirements(root, normalized_prompt)
+    change_set_id = _suggest_change_set_id(root)
+    path = root / "docs/changes/active" / f"{change_set_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        render_initial_changeset(
+            change_set_id=change_set_id,
+            title=normalized_prompt.splitlines()[0][:80],
+            request_summary=normalized_prompt,
+        ),
+        encoding="utf-8",
+    )
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
 
 
 def run_ui_server(
@@ -62,6 +100,7 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
                 self._write_json(HTTPStatus.NOT_FOUND, {"error": str(exc)})
             return
         asset = {
+            "/": ("dashboard.html", "text/html; charset=utf-8"),
             "/dashboard": ("dashboard.html", "text/html; charset=utf-8"),
             "/assets/dashboard.css": ("dashboard.css", "text/css; charset=utf-8"),
             "/assets/dashboard.js": ("dashboard.js", "text/javascript; charset=utf-8"),
@@ -75,6 +114,19 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
         try:
             body = self._read_body()
             path = self._path()
+            if path == "/api/change-sets/requirements/start":
+                self._write_json(
+                    HTTPStatus.OK,
+                    start_requirements_changeset(self.repo_root, str(body.get("prompt", ""))),
+                )
+                return
+            if path == "/api/change-sets/requirements/answer":
+                result = answer_requirements(self.repo_root, str(body.get("answer", "")))
+                self._write_json(
+                    HTTPStatus.OK,
+                    {"change_set_id": str(body.get("change_set_id", "")), "harvest": result.as_dict()},
+                )
+                return
             if path == "/api/requirements/start":
                 result = start_requirements(self.repo_root, str(body.get("prompt", "")))
             elif path == "/api/requirements/answer":
@@ -116,6 +168,19 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
             return
         except DashboardDocumentValidationError as exc:
             self._write_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        self._write_json(HTTPStatus.OK, result)
+
+    def do_DELETE(self) -> None:
+        path = self._path()
+        if not path.startswith("/api/dashboard/change-sets/"):
+            self._write_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+        change_set_id = unquote(path.removeprefix("/api/dashboard/change-sets/"))
+        try:
+            result = delete_active_changeset(self.repo_root, change_set_id)
+        except DashboardChangeSetNotFound as exc:
+            self._write_json(HTTPStatus.NOT_FOUND, {"error": str(exc)})
             return
         self._write_json(HTTPStatus.OK, result)
 

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -8,14 +8,16 @@ from urllib.request import Request, urlopen
 
 import pytest
 
-from harness_codex.runtime import document_dashboard
+from harness_codex.runtime import document_dashboard, ui_server
 from harness_codex.runtime.changes.models import WorkItemType
 from harness_codex.runtime.dashboard import DashboardRun, DashboardWorkItem
 from harness_codex.runtime.document_dashboard import (
+    DashboardChangeSetNotFound,
     DashboardDocumentConflict,
     DashboardDocumentNotFound,
     DashboardDocumentValidationError,
     document_dashboard_state,
+    delete_active_changeset,
     read_dashboard_document,
     save_dashboard_document,
 )
@@ -294,6 +296,84 @@ def test_ui_server_serves_dashboard_and_edit_api(tmp_path: Path) -> None:
             refreshed = json.loads(response.read().decode("utf-8"))
         statuses = {stage["id"]: stage["status"] for stage in refreshed["change_sets"][0]["stages"]}
         assert statuses["use-case-definition"] == "stale"
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Path) -> None:
+    class Handler(HarvestUiRequestHandler):
+        repo_root = tmp_path
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        with urlopen(f"{base}/") as response:
+            html = response.read().decode("utf-8")
+        assert "New ChangeSet" in html
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def test_start_requirements_changeset_serializes_harvest_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = type(
+        "HarvestResult",
+        (),
+        {"as_dict": lambda self: {"status": "requirements_running", "current_question": {"question": "Who?"}}},
+    )()
+    monkeypatch.setattr(ui_server, "start_requirements", lambda _root, _prompt: result)
+    monkeypatch.setattr(ui_server, "_suggest_change_set_id", lambda _root: "CHG-20260526-099")
+
+    payload = ui_server.start_requirements_changeset(tmp_path, "Build note capture")
+
+    assert payload["harvest"]["status"] == "requirements_running"
+    assert payload["change_set_id"] == "CHG-20260526-099"
+    assert (tmp_path / "docs/changes/active/CHG-20260526-099.md").exists()
+
+
+def test_delete_active_changeset_removes_only_selected_active_file(tmp_path: Path) -> None:
+    active_path = _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    completed_path = _write_change_set(tmp_path, "completed")
+
+    payload = delete_active_changeset(tmp_path, "CHG-001")
+
+    assert payload["id"] == "CHG-001"
+    assert not active_path.exists()
+    assert completed_path.exists()
+    assert (tmp_path / "docs/design/요구사항.md").exists()
+
+
+def test_delete_active_changeset_rejects_completed_changeset(tmp_path: Path) -> None:
+    completed_path = _write_change_set(tmp_path, "completed")
+
+    with pytest.raises(DashboardChangeSetNotFound, match="Active ChangeSet does not exist."):
+        delete_active_changeset(tmp_path, "CHG-001")
+
+    assert completed_path.exists()
+
+
+def test_ui_server_deletes_selected_active_changeset(tmp_path: Path) -> None:
+    _write_change_set(tmp_path)
+
+    class Handler(HarvestUiRequestHandler):
+        repo_root = tmp_path
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        request = Request(f"{base}/api/dashboard/change-sets/CHG-001", method="DELETE")
+        with urlopen(request) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["id"] == "CHG-001"
+        assert not (tmp_path / "docs/changes/active/CHG-001.md").exists()
     finally:
         server.shutdown()
         thread.join()


### PR DESCRIPTION
## Implementation intent
- Connect the document dashboard to the initial `requirements-definition` interaction flow.
- Allow users to delete one abandoned active ChangeSet from the dashboard.
- Fix the response serialization failure that caused prompt submission to surface `Failed to fetch`.

Closes #201

## Implementation approach
- Add a `New ChangeSet` toolbar action. Initial prompt submission starts the existing requirements harvest runtime, creates the active ChangeSet document, then opens a requirements workspace.
- Reuse dashboard Markdown preview/editor UI in the requirements workspace. Grill-Me answers post to the runtime endpoint; after each answer, the UI reloads the requirements document so generated changes appear in preview.
- Add `HarvestUiResult.as_dict()` so HTTP handlers serialize runtime results instead of crashing after runtime work finishes.
- Add scoped active deletion: `DELETE /api/dashboard/change-sets/<CHG-ID>` removes only `docs/changes/active/<CHG-ID>.md`; dashboard exposes it only for active entries and asks for confirmation.

## Verification method
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py tests/runtime/test_harvest_ui.py tests/runtime/test_procedure_stage_runtime.py` -> `39 passed`.
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> passed.
- `git diff --check` -> passed.

## Risks and rollback
- Deleting an active ChangeSet intentionally preserves generated requirements/use-case/plan artifacts because cleanup ownership is not defined in this slice; those artifacts can remain after deletion.
- Requirements prompt processing remains synchronous while the runtime asks the next question, so long agent response times still hold the HTTP request open.
- Rollback by reverting this PR; no schema or irreversible migration is introduced.