### PR TITLE
[codex] 생성된 유스케이스 슬라이스를 편집 가능하게 노출

### DIFF
--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -205,7 +205,8 @@ def _document_summaries(
                 "editable": True,
             }
         )
-    use_cases = root / "docs/design/유스케이스.md"
+    scoped_root = root / SCOPED_UI_STATE_ROOT / change_set.change_set_id
+    use_cases = scoped_root / "docs/design/유스케이스.md"
     if workflow_state and workflow_state.get("use_cases_ready") and use_cases.exists():
         summaries.append(
             {
@@ -216,6 +217,24 @@ def _document_summaries(
                 "editable": False,
             }
         )
+    declared_use_case_ids = {
+        item.work_item_id
+        for item in change_set.ordered_work_items()
+        if item.work_item_type is WorkItemType.USE_CASE
+    }
+    if workflow_state and workflow_state.get("use_cases_ready"):
+        for path in sorted((scoped_root / "docs/use-cases").glob("UC-*/use-case.md")):
+            uc_id = path.parent.name
+            if uc_id not in declared_use_case_ids:
+                summaries.append(
+                    {
+                        "id": f"generated-use-case:{change_set.change_set_id}:{uc_id}",
+                        "kind": "generated-use-case",
+                        "label": f"{uc_id} Use Case",
+                        "path": _relative_path(root, path),
+                        "editable": True,
+                    }
+                )
     for item in change_set.ordered_work_items():
         if item.work_item_type is WorkItemType.USE_CASE:
             path = root / "docs/use-cases" / item.work_item_id / "use-case.md"
@@ -252,7 +271,7 @@ def _resolve_readable_document(root: Path, document_id: str) -> dict[str, Any]:
         if not re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id):
             raise DashboardDocumentNotFound("Unknown generated Use Cases document.")
         change_path = root / "docs/changes/active" / f"{change_set_id}.md"
-        path = root / "docs/design/유스케이스.md"
+        path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/design/유스케이스.md"
         state = _scoped_workflow_state(root, change_set_id, "active")
         if not change_path.exists() or not path.exists() or not state or not state.get("use_cases_ready"):
             raise DashboardDocumentNotFound("Generated Use Cases document does not exist.")
@@ -318,6 +337,17 @@ def _resolve_editable_document(root: Path, document_id: str) -> dict[str, Any]:
         ):
             raise DashboardDocumentNotFound("Use case is not part of the active ChangeSet.")
         path = root / "docs/use-cases" / uc_id / "use-case.md"
+        label = f"{uc_id} Use Case"
+    elif kind == "generated-use-case" and len(parts) == 3:
+        uc_id = parts[2]
+        state = _scoped_workflow_state(root, change_set_id, "active")
+        if (
+            not re.fullmatch(r"UC-\d+", uc_id)
+            or not state
+            or not state.get("use_cases_ready")
+        ):
+            raise DashboardDocumentNotFound("Use case is not part of completed UI workflow.")
+        path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "use-case.md"
         label = f"{uc_id} Use Case"
     else:
         raise DashboardDocumentNotFound("Unknown editable document.")

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -81,7 +81,7 @@ EVENT_STORMING_MARKDOWN = """# UC-001 Event Storming
 """
 
 
-def _write_change_set(root: Path, lifecycle: str = "active") -> Path:
+def _write_change_set(root: Path, lifecycle: str = "active", *, with_use_case: bool = True) -> Path:
     path = root / "docs/changes" / lifecycle / "CHG-001.md"
     path.parent.mkdir(parents=True)
     content = render_initial_changeset(
@@ -89,7 +89,8 @@ def _write_change_set(root: Path, lifecycle: str = "active") -> Path:
         title="Save Fleeting Note",
         request_summary="Create note flow.",
     )
-    content += """\
+    if with_use_case:
+        content += """\
 
 ## 5. Affected Use Cases
 
@@ -119,9 +120,12 @@ def _write_completed_ui_workflow(root: Path) -> None:
         json.dumps({"requirements_gate_passed": True, "use_cases_ready": True}),
         encoding="utf-8",
     )
