### PR TITLE
[codex] 유스케이스 생성 타임아웃 오류 처리

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -261,7 +261,8 @@ function renderUseCaseWorkspace() {
           <textarea id="use-case-answer" required></textarea>
           <button class="primary" type="submit" ${app.busy ? "disabled" : ""}>${app.busy ? "Processing..." : "Submit answer"}</button>
         </form>`
-      : '<p>Start use case definition to receive next runtime question.</p>';
+      : `<p>Start use case definition to receive next runtime question.</p>
+         <button class="primary next-stage" id="start-use-cases" type="button" ${app.busy ? "disabled" : ""}>${app.error ? "Retry Use Case Definition" : "Start Use Case Definition"}</button>`;
   const document = app.harvest?.use_cases_markdown
     ? `<div class="markdown-preview">${markdownPreview(app.harvest.use_cases_markdown)}</div>`
     : '<p class="small">Generated use-case document appears here when runtime completes.</p>';

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -823,15 +823,20 @@ def _run_use_case_harvest(root: Path, session: dict[str, Any], idea: str) -> dic
         command.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
     command.append("-")
     command_path.write_text(json.dumps(command, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    completed = subprocess.run(
-        command,
-        cwd=root,
-        input=prompt,
-        text=True,
-        capture_output=True,
-        timeout=300,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=root,
+            input=prompt,
+            text=True,
+            capture_output=True,
+            timeout=300,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(
+            "use-case definition timed out after 300 seconds. Retry to continue from this stage."
+        ) from exc
     (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
     (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
     if completed.returncode != 0:

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -322,6 +322,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "Resume Workflow" in javascript
         assert "/resume" in javascript
         assert "Continue to Use Case Definition" in javascript
+        assert "Retry Use Case Definition" in javascript
         assert "Continue to Event Storming (next slice)" in javascript
         assert "runtime-progress" in stylesheet
         assert "stage-tabs" in stylesheet

--- a/tests/runtime/test_harvest_ui_grill_me_command.py
+++ b/tests/runtime/test_harvest_ui_grill_me_command.py
@@ -2,7 +2,15 @@ import json
 import subprocess
 from pathlib import Path
 
-from harness_codex.runtime.harvest_ui import GRILL_ME_SKILL_PATH, _run_grill_me
+import pytest
+
+from harness_codex.runtime.harvest_ui import (
+    GRILL_ME_SKILL_PATH,
+    USE_CASE_AGENT_CONFIG_PATH,
+    USE_CASE_SKILL_PATH,
+    _run_grill_me,
+    _run_use_case_harvest,
+)
 
 
 def test_grill_me_command_skips_git_repo_check(tmp_path: Path, monkeypatch) -> None:
@@ -37,3 +45,23 @@ def test_grill_me_command_skips_git_repo_check(tmp_path: Path, monkeypatch) -> N
     assert result == {"complete": True, "questions": []}
     assert "--skip-git-repo-check" in captured["command"]
     assert captured["command"].index("--skip-git-repo-check") > captured["command"].index(str(tmp_path))
+
+
+def test_use_case_timeout_returns_actionable_error(tmp_path: Path, monkeypatch) -> None:
+    agent_config = tmp_path / USE_CASE_AGENT_CONFIG_PATH
+    agent_config.parent.mkdir(parents=True)
+    agent_config.write_text('name = "harness_usecases"\n', encoding="utf-8")
+    skill_path = tmp_path / USE_CASE_SKILL_PATH
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Use Cases\n", encoding="utf-8")
+
+    def time_out(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(["codex", "exec"], timeout=300)
+
+    monkeypatch.setattr(subprocess, "run", time_out)
+
+    with pytest.raises(
+        ValueError,
+        match="use-case definition timed out after 300 seconds. Retry to continue from this stage.",
+    ):
+        _run_use_case_harvest(tmp_path, {"initial_prompt": "build feature", "use_case_clarifications": []}, "")


### PR DESCRIPTION
Closes #207

## Implementation intent (구현 의도)
Use Case Definition 실행이 300초 제한을 초과할 때 HTTP 연결이 끊어져 UI가 `Failed to fetch`만 표시하는 문제를 수정한다. 사용자는 중단된 ChangeSet 상태를 유지한 채 Use Cases 화면에서 다시 시도할 수 있어야 한다.

## Implementation approach (구현 방식)
- interactive use-case agent 실행의 `subprocess.TimeoutExpired`를 `ValueError` 기반의 명시적 런타임 오류로 변환한다.
- 기존 UI 서버의 오류 응답 경로가 이 오류를 JSON으로 전달하므로 브라우저 연결이 비정상 종료되지 않는다.
- Use Cases 탭에 질문/문서가 아직 없을 때 `Start Use Case Definition` 버튼을 제공하고, 오류가 표시된 상태에서는 `Retry Use Case Definition`으로 표시한다.
- 타임아웃 시 scoped ChangeSet 저장 상태는 변경하지 않으므로 다시 시도하거나 재개할 수 있다.

## Verification method (검증 방법)
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> `280 passed in 51.04s`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> 통과
- `git diff --check` -> 통과
- `subprocess.TimeoutExpired` 재현 테스트와 UI retry 문구 테스트를 추가했다.

## Risks and rollback (위험 및 롤백)
- 이 변경은 300초 제한 자체를 늘리거나 agent 성능을 바꾸지 않는다. 장시간 실행이면 명시적 timeout 오류 후 재시도가 필요하다.
- 문제가 있으면 이 PR을 revert하여 기존 실행 경로로 복원할 수 있다.