### PR TITLE
[codex] 대시보드 마크다운 미리보기 렌더링 수정

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -58,6 +58,9 @@ button:disabled { cursor: progress; opacity: .65; }
 .danger { background: #fff3f0; border-color: #e5aaa0; color: #8d291c; }
 textarea { border: 1px solid var(--line); border-radius: 7px; font: 13px/1.48 "SFMono-Regular", Consolas, monospace; min-height: 420px; padding: 12px; resize: vertical; width: 100%; }
 .markdown-preview { background: #fbfbf7; border-radius: 8px; padding: 15px; white-space: pre-wrap; }
+.markdown-preview ul, .markdown-preview ol { margin: 8px 0 16px; padding-left: 25px; white-space: normal; }
+.markdown-preview li { margin: 4px 0; }
+.markdown-preview code { background: #eef1e8; border-radius: 4px; font: 12px "SFMono-Regular", Consolas, monospace; padding: 1px 4px; }
 .markdown-table { margin: 12px 0; overflow-x: auto; white-space: normal; }
 .markdown-table table { border-collapse: collapse; min-width: 100%; }
 .markdown-table th, .markdown-table td { border: 1px solid var(--line); padding: 7px 10px; text-align: left; vertical-align: top; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -22,14 +22,24 @@ const escapeHtml = (value) => String(value ?? "")
 function markdownPreview(content) {
   const lines = String(content ?? "").split(/\r?\n/);
   const html = [];
+  let listType = "";
+  let listItems = [];
+  const flushList = () => {
+    if (!listType) return;
+    html.push(`<${listType}>${listItems.map((item) => `<li>${renderInline(item)}</li>`).join("")}</${listType}>`);
+    listType = "";
+    listItems = [];
+  };
   for (let index = 0; index < lines.length; index += 1) {
     const heading = renderHeading(lines[index]);
     if (heading) {
+      flushList();
       html.push(heading);
       continue;
     }
     const headers = splitTableRow(lines[index]);
     if (headers && isTableDivider(lines[index + 1], headers.length)) {
+      flushList();
       const rows = [];
       index += 2;
       while (index < lines.length) {
@@ -42,16 +52,38 @@ function markdownPreview(content) {
       html.push(renderTable(headers, rows));
       continue;
     }
-    html.push(escapeHtml(lines[index]));
+    const unordered = lines[index].match(/^\s*[-*]\s+(.+)$/);
+    const ordered = lines[index].match(/^\s*\d+\.\s+(.+)$/);
+    const nextListType = unordered ? "ul" : ordered ? "ol" : "";
+    if (nextListType) {
+      if (listType && listType !== nextListType) flushList();
+      listType = nextListType;
+      listItems.push((unordered || ordered)[1]);
+      continue;
+    }
+    flushList();
+    html.push(renderInline(lines[index]));
   }
+  flushList();
   return html.join("\n");
+}
+
+function renderInline(text) {
+  const codeSpans = [];
+  const escaped = escapeHtml(text).replace(/`([^`]+)`/g, (_match, code) => {
+    codeSpans.push(`<code>${code}</code>`);
+    return `\u0000CODE${codeSpans.length - 1}\u0000`;
+  });
+  return escaped
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\u0000CODE(\d+)\u0000/g, (_match, index) => codeSpans[Number(index)]);
 }
 
 function renderHeading(line) {
   const heading = line.match(/^(#{1,3}) (.+)$/);
   if (!heading) return "";
   const level = Number(heading[1].length) + 1;
-  return `<h${level}>${escapeHtml(heading[2])}</h${level}>`;
+  return `<h${level}>${renderInline(heading[2])}</h${level}>`;
 }
 
 function splitTableRow(line) {
@@ -84,8 +116,8 @@ function isTableDivider(line, columnCount) {
 }
 
 function renderTable(headers, rows) {
-  const head = headers.map((cell) => `<th>${escapeHtml(cell)}</th>`).join("");
-  const body = rows.map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join("")}</tr>`).join("");
+  const head = headers.map((cell) => `<th>${renderInline(cell)}</th>`).join("");
+  const body = rows.map((row) => `<tr>${row.map((cell) => `<td>${renderInline(cell)}</td>`).join("")}</tr>`).join("");
   return `<div class="markdown-table"><table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>`;
 }
 

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -324,8 +324,11 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "Continue to Use Case Definition" in javascript
         assert "Retry Use Case Definition" in javascript
         assert "Continue to Event Storming (next slice)" in javascript
+        assert "function renderInline" in javascript
+        assert "listItems.map" in javascript
         assert "runtime-progress" in stylesheet
         assert "stage-tabs" in stylesheet
+        assert ".markdown-preview code" in stylesheet
     finally:
         server.shutdown()
         thread.join()


### PR DESCRIPTION
Closes #213

## Implementation intent (구현 의도)
대시보드 Use Case Document 미리보기에서 `**Actor**`, `` `Note Author` ``, 목록 표기 등이 그대로 노출되는 문제를 수정한다. 생성된 문서가 문서 구조대로 읽히도록 한다.

## Implementation approach (구현 방식)
- 번들 대시보드 Markdown renderer에 안전한 inline 렌더링을 추가한다: inline code와 bold를 지원한다.
- HTML escaping을 먼저 수행한 뒤 허용된 Markdown 구문만 변환하여 raw HTML 주입 경로를 만들지 않는다.
- `-` 목록과 `1.` 순서 목록을 각각 `ul`/`ol` 구조로 렌더링한다.
- 기존 heading/table 처리에도 동일한 inline formatting을 적용한다.
- code/list에 필요한 preview CSS를 추가한다.

## Verification method (검증 방법)
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> `280 passed in 43.05s`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> 통과
- Node 기반 렌더링 확인: bold, inline code, unordered/ordered list HTML 출력 확인
- 로컬 프로젝트 focused test: `13 passed in 4.59s`
- `git diff --check` -> 통과

## Risks and rollback (위험 및 롤백)
- Renderer는 현재 문서가 사용하는 Markdown subset만 지원하며 전체 Markdown parser는 아니다.
- 문제가 있으면 이 PR을 revert하여 이전 plain-text fallback 미리보기로 복원할 수 있다.