### PR TITLE
[codex] 업데이트 후 ChangeSet 재개 상태 복구

### DIFF
--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -180,14 +180,18 @@ def save_changeset_harvest_ui(root: Path | str, change_set_id: str) -> None:
     session = _load_session(root_path)
     if session is None:
         raise ValueError("harvest session has not started")
-    scoped_root = _changeset_session_root(root_path, change_set_id)
+    _write_changeset_harvest_snapshot(root_path, change_set_id, session)
+
+
+def _write_changeset_harvest_snapshot(root: Path, change_set_id: str, session: dict[str, Any]) -> None:
+    scoped_root = _changeset_session_root(root, change_set_id)
     scoped_root.mkdir(parents=True, exist_ok=True)
     (scoped_root / "harvest-session.json").write_text(
         json.dumps(session, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
     )
     for artifact in (REQUIREMENTS_PATH, CONTEXT_PATH):
-        _copy_optional_artifact(root_path / artifact, scoped_root / artifact)
+        _copy_optional_artifact(root / artifact, scoped_root / artifact)
     use_cases_started = (
         session.get("active_stage") == "useCases"
         or session.get("use_cases_ready")
@@ -195,8 +199,8 @@ def save_changeset_harvest_ui(root: Path | str, change_set_id: str) -> None:
         or session.get("use_case_clarifications")
     )
     if use_cases_started:
-        _copy_optional_artifact(root_path / USE_CASES_PATH, scoped_root / USE_CASES_PATH)
-        _copy_optional_tree(root_path / USE_CASE_SLICE_ROOT, scoped_root / USE_CASE_SLICE_ROOT)
+        _copy_optional_artifact(root / USE_CASES_PATH, scoped_root / USE_CASES_PATH)
+        _copy_optional_tree(root / USE_CASE_SLICE_ROOT, scoped_root / USE_CASE_SLICE_ROOT)
     else:
         use_case_document = scoped_root / USE_CASES_PATH
         if use_case_document.exists():
@@ -212,8 +216,10 @@ def load_changeset_harvest_ui(root: Path | str, change_set_id: str) -> HarvestUi
     scoped_root = _changeset_session_root(root_path, change_set_id)
     session_path = scoped_root / "harvest-session.json"
     if not session_path.exists():
-        raise ValueError(f"Resume unavailable for {change_set_id}: no saved workflow state.")
-    session = json.loads(session_path.read_text(encoding="utf-8"))
+        session = _recover_changeset_session(root_path, change_set_id)
+        _write_changeset_harvest_snapshot(root_path, change_set_id, session)
+    else:
+        session = json.loads(session_path.read_text(encoding="utf-8"))
     _normalize_session(session)
     _normalize_resumed_stage(session)
     return _result(root_path, session, artifact_root=scoped_root)
@@ -336,7 +342,7 @@ def _session_from_requirements_doc(root: Path) -> dict[str, Any] | None:
     if not initial_prompt:
         return None
     clarifications = tuple(_parse_grill_me_rows(text))
-    gate_passed = "Current gate: Passed" in text
+    gate_passed = _requirements_gate_passed_from_doc(text)
     use_cases_ready, _ = _validate_runtime_ready_use_case_slices(root)
     session = {
         "initial_prompt": initial_prompt,
@@ -356,6 +362,24 @@ def _session_from_requirements_doc(root: Path) -> dict[str, Any] | None:
     if session["use_cases_ready"]:
         session["active_stage"] = "useCases"
     return session
+
+
+def _requirements_gate_passed_from_doc(text: str) -> bool:
+    if "Current gate: Passed" in text:
+        return True
+    required_sections = (
+        "Business Policy Decisions Needed",
+        "Foundational Technology Decisions Needed",
+    )
+    for heading in required_sections:
+        match = re.search(
+            rf"^## \d+\. {re.escape(heading)}\s*$([\s\S]*?)(?=^## |\Z)",
+            text,
+            flags=re.MULTILINE,
+        )
+        if match is None or not re.search(r"^\s*-\s+None(?:\.|\s|$)", match.group(1), flags=re.MULTILINE):
+            return False
+    return True
 
 
 def _extract_markdown_value(text: str, label: str) -> str:
@@ -470,6 +494,17 @@ def _require_active_changeset(root: Path, change_set_id: str) -> None:
     _changeset_session_root(root, change_set_id)
     if not (root / "docs/changes/active" / f"{change_set_id}.md").exists():
         raise ValueError(f"Active ChangeSet does not exist: {change_set_id}.")
+
+
+def _recover_changeset_session(root: Path, change_set_id: str) -> dict[str, Any]:
+    active_ids = sorted(path.stem for path in (root / "docs/changes/active").glob("CHG-*.md"))
+    if active_ids != [change_set_id]:
+        raise ValueError(f"Resume unavailable for {change_set_id}: no saved workflow state.")
+    session = _session_from_requirements_doc(root)
+    if session is None:
+        raise ValueError(f"Resume unavailable for {change_set_id}: no saved workflow state.")
+    _normalize_session(session)
+    return session
 
 
 def _copy_optional_artifact(source: Path, target: Path) -> None:

--- a/harness_codex/runtime/self_update.py
+++ b/harness_codex/runtime/self_update.py
@@ -180,7 +180,7 @@ def _warning(repo: str, ref: str) -> str:
     return (
         f"Update source: {source}\n"
         "Update will refresh runtime-managed files but preserves workflow-generated "
-        "artifacts: .harness runs/sessions/state, ChangeSets, work-item docs, plans, "
+        "artifacts: .harness runs/sessions/state/ui, ChangeSets, work-item docs, plans, "
         "harvested docs, and project-local config."
     )
 

--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -79,7 +79,7 @@ PRESERVED_PATHS=(
   ".harness/sessions"
   ".harness/state"
   ".harness/checkpoints"
-  ".harness/ui/grill-me-runs"
+  ".harness/ui"
   "docs/changes"
   "docs/use-cases"
   "docs/maintenance"

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -261,8 +261,34 @@ def test_changeset_sessions_continue_independently(
     assert second.initial_prompt == "second workflow"
 
 
-def test_changeset_resume_rejects_active_legacy_session_without_scoped_state(tmp_path: Path) -> None:
+def test_changeset_resume_recovers_single_active_session_from_completed_requirements_doc(tmp_path: Path) -> None:
     write_active_changeset(tmp_path, "CHG-20260526-001")
+    (tmp_path / REQUIREMENTS_PATH).parent.mkdir(parents=True)
+    (tmp_path / REQUIREMENTS_PATH).write_text(
+        """# Requirements Specification
+
+## 1. Overview
+- Initial idea: build note explorer
+
+## 8. Business Policy Decisions Needed
+- None.
+
+## 9. Foundational Technology Decisions Needed
+- None required to define this MVP ChangeSet.
+""",
+        encoding="utf-8",
+    )
+
+    result = load_changeset_harvest_ui(tmp_path, "CHG-20260526-001")
+
+    assert result.requirements_gate_passed is True
+    assert result.active_stage == "requirements"
+    assert (tmp_path / ".harness/ui/change-sets/CHG-20260526-001/harvest-session.json").exists()
+
+
+def test_changeset_resume_rejects_missing_scoped_state_when_active_owner_is_ambiguous(tmp_path: Path) -> None:
+    write_active_changeset(tmp_path, "CHG-20260526-001")
+    write_active_changeset(tmp_path, "CHG-20260526-002")
 
     with pytest.raises(ValueError, match="Resume unavailable for CHG-20260526-001"):
         load_changeset_harvest_ui(tmp_path, "CHG-20260526-001")

--- a/tests/runtime/test_install_update_preservation.py
+++ b/tests/runtime/test_install_update_preservation.py
@@ -10,7 +10,7 @@ def test_installer_defines_workflow_artifacts_as_preserved_paths():
         ".harness/sessions",
         ".harness/state",
         ".harness/checkpoints",
-        ".harness/ui/grill-me-runs",
+        ".harness/ui",
         "docs/changes",
         "docs/use-cases",
         "docs/maintenance",


### PR DESCRIPTION
Closes #209

## Implementation intent (구현 의도)
`harness update` 이후 active ChangeSet의 scoped resume 상태가 삭제되어 `Resume unavailable ... no saved workflow state.`로 중단되는 문제를 해결한다. 업데이트 전 진행하던 흐름을 보존하고, 이미 영향을 받은 단일 active ChangeSet은 보존된 requirements 문서에서 안전하게 복구한다.

## Implementation approach (구현 방식)
- 설치/업데이트 보존 대상에서 `.harness/ui/grill-me-runs` 대신 전체 `.harness/ui`를 보존하여 `change-sets/<CHG-ID>` snapshot, session, UI 실행 기록이 모두 유지되도록 한다.
- scoped snapshot이 없는 경우 active ChangeSet이 정확히 하나일 때만 `docs/design/요구사항.md`에서 세션을 복구하고 scoped snapshot을 재생성한다.
- 복구는 문서 읽기와 snapshot 저장만 수행하며 Grill-Me 또는 Use Case agent를 자동 실행하지 않는다.
- 현재 문서 포맷의 `Business Policy Decisions Needed: None` 및 `Foundational Technology Decisions Needed: None`를 requirements 통과 상태로 인식한다.
- 여러 active ChangeSet이 있어 문서 소유권이 모호하면 기존 resume-unavailable 오류를 유지한다.

## Verification method (검증 방법)
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> `281 passed in 47.22s`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> 통과
- `git diff --check` -> 통과
- 단일 active 문서 기반 복구, 다중 active 모호성 거부, 업데이트 보존 경로 테스트를 검증했다.

## Risks and rollback (위험 및 롤백)
- 이미 삭제된 pending 질문 자체는 문서에 기록되지 않았으면 완전 재현할 수 없다. 완료된 requirements 문서에서는 명시적 다음 단계 버튼부터 복구한다.
- `.harness/ui` 전체를 보존하므로 업데이트 후 UI 실행 기록도 유지된다. 문제가 있으면 이 PR을 revert하여 기존 보존 범위로 되돌릴 수 있다.