### PR TITLE
[codex] 유스케이스 생성 제한 시간을 한 시간으로 조정

### DIFF
--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -25,6 +25,7 @@ GRILL_ME_SKILL_PATH = Path(".codex/skills/grill-me/SKILL.md")
 REQUIREMENTS_SKILL_PATH = Path(".codex/skills/harness-requirements/SKILL.md")
 USE_CASE_AGENT_CONFIG_PATH = Path(".codex/agents/harness_usecases.toml")
 USE_CASE_SKILL_PATH = Path(".codex/skills/harness-usecases/SKILL.md")
+USE_CASE_DEFINITION_TIMEOUT_SEC = 3600
 
 
 @dataclass(frozen=True)
@@ -768,7 +769,7 @@ def _run_use_case_harvest(root: Path, session: dict[str, Any], idea: str) -> dic
         skill_id="harness-usecases",
         inputs=(CONTEXT_PATH, REQUIREMENTS_PATH),
         outputs=(USE_CASES_PATH, USE_CASE_SLICE_ROOT),
-        timeout_sec=300,
+        timeout_sec=USE_CASE_DEFINITION_TIMEOUT_SEC,
         metadata={
             "stage": "harvest",
             "scope": "runtime_ready_use_cases",
@@ -830,12 +831,13 @@ def _run_use_case_harvest(root: Path, session: dict[str, Any], idea: str) -> dic
             input=prompt,
             text=True,
             capture_output=True,
-            timeout=300,
+            timeout=USE_CASE_DEFINITION_TIMEOUT_SEC,
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
         raise ValueError(
-            "use-case definition timed out after 300 seconds. Retry to continue from this stage."
+            f"use-case definition timed out after {USE_CASE_DEFINITION_TIMEOUT_SEC} seconds. "
+            "Retry to continue from this stage."
         ) from exc
     (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
     (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")

--- a/tests/runtime/test_harvest_ui_grill_me_command.py
+++ b/tests/runtime/test_harvest_ui_grill_me_command.py
@@ -6,6 +6,7 @@ import pytest
 
 from harness_codex.runtime.harvest_ui import (
     GRILL_ME_SKILL_PATH,
+    USE_CASE_DEFINITION_TIMEOUT_SEC,
     USE_CASE_AGENT_CONFIG_PATH,
     USE_CASE_SKILL_PATH,
     _run_grill_me,
@@ -55,13 +56,18 @@ def test_use_case_timeout_returns_actionable_error(tmp_path: Path, monkeypatch) 
     skill_path.parent.mkdir(parents=True)
     skill_path.write_text("# Use Cases\n", encoding="utf-8")
 
-    def time_out(*_args, **_kwargs):
-        raise subprocess.TimeoutExpired(["codex", "exec"], timeout=300)
+    captured = {}
+
+    def time_out(*_args, **kwargs):
+        captured["timeout"] = kwargs["timeout"]
+        raise subprocess.TimeoutExpired(["codex", "exec"], timeout=kwargs["timeout"])
 
     monkeypatch.setattr(subprocess, "run", time_out)
 
     with pytest.raises(
         ValueError,
-        match="use-case definition timed out after 300 seconds. Retry to continue from this stage.",
+        match="use-case definition timed out after 3600 seconds. Retry to continue from this stage.",
     ):
         _run_use_case_harvest(tmp_path, {"initial_prompt": "build feature", "use_case_clarifications": []}, "")
+
+    assert captured["timeout"] == USE_CASE_DEFINITION_TIMEOUT_SEC == 3600


### PR DESCRIPTION
Closes #211

## Implementation intent (구현 의도)
대시보드 Use Case Definition이 300초 후 중단되는 제한을 기존 interactive harvest 유스케이스 단계와 동일한 3600초로 조정한다. 실제 생성 작업이 5분 이상 필요한 경우 불필요한 재시도 없이 완료될 시간을 제공한다.

## Implementation approach (구현 방식)
- `harvest_ui.py`에 `USE_CASE_DEFINITION_TIMEOUT_SEC = 3600` 상수를 추가한다.
- UI use-case agent용 `Step.timeout_sec`와 실제 `subprocess.run(timeout=...)` 모두 같은 상수를 사용한다.
- 시간 초과 오류 메시지도 동일한 유효 제한 시간을 표시하도록 변경한다.
- 기존 timeout JSON 오류/Retry UI 동작은 유지한다.

## Verification method (검증 방법)
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> `280 passed in 43.04s`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> 통과
- `git diff --check` -> 통과
- timeout 단위 테스트가 호출 제한 값과 오류 메시지의 3600초 적용을 검증한다.

## Risks and rollback (위험 및 롤백)
- agent가 실제로 멈춘 경우 사용자 대기 시간은 최대 한 시간으로 늘어난다. UI 진행중 표시와 timeout 후 Retry 경로는 유지된다.
- 문제가 있으면 이 PR을 revert하여 300초 제한으로 복원할 수 있다.