### PR TITLE
[codex] 이벤트 스토밍 후속 대시보드 수정 반영

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -694,6 +694,10 @@ function renderEditor(message = "") {
   if (editing) document.querySelector("#save-doc").onclick = saveDocument;
 }
 
+function isEditingDashboardDocument() {
+  return app.view === "dashboard" && app.openDocument?.editable !== false && app.editorMode === "edit";
+}
+
 function parseEventStormingMarkdown(content) {
   const lines = String(content || "").split(/\r?\n/);
   const flows = [];
@@ -847,5 +851,5 @@ document.querySelector("#dashboard-home").onclick = () => {
   render();
 };
 setInterval(() => {
-  if (app.view === "dashboard") loadDashboard().catch(() => {});
+  if (app.view === "dashboard" && !isEditingDashboardDocument()) loadDashboard().catch(() => {});
 }, 5000);

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -702,11 +702,15 @@ function parseEventStormingMarkdown(content) {
   const lines = String(content || "").split(/\r?\n/);
   const flows = [];
   const supportingNotes = [];
+  const domainElements = [];
   const systems = new Set();
   const externalSystems = new Set();
   let active = null;
+  let inDomainElements = false;
   let inExternalSystems = false;
   lines.forEach((line) => {
+    if (line.startsWith("## 5.")) inDomainElements = true;
+    else if (inDomainElements && line.startsWith("## ")) inDomainElements = false;
     if (line.startsWith("## 6.")) inExternalSystems = true;
     else if (inExternalSystems && line.startsWith("## ")) inExternalSystems = false;
     const header = line.match(/^### \[Flow: ([^\]]+)\]/);
@@ -721,16 +725,42 @@ function parseEventStormingMarkdown(content) {
       active.notes.push({ type: types[match[1]], text: stickyText(match[2]) });
     }
     const cells = splitTableRow(line);
-    if (cells?.length >= 5 && ["🟦", "🟧", "🟪"].includes(cells[0]) && cells[4] && cells[4] !== "없음") {
-      systems.add(stickyText(cells[4]));
+    if (inDomainElements && cells?.length >= 5 && ["🟦", "🟧", "🟪"].includes(cells[0])) {
+      const types = { "🟦": "command", "🟧": "event", "🟪": "policy" };
+      domainElements.push({ type: types[cells[0]], text: stickyText(cells[1]), trigger: stickyText(cells[2]), result: stickyText(cells[3]) });
+      if (cells[4] && cells[4] !== "없음") systems.add(stickyText(cells[4]));
     }
     if (inExternalSystems && cells?.length >= 2 && !["시스템", "---", "없음", ""].includes(cells[0]) && !/^-+$/.test(cells[0])) {
       externalSystems.add(stickyText(cells[0]));
     }
   });
+  applyDomainElementLabels(flows, domainElements);
   systems.forEach((text) => supportingNotes.push({ type: "system", text }));
   externalSystems.forEach((text) => supportingNotes.push({ type: "external_system", text }));
   return { flows, supporting_notes: supportingNotes };
+}
+
+function applyDomainElementLabels(flows, domainElements) {
+  flows.forEach((flow) => {
+    const original = flow.notes.map((note) => ({ ...note }));
+    flow.notes.forEach((note, index) => {
+      const previous = original[index - 1]?.text || "";
+      const following = original[index + 1]?.text || "";
+      const candidates = domainElements.filter((element) => element.type === note.type);
+      const best = candidates.reduce((selected, element) => (
+        domainElementScore(element, original[index].text, previous, following) >
+        domainElementScore(selected, original[index].text, previous, following) ? element : selected
+      ), null);
+      if (domainElementScore(best, original[index].text, previous, following) > 0) note.text = best.text;
+    });
+  });
+}
+
+function domainElementScore(element, text, previous, following) {
+  if (!element) return 0;
+  return (element.text === text ? 4 : 0) +
+    (previous && element.trigger === previous ? 2 : 0) +
+    (following && element.result === following ? 2 : 0);
 }
 
 function renderEventDocumentEditor(message = "") {

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -525,10 +525,16 @@ def _parse_event_storming(text: str) -> dict[str, Any]:
                 {"name": label, "source_name": source_name, "kind": kind, "notes": notes}
             )
     supporting: list[dict[str, str]] = []
+    domain_elements: list[dict[str, str]] = []
     systems: set[str] = set()
     externals: set[str] = set()
+    in_domain_elements = False
     in_external_systems = False
     for line in text.splitlines():
+        if line.startswith("## 5."):
+            in_domain_elements = True
+        elif in_domain_elements and line.startswith("## "):
+            in_domain_elements = False
         if line.startswith("## 6."):
             in_external_systems = True
         elif in_external_systems and line.startswith("## "):
@@ -537,8 +543,17 @@ def _parse_event_storming(text: str) -> dict[str, Any]:
         if len(cells) > 1 and cells[0] in ("⬛", "🟩"):
             note_type = "system" if cells[0] == "⬛" else "external_system"
             supporting.append({"type": note_type, "text": _sticky_text(cells[1])})
-        if len(cells) >= 5 and cells[0] in ("🟦", "🟧", "🟪") and cells[4] not in ("", "없음"):
-            systems.add(_sticky_text(cells[4]))
+        if in_domain_elements and len(cells) >= 5 and cells[0] in ("🟦", "🟧", "🟪"):
+            domain_elements.append(
+                {
+                    "type": _sticky_type(cells[0]) or "",
+                    "text": _sticky_text(cells[1]),
+                    "trigger": _sticky_text(cells[2]),
+                    "result": _sticky_text(cells[3]),
+                }
+            )
+            if cells[4] not in ("", "없음"):
+                systems.add(_sticky_text(cells[4]))
         if (
             in_external_systems
             and len(cells) >= 2
@@ -546,6 +561,7 @@ def _parse_event_storming(text: str) -> dict[str, Any]:
             and not set(cells[0]) <= {"-"}
         ):
             externals.add(_sticky_text(cells[0]))
+    _apply_domain_element_labels(flows, domain_elements)
     supporting.extend({"type": "system", "text": value} for value in sorted(systems))
     supporting.extend({"type": "external_system", "text": value} for value in sorted(externals))
     return {"flows": flows, "supporting_notes": supporting}
@@ -584,6 +600,36 @@ def _sticky_type(value: str) -> str | None:
 
 def _sticky_text(value: str) -> str:
     return re.sub(r"`([^`]*)`", r"\1", value.strip())
+
+
+def _apply_domain_element_labels(
+    flows: list[dict[str, Any]], domain_elements: list[dict[str, str]]
+) -> None:
+    for flow in flows:
+        original = [dict(note) for note in flow["notes"]]
+        for index, note in enumerate(original):
+            previous = original[index - 1]["text"] if index else ""
+            following = original[index + 1]["text"] if index + 1 < len(original) else ""
+            candidates = [
+                element for element in domain_elements if element["type"] == note["type"]
+            ]
+            best = max(
+                candidates,
+                key=lambda element: _domain_element_score(element, note["text"], previous, following),
+                default=None,
+            )
+            if best and _domain_element_score(best, note["text"], previous, following) > 0:
+                flow["notes"][index]["text"] = best["text"]
+
+
+def _domain_element_score(
+    element: dict[str, str], text: str, previous: str, following: str
+) -> int:
+    return (
+        (4 if element["text"] == text else 0)
+        + (2 if previous and element["trigger"] == previous else 0)
+        + (2 if following and element["result"] == following else 0)
+    )
 
 
 def _run_payload(run: DashboardRun) -> dict[str, Any]:

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -468,6 +468,8 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "renderEventDocumentEditor" in javascript
         assert "bindCanvas" in javascript
         assert "function stickyText" in javascript
+        assert "function isEditingDashboardDocument" in javascript
+        assert 'app.view === "dashboard" && !isEditingDashboardDocument()' in javascript
         assert 'if (event.target.closest(".sticky")) return;\n    event.preventDefault();' in javascript
         assert "function renderInline" in javascript
         assert "listItems.map" in javascript

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -83,6 +83,8 @@ EVENT_STORMING_MARKDOWN = """# UC-001 Event Storming
 |Type|Content|Trigger|Result|System|Notes|
 |---|---|---|---|---|---|
 |🟦|Save Fleeting Note|Author|Saved|`Note System`|-|
+|🟧|`Persisted Note`|Save Fleeting Note|Show saved note|`Note System`|-|
+|🟪|`Display Saved Note`|Fleeting Note was saved|none|`Note System`|-|
 
 ## 6. External Systems
 |시스템|연동 목적|
@@ -179,7 +181,7 @@ def test_document_dashboard_projects_docs_board_and_folder_lifecycle(tmp_path: P
     flows = work_item["event_storming"]["flows"]
     assert [flow["kind"] for flow in flows] == ["main", "exception"]
     assert flows[0]["notes"][0] == {"type": "command", "text": "Save Fleeting Note"}
-    assert flows[0]["notes"][1] == {"type": "event", "text": "Fleeting Note was saved"}
+    assert flows[0]["notes"][1] == {"type": "event", "text": "Persisted Note"}
 
 
 def test_document_dashboard_attaches_latest_runtime_summary_and_history(
@@ -268,8 +270,12 @@ def test_dashboard_exposes_completed_event_storming_document_and_aggregate_board
     assert change_set["event_storming_board"]["slices"][0]["uc_id"] == "UC-001"
     assert change_set["event_storming_board"]["slices"][0]["flows"][0]["notes"][:2] == [
         {"type": "command", "text": "Save Fleeting Note"},
-        {"type": "event", "text": "Fleeting Note was saved"},
+        {"type": "event", "text": "Persisted Note"},
     ]
+    assert change_set["event_storming_board"]["slices"][0]["flows"][0]["notes"][2] == {
+        "type": "policy",
+        "text": "Display Saved Note",
+    }
     assert {"type": "system", "text": "Note System"} in change_set["event_storming_board"]["slices"][0][
         "supporting_notes"
     ]
@@ -280,10 +286,15 @@ def test_dashboard_exposes_completed_event_storming_document_and_aggregate_board
     saved = save_dashboard_document(
         tmp_path,
         document_id,
-        content=loaded["content"].replace("`Fleeting Note` was saved", "`Fleeting Note` was stored"),
+        content=loaded["content"].replace("`Persisted Note`", "`Stored Note`"),
         revision=loaded["revision"],
     )
-    assert "was stored" in saved["content"]
+    assert "Stored Note" in saved["content"]
+    refreshed = document_dashboard_state(tmp_path)["change_sets"][0]
+    assert refreshed["event_storming_board"]["slices"][0]["flows"][0]["notes"][1] == {
+        "type": "event",
+        "text": "Stored Note",
+    }
     assert "|ddd-architecture-definition|DDD Architecture Definition|stale|" in change_path.read_text(
         encoding="utf-8"
     )
@@ -468,6 +479,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "renderEventDocumentEditor" in javascript
         assert "bindCanvas" in javascript
         assert "function stickyText" in javascript
+        assert "function applyDomainElementLabels" in javascript
         assert "function isEditingDashboardDocument" in javascript
         assert 'app.view === "dashboard" && !isEditingDashboardDocument()' in javascript
         assert 'if (event.target.closest(".sticky")) return;\n    event.preventDefault();' in javascript


### PR DESCRIPTION
## Implementation intent
PR #220 병합 이후 브랜치에만 남아 있던 Event Storming 대시보드 수정 사항을 `main`에 반영합니다.

Closes #221

## Implementation approach
- 대시보드 문서가 Edit 모드일 때 5초 자동 refresh를 건너뛰어 입력 내용과 scroll 위치가 초기화되지 않게 합니다.
- Event Storming flow note와 Domain Elements 행을 type/이웃 trigger-result 근거로 매칭하여, Domain Elements의 `Content` 편집 결과가 live preview와 저장된 aggregate canvas 양쪽에 표시되게 합니다.
- Markdown source의 inline-code 표기는 유지하되 sticky 표시 text는 정규화합니다.

## Verification method
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` -> `17 passed`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> `289 passed`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js` -> pass
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/runtime/document_dashboard.py` -> pass
- `git diff --check origin/main...HEAD` -> pass

## Risks and rollback
- 위험: flow와 Domain Elements가 모두 불완전하여 매칭 근거가 없으면 기존 flow text가 그대로 유지됩니다.
- 롤백: 이 PR을 revert하면 기존 refresh 및 flow-text 기반 canvas 표시 동작으로 복귀합니다.