-    canonical = root / "docs/design/유스케이스.md"
+    canonical = root / ".harness/ui/change-sets/CHG-001/docs/design/유스케이스.md"
     canonical.parent.mkdir(parents=True, exist_ok=True)
     canonical.write_text("# Use Case Document\n\n- UC-001. Save Fleeting Note\n", encoding="utf-8")
+    use_case = root / ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/use-case.md"
+    use_case.parent.mkdir(parents=True, exist_ok=True)
+    use_case.write_text(USE_CASE_MARKDOWN, encoding="utf-8")
 
 
 def test_document_dashboard_projects_docs_board_and_folder_lifecycle(tmp_path: Path) -> None:
@@ -194,7 +198,33 @@ def test_dashboard_projects_completed_ui_workflow_and_generated_use_cases_docume
     assert documents["generated-use-cases:CHG-001"]["label"] == "Use Cases (Read only)"
     loaded = read_dashboard_document(tmp_path, "generated-use-cases:CHG-001")
     assert loaded["editable"] is False
+    assert loaded["path"] == ".harness/ui/change-sets/CHG-001/docs/design/유스케이스.md"
     assert "UC-001. Save Fleeting Note" in loaded["content"]
+
+
+def test_dashboard_exposes_editable_scoped_generated_use_case_slice(tmp_path: Path) -> None:
+    change_path = _write_change_set(tmp_path, with_use_case=False)
+    _write_documents(tmp_path)
+    _write_completed_ui_workflow(tmp_path)
+
+    change_set = document_dashboard_state(tmp_path)["change_sets"][0]
+    documents = {document["id"]: document for document in change_set["documents"]}
+    document_id = "generated-use-case:CHG-001:UC-001"
+
+    assert documents[document_id]["editable"] is True
+    assert documents[document_id]["path"] == (
+        ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/use-case.md"
+    )
+    loaded = read_dashboard_document(tmp_path, document_id)
+    saved = save_dashboard_document(
+        tmp_path,
+        document_id,
+        content=loaded["content"].replace("Save one note.", "Save edited note."),
+        revision=loaded["revision"],
+    )
+
+    assert "Save edited note." in saved["content"]
+    assert "|event-storming|Event Storming|stale|" in change_path.read_text(encoding="utf-8")
 
 
 def test_save_requirements_requires_current_revision_and_stales_downstream_stages(


### PR DESCRIPTION
## Implementation intent
완료된 canonical Use Cases 문서는 읽기 전용으로 유지하면서, UI 워크플로우가 생성한 개별 use-case slice를 대시보드에서 수정할 수 있게 합니다.

Closes #217

## Implementation approach
- #216에서 노출한 canonical Use Cases preview를 selected ChangeSet의 scoped snapshot 경로에서 읽도록 좁혀 active ChangeSet 간 문서 혼선을 방지합니다.
- scoped workflow가 완료된 경우 `.harness/ui/change-sets/<CHG-ID>/docs/use-cases/<UC-ID>/use-case.md` 파일을 `generated-use-case` editable document로 목록에 추가합니다.
- ChangeSet에 이미 선언된 work-item slice는 기존 editable 문서 흐름을 유지하고 generated 항목을 중복 추가하지 않습니다.
- generated slice 읽기/저장은 active ChangeSet과 scoped `use_cases_ready` 상태를 검증한 뒤 수행합니다.
- 저장 시 기존 use-case 구조 검증과 downstream stage stale 전이를 재사용합니다.

## Verification method
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` -> `15 passed`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime` -> `225 passed`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> pass
- `git diff --check origin/main...HEAD` -> pass

## Risks and rollback
- 위험: legacy active ChangeSet처럼 scoped snapshot이 없는 경우 generated slice는 표시되지 않습니다.
- 위험: generated slice 수정 시 후속 단계는 stale로 표시되며 재실행이 필요합니다.
- 롤백: 이 PR을 revert하면 #216의 canonical read-only preview 동작만 남고 generated slice 편집 노출은 제거됩니다.