### PR TITLE
[codex] 이벤트 스토밍 UI와 스티키 캔버스 추가

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -94,4 +94,21 @@ details { margin-top: 10px; }
 .runtime-progress p { color: var(--muted); margin: 3px 0 0; }
 .spinner { animation: spin 900ms linear infinite; border: 3px solid #bdd0c4; border-radius: 50%; border-top-color: var(--accent); display: block; height: 24px; width: 24px; }
 .next-stage { margin-top: 12px; }
+.event-progress { display: flex; flex-wrap: wrap; gap: 8px; }
+.event-progress-item { background: #f1f2ec; border-radius: 14px; font-size: 12px; padding: 5px 11px; }
+.event-progress-item.complete { background: var(--active); color: var(--accent); }
+.event-progress-item.needs_input { background: var(--stale); }
+.event-progress-item.error { background: #fff3f0; color: #8d291c; }
+.event-live-preview .flow-lane { flex-wrap: wrap; overflow: visible; }
+.canvas-header { align-items: center; display: flex; justify-content: space-between; }
+.canvas-header div { align-items: center; display: flex; gap: 10px; }
+#canvas-zoom-label { color: var(--muted); font-size: 12px; min-width: 44px; }
+.event-canvas { background: #f3f2ea; border: 1px solid var(--line); border-radius: 10px; cursor: grab; height: 560px; overflow: hidden; position: relative; touch-action: none; }
+.event-canvas:active { cursor: grabbing; }
+.event-canvas-content { left: 25px; position: absolute; top: 20px; transform-origin: 0 0; width: max-content; }
+.canvas-slice { background: rgba(255, 254, 249, .7); border-radius: 10px; display: inline-block; margin-right: 28px; padding: 16px; vertical-align: top; }
+.canvas-slice h4 { font-size: 17px; margin: 0 0 14px; }
+.canvas-lane strong { color: var(--muted); display: block; font-size: 12px; }
+.canvas-lane .flow-lane { overflow: visible; }
+.flow-lane.supporting { border-top: 1px dashed var(--line); margin-top: 8px; padding-top: 13px; }
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -103,7 +103,7 @@ details { margin-top: 10px; }
 .canvas-header { align-items: center; display: flex; justify-content: space-between; }
 .canvas-header div { align-items: center; display: flex; gap: 10px; }
 #canvas-zoom-label { color: var(--muted); font-size: 12px; min-width: 44px; }
-.event-canvas { background: #f3f2ea; border: 1px solid var(--line); border-radius: 10px; cursor: grab; height: 560px; overflow: hidden; position: relative; touch-action: none; }
+.event-canvas { background: #f3f2ea; border: 1px solid var(--line); border-radius: 10px; cursor: grab; height: 560px; overflow: hidden; position: relative; touch-action: none; user-select: none; -webkit-user-select: none; }
 .event-canvas:active { cursor: grabbing; }
 .event-canvas-content { left: 25px; position: absolute; top: 20px; transform-origin: 0 0; width: max-content; }
 .canvas-slice { background: rgba(255, 254, 249, .7); border-radius: 10px; display: inline-block; margin-right: 28px; padding: 16px; vertical-align: top; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -784,6 +784,7 @@ function bindCanvas() {
   let previous = null;
   canvas.onpointerdown = (event) => {
     if (event.target.closest(".sticky")) return;
+    event.preventDefault();
     dragging = true;
     previous = { x: event.clientX, y: event.clientY };
     canvas.setPointerCapture(event.pointerId);

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -7,10 +7,12 @@ const app = {
   harvest: null,
   requirementsChangeSet: null,
   stageTab: "requirements",
+  eventSelectedUc: null,
   workflowRecovered: false,
   busy: false,
   busyLabel: "",
   error: "",
+  canvas: { scale: 1, x: 0, y: 0 },
 };
 
 const escapeHtml = (value) => String(value ?? "")
@@ -145,6 +147,8 @@ function render() {
     app.selectedChangeSet = node.dataset.change;
     app.openDocument = null;
     app.error = "";
+    app.eventSelectedUc = null;
+    app.canvas = { scale: 1, x: 0, y: 0 };
     app.view = "dashboard";
     render();
   });
@@ -157,12 +161,22 @@ function render() {
   if (app.view === "requirements") {
     detail.innerHTML = renderRequirementsWorkspace();
     if (app.stageTab === "requirements") renderEditor();
+    if (app.stageTab === "eventStorming") renderEventDocumentEditor();
     const requirementForm = document.querySelector("#grill-form");
     if (requirementForm) requirementForm.onsubmit = submitRequirementAnswer;
     const useCaseForm = document.querySelector("#use-case-form");
     if (useCaseForm) useCaseForm.onsubmit = submitUseCaseAnswer;
     const startUseCases = document.querySelector("#start-use-cases");
     if (startUseCases) startUseCases.onclick = startUseCaseDefinition;
+    const startEventStorming = document.querySelector("#start-event-storming");
+    if (startEventStorming) startEventStorming.onclick = startEventStormingDefinition;
+    const advanceEventStorming = document.querySelector("#advance-event-storming");
+    if (advanceEventStorming) advanceEventStorming.onclick = continueEventStormingDefinition;
+    const eventForm = document.querySelector("#event-storming-form");
+    if (eventForm) eventForm.onsubmit = submitEventStormingAnswer;
+    document.querySelectorAll("[data-event-uc]").forEach((node) => {
+      node.onclick = () => selectEventUseCase(node.dataset.eventUc);
+    });
     document.querySelectorAll("[data-stage-tab]").forEach((node) => {
       node.onclick = () => selectStageTab(node.dataset.stageTab);
     });
@@ -230,7 +244,9 @@ function renderRequirementsWorkspace() {
   const title = selected?.title || "";
   const busy = app.busy ? renderBusyState() : "";
   const tabs = renderStageTabs();
-  const body = app.stageTab === "useCases" ? renderUseCaseWorkspace() : renderRequirementsTab();
+  const body = app.stageTab === "eventStorming"
+    ? renderEventStormingWorkspace()
+    : app.stageTab === "useCases" ? renderUseCaseWorkspace() : renderRequirementsTab();
   return `<section class="workflow-page">
     <div class="workspace-heading"><div><p class="eyebrow">ChangeSet Workflow</p><h2>${escapeHtml(app.requirementsChangeSet)} ${escapeHtml(title)}</h2></div></div>
     ${tabs}
@@ -243,12 +259,16 @@ function renderRequirementsWorkspace() {
 function renderStageTabs() {
   const requirementsDone = app.harvest?.requirements_gate_passed;
   const useCasesDone = app.harvest?.use_cases_ready;
+  const eventsDone = app.harvest?.event_storming?.complete;
   return `<nav class="stage-tabs" aria-label="Workflow stages">
     <button class="stage-tab ${app.stageTab === "requirements" ? "selected" : ""}" data-stage-tab="requirements">
       <span class="progress-dot ${requirementsDone ? "complete" : "active"}"></span>Requirements
     </button>
     <button class="stage-tab ${app.stageTab === "useCases" ? "selected" : ""}" data-stage-tab="useCases" ${!requirementsDone ? "disabled" : ""}>
       <span class="progress-dot ${useCasesDone ? "complete" : requirementsDone ? "active" : ""}"></span>Use Cases
+    </button>
+    <button class="stage-tab ${app.stageTab === "eventStorming" ? "selected" : ""}" data-stage-tab="eventStorming" ${!useCasesDone ? "disabled" : ""}>
+      <span class="progress-dot ${eventsDone ? "complete" : useCasesDone ? "active" : ""}"></span>Event Storming
     </button>
   </nav>`;
 }
@@ -284,7 +304,7 @@ function renderUseCaseWorkspace() {
   const question = app.harvest?.current_question;
   const questionPanel = app.harvest?.use_cases_ready
     ? `<p class="completion">Use case definition complete.</p>
-       <button class="primary next-stage" type="button" disabled title="Event Storming UI is next implementation slice.">Continue to Event Storming (next slice)</button>`
+       <button class="primary next-stage" id="start-event-storming" type="button" ${app.busy ? "disabled" : ""}>Continue to Event Storming</button>`
     : question
       ? `<form id="use-case-form" class="grill-form">
           <p class="question">${escapeHtml(question.question)}</p>
@@ -302,6 +322,42 @@ function renderUseCaseWorkspace() {
     <section class="panel requirements-document"><h3>Use Case Document</h3>${document}</section>
     <section class="panel grill-panel"><h3>Use Case Questions</h3>${questionPanel}</section>
   `;
+}
+
+function renderEventStormingWorkspace() {
+  const state = app.harvest?.event_storming || { items: {}, uc_ids: [], status: "not_started" };
+  const currentId = app.eventSelectedUc || state.current_uc || state.uc_ids.find((id) => state.items[id]?.status === "complete");
+  const item = currentId ? state.items[currentId] : null;
+  const statusItems = state.uc_ids.map((id) => `<button type="button" data-event-uc="${escapeHtml(id)}" class="event-progress-item ${escapeHtml(state.items[id]?.status || "pending")}">${escapeHtml(id)}: ${escapeHtml(state.items[id]?.status || "pending")}</button>`).join("");
+  const progress = state.uc_ids.length
+    ? `<p class="small">Completed ${escapeHtml(state.completed_count || 0)} / ${escapeHtml(state.total_count || state.uc_ids.length)}</p><div class="event-progress">${statusItems}</div>`
+    : '<p class="small">Start Event Storming to process generated use cases.</p>';
+  let interaction = "";
+  if (item?.status === "needs_input" && item.current_question) {
+    interaction = `<form id="event-storming-form" class="grill-form">
+      <p class="question">${escapeHtml(item.current_question.question)}</p>
+      ${item.current_question.recommended ? `<p class="recommended">Recommended answer: ${escapeHtml(item.current_question.recommended)}</p>` : ""}
+      <label for="event-storming-answer">Your answer</label>
+      <textarea id="event-storming-answer" required></textarea>
+      <button class="primary" type="submit" ${app.busy ? "disabled" : ""}>Submit answer</button>
+    </form>`;
+  } else if (state.complete) {
+    interaction = `<p class="completion">Event storming complete.</p>
+      <button class="primary next-stage" type="button" disabled title="DDD Architecture UI is next implementation slice.">Continue to DDD Architecture (next slice)</button>`;
+  } else if (state.status === "error") {
+    interaction = `<p class="error">${escapeHtml(item?.error || app.harvest?.runtime_error || "Event storming failed.")}</p>
+      <button class="primary next-stage" id="start-event-storming" type="button">Retry Event Storming</button>`;
+  } else if (state.status === "not_started") {
+    interaction = `<button class="primary next-stage" id="start-event-storming" type="button">Start Event Storming</button>`;
+  } else {
+    interaction = `<p class="small">Ready to process the next use case.</p>
+      <button class="primary next-stage" id="advance-event-storming" type="button" ${app.busy ? "disabled" : ""}>Continue Event Storming</button>`;
+  }
+  return `
+    <section class="panel event-progress-panel"><h3>Event Storming Progress</h3>${progress}</section>
+    <section class="panel event-document"><h3>${escapeHtml(currentId || "Event Storming")} Document</h3><div id="event-document-editor"></div></section>
+    <section class="panel event-live-preview"><h3>Sticky Notes Preview</h3><div id="event-live-board"></div></section>
+    <section class="panel grill-panel"><h3>Oracle Questions</h3>${interaction}</section>`;
 }
 
 async function openRequirementsDocument() {
@@ -344,11 +400,13 @@ async function submitRequirementAnswer(event) {
 
 async function selectStageTab(tab) {
   if (tab === "useCases" && !app.harvest?.requirements_gate_passed) return;
+  if (tab === "eventStorming" && !app.harvest?.use_cases_ready) return;
   app.stageTab = tab;
   if (tab === "requirements") {
     if (app.workflowRecovered) setRecoveredRequirementsDocument();
     else await openRequirementsDocument();
   }
+  if (tab === "eventStorming") await openCurrentEventDocument();
   render();
 }
 
@@ -406,6 +464,80 @@ async function submitUseCaseAnswer(event) {
   }
 }
 
+async function startEventStormingDefinition() {
+  app.stageTab = "eventStorming";
+  app.eventSelectedUc = null;
+  await runEventStormingTurn("/api/event-storming/start", "Starting Event Storming");
+}
+
+async function continueEventStormingDefinition() {
+  await runEventStormingTurn("/api/event-storming/advance", "Processing next use case");
+}
+
+async function submitEventStormingAnswer(event) {
+  event.preventDefault();
+  const answer = document.querySelector("#event-storming-answer").value.trim();
+  if (!answer) return;
+  await runEventStormingTurn("/api/event-storming/answer", "Submitting event-storming answer", {
+    uc_id: app.harvest.event_storming.current_uc,
+    answer,
+  });
+}
+
+async function runEventStormingTurn(endpoint, label, extra = {}) {
+  app.busy = true;
+  app.busyLabel = label;
+  app.error = "";
+  render();
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ change_set_id: app.requirementsChangeSet, ...extra }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Unable to run event storming.");
+    app.harvest = result.harvest;
+    if (app.harvest.event_storming?.current_uc) {
+      app.eventSelectedUc = app.harvest.event_storming.current_uc;
+    }
+    await openCurrentEventDocument();
+    await loadDashboard();
+    render();
+    const state = app.harvest.event_storming;
+    if (!state.complete && state.status === "running") {
+      await runEventStormingTurn("/api/event-storming/advance", "Processing next use case");
+      return;
+    }
+  } catch (error) {
+    app.error = error.message;
+  }
+  app.busy = false;
+  app.busyLabel = "";
+  render();
+}
+
+async function openCurrentEventDocument() {
+  const state = app.harvest?.event_storming;
+  const ucId = app.eventSelectedUc || state?.current_uc || state?.uc_ids?.find((id) => state.items[id]?.status === "complete");
+  if (!ucId || state.items[ucId]?.status !== "complete") {
+    app.openDocument = null;
+    return;
+  }
+  const id = `event-storming:${app.requirementsChangeSet}:${ucId}`;
+  const response = await fetch(`/api/dashboard/documents/${encodeURIComponent(id)}`);
+  if (response.ok) {
+    app.openDocument = await response.json();
+    app.editorMode = "preview";
+  }
+}
+
+async function selectEventUseCase(ucId) {
+  app.eventSelectedUc = ucId;
+  await openCurrentEventDocument();
+  render();
+}
+
 function renderDetail(change) {
   const stages = change.stages.map((stage) => `
     <div class="stage ${stage.status}">
@@ -413,11 +545,12 @@ function renderDetail(change) {
       <span class="pill ${stage.status}">${escapeHtml(stage.status)}</span>
       <div class="small">${escapeHtml(stage.verified_at)}</div>
     </div>`).join("");
+  const hasAggregateBoard = Boolean(change.event_storming_board?.slices?.length);
   const workItems = change.work_items.map((item) => `
     <div class="panel">
       <h3>${escapeHtml(item.id)}: ${escapeHtml(item.name)}</h3>
       ${item.artifacts.map((artifact) => `<span class="artifact">${escapeHtml(artifact.path)}</span>`).join("")}
-      ${renderBoard(item.event_storming)}
+      ${hasAggregateBoard ? "" : renderBoard(item.event_storming)}
     </div>`).join("");
   const documents = change.documents.map((document) => `
     <button data-document="${escapeHtml(document.id)}">${escapeHtml(document.label)}</button>`).join("");
@@ -435,6 +568,7 @@ function renderDetail(change) {
     </div>` : ""}
     <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div></section>
     ${documents ? `<section class="panel"><h3>Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
+    ${renderCanvasBoard(change.event_storming_board)}
     ${workItems}
     <details class="panel"><summary>Runtime history</summary><ul>${runs || "<li>No recorded runs.</li>"}</ul></details>`;
 }
@@ -450,6 +584,26 @@ function renderBoard(board) {
       </article>`).join("")}</div>`).join("")}`;
 }
 
+function renderCanvasBoard(board) {
+  if (!board?.slices?.length) return "";
+  const contents = board.slices.map((slice) => `
+    <section class="canvas-slice"><h4>${escapeHtml(slice.uc_id)}</h4>
+      ${slice.flows.map((flow) => `<div class="canvas-lane"><strong>${escapeHtml(flow.name)}</strong>
+        <div class="flow-lane">${flow.notes.map(renderSticky).join("")}</div></div>`).join("")}
+      ${slice.supporting_notes?.length ? `<div class="flow-lane supporting">${slice.supporting_notes.map(renderSticky).join("")}</div>` : ""}
+    </section>`).join("");
+  return `<section class="panel event-canvas-panel"><div class="canvas-header"><h3>Event Storming Canvas</h3>
+    <div><span id="canvas-zoom-label">100%</span><button id="canvas-reset" type="button">Reset view</button></div></div>
+    <p class="small">Drag canvas to pan. Scroll over canvas to zoom.</p>
+    <div id="event-canvas" class="event-canvas"><div id="event-canvas-content" class="event-canvas-content">${contents}</div></div></section>`;
+}
+
+function renderSticky(note) {
+  return `<article class="sticky ${escapeHtml(note.type)}">
+    <div class="sticky-type">${escapeHtml(note.type.replace("_", " "))}</div>${escapeHtml(note.text)}
+  </article>`;
+}
+
 function bindDetail(change) {
   document.querySelectorAll("[data-document]").forEach((node) => node.onclick = () => openDocument(node.dataset.document));
   const deleteButton = document.querySelector("[data-delete-change-set]");
@@ -459,6 +613,7 @@ function bindDetail(change) {
   if (app.openDocument && change.documents.some((item) => item.id === app.openDocument.id)) {
     renderEditor();
   }
+  bindCanvas();
 }
 
 async function loadWorkflowResults(changeSetId) {
@@ -471,10 +626,16 @@ async function loadWorkflowResults(changeSetId) {
   }
   app.requirementsChangeSet = changeSetId;
   app.harvest = result.harvest;
-  app.stageTab = result.harvest.active_stage === "useCases" ? "useCases" : "requirements";
+  app.stageTab = result.harvest.active_stage === "eventStorming"
+    ? "eventStorming" : result.harvest.active_stage === "useCases" ? "useCases" : "requirements";
   app.workflowRecovered = true;
   app.view = "requirements";
-  setRecoveredRequirementsDocument();
+  if (app.stageTab === "eventStorming") {
+    app.eventSelectedUc = result.harvest.event_storming?.current_uc;
+    await openCurrentEventDocument();
+  } else {
+    setRecoveredRequirementsDocument();
+  }
   app.error = "";
   render();
 }
@@ -527,6 +688,124 @@ function renderEditor(message = "") {
   document.querySelector("#preview-mode").onclick = () => { app.editorMode = "preview"; renderEditor(); };
   if (editable) document.querySelector("#edit-mode").onclick = () => { app.editorMode = "edit"; renderEditor(); };
   if (editing) document.querySelector("#save-doc").onclick = saveDocument;
+}
+
+function parseEventStormingMarkdown(content) {
+  const lines = String(content || "").split(/\r?\n/);
+  const flows = [];
+  const supportingNotes = [];
+  const systems = new Set();
+  const externalSystems = new Set();
+  let active = null;
+  let inExternalSystems = false;
+  lines.forEach((line) => {
+    if (line.startsWith("## 6.")) inExternalSystems = true;
+    else if (inExternalSystems && line.startsWith("## ")) inExternalSystems = false;
+    const header = line.match(/^### \[Flow: ([^\]]+)\]/);
+    if (header) {
+      active = { name: header[1], notes: [] };
+      flows.push(active);
+      return;
+    }
+    const match = line.trim().replace(/^→\s*/, "").match(/^([🟦🟧🟪⬛🟩])\s*(.+)$/u);
+    if (active && match) {
+      const types = { "🟦": "command", "🟧": "event", "🟪": "policy", "⬛": "system", "🟩": "external_system" };
+      active.notes.push({ type: types[match[1]], text: match[2] });
+    }
+    const cells = splitTableRow(line);
+    if (cells?.length >= 5 && ["🟦", "🟧", "🟪"].includes(cells[0]) && cells[4] && cells[4] !== "없음") {
+      systems.add(cells[4]);
+    }
+    if (inExternalSystems && cells?.length >= 2 && !["시스템", "---", "없음", ""].includes(cells[0]) && !/^-+$/.test(cells[0])) {
+      externalSystems.add(cells[0]);
+    }
+  });
+  systems.forEach((text) => supportingNotes.push({ type: "system", text }));
+  externalSystems.forEach((text) => supportingNotes.push({ type: "external_system", text }));
+  return { flows, supporting_notes: supportingNotes };
+}
+
+function renderEventDocumentEditor(message = "") {
+  const target = document.querySelector("#event-document-editor");
+  const preview = document.querySelector("#event-live-board");
+  if (!target) return;
+  if (!app.openDocument?.id?.startsWith("event-storming:")) {
+    target.innerHTML = '<p class="small">Generated event-storming Markdown appears after a use case completes.</p>';
+    if (preview) preview.innerHTML = '<p class="small">Sticky notes appear from generated Markdown.</p>';
+    return;
+  }
+  const editing = app.editorMode === "edit";
+  target.innerHTML = `<div class="doc-actions"><button id="event-preview-mode">Preview</button>
+    <button id="event-edit-mode">Edit</button>${editing ? '<button class="primary" id="event-save-doc">Save</button>' : ""}</div>
+    ${message ? `<p class="error">${escapeHtml(message)}</p>` : ""}
+    ${editing ? `<textarea id="event-doc-content">${escapeHtml(app.openDocument.content)}</textarea>`
+      : `<div class="markdown-preview">${markdownPreview(app.openDocument.content)}</div>`}`;
+  const updatePreview = (content) => {
+    if (preview) {
+      const board = parseEventStormingMarkdown(content);
+      const support = board.supporting_notes?.length ? `<div class="flow-lane supporting">${board.supporting_notes.map(renderSticky).join("")}</div>` : "";
+      preview.innerHTML = (renderBoard(board) + support) || '<p class="small">No parseable flow notes.</p>';
+    }
+  };
+  updatePreview(app.openDocument.content);
+  document.querySelector("#event-preview-mode").onclick = () => { app.editorMode = "preview"; renderEventDocumentEditor(); };
+  document.querySelector("#event-edit-mode").onclick = () => { app.editorMode = "edit"; renderEventDocumentEditor(); };
+  if (editing) {
+    document.querySelector("#event-doc-content").oninput = (event) => updatePreview(event.target.value);
+    document.querySelector("#event-save-doc").onclick = async () => {
+      const content = document.querySelector("#event-doc-content").value;
+      const response = await fetch(`/api/dashboard/documents/${encodeURIComponent(app.openDocument.id)}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content, revision: app.openDocument.revision }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        renderEventDocumentEditor(result.error);
+        return;
+      }
+      app.openDocument = result;
+      app.editorMode = "preview";
+      await loadDashboard();
+      renderEventDocumentEditor();
+    };
+  }
+}
+
+function bindCanvas() {
+  const canvas = document.querySelector("#event-canvas");
+  const content = document.querySelector("#event-canvas-content");
+  if (!canvas || !content) return;
+  const apply = () => {
+    content.style.transform = `translate(${app.canvas.x}px, ${app.canvas.y}px) scale(${app.canvas.scale})`;
+    document.querySelector("#canvas-zoom-label").textContent = `${Math.round(app.canvas.scale * 100)}%`;
+  };
+  let dragging = false;
+  let previous = null;
+  canvas.onpointerdown = (event) => {
+    if (event.target.closest(".sticky")) return;
+    dragging = true;
+    previous = { x: event.clientX, y: event.clientY };
+    canvas.setPointerCapture(event.pointerId);
+  };
+  canvas.onpointermove = (event) => {
+    if (!dragging) return;
+    app.canvas.x += event.clientX - previous.x;
+    app.canvas.y += event.clientY - previous.y;
+    previous = { x: event.clientX, y: event.clientY };
+    apply();
+  };
+  canvas.onpointerup = () => { dragging = false; };
+  canvas.onwheel = (event) => {
+    event.preventDefault();
+    app.canvas.scale = Math.max(0.4, Math.min(2.5, app.canvas.scale + (event.deltaY < 0 ? 0.1 : -0.1)));
+    apply();
+  };
+  document.querySelector("#canvas-reset").onclick = () => {
+    app.canvas = { scale: 1, x: 0, y: 0 };
+    apply();
+  };
+  apply();
 }
 
 async function saveDocument() {

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -580,7 +580,7 @@ function renderBoard(board) {
     <div class="flow-lane">${flow.notes.map((note) => `
       <article class="sticky ${escapeHtml(note.type)}">
         <div class="sticky-type">${escapeHtml(note.type.replace("_", " "))}</div>
-        ${escapeHtml(note.text)}
+        ${escapeHtml(stickyText(note.text))}
       </article>`).join("")}</div>`).join("")}`;
 }
 
@@ -600,8 +600,12 @@ function renderCanvasBoard(board) {
 
 function renderSticky(note) {
   return `<article class="sticky ${escapeHtml(note.type)}">
-    <div class="sticky-type">${escapeHtml(note.type.replace("_", " "))}</div>${escapeHtml(note.text)}
+    <div class="sticky-type">${escapeHtml(note.type.replace("_", " "))}</div>${escapeHtml(stickyText(note.text))}
   </article>`;
+}
+
+function stickyText(text) {
+  return String(text || "").replace(/`([^`]*)`/g, "$1");
 }
 
 function bindDetail(change) {
@@ -710,14 +714,14 @@ function parseEventStormingMarkdown(content) {
     const match = line.trim().replace(/^→\s*/, "").match(/^([🟦🟧🟪⬛🟩])\s*(.+)$/u);
     if (active && match) {
       const types = { "🟦": "command", "🟧": "event", "🟪": "policy", "⬛": "system", "🟩": "external_system" };
-      active.notes.push({ type: types[match[1]], text: match[2] });
+      active.notes.push({ type: types[match[1]], text: stickyText(match[2]) });
     }
     const cells = splitTableRow(line);
     if (cells?.length >= 5 && ["🟦", "🟧", "🟪"].includes(cells[0]) && cells[4] && cells[4] !== "없음") {
-      systems.add(cells[4]);
+      systems.add(stickyText(cells[4]));
     }
     if (inExternalSystems && cells?.length >= 2 && !["시스템", "---", "없음", ""].includes(cells[0]) && !/^-+$/.test(cells[0])) {
-      externalSystems.add(cells[0]);
+      externalSystems.add(stickyText(cells[0]));
     }
   });
   systems.forEach((text) => supportingNotes.push({ type: "system", text }));

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -517,7 +517,7 @@ def _parse_event_storming(text: str) -> dict[str, Any]:
             value = line.strip().removeprefix("→").strip()
             note_type = _sticky_type(value)
             if note_type:
-                notes.append({"type": note_type, "text": value[2:].strip()})
+                notes.append({"type": note_type, "text": _sticky_text(value[2:])})
         if notes:
             ordinal = sum(1 for flow in flows if flow["kind"] == kind) + 1
             label = "Main Flow" if kind == "main" else f"Exception Flow {ordinal}"
@@ -536,16 +536,16 @@ def _parse_event_storming(text: str) -> dict[str, Any]:
         cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
         if len(cells) > 1 and cells[0] in ("⬛", "🟩"):
             note_type = "system" if cells[0] == "⬛" else "external_system"
-            supporting.append({"type": note_type, "text": cells[1]})
+            supporting.append({"type": note_type, "text": _sticky_text(cells[1])})
         if len(cells) >= 5 and cells[0] in ("🟦", "🟧", "🟪") and cells[4] not in ("", "없음"):
-            systems.add(cells[4])
+            systems.add(_sticky_text(cells[4]))
         if (
             in_external_systems
             and len(cells) >= 2
             and cells[0] not in ("시스템", "---", "없음", "")
             and not set(cells[0]) <= {"-"}
         ):
-            externals.add(cells[0])
+            externals.add(_sticky_text(cells[0]))
     supporting.extend({"type": "system", "text": value} for value in sorted(systems))
     supporting.extend({"type": "external_system", "text": value} for value in sorted(externals))
     return {"flows": flows, "supporting_notes": supporting}
@@ -580,6 +580,10 @@ def _sticky_type(value: str) -> str | None:
         "⬛": "system",
         "🟩": "external_system",
     }.get(value[:1])
+
+
+def _sticky_text(value: str) -> str:
+    return re.sub(r"`([^`]*)`", r"\1", value.strip())
 
 
 def _run_payload(run: DashboardRun) -> dict[str, Any]:

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -70,6 +70,9 @@ def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
                         for item in change_set.ordered_work_items()
                     ],
                     "documents": _document_summaries(root, change_set, lifecycle, path, workflow_state),
+                    "event_storming_board": _scoped_event_storming_board(
+                        root, change_set.change_set_id, lifecycle, workflow_state
+                    ),
                     "latest_run": run_payloads[0] if run_payloads else None,
                     "run_history": run_payloads,
                 }
@@ -131,6 +134,8 @@ def save_dashboard_document(
 
     path.write_text(normalized, encoding="utf-8")
     change_path.write_text(change_text, encoding="utf-8")
+    if document["kind"] == "generated-use-case":
+        _invalidate_scoped_event_storming(root, document_id.split(":")[1], document_id.split(":")[2])
     return _document_payload(root, document, normalized)
 
 
@@ -235,6 +240,20 @@ def _document_summaries(
                         "editable": True,
                     }
                 )
+    event_state = (workflow_state or {}).get("event_storming") or {}
+    for uc_id in event_state.get("uc_ids", []):
+        item = event_state.get("items", {}).get(uc_id, {})
+        path = scoped_root / "docs/use-cases" / uc_id / "event-storming.md"
+        if item.get("status") == "complete" and path.exists():
+            summaries.append(
+                {
+                    "id": f"event-storming:{change_set.change_set_id}:{uc_id}",
+                    "kind": "event-storming",
+                    "label": f"{uc_id} Event Storming",
+                    "path": _relative_path(root, path),
+                    "editable": True,
+                }
+            )
     for item in change_set.ordered_work_items():
         if item.work_item_type is WorkItemType.USE_CASE:
             path = root / "docs/use-cases" / item.work_item_id / "use-case.md"
@@ -298,6 +317,26 @@ def _scoped_workflow_state(root: Path, change_set_id: str, lifecycle: str) -> di
     return state if isinstance(state, dict) else None
 
 
+def _invalidate_scoped_event_storming(root: Path, change_set_id: str, uc_id: str) -> None:
+    session_path = root / SCOPED_UI_STATE_ROOT / change_set_id / "harvest-session.json"
+    state = _scoped_workflow_state(root, change_set_id, "active")
+    event_state = (state or {}).get("event_storming")
+    if not isinstance(event_state, dict) or uc_id not in event_state.get("items", {}):
+        return
+    item = event_state["items"][uc_id]
+    item.update({"status": "pending", "current_question": None, "clarifications": [], "error": ""})
+    event_state["complete"] = False
+    event_state["status"] = "pending"
+    event_state["completed_count"] = sum(
+        1 for value in event_state["items"].values() if value.get("status") == "complete"
+    )
+    event_state["current_uc"] = uc_id
+    output = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "event-storming.md"
+    if output.exists():
+        output.unlink()
+    session_path.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
 def _project_workflow_stages(
     stages: list[dict[str, str]], workflow_state: dict[str, Any] | None
 ) -> list[dict[str, str]]:
@@ -308,6 +347,8 @@ def _project_workflow_stages(
         completed.add("requirements-definition")
     if workflow_state.get("use_cases_ready"):
         completed.add("use-case-definition")
+    if (workflow_state.get("event_storming") or {}).get("complete"):
+        completed.add("event-storming")
     for stage in stages:
         if stage["id"] in completed:
             stage["status"] = "verified"
@@ -349,6 +390,14 @@ def _resolve_editable_document(root: Path, document_id: str) -> dict[str, Any]:
             raise DashboardDocumentNotFound("Use case is not part of completed UI workflow.")
         path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "use-case.md"
         label = f"{uc_id} Use Case"
+    elif kind == "event-storming" and len(parts) == 3:
+        uc_id = parts[2]
+        state = _scoped_workflow_state(root, change_set_id, "active") or {}
+        item = (state.get("event_storming") or {}).get("items", {}).get(uc_id, {})
+        if not re.fullmatch(r"UC-\d+", uc_id) or item.get("status") != "complete":
+            raise DashboardDocumentNotFound("Event storming is not complete for this use case.")
+        path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "event-storming.md"
+        label = f"{uc_id} Event Storming"
     else:
         raise DashboardDocumentNotFound("Unknown editable document.")
     if not path.exists():
@@ -388,6 +437,13 @@ def _validate_document(document: dict[str, Any], content: str) -> None:
             ("## 1. Overview", "## 1. 개요"),
             ("## 3. Functional Requirements", "## 3. 기능 요구사항"),
         )
+    elif document["kind"] == "event-storming":
+        required_groups = (
+            ("### [Flow:",),
+            ("🟦",),
+            ("🟧",),
+            ("🟪",),
+        )
     else:
         uc_id = document["id"].split(":")[-1]
         required_groups = (
@@ -409,6 +465,13 @@ def _stale_stage_ids(kind: str) -> tuple[str, ...]:
         return (
             "use-case-definition",
             "event-storming",
+            "ddd-architecture-definition",
+            "technical-decisions",
+            "plan-writing",
+            "implementation",
+        )
+    if kind == "event-storming":
+        return (
             "ddd-architecture-definition",
             "technical-decisions",
             "plan-writing",
@@ -461,7 +524,52 @@ def _parse_event_storming(text: str) -> dict[str, Any]:
             flows.append(
                 {"name": label, "source_name": source_name, "kind": kind, "notes": notes}
             )
-    return {"flows": flows}
+    supporting: list[dict[str, str]] = []
+    systems: set[str] = set()
+    externals: set[str] = set()
+    in_external_systems = False
+    for line in text.splitlines():
+        if line.startswith("## 6."):
+            in_external_systems = True
+        elif in_external_systems and line.startswith("## "):
+            in_external_systems = False
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) > 1 and cells[0] in ("⬛", "🟩"):
+            note_type = "system" if cells[0] == "⬛" else "external_system"
+            supporting.append({"type": note_type, "text": cells[1]})
+        if len(cells) >= 5 and cells[0] in ("🟦", "🟧", "🟪") and cells[4] not in ("", "없음"):
+            systems.add(cells[4])
+        if (
+            in_external_systems
+            and len(cells) >= 2
+            and cells[0] not in ("시스템", "---", "없음", "")
+            and not set(cells[0]) <= {"-"}
+        ):
+            externals.add(cells[0])
+    supporting.extend({"type": "system", "text": value} for value in sorted(systems))
+    supporting.extend({"type": "external_system", "text": value} for value in sorted(externals))
+    return {"flows": flows, "supporting_notes": supporting}
+
+
+def _scoped_event_storming_board(
+    root: Path,
+    change_set_id: str,
+    lifecycle: str,
+    workflow_state: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if lifecycle != "active" or not workflow_state:
+        return {"slices": []}
+    state = workflow_state.get("event_storming") or {}
+    slices: list[dict[str, Any]] = []
+    for uc_id in state.get("uc_ids", []):
+        if state.get("items", {}).get(uc_id, {}).get("status") != "complete":
+            continue
+        path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "event-storming.md"
+        if not path.exists():
+            continue
+        board = _parse_event_storming(path.read_text(encoding="utf-8"))
+        slices.append({"uc_id": uc_id, **board})
+    return {"slices": slices}
 
 
 def _sticky_type(value: str) -> str | None:

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -26,6 +26,9 @@ REQUIREMENTS_SKILL_PATH = Path(".codex/skills/harness-requirements/SKILL.md")
 USE_CASE_AGENT_CONFIG_PATH = Path(".codex/agents/harness_usecases.toml")
 USE_CASE_SKILL_PATH = Path(".codex/skills/harness-usecases/SKILL.md")
 USE_CASE_DEFINITION_TIMEOUT_SEC = 3600
+EVENT_STORMING_AGENT_CONFIG_PATH = Path(".codex/agents/oracle.toml")
+EVENT_STORMING_SKILL_PATH = Path(".codex/skills/harness-event-storming/SKILL.md")
+EVENT_STORMING_TIMEOUT_SEC = 3600
 
 
 @dataclass(frozen=True)
@@ -40,6 +43,7 @@ class HarvestUiResult:
     current_questions: tuple[dict[str, Any], ...]
     requirements_gate_passed: bool
     use_cases_ready: bool
+    event_storming: dict[str, Any]
     runtime_error: str
     workflow: dict[str, Any]
 
@@ -161,6 +165,73 @@ def answer_use_cases(root: Path | str, answer: str, idea: str = "") -> HarvestUi
     return _result(root_path, session)
 
 
+def start_event_storming(root: Path | str, change_set_id: str) -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    if not session.get("use_cases_ready"):
+        raise ValueError("use-case gate has not passed")
+    uc_ids = _parse_canonical_use_case_ids(_read_optional(root_path / USE_CASES_PATH))
+    if not uc_ids:
+        raise ValueError("no generated use-case slices are available for event storming")
+    state = session.get("event_storming")
+    if not isinstance(state, dict) or state.get("uc_ids") != uc_ids:
+        state = _new_event_storming_state(uc_ids)
+        session["event_storming"] = state
+    session["active_stage"] = "eventStorming"
+    if not state.get("complete") and not _current_event_storming_question(session):
+        _advance_event_storming(root_path, session, change_set_id)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
+def advance_event_storming(root: Path | str, change_set_id: str) -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    if not session.get("use_cases_ready"):
+        raise ValueError("use-case gate has not passed")
+    state = session.get("event_storming")
+    if not isinstance(state, dict):
+        raise ValueError("event storming has not started")
+    if _current_event_storming_question(session):
+        raise ValueError("answer the current event-storming question before continuing")
+    _advance_event_storming(root_path, session, change_set_id)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
+def answer_event_storming(
+    root: Path | str,
+    change_set_id: str,
+    uc_id: str,
+    answer: str,
+) -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    state = session.get("event_storming")
+    if not isinstance(state, dict) or state.get("current_uc") != uc_id:
+        raise ValueError("no active event-storming question for use case")
+    item = state.get("items", {}).get(uc_id, {})
+    question = item.get("current_question")
+    normalized_answer = answer.strip()
+    if not isinstance(question, dict) or not normalized_answer:
+        raise ValueError("answer is required for the current event-storming question")
+    item.setdefault("clarifications", []).append(
+        {
+            "questions": [
+                {
+                    "question": str(question.get("question", "")),
+                    "recommended": str(question.get("recommended", "")),
+                }
+            ],
+            "answer": normalized_answer,
+        }
+    )
+    item["current_question"] = None
+    _advance_event_storming(root_path, session, change_set_id, uc_id=uc_id)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
 def load_harvest_ui(root: Path | str) -> HarvestUiResult:
     root_path = Path(root)
     session = _load_session(root_path)
@@ -201,7 +272,7 @@ def _write_changeset_harvest_snapshot(root: Path, change_set_id: str, session: d
     )
     if use_cases_started:
         _copy_optional_artifact(root / USE_CASES_PATH, scoped_root / USE_CASES_PATH)
-        _copy_optional_tree(root / USE_CASE_SLICE_ROOT, scoped_root / USE_CASE_SLICE_ROOT)
+        _copy_scoped_use_case_outputs(root, scoped_root, session)
     else:
         use_case_document = scoped_root / USE_CASES_PATH
         if use_case_document.exists():
@@ -258,6 +329,7 @@ def _new_session(prompt: str) -> dict[str, Any]:
         "use_case_current_question": None,
         "use_case_current_questions": [],
         "use_case_pending_questions": [],
+        "event_storming": None,
     }
 
 
@@ -266,6 +338,7 @@ def _workflow_projection() -> dict[str, Any]:
         "stages": [
             {"id": "requirements", "label": "Requirements", "document": str(REQUIREMENTS_PATH)},
             {"id": "useCases", "label": "Use Cases", "document": str(USE_CASES_PATH)},
+            {"id": "eventStorming", "label": "Event Storming", "document": ""},
         ]
     }
 
@@ -293,6 +366,7 @@ def _normalize_session(session: dict[str, Any]) -> None:
     session.setdefault("use_case_current_question", None)
     session.setdefault("use_case_current_questions", [])
     session.setdefault("use_case_pending_questions", [])
+    session.setdefault("event_storming", None)
     current = session.get("current_question")
     current_questions = session.get("current_questions") or []
     if current is None and current_questions:
@@ -309,6 +383,14 @@ def _normalize_session(session: dict[str, Any]) -> None:
         session["use_case_current_questions"] = [session["use_case_current_question"]]
     else:
         session["use_case_current_questions"] = []
+    state = session.get("event_storming")
+    if isinstance(state, dict):
+        state.setdefault("uc_ids", [])
+        state.setdefault("items", {})
+        state.setdefault("current_uc", None)
+        state.setdefault("completed_count", 0)
+        state.setdefault("complete", False)
+        state.setdefault("status", "pending")
 
 
 def _load_session(root: Path) -> dict[str, Any] | None:
@@ -359,6 +441,7 @@ def _session_from_requirements_doc(root: Path) -> dict[str, Any] | None:
         "use_case_current_question": None,
         "use_case_current_questions": [],
         "use_case_pending_questions": [],
+        "event_storming": None,
     }
     if session["use_cases_ready"]:
         session["active_stage"] = "useCases"
@@ -457,15 +540,20 @@ def _result(root: Path, session: dict[str, Any], *, artifact_root: Path | None =
         else ""
     )
     gate_passed = bool(session["requirements_gate_passed"])
+    event_storming = _event_storming_payload(documents_root, session)
     status = "idle" if not session_started else (
+        "event_storming_ready" if event_storming.get("complete") else (
+        "event_storming_running" if session.get("active_stage") == "eventStorming" else (
         "use_cases_ready" if session.get("use_cases_ready") else (
             "requirements_passed" if gate_passed else "requirements_running"
-        )
+        )))
     )
     if session_started and not gate_passed:
         current_question = _current_question(session)
     elif session_started and gate_passed and not session.get("use_cases_ready"):
         current_question = _current_use_case_question(session)
+    elif session_started and session.get("active_stage") == "eventStorming":
+        current_question = _current_event_storming_question(session)
     else:
         current_question = None
     current_questions = (current_question,) if current_question else ()
@@ -480,6 +568,7 @@ def _result(root: Path, session: dict[str, Any], *, artifact_root: Path | None =
         current_questions=current_questions,
         requirements_gate_passed=gate_passed,
         use_cases_ready=bool(session.get("use_cases_ready")),
+        event_storming=event_storming,
         runtime_error=str(session.get("runtime_error", "")),
         workflow=_workflow_projection(),
     )
@@ -523,12 +612,33 @@ def _copy_optional_tree(source: Path, target: Path, *, replace: bool = True) -> 
         shutil.copytree(source, target, dirs_exist_ok=not replace)
 
 
+def _copy_scoped_use_case_outputs(root: Path, scoped_root: Path, session: dict[str, Any]) -> None:
+    target_root = scoped_root / USE_CASE_SLICE_ROOT
+    if target_root.exists():
+        shutil.rmtree(target_root)
+    uc_ids = _parse_canonical_use_case_ids(_read_optional(root / USE_CASES_PATH))
+    event_items = (session.get("event_storming") or {}).get("items", {})
+    for uc_id in uc_ids:
+        for name in ("use-case.md", "e2e-goal.md"):
+            _copy_optional_artifact(
+                root / USE_CASE_SLICE_ROOT / uc_id / name,
+                target_root / uc_id / name,
+            )
+        if event_items.get(uc_id, {}).get("status") == "complete":
+            _copy_optional_artifact(
+                root / USE_CASE_SLICE_ROOT / uc_id / "event-storming.md",
+                target_root / uc_id / "event-storming.md",
+            )
+
+
 def _normalize_resumed_stage(session: dict[str, Any]) -> None:
     if not session.get("requirements_gate_passed"):
         session["active_stage"] = "requirements"
         session["use_cases_ready"] = False
         return
-    if (
+    if isinstance(session.get("event_storming"), dict):
+        session["active_stage"] = "eventStorming"
+    elif (
         session.get("use_cases_ready")
         or session.get("use_case_current_question")
         or session.get("use_case_clarifications")
@@ -557,6 +667,15 @@ def _current_use_case_question(session: dict[str, Any]) -> dict[str, Any] | None
     if current_questions:
         return current_questions[0]
     return None
+
+
+def _current_event_storming_question(session: dict[str, Any]) -> dict[str, Any] | None:
+    state = session.get("event_storming")
+    if not isinstance(state, dict):
+        return None
+    item = state.get("items", {}).get(state.get("current_uc"), {})
+    current = item.get("current_question")
+    return current if isinstance(current, dict) and current.get("question") else None
 
 
 def _activate_next_pending_question(session: dict[str, Any]) -> None:
@@ -633,6 +752,7 @@ def _advance_use_case_harvest(root: Path, session: dict[str, Any], idea: str) ->
         session["use_case_current_question"] = None
         session["use_case_current_questions"] = []
         session["use_case_pending_questions"] = []
+        session["event_storming"] = None
         session["runtime_error"] = ""
         return
     if status == "blocked":
@@ -647,6 +767,133 @@ def _advance_use_case_harvest(root: Path, session: dict[str, Any], idea: str) ->
     session["use_case_current_questions"] = [questions[0]]
     session["use_case_pending_questions"] = questions[1:]
     session["runtime_error"] = ""
+
+
+def _new_event_storming_state(uc_ids: list[str]) -> dict[str, Any]:
+    return {
+        "uc_ids": uc_ids,
+        "items": {
+            uc_id: {
+                "status": "pending",
+                "current_question": None,
+                "clarifications": [],
+                "error": "",
+            }
+            for uc_id in uc_ids
+        },
+        "current_uc": None,
+        "completed_count": 0,
+        "complete": False,
+        "status": "pending",
+    }
+
+
+def _event_storming_payload(documents_root: Path, session: dict[str, Any]) -> dict[str, Any]:
+    state = session.get("event_storming")
+    if not isinstance(state, dict):
+        return {
+            "uc_ids": [],
+            "items": {},
+            "current_uc": None,
+            "completed_count": 0,
+            "total_count": 0,
+            "complete": False,
+            "status": "not_started",
+        }
+    payload = json.loads(json.dumps(state, ensure_ascii=False))
+    payload["total_count"] = len(payload.get("uc_ids", []))
+    for uc_id, item in payload.get("items", {}).items():
+        item["document_id"] = f"event-storming:{uc_id}"
+        if item.get("status") == "complete":
+            item["markdown"] = _read_optional(
+                documents_root / USE_CASE_SLICE_ROOT / uc_id / "event-storming.md"
+            )
+    return payload
+
+
+def _advance_event_storming(
+    root: Path,
+    session: dict[str, Any],
+    change_set_id: str,
+    *,
+    uc_id: str | None = None,
+) -> None:
+    state = session["event_storming"]
+    target_id = uc_id
+    if target_id is None:
+        target_id = next(
+            (
+                item_id
+                for item_id in state["uc_ids"]
+                if state["items"][item_id]["status"] in {"pending", "error"}
+            ),
+            None,
+        )
+    if target_id is None:
+        state["complete"] = True
+        state["status"] = "complete"
+        state["current_uc"] = None
+        session["runtime_error"] = ""
+        return
+    item = state["items"][target_id]
+    state["current_uc"] = target_id
+    state["status"] = "running"
+    item["status"] = "running"
+    item["error"] = ""
+    output_path = root / USE_CASE_SLICE_ROOT / target_id / "event-storming.md"
+    if output_path.exists():
+        output_path.unlink()
+    try:
+        result = _run_event_storming(root, session, change_set_id, target_id)
+        status = str(result.get("status", "")).strip().lower()
+        if status == "complete":
+            ready, error = _validate_event_storming_slice(output_path)
+            if not ready:
+                raise ValueError(f"event storming reported complete but {error}")
+            item["status"] = "complete"
+            item["current_question"] = None
+            item["error"] = ""
+            state["completed_count"] = sum(
+                1 for value in state["items"].values() if value.get("status") == "complete"
+            )
+            state["complete"] = state["completed_count"] == len(state["uc_ids"])
+            state["status"] = "complete" if state["complete"] else "running"
+            session["runtime_error"] = ""
+            return
+        if status == "blocked":
+            raise ValueError(str(result.get("blocker", "") or "event storming blocked"))
+        questions = result.get("questions", [])
+        if not isinstance(questions, list) or not questions:
+            raise ValueError("event storming needs input but returned no question")
+        question = questions[0]
+        item["status"] = "needs_input"
+        item["current_question"] = {
+            "question": str(question.get("question", "")).strip(),
+            "recommended": str(question.get("recommended", "") or "").strip(),
+        }
+        state["status"] = "needs_input"
+        session["runtime_error"] = ""
+    except ValueError as exc:
+        item["status"] = "error"
+        item["error"] = str(exc)
+        item["current_question"] = None
+        state["status"] = "error"
+        state["complete"] = False
+        session["runtime_error"] = str(exc)
+
+
+def _validate_event_storming_slice(path: Path) -> tuple[bool, str]:
+    if not path.is_file():
+        return False, f"missing output: {path}"
+    text = path.read_text(encoding="utf-8")
+    if _looks_like_placeholder(text):
+        return False, f"unverified placeholder in {path}"
+    if not re.search(r"^### \[Flow: [^\]]+\]\s*$", text, flags=re.MULTILINE):
+        return False, f"no parseable flow in {path}"
+    for marker, label in (("🟦", "command"), ("🟧", "event"), ("🟪", "policy")):
+        if marker not in text:
+            return False, f"missing {label} sticky in {path}"
+    return True, ""
 
 
 def _filter_new_questions(
@@ -881,6 +1128,152 @@ def _run_use_case_harvest(root: Path, session: dict[str, Any], idea: str) -> dic
         raise ValueError(f"use-case harvest execution failed: {error}")
     final_message = final_message_path.read_text(encoding="utf-8")
     return _parse_use_case_harvest_json(final_message)
+
+
+def _run_event_storming(
+    root: Path,
+    session: dict[str, Any],
+    change_set_id: str,
+    uc_id: str,
+) -> dict[str, Any]:
+    agent_config_path = root / EVENT_STORMING_AGENT_CONFIG_PATH
+    skill_path = root / EVENT_STORMING_SKILL_PATH
+    if not agent_config_path.exists():
+        raise ValueError(f"missing event-storming agent config: {EVENT_STORMING_AGENT_CONFIG_PATH}")
+    if not skill_path.exists():
+        raise ValueError(f"missing event-storming skill config: {EVENT_STORMING_SKILL_PATH}")
+    with agent_config_path.open("rb") as file:
+        agent_config = tomllib.load(file)
+
+    run_id = f"interactive-event-storming-{uuid4().hex[:12]}"
+    run_dir = root / ".harness/ui/event-storming-runs" / run_id
+    step_dir = run_dir / "step"
+    step_dir.mkdir(parents=True, exist_ok=True)
+    final_message_path = step_dir / "final-message.md"
+    prompt_path = step_dir / "prompt.md"
+    command_path = step_dir / "command.json"
+    output_path = USE_CASE_SLICE_ROOT / uc_id / "event-storming.md"
+    step = Step(
+        id=f"event-storming-{uc_id}",
+        kind=StepKind.AGENT,
+        name=f"Derive event storming for {uc_id}",
+        agent_id="oracle",
+        skill_id="harness-event-storming",
+        inputs=(
+            Path("docs/changes/active") / f"{change_set_id}.md",
+            USE_CASE_SLICE_ROOT / uc_id / "use-case.md",
+            USE_CASE_SLICE_ROOT / uc_id / "e2e-goal.md",
+        ),
+        outputs=(output_path,),
+        timeout_sec=EVENT_STORMING_TIMEOUT_SEC,
+        metadata={"stage": "event-storming", "scope": uc_id, "interactive": True},
+    )
+    context = RunContext(
+        run_id=run_id,
+        workflow_name="event-storming-workflow",
+        mode=RunMode.APPLY,
+        repo_root=root,
+        workdir=root,
+        run_dir=run_dir,
+        metadata={"stage": "event_storming", "change_set_id": change_set_id, "uc_id": uc_id},
+    )
+    prompt = build_agent_prompt(
+        step=step,
+        context=context,
+        agent_config=agent_config,
+        agent_config_path=EVENT_STORMING_AGENT_CONFIG_PATH,
+        skill_path=skill_path,
+        skill_body=skill_path.read_text(encoding="utf-8"),
+    )
+    item = session.get("event_storming", {}).get("items", {}).get(uc_id, {})
+    prompt = f"{prompt}\n\n{_event_storming_turn_contract(change_set_id, uc_id, item)}"
+    prompt_path.write_text(prompt, encoding="utf-8")
+    command = [
+        "codex",
+        "exec",
+        "--cd",
+        str(root),
+        "--skip-git-repo-check",
+        "-c",
+        'approval_policy="never"',
+        "--sandbox",
+        "workspace-write",
+        "--output-last-message",
+        str(final_message_path),
+    ]
+    model = agent_config.get("model")
+    if isinstance(model, str) and model:
+        command.extend(["--model", model])
+    reasoning_effort = agent_config.get("model_reasoning_effort")
+    if isinstance(reasoning_effort, str) and reasoning_effort:
+        command.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
+    command.append("-")
+    command_path.write_text(json.dumps(command, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=root,
+            input=prompt,
+            text=True,
+            capture_output=True,
+            timeout=EVENT_STORMING_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(
+            f"event storming timed out after {EVENT_STORMING_TIMEOUT_SEC} seconds. "
+            "Retry to continue from this use case."
+        ) from exc
+    (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
+    (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    if completed.returncode != 0:
+        error = completed.stderr.strip() or completed.stdout.strip()
+        raise ValueError(f"event-storming execution failed: {error}")
+    return _parse_event_storming_json(final_message_path.read_text(encoding="utf-8"))
+
+
+def _event_storming_turn_contract(
+    change_set_id: str,
+    uc_id: str,
+    item: dict[str, Any],
+) -> str:
+    return f"""## Interactive Event Storming Turn
+
+Target ChangeSet: {change_set_id}
+Target Use Case: {uc_id}
+
+Return only JSON with keys: status, questions, changed_files, blocker.
+- Return `needs_input` with exactly one question object when one business-policy answer is required.
+- Return `complete` only after writing `docs/use-cases/{uc_id}/event-storming.md` with validated commands, events, policies, systems, external systems, and invariants.
+- Return `blocked` only when existing inputs cannot be corrected by one user answer in this stage.
+- Model only `{uc_id}`; use its goal or first actor action as initial command.
+
+Event-storming answer history:
+{json.dumps(item.get("clarifications", []), ensure_ascii=False, indent=2)}
+"""
+
+
+def _parse_event_storming_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", stripped, flags=re.DOTALL)
+        if match is None:
+            raise ValueError(f"event storming returned non-JSON output: {stripped}")
+        data = json.loads(match.group(0))
+    status = str(data.get("status", "") or "").strip().lower()
+    if status not in {"needs_input", "complete", "blocked"}:
+        raise ValueError(f"event storming returned invalid status: {status or '<empty>'}")
+    questions = data.get("questions", [])
+    if not isinstance(questions, list):
+        raise ValueError("event storming returned invalid questions")
+    return {
+        "status": status,
+        "questions": questions,
+        "changed_files": [str(item) for item in data.get("changed_files", [])],
+        "blocker": str(data.get("blocker", "") or ""),
+    }
 
 
 def _use_case_turn_contract(session: dict[str, Any]) -> str:
@@ -1288,7 +1681,9 @@ def _sync_use_case_readiness(root: Path, session: dict[str, Any]) -> None:
     ready, _ = _validate_runtime_ready_use_case_slices(root)
     was_ready = bool(session.get("use_cases_ready"))
     session["use_cases_ready"] = ready
-    if ready:
+    if ready and isinstance(session.get("event_storming"), dict):
+        session["active_stage"] = "eventStorming"
+    elif ready:
         session["active_stage"] = "useCases"
     elif was_ready:
         session["active_stage"] = "requirements"

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -23,12 +23,15 @@ from harness_codex.runtime.document_dashboard import (
 )
 from harness_codex.runtime.harvest_ui import (
     activate_changeset_harvest_ui,
+    advance_event_storming,
+    answer_event_storming,
     answer_use_cases,
     answer_requirements,
     load_changeset_harvest_ui,
     load_harvest_ui,
     save_changeset_harvest_ui,
     start_requirements,
+    start_event_storming,
     start_use_case_generation,
     start_use_cases,
 )
@@ -95,6 +98,35 @@ def answer_use_cases_changeset(repo_root: Path | str, change_set_id: str, answer
     root = Path(repo_root).resolve()
     activate_changeset_harvest_ui(root, change_set_id)
     result = answer_use_cases(root, answer, idea)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def start_event_storming_changeset(repo_root: Path | str, change_set_id: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    result = start_event_storming(root, change_set_id)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def advance_event_storming_changeset(repo_root: Path | str, change_set_id: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    result = advance_event_storming(root, change_set_id)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def answer_event_storming_changeset(
+    repo_root: Path | str,
+    change_set_id: str,
+    uc_id: str,
+    answer: str,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    result = answer_event_storming(root, change_set_id, uc_id, answer)
     save_changeset_harvest_ui(root, change_set_id)
     return {"change_set_id": change_set_id, "harvest": result.as_dict()}
 
@@ -195,6 +227,29 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
                     _required_change_set_id(body),
                     str(body.get("answer", "")),
                     str(body.get("idea", "")),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path == "/api/event-storming/start":
+                payload = start_event_storming_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path == "/api/event-storming/advance":
+                payload = advance_event_storming_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path == "/api/event-storming/answer":
+                payload = answer_event_storming_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                    str(body.get("uc_id", "")).strip(),
+                    str(body.get("answer", "")),
                 )
                 self._write_json(HTTPStatus.OK, payload)
                 return

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -463,12 +463,14 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert '"/api/event-storming/start"' in javascript
         assert "renderEventDocumentEditor" in javascript
         assert "bindCanvas" in javascript
+        assert 'if (event.target.closest(".sticky")) return;\n    event.preventDefault();' in javascript
         assert "function renderInline" in javascript
         assert "listItems.map" in javascript
         assert "runtime-progress" in stylesheet
         assert "stage-tabs" in stylesheet
         assert ".markdown-preview code" in stylesheet
         assert ".event-canvas" in stylesheet
+        assert "user-select: none" in stylesheet
     finally:
         server.shutdown()
         thread.join()

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -70,8 +70,8 @@ EVENT_STORMING_MARKDOWN = """# UC-001 Event Storming
 
 ## Flow
 ### [Flow: Main Flow]
-🟦 Save Fleeting Note
-→ 🟧 Fleeting Note was saved
+🟦 Save `Fleeting Note`
+→ 🟧 `Fleeting Note` was saved
 → 🟪 Show saved note
 
 ---
@@ -82,12 +82,12 @@ EVENT_STORMING_MARKDOWN = """# UC-001 Event Storming
 ## 5. Domain Elements
 |Type|Content|Trigger|Result|System|Notes|
 |---|---|---|---|---|---|
-|🟦|Save Fleeting Note|Author|Saved|Note System|-|
+|🟦|Save Fleeting Note|Author|Saved|`Note System`|-|
 
 ## 6. External Systems
 |시스템|연동 목적|
 |---|---|
-|Browser Store|Persist draft|
+|`Browser Store`|Persist draft|
 """
 
 
@@ -266,6 +266,10 @@ def test_dashboard_exposes_completed_event_storming_document_and_aggregate_board
     assert statuses["event-storming"] == "verified"
     assert document_id in {item["id"] for item in change_set["documents"]}
     assert change_set["event_storming_board"]["slices"][0]["uc_id"] == "UC-001"
+    assert change_set["event_storming_board"]["slices"][0]["flows"][0]["notes"][:2] == [
+        {"type": "command", "text": "Save Fleeting Note"},
+        {"type": "event", "text": "Fleeting Note was saved"},
+    ]
     assert {"type": "system", "text": "Note System"} in change_set["event_storming_board"]["slices"][0][
         "supporting_notes"
     ]
@@ -276,7 +280,7 @@ def test_dashboard_exposes_completed_event_storming_document_and_aggregate_board
     saved = save_dashboard_document(
         tmp_path,
         document_id,
-        content=loaded["content"].replace("Fleeting Note was saved", "Fleeting Note was stored"),
+        content=loaded["content"].replace("`Fleeting Note` was saved", "`Fleeting Note` was stored"),
         revision=loaded["revision"],
     )
     assert "was stored" in saved["content"]
@@ -463,6 +467,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert '"/api/event-storming/start"' in javascript
         assert "renderEventDocumentEditor" in javascript
         assert "bindCanvas" in javascript
+        assert "function stickyText" in javascript
         assert 'if (event.target.closest(".sticky")) return;\n    event.preventDefault();' in javascript
         assert "function renderInline" in javascript
         assert "listItems.map" in javascript

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -78,6 +78,16 @@ EVENT_STORMING_MARKDOWN = """# UC-001 Event Storming
 ### [Flow: Exception Flow]
 🟦 Save Fleeting Note
 → 🟧 Save failed
+
+## 5. Domain Elements
+|Type|Content|Trigger|Result|System|Notes|
+|---|---|---|---|---|---|
+|🟦|Save Fleeting Note|Author|Saved|Note System|-|
+
+## 6. External Systems
+|시스템|연동 목적|
+|---|---|
+|Browser Store|Persist draft|
 """
 
 
@@ -126,6 +136,23 @@ def _write_completed_ui_workflow(root: Path) -> None:
     use_case = root / ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/use-case.md"
     use_case.parent.mkdir(parents=True, exist_ok=True)
     use_case.write_text(USE_CASE_MARKDOWN, encoding="utf-8")
+
+
+def _write_completed_event_storming_workflow(root: Path) -> None:
+    _write_completed_ui_workflow(root)
+    session_path = root / ".harness/ui/change-sets/CHG-001/harvest-session.json"
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    session["event_storming"] = {
+        "uc_ids": ["UC-001"],
+        "items": {"UC-001": {"status": "complete"}},
+        "current_uc": "UC-001",
+        "completed_count": 1,
+        "complete": True,
+        "status": "complete",
+    }
+    session_path.write_text(json.dumps(session), encoding="utf-8")
+    path = root / ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/event-storming.md"
+    path.write_text(EVENT_STORMING_MARKDOWN, encoding="utf-8")
 
 
 def test_document_dashboard_projects_docs_board_and_folder_lifecycle(tmp_path: Path) -> None:
@@ -225,6 +252,55 @@ def test_dashboard_exposes_editable_scoped_generated_use_case_slice(tmp_path: Pa
 
     assert "Save edited note." in saved["content"]
     assert "|event-storming|Event Storming|stale|" in change_path.read_text(encoding="utf-8")
+
+
+def test_dashboard_exposes_completed_event_storming_document_and_aggregate_board(tmp_path: Path) -> None:
+    change_path = _write_change_set(tmp_path, with_use_case=False)
+    _write_documents(tmp_path)
+    _write_completed_event_storming_workflow(tmp_path)
+
+    change_set = document_dashboard_state(tmp_path)["change_sets"][0]
+    statuses = {stage["id"]: stage["status"] for stage in change_set["stages"]}
+    document_id = "event-storming:CHG-001:UC-001"
+
+    assert statuses["event-storming"] == "verified"
+    assert document_id in {item["id"] for item in change_set["documents"]}
+    assert change_set["event_storming_board"]["slices"][0]["uc_id"] == "UC-001"
+    assert {"type": "system", "text": "Note System"} in change_set["event_storming_board"]["slices"][0][
+        "supporting_notes"
+    ]
+    assert {"type": "external_system", "text": "Browser Store"} in change_set["event_storming_board"]["slices"][0][
+        "supporting_notes"
+    ]
+    loaded = read_dashboard_document(tmp_path, document_id)
+    saved = save_dashboard_document(
+        tmp_path,
+        document_id,
+        content=loaded["content"].replace("Fleeting Note was saved", "Fleeting Note was stored"),
+        revision=loaded["revision"],
+    )
+    assert "was stored" in saved["content"]
+    assert "|ddd-architecture-definition|DDD Architecture Definition|stale|" in change_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_editing_generated_use_case_invalidates_scoped_event_storming_output(tmp_path: Path) -> None:
+    _write_change_set(tmp_path, with_use_case=False)
+    _write_documents(tmp_path)
+    _write_completed_event_storming_workflow(tmp_path)
+    loaded = read_dashboard_document(tmp_path, "generated-use-case:CHG-001:UC-001")
+
+    save_dashboard_document(
+        tmp_path,
+        "generated-use-case:CHG-001:UC-001",
+        content=loaded["content"].replace("Save one note.", "Save changed note."),
+        revision=loaded["revision"],
+    )
+
+    change_set = document_dashboard_state(tmp_path)["change_sets"][0]
+    assert "event-storming:CHG-001:UC-001" not in {item["id"] for item in change_set["documents"]}
+    assert change_set["event_storming_board"]["slices"] == []
 
 
 def test_save_requirements_requires_current_revision_and_stales_downstream_stages(
@@ -382,12 +458,17 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "/resume" in javascript
         assert "Continue to Use Case Definition" in javascript
         assert "Retry Use Case Definition" in javascript
-        assert "Continue to Event Storming (next slice)" in javascript
+        assert "Continue to Event Storming" in javascript
+        assert "Continue Event Storming" in javascript
+        assert '"/api/event-storming/start"' in javascript
+        assert "renderEventDocumentEditor" in javascript
+        assert "bindCanvas" in javascript
         assert "function renderInline" in javascript
         assert "listItems.map" in javascript
         assert "runtime-progress" in stylesheet
         assert "stage-tabs" in stylesheet
         assert ".markdown-preview code" in stylesheet
+        assert ".event-canvas" in stylesheet
     finally:
         server.shutdown()
         thread.join()

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -9,12 +9,15 @@ from harness_codex.runtime.harvest_ui import (
     REQUIREMENTS_PATH,
     USE_CASES_PATH,
     activate_changeset_harvest_ui,
+    advance_event_storming,
+    answer_event_storming,
     answer_use_cases,
     answer_requirements,
     load_changeset_harvest_ui,
     load_harvest_ui,
     save_changeset_harvest_ui,
     start_requirements,
+    start_event_storming,
     start_use_case_generation,
     start_use_cases,
 )
@@ -142,6 +145,22 @@ def write_use_case_slice(root: Path, uc_id: str = "UC-001") -> None:
     )
     (use_case_dir / "e2e-goal.md").write_text(
         f"# {uc_id} E2E Goal\n\n## Given\n- Ready.\n\n## When\n- User acts.\n\n## Then\n- Goal succeeds.\n",
+        encoding="utf-8",
+    )
+
+
+def write_event_storming_slice(root: Path, uc_id: str) -> None:
+    path = root / f"docs/use-cases/{uc_id}/event-storming.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"""# {uc_id}. Event Storming
+
+## Flow
+### [Flow: Main Flow]
+🟦 Start {uc_id}
+→ 🟧 {uc_id} was started
+→ 🟪 {uc_id} is valid
+""",
         encoding="utf-8",
     )
 
@@ -717,3 +736,87 @@ def test_harvest_ui_clears_stale_ready_flag_when_canonical_use_cases_invalid(tmp
 
     assert result.use_cases_ready is False
     assert result.active_stage == "requirements"
+
+
+def test_event_storming_processes_use_case_queue_and_resumes_question(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_passed_requirements(tmp_path)
+    write_canonical_use_cases(
+        tmp_path,
+        "# Use Case Document\n\n- UC-001. First goal\n- UC-002. Second goal\n",
+    )
+    write_use_case_slice(tmp_path, "UC-001")
+    write_use_case_slice(tmp_path, "UC-002")
+    start_use_cases(tmp_path)
+    calls: list[tuple[str, int]] = []
+
+    def fake_event_storming(_root: Path, session: dict, _change_set_id: str, uc_id: str) -> dict:
+        item = session["event_storming"]["items"][uc_id]
+        calls.append((uc_id, len(item["clarifications"])))
+        if uc_id == "UC-002" and not item["clarifications"]:
+            return {
+                "status": "needs_input",
+                "questions": [{"question": "Which failure result?", "recommended": "Show error."}],
+                "changed_files": [],
+                "blocker": "",
+            }
+        write_event_storming_slice(tmp_path, uc_id)
+        return {"status": "complete", "questions": [], "changed_files": [], "blocker": ""}
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_event_storming", fake_event_storming)
+
+    first = start_event_storming(tmp_path, "CHG-001")
+    paused = advance_event_storming(tmp_path, "CHG-001")
+    completed = answer_event_storming(tmp_path, "CHG-001", "UC-002", "Show error.")
+
+    assert first.event_storming["items"]["UC-001"]["status"] == "complete"
+    assert paused.current_question["question"] == "Which failure result?"
+    assert completed.event_storming["complete"] is True
+    assert completed.active_stage == "eventStorming"
+    assert calls == [("UC-001", 0), ("UC-002", 0), ("UC-002", 1)]
+
+
+def test_changeset_snapshot_excludes_stale_event_output_until_stage_completes(tmp_path: Path) -> None:
+    write_passed_requirements(tmp_path)
+    write_runtime_ready_use_cases(tmp_path)
+    start_use_cases(tmp_path)
+    write_event_storming_slice(tmp_path, "UC-001")
+    write_active_changeset(tmp_path, "CHG-001")
+
+    save_changeset_harvest_ui(tmp_path, "CHG-001")
+
+    assert not (
+        tmp_path / ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/event-storming.md"
+    ).exists()
+
+
+def test_changeset_resume_restores_event_storming_question_without_runtime_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_passed_requirements(tmp_path)
+    write_runtime_ready_use_cases(tmp_path)
+    start_use_cases(tmp_path)
+    write_active_changeset(tmp_path, "CHG-001")
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_event_storming",
+        lambda *_args: {
+            "status": "needs_input",
+            "questions": [{"question": "Confirm policy?", "recommended": "Confirm."}],
+            "changed_files": [],
+            "blocker": "",
+        },
+    )
+    start_event_storming(tmp_path, "CHG-001")
+    save_changeset_harvest_ui(tmp_path, "CHG-001")
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_event_storming",
+        lambda *_args: pytest.fail("resume must not execute oracle"),
+    )
+
+    result = load_changeset_harvest_ui(tmp_path, "CHG-001")
+
+    assert result.active_stage == "eventStorming"
+    assert result.current_question["question"] == "Confirm policy?"

--- a/tests/runtime/test_harvest_ui_grill_me_command.py
+++ b/tests/runtime/test_harvest_ui_grill_me_command.py
@@ -5,11 +5,15 @@ from pathlib import Path
 import pytest
 
 from harness_codex.runtime.harvest_ui import (
+    EVENT_STORMING_AGENT_CONFIG_PATH,
+    EVENT_STORMING_SKILL_PATH,
+    EVENT_STORMING_TIMEOUT_SEC,
     GRILL_ME_SKILL_PATH,
     USE_CASE_DEFINITION_TIMEOUT_SEC,
     USE_CASE_AGENT_CONFIG_PATH,
     USE_CASE_SKILL_PATH,
     _run_grill_me,
+    _run_event_storming,
     _run_use_case_harvest,
 )
 
@@ -71,3 +75,30 @@ def test_use_case_timeout_returns_actionable_error(tmp_path: Path, monkeypatch) 
         _run_use_case_harvest(tmp_path, {"initial_prompt": "build feature", "use_case_clarifications": []}, "")
 
     assert captured["timeout"] == USE_CASE_DEFINITION_TIMEOUT_SEC == 3600
+
+
+def test_event_storming_timeout_returns_actionable_error(tmp_path: Path, monkeypatch) -> None:
+    agent_config = tmp_path / EVENT_STORMING_AGENT_CONFIG_PATH
+    agent_config.parent.mkdir(parents=True)
+    agent_config.write_text('name = "oracle"\n', encoding="utf-8")
+    skill_path = tmp_path / EVENT_STORMING_SKILL_PATH
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Event Storming\n", encoding="utf-8")
+
+    def time_out(*_args, **kwargs):
+        raise subprocess.TimeoutExpired(["codex", "exec"], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", time_out)
+
+    with pytest.raises(
+        ValueError,
+        match="event storming timed out after 3600 seconds. Retry to continue from this use case.",
+    ):
+        _run_event_storming(
+            tmp_path,
+            {"event_storming": {"items": {"UC-001": {"clarifications": []}}}},
+            "CHG-001",
+            "UC-001",
+        )
+
+    assert EVENT_STORMING_TIMEOUT_SEC == 3600


### PR DESCRIPTION
## Implementation intent
Use Case Definition 이후 Event Storming 단계를 웹 UI에서 진행할 수 있게 하고, 완료된 ChangeSet별 이벤트 스토밍 결과를 하나의 이동/확대 가능한 sticky-note canvas로 확인할 수 있게 합니다.

Closes #219

## Implementation approach
- ChangeSet scoped harvest session에 Event Storming UC 큐, 현재 UC, per-UC 상태/질문/답변/완료 상태를 저장합니다.
- `POST /api/event-storming/start`, `/advance`, `/answer`를 추가하여 oracle이 한 UC씩 실행되고, 질문 발생 시 UI에서 답한 뒤 동일 UC를 재개하도록 연결합니다.
- Use Case snapshot 저장은 stage-owned 파일(`use-case.md`, `e2e-goal.md`)과 완료가 확인된 `event-storming.md`만 복사하도록 제한하여 이전 downstream 산출물이 완료 결과로 노출되지 않게 합니다.
- Event Storming 편집 문서 `event-storming:<CHG-ID>:<UC-ID>`를 scoped snapshot에 연결하고, 저장 시 흐름/command/event/policy 구조를 검증하며 이후 단계만 stale 처리합니다. Generated Use Case를 수정하면 해당 Event Storming 완료 상태와 출력은 무효화합니다.
- 워크플로우 화면에 Event Storming 탭, UC별 진행 상태, oracle 질문 입력, Markdown preview/editor, 입력 중 즉시 갱신되는 sticky preview를 추가합니다. 중단 후 복구는 자동 실행하지 않고 명시적 Continue 동작을 제공합니다.
- 대시보드는 완료된 scoped event slices만 합산하여 하나의 canvas로 렌더링합니다. Flow arrows뿐 아니라 document table의 owning system/external system도 sticky로 파싱하며, canvas drag pan과 wheel zoom/reset을 제공합니다.

## Verification method
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_harvest_ui.py tests/runtime/test_harvest_ui_grill_me_command.py tests/runtime/test_document_dashboard.py tests/test_oracle_use_case_event_storming.py` -> `49 passed`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> `289 passed`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> pass
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/runtime/harvest_ui.py harness_codex/runtime/ui_server.py harness_codex/runtime/document_dashboard.py` -> pass
- `git diff --check` -> pass

## Risks and rollback
- 위험: oracle 실행은 UC별 장시간 작업이므로 진행 중 브라우저 새로고침 시 다음 UC 자동 진행은 멈추고 사용자가 Continue를 눌러야 합니다. 이는 resume 시 자동 실행 금지 요구사항에 맞춘 동작입니다.
- 위험: 기존 scoped snapshot에 있던 미검증 downstream 파일은 이제 Event Storming 완료로 노출되지 않습니다.
- 롤백: 이 PR을 revert하면 기존 Requirements/Use Cases UI와 정적 work-item board 표시로 복귀합니다.