### PR TITLE
[codex] 중단된 활성 ChangeSet 워크플로우 재개 지원

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -7,6 +7,7 @@ const app = {
   harvest: null,
   requirementsChangeSet: null,
   stageTab: "requirements",
+  workflowRecovered: false,
   busy: false,
   busyLabel: "",
   error: "",
@@ -111,6 +112,7 @@ function render() {
   document.querySelectorAll("[data-change]").forEach((node) => node.onclick = () => {
     app.selectedChangeSet = node.dataset.change;
     app.openDocument = null;
+    app.error = "";
     app.view = "dashboard";
     render();
   });
@@ -175,6 +177,7 @@ async function submitInitialPrompt(event) {
     app.requirementsChangeSet = result.change_set_id;
     app.selectedChangeSet = result.change_set_id;
     app.harvest = result.harvest;
+    app.workflowRecovered = false;
     app.view = "requirements";
     app.stageTab = "requirements";
     await loadDashboard();
@@ -293,6 +296,7 @@ async function submitRequirementAnswer(event) {
     const result = await response.json();
     if (!response.ok) throw new Error(result.error || "Unable to submit answer.");
     app.harvest = result.harvest;
+    app.workflowRecovered = false;
     await openRequirementsDocument();
     app.busy = false;
     app.busyLabel = "";
@@ -308,7 +312,10 @@ async function submitRequirementAnswer(event) {
 async function selectStageTab(tab) {
   if (tab === "useCases" && !app.harvest?.requirements_gate_passed) return;
   app.stageTab = tab;
-  if (tab === "requirements") await openRequirementsDocument();
+  if (tab === "requirements") {
+    if (app.workflowRecovered) setRecoveredRequirementsDocument();
+    else await openRequirementsDocument();
+  }
   render();
 }
 
@@ -321,11 +328,12 @@ async function startUseCaseDefinition() {
     const response = await fetch("/api/use-cases/start", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ idea: app.harvest?.initial_prompt || "" }),
+      body: JSON.stringify({ change_set_id: app.requirementsChangeSet, idea: app.harvest?.initial_prompt || "" }),
     });
     const result = await response.json();
     if (!response.ok) throw new Error(result.error || "Unable to start use case definition.");
-    app.harvest = result;
+    app.harvest = result.harvest;
+    app.workflowRecovered = false;
     app.busy = false;
     app.busyLabel = "";
     render();
@@ -348,11 +356,12 @@ async function submitUseCaseAnswer(event) {
     const response = await fetch("/api/use-cases/answer", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ answer, idea: app.harvest?.initial_prompt || "" }),
+      body: JSON.stringify({ change_set_id: app.requirementsChangeSet, answer, idea: app.harvest?.initial_prompt || "" }),
     });
     const result = await response.json();
     if (!response.ok) throw new Error(result.error || "Unable to submit use case answer.");
-    app.harvest = result;
+    app.harvest = result.harvest;
+    app.workflowRecovered = false;
     app.busy = false;
     app.busyLabel = "";
     render();
@@ -381,6 +390,7 @@ function renderDetail(change) {
     <button data-document="${escapeHtml(document.id)}">${escapeHtml(document.label)}</button>`).join("");
   const runs = change.run_history.map((run) => `<li>${escapeHtml(run.run_id)}: ${escapeHtml(run.status)}</li>`).join("");
   return `
+    ${app.error ? `<p class="error">${escapeHtml(app.error)}</p>` : ""}
     <div class="change-heading">
       <div><span class="pill ${change.lifecycle}">${escapeHtml(change.lifecycle)}</span>
       <h2>${escapeHtml(change.id)} ${escapeHtml(change.title)}</h2></div>
@@ -388,7 +398,7 @@ function renderDetail(change) {
     </div>
     <p>${escapeHtml(change.intent)}</p>
     ${change.lifecycle === "active" ? `<div class="stage-tabs dashboard-tabs">
-      <button data-open-workflow="requirements" class="stage-tab"><span class="progress-dot"></span>Open Requirements Results</button>
+      <button data-resume-workflow class="stage-tab"><span class="progress-dot"></span>Resume Workflow</button>
     </div>` : ""}
     <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div></section>
     ${documents ? `<section class="panel"><h3>Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
@@ -411,23 +421,39 @@ function bindDetail(change) {
   document.querySelectorAll("[data-document]").forEach((node) => node.onclick = () => openDocument(node.dataset.document));
   const deleteButton = document.querySelector("[data-delete-change-set]");
   if (deleteButton) deleteButton.onclick = () => deleteActiveChangeSet(change);
-  const openWorkflow = document.querySelector("[data-open-workflow]");
-  if (openWorkflow) openWorkflow.onclick = () => loadWorkflowResults(change.id);
+  const resumeWorkflow = document.querySelector("[data-resume-workflow]");
+  if (resumeWorkflow) resumeWorkflow.onclick = () => loadWorkflowResults(change.id);
   if (app.openDocument && change.documents.some((item) => item.id === app.openDocument.id)) {
     renderEditor();
   }
 }
 
 async function loadWorkflowResults(changeSetId) {
-  const response = await fetch("/api/harvest");
+  const response = await fetch(`/api/dashboard/change-sets/${encodeURIComponent(changeSetId)}/resume`);
   const result = await response.json();
-  if (!response.ok) return;
+  if (!response.ok) {
+    app.error = result.error || "Unable to resume workflow.";
+    render();
+    return;
+  }
   app.requirementsChangeSet = changeSetId;
-  app.harvest = result;
-  app.stageTab = "requirements";
+  app.harvest = result.harvest;
+  app.stageTab = result.harvest.active_stage === "useCases" ? "useCases" : "requirements";
+  app.workflowRecovered = true;
   app.view = "requirements";
-  await openRequirementsDocument();
+  setRecoveredRequirementsDocument();
+  app.error = "";
   render();
+}
+
+function setRecoveredRequirementsDocument() {
+  app.openDocument = {
+    id: `requirements:${app.requirementsChangeSet}`,
+    label: "Requirements",
+    content: app.harvest?.requirements_markdown || "",
+    editable: false,
+  };
+  app.editorMode = "preview";
 }
 
 async function deleteActiveChangeSet(change) {

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import subprocess
 import tomllib
 from dataclasses import asdict, dataclass
@@ -15,6 +16,7 @@ from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind
 from harness_codex.runtime.prompt import build_agent_prompt
 
 SESSION_PATH = Path(".harness/ui/harvest-session.json")
+CHANGESET_SESSION_ROOT = Path(".harness/ui/change-sets")
 REQUIREMENTS_PATH = Path("docs/design/요구사항.md")
 CONTEXT_PATH = Path("context.md")
 USE_CASES_PATH = Path("docs/design/유스케이스.md")
@@ -170,6 +172,66 @@ def load_harvest_ui(root: Path | str) -> HarvestUiResult:
         _sync_use_case_readiness(root_path, session)
         _resume_if_needed(root_path, session)
     return _result(root_path, session)
+
+
+def save_changeset_harvest_ui(root: Path | str, change_set_id: str) -> None:
+    root_path = Path(root)
+    _require_active_changeset(root_path, change_set_id)
+    session = _load_session(root_path)
+    if session is None:
+        raise ValueError("harvest session has not started")
+    scoped_root = _changeset_session_root(root_path, change_set_id)
+    scoped_root.mkdir(parents=True, exist_ok=True)
+    (scoped_root / "harvest-session.json").write_text(
+        json.dumps(session, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    for artifact in (REQUIREMENTS_PATH, CONTEXT_PATH):
+        _copy_optional_artifact(root_path / artifact, scoped_root / artifact)
+    use_cases_started = (
+        session.get("active_stage") == "useCases"
+        or session.get("use_cases_ready")
+        or session.get("use_case_current_question")
+        or session.get("use_case_clarifications")
+    )
+    if use_cases_started:
+        _copy_optional_artifact(root_path / USE_CASES_PATH, scoped_root / USE_CASES_PATH)
+        _copy_optional_tree(root_path / USE_CASE_SLICE_ROOT, scoped_root / USE_CASE_SLICE_ROOT)
+    else:
+        use_case_document = scoped_root / USE_CASES_PATH
+        if use_case_document.exists():
+            use_case_document.unlink()
+        use_case_slices = scoped_root / USE_CASE_SLICE_ROOT
+        if use_case_slices.exists():
+            shutil.rmtree(use_case_slices)
+
+
+def load_changeset_harvest_ui(root: Path | str, change_set_id: str) -> HarvestUiResult:
+    root_path = Path(root)
+    _require_active_changeset(root_path, change_set_id)
+    scoped_root = _changeset_session_root(root_path, change_set_id)
+    session_path = scoped_root / "harvest-session.json"
+    if not session_path.exists():
+        raise ValueError(f"Resume unavailable for {change_set_id}: no saved workflow state.")
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    _normalize_session(session)
+    _normalize_resumed_stage(session)
+    return _result(root_path, session, artifact_root=scoped_root)
+
+
+def activate_changeset_harvest_ui(root: Path | str, change_set_id: str) -> None:
+    root_path = Path(root)
+    load_changeset_harvest_ui(root_path, change_set_id)
+    scoped_root = _changeset_session_root(root_path, change_set_id)
+    session_path = scoped_root / "harvest-session.json"
+    _copy_optional_artifact(session_path, root_path / SESSION_PATH)
+    for artifact in (REQUIREMENTS_PATH, CONTEXT_PATH, USE_CASES_PATH):
+        _copy_optional_artifact(scoped_root / artifact, root_path / artifact)
+    _copy_optional_tree(
+        scoped_root / USE_CASE_SLICE_ROOT,
+        root_path / USE_CASE_SLICE_ROOT,
+        replace=False,
+    )
 
 
 def _new_session(prompt: str) -> dict[str, Any]:
@@ -358,13 +420,14 @@ def _write_session(root: Path, session: dict[str, Any]) -> None:
     )
 
 
-def _result(root: Path, session: dict[str, Any]) -> HarvestUiResult:
+def _result(root: Path, session: dict[str, Any], *, artifact_root: Path | None = None) -> HarvestUiResult:
+    documents_root = artifact_root or root
     session_started = bool(session["initial_prompt"])
     requirements_markdown = (
-        _read_optional(root / REQUIREMENTS_PATH) if session_started else ""
+        _read_optional(documents_root / REQUIREMENTS_PATH) if session_started else ""
     )
     use_cases_markdown = (
-        _read_optional(root / USE_CASES_PATH)
+        _read_optional(documents_root / USE_CASES_PATH)
         if session_started and session.get("use_cases_ready")
         else ""
     )
@@ -395,6 +458,49 @@ def _result(root: Path, session: dict[str, Any]) -> HarvestUiResult:
         runtime_error=str(session.get("runtime_error", "")),
         workflow=_workflow_projection(),
     )
+
+
+def _changeset_session_root(root: Path, change_set_id: str) -> Path:
+    if not re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id):
+        raise ValueError("invalid ChangeSet id")
+    return root / CHANGESET_SESSION_ROOT / change_set_id
+
+
+def _require_active_changeset(root: Path, change_set_id: str) -> None:
+    _changeset_session_root(root, change_set_id)
+    if not (root / "docs/changes/active" / f"{change_set_id}.md").exists():
+        raise ValueError(f"Active ChangeSet does not exist: {change_set_id}.")
+
+
+def _copy_optional_artifact(source: Path, target: Path) -> None:
+    if source.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+    elif target.exists():
+        target.unlink()
+
+
+def _copy_optional_tree(source: Path, target: Path, *, replace: bool = True) -> None:
+    if replace and target.exists():
+        shutil.rmtree(target)
+    if source.exists():
+        shutil.copytree(source, target, dirs_exist_ok=not replace)
+
+
+def _normalize_resumed_stage(session: dict[str, Any]) -> None:
+    if not session.get("requirements_gate_passed"):
+        session["active_stage"] = "requirements"
+        session["use_cases_ready"] = False
+        return
+    if (
+        session.get("use_cases_ready")
+        or session.get("use_case_current_question")
+        or session.get("use_case_clarifications")
+        or session.get("active_stage") == "useCases"
+    ):
+        session["active_stage"] = "useCases"
+    else:
+        session["active_stage"] = "requirements"
 
 
 def _current_question(session: dict[str, Any]) -> dict[str, Any] | None:

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -22,9 +22,12 @@ from harness_codex.runtime.document_dashboard import (
     save_dashboard_document,
 )
 from harness_codex.runtime.harvest_ui import (
+    activate_changeset_harvest_ui,
     answer_use_cases,
     answer_requirements,
+    load_changeset_harvest_ui,
     load_harvest_ui,
+    save_changeset_harvest_ui,
     start_requirements,
     start_use_case_generation,
     start_use_cases,
@@ -63,7 +66,44 @@ def start_requirements_changeset(repo_root: Path | str, prompt: str) -> dict[str
         ),
         encoding="utf-8",
     )
+    save_changeset_harvest_ui(root, change_set_id)
     return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def resume_changeset(repo_root: Path | str, change_set_id: str) -> dict[str, Any]:
+    result = load_changeset_harvest_ui(Path(repo_root).resolve(), change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def answer_requirements_changeset(repo_root: Path | str, change_set_id: str, answer: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    result = answer_requirements(root, answer)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def start_use_cases_changeset(repo_root: Path | str, change_set_id: str, idea: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    result = start_use_case_generation(root, idea)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def answer_use_cases_changeset(repo_root: Path | str, change_set_id: str, answer: str, idea: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    result = answer_use_cases(root, answer, idea)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def _required_change_set_id(body: dict[str, Any]) -> str:
+    change_set_id = str(body.get("change_set_id", "")).strip()
+    if not change_set_id:
+        raise ValueError("change_set_id is required")
+    return change_set_id
 
 
 def run_ui_server(
@@ -91,6 +131,13 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
             return
         if path == "/api/dashboard":
             self._write_json(HTTPStatus.OK, document_dashboard_state(self.repo_root))
+            return
+        if path.startswith("/api/dashboard/change-sets/") and path.endswith("/resume"):
+            change_set_id = unquote(path.removeprefix("/api/dashboard/change-sets/").removesuffix("/resume"))
+            try:
+                self._write_json(HTTPStatus.OK, resume_changeset(self.repo_root, change_set_id))
+            except ValueError as exc:
+                self._write_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
             return
         if path.startswith("/api/dashboard/documents/"):
             document_id = unquote(path.removeprefix("/api/dashboard/documents/"))
@@ -121,10 +168,13 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
                 )
                 return
             if path == "/api/change-sets/requirements/answer":
-                result = answer_requirements(self.repo_root, str(body.get("answer", "")))
                 self._write_json(
                     HTTPStatus.OK,
-                    {"change_set_id": str(body.get("change_set_id", "")), "harvest": result.as_dict()},
+                    answer_requirements_changeset(
+                        self.repo_root,
+                        _required_change_set_id(body),
+                        str(body.get("answer", "")),
+                    ),
                 )
                 return
             if path == "/api/requirements/start":
@@ -132,9 +182,22 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
             elif path == "/api/requirements/answer":
                 result = answer_requirements(self.repo_root, str(body.get("answer", "")))
             elif path == "/api/use-cases/start":
-                result = start_use_case_generation(self.repo_root, str(body.get("idea", "")))
+                payload = start_use_cases_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                    str(body.get("idea", "")),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
             elif path == "/api/use-cases/answer":
-                result = answer_use_cases(self.repo_root, str(body.get("answer", "")), str(body.get("idea", "")))
+                payload = answer_use_cases_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                    str(body.get("answer", "")),
+                    str(body.get("idea", "")),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
             elif path == "/api/use-cases/complete":
                 result = start_use_cases(self.repo_root)
             else:
@@ -169,6 +232,14 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
         except DashboardDocumentValidationError as exc:
             self._write_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
             return
+        if document_id.startswith("requirements:"):
+            change_set_id = document_id.removeprefix("requirements:")
+            try:
+                load_changeset_harvest_ui(self.repo_root, change_set_id)
+            except ValueError:
+                pass
+            else:
+                save_changeset_harvest_ui(self.repo_root, change_set_id)
         self._write_json(HTTPStatus.OK, result)
 
     def do_DELETE(self) -> None:

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -319,6 +319,8 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
             stylesheet = response.read().decode("utf-8")
         assert "New ChangeSet" in html
         assert '"/api/use-cases/start"' in javascript
+        assert "Resume Workflow" in javascript
+        assert "/resume" in javascript
         assert "Continue to Use Case Definition" in javascript
         assert "Continue to Event Storming (next slice)" in javascript
         assert "runtime-progress" in stylesheet
@@ -336,6 +338,7 @@ def test_start_requirements_changeset_serializes_harvest_result(tmp_path: Path, 
         {"as_dict": lambda self: {"status": "requirements_running", "current_question": {"question": "Who?"}}},
     )()
     monkeypatch.setattr(ui_server, "start_requirements", lambda _root, _prompt: result)
+    monkeypatch.setattr(ui_server, "save_changeset_harvest_ui", lambda _root, _change_set_id: None)
     monkeypatch.setattr(ui_server, "_suggest_change_set_id", lambda _root: "CHG-20260526-099")
 
     payload = ui_server.start_requirements_changeset(tmp_path, "Build note capture")
@@ -343,6 +346,40 @@ def test_start_requirements_changeset_serializes_harvest_result(tmp_path: Path, 
     assert payload["harvest"]["status"] == "requirements_running"
     assert payload["change_set_id"] == "CHG-20260526-099"
     assert (tmp_path / "docs/changes/active/CHG-20260526-099.md").exists()
+
+
+def test_ui_server_loads_scoped_changeset_resume_without_starting_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_resume(_root: Path, change_set_id: str) -> dict:
+        calls.append(change_set_id)
+        return {
+            "change_set_id": change_set_id,
+            "harvest": {"status": "requirements_running", "current_question": {"question": "Continue?"}},
+        }
+
+    monkeypatch.setattr(ui_server, "resume_changeset", fake_resume)
+
+    class Handler(HarvestUiRequestHandler):
+        repo_root = tmp_path
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        with urlopen(f"{base}/api/dashboard/change-sets/CHG-20260526-001/resume") as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["change_set_id"] == "CHG-20260526-001"
+        assert payload["harvest"]["current_question"]["question"] == "Continue?"
+        assert calls == ["CHG-20260526-001"]
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
 
 
 def test_delete_active_changeset_removes_only_selected_active_file(tmp_path: Path) -> None:

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -8,13 +8,22 @@ from harness_codex.runtime.harvest_ui import (
     CONTEXT_PATH,
     REQUIREMENTS_PATH,
     USE_CASES_PATH,
+    activate_changeset_harvest_ui,
     answer_use_cases,
     answer_requirements,
+    load_changeset_harvest_ui,
     load_harvest_ui,
+    save_changeset_harvest_ui,
     start_requirements,
     start_use_case_generation,
     start_use_cases,
 )
+
+
+def write_active_changeset(root: Path, change_set_id: str) -> None:
+    path = root / "docs/changes/active" / f"{change_set_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# {change_set_id}\n", encoding="utf-8")
 
 
 def fake_grill_me(_root: Path, session: dict) -> dict:
@@ -183,6 +192,80 @@ def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
     assert result.active_stage == "useCases"
     assert result.use_cases_ready is True
     assert (tmp_path / USE_CASES_PATH).is_file()
+
+
+def test_changeset_resume_restores_pending_question_without_advancing_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
+    start_requirements(tmp_path, "build a queue system")
+    write_active_changeset(tmp_path, "CHG-20260526-001")
+    save_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+    scoped_session = tmp_path / ".harness/ui/change-sets/CHG-20260526-001/harvest-session.json"
+    session_before = scoped_session.read_text(encoding="utf-8")
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_grill_me",
+        lambda _root, _session: pytest.fail("resume must not run Grill-Me"),
+    )
+
+    result = load_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+
+    assert result.active_stage == "requirements"
+    assert result.current_question is not None
+    assert result.current_question["question"] == "Question 1?"
+    assert scoped_session.read_text(encoding="utf-8") == session_before
+
+
+def test_changeset_resume_corrects_stale_stage_from_requirements_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
+    start_requirements(tmp_path, "build a queue system")
+    write_active_changeset(tmp_path, "CHG-20260526-001")
+    save_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+    scoped_session = tmp_path / ".harness/ui/change-sets/CHG-20260526-001/harvest-session.json"
+    session = json.loads(scoped_session.read_text(encoding="utf-8"))
+    session["active_stage"] = "useCases"
+    scoped_session.write_text(json.dumps(session), encoding="utf-8")
+
+    result = load_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+
+    assert result.requirements_gate_passed is False
+    assert result.active_stage == "requirements"
+
+
+def test_changeset_sessions_continue_independently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", fake_grill_me)
+    start_requirements(tmp_path, "first workflow")
+    write_active_changeset(tmp_path, "CHG-20260526-001")
+    save_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+    start_requirements(tmp_path, "second workflow")
+    write_active_changeset(tmp_path, "CHG-20260526-002")
+    save_changeset_harvest_ui(tmp_path, "CHG-20260526-002")
+
+    activate_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+    answer_requirements(tmp_path, "first answer")
+    save_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+
+    first = load_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+    second = load_changeset_harvest_ui(tmp_path, "CHG-20260526-002")
+    assert first.current_question is not None
+    assert first.current_question["question"] == "Question 2?"
+    assert second.current_question is not None
+    assert second.current_question["question"] == "Question 1?"
+    assert second.initial_prompt == "second workflow"
+
+
+def test_changeset_resume_rejects_active_legacy_session_without_scoped_state(tmp_path: Path) -> None:
+    write_active_changeset(tmp_path, "CHG-20260526-001")
+
+    with pytest.raises(ValueError, match="Resume unavailable for CHG-20260526-001"):
+        load_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
 
 
 def test_harvest_ui_requires_canonical_use_case_doc_before_ready(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #205

## Implementation intent (구현 의도)
중단된 active ChangeSet을 대시보드에서 다시 열었을 때, 선택한 ChangeSet이 대기 중이던 requirements 또는 use-case 질문 위치를 그대로 복구한다. Resume 클릭 자체는 다음 질문 생성, 답변 제출, 단계 이동을 실행하지 않는다.

## Implementation approach (구현 방식)
- 새 ChangeSet 실행마다 `.harness/ui/change-sets/<CHG-ID>/` 아래에 세션과 requirements/context/use-case 산출물 스냅샷을 저장한다.
- `GET /api/dashboard/change-sets/<CHG-ID>/resume`는 scoped 스냅샷만 읽어 pending 질문과 미리보기를 복구하며 런타임 진행 함수를 호출하지 않는다.
- requirements 답변, use-case 시작, use-case 답변 요청은 `change_set_id`를 요구하고, 선택된 스냅샷을 실행 컨텍스트로 활성화한 뒤 한 번의 명시적 사용자 동작 결과만 다시 저장한다.
- 저장된 stage 값이 stale이어도 requirements gate가 미통과이면 requirements 화면으로 교정한다.
- 기존 scoped 데이터가 없는 active ChangeSet은 자동 마이그레이션하지 않고 resume unavailable 오류를 반환한다.
- 대시보드 active 상세에 `Resume Workflow`를 추가하고, 복구된 요구사항 미리보기와 pending 질문을 표시한다.

## Verification method (검증 방법)
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> `279 passed in 64.62s`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> 통과
- `git diff --check` -> 통과
- 테스트로 read-only resume, stale stage 교정, 두 active ChangeSet의 상태 분리, legacy resume 오류, HTTP resume 라우팅을 검증했다.

## Risks and rollback (위험 및 롤백)
- scoped 상태는 이 변경 이후 새로 생성된 ChangeSet부터 사용되므로, 기존 active ChangeSet은 재개되지 않고 명시적 오류가 표시된다.
- 명시적 계속 동작 시에만 selected snapshot을 canonical 실행 컨텍스트로 복원한다. 문제가 발생하면 이 PR을 revert하면 기존 global-session 동작으로 되돌릴 수 있다.