### PR TITLE
단계형 DDD 아키텍처 워크플로우 추가

### DIFF
--- a/.codex/agents/ddd_architect.toml
+++ b/.codex/agents/ddd_architect.toml
@@ -60,9 +60,10 @@ Ownership:
 
 Design order:
 0. Run the design readiness gate for unresolved business and foundational technical decisions.
-1. Derive domain model, aggregate, application service, bounded context, and architecture constraints from the selected use-case event-storming slice.
-2. Write the complete use-case-scoped DDD design to docs/use-cases/<UC-ID>/ddd-design.md.
-3. Update ARCHITECTURE.md with only the architecture constraints needed by this ChangeSet and selected UC.
+1. In interactive UI execution, perform only the requested substep: entity_vo, behaviors, application_flow, aggregates, or bounded_contexts.
+2. For entity_vo, classify each relevant BC, aggregate, entity, and VO as new, modify, or reuse before deriving definitions. Use completed DDD designs and ARCHITECTURE.md first; use implementation source read-only only when design artifacts do not establish the baseline. Record evidence source.
+3. Extend one evolving use-case-scoped DDD document at docs/use-cases/<UC-ID>/ddd-design.md, preserving completed prior substep sections.
+4. Update ARCHITECTURE.md only while completing bounded_contexts, with constraints needed by this ChangeSet and selected UC.
 
 Domain model standards:
 - A domain model is a conceptual abstraction of the domain and consists of entities, value objects, and methods.
@@ -100,6 +101,8 @@ Application service standards:
 - Business rules remain in aggregate/domain model/domain service methods.
 - Application services coordinate retrieval, external calls, ordering, transaction scope, saving, and result composition.
 - When another BC is needed, call it through a client/messaging port and do not depend on its internal model.
+- A cross-BC synchronous integration named internal_http means a public internal HTTP API/client boundary, never direct invocation of another BC's internal service or model.
+- Direct calls into another BC's internal model are forbidden.
 
 Bounded context standards:
 - A bounded context is a boundary where a domain model has one consistent meaning.
@@ -108,6 +111,7 @@ Bounded context standards:
 - Keep concepts in the same bounded context when their rules must change together.
 - Use event storming event groups, policies, and communication points to find BC candidates.
 - Describe responsibility, owned aggregates/domain models, external dependencies, published events/commands, and reasons for each boundary.
+- For each cross-BC relationship select exactly one communication type: internal_http, domain_event, or shared_database.
 
 Traceability rules:
 - Every entity, value object, aggregate, service, and bounded context must trace back to at least one event, command, policy, or use case.
@@ -149,6 +153,15 @@ Output document rules:
 - If a template field is unknown, keep the field and write 확인 필요.
 - Do not include implementation code. Method names and signatures are allowed as design notation.
 - Only write output documents after the design readiness gate passes.
+- Interactive output must use these exact parseable headings and table columns for completed substeps:
+  - `## Impact Assessment`: `Element Type | Element | Status | Baseline Evidence | Event Storming Evidence`
+  - `## Entity / Value Objects`: `Entity | Attributes / VOs | Status | Previous Definition | Proposed Definition | Evidence`
+  - `## Behaviors`: `Owner / Service | Signature | Participants | Placement | Policy Evidence`
+  - `## Application Flow`: `Application Service | Signature | Pseudocode | Calls | Evidence`
+  - `## Aggregates`: `Aggregate | Aggregate Root | Members | Atomic Invariant | Evidence`
+  - `## Bounded Contexts`: `Bounded Context | Owned Aggregates / Entities | Boundary Reason | Communication Type | Target BC | Evidence`
+- For modified attributes or VOs, include prior values wrapped in `~~` in Previous Definition and replacements in Proposed Definition.
+- Do not write later substep sections before their explicit interactive invocation.
 
 Template for docs/use-cases/<UC-ID>/ddd-design.md:
 

--- a/.codex/skills/harness-ddd-design/SKILL.md
+++ b/.codex/skills/harness-ddd-design/SKILL.md
@@ -89,6 +89,15 @@ description: >
 - setter나 하위 객체 직접 변경은 금지한다.
 - 애플리케이션 서비스는 유스케이스 오케스트레이션을 담당하며, 비즈니스 로직을
   직접 구현하지 않는다.
-- 애플리케이션 서비스는 `애플리케이션서비스.md`에 별도로 작성한다.
+- 애플리케이션 서비스는 selected UC의 단일 `ddd-design.md` 안에 작성한다.
 - BC는 변경 전파 범위와 같은 도메인 용어의 다른 모델 표현 여부로 결정한다.
 - 설계 차원에 영향을 주는 미결정 사항은 추정해서 산출물에 반영하지 않는다.
+
+## Interactive UI Substeps
+
+- UI 실행에서는 하나의 호출이 하나의 substep만 완료한다:
+  `entity_vo`, `behaviors`, `application_flow`, `aggregates`, `bounded_contexts`.
+- 같은 `docs/use-cases/<UC-ID>/ddd-design.md`를 점진적으로 확장하며 앞 단계 섹션을 보존한다.
+- `entity_vo`는 기존 완료 DDD 문서와 `ARCHITECTURE.md`를 우선 확인하고, 부족할 때만 구현 코드를 읽어 `new`, `modify`, `reuse`를 판정한다.
+- 모든 모델/서비스/경계는 command, event, policy 중 하나 이상의 근거를 기록한다.
+- BC 통신 방식은 `internal_http`, `domain_event`, `shared_database` 중 하나만 사용한다. `internal_http`는 공개 client/API 경계이며 다른 BC 내부 모델 직접 호출이 아니다.

--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -111,4 +111,24 @@ details { margin-top: 10px; }
 .canvas-lane strong { color: var(--muted); display: block; font-size: 12px; }
 .canvas-lane .flow-lane { overflow: visible; }
 .flow-lane.supporting { border-top: 1px dashed var(--line); margin-top: 8px; padding-top: 13px; }
+.ddd-steps { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 15px; }
+.ddd-step { background: #f1f2ec; }
+.ddd-step.complete { background: var(--active); color: var(--accent); }
+.ddd-step.needs_input, .ddd-step.stale { background: var(--stale); }
+.ddd-step.selected { border-color: var(--accent); font-weight: 600; }
+.ddd-grid { display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0; }
+.sticky.ddd-entity { background: #d6ecff; min-height: 130px; }
+.sticky.ddd-behavior { background: #ead7ff; min-height: 125px; }
+.sticky p { font-size: 12px; margin: 7px 0 0; }
+.ddd-evidence { border-top: 1px dashed var(--line); font-size: 12px; margin-top: 12px; padding-top: 10px; }
+.ddd-evidence p { margin: 5px 0; }
+.ddd-flow { display: flex; gap: 13px; margin: 14px 0; }
+.ddd-service { background: #d5efd5; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,.10); max-width: 310px; padding: 13px; }
+.ddd-service code { display: block; font-size: 12px; margin-top: 8px; }
+.ddd-boundary { border: 2px dashed #8fa598; border-radius: 9px; min-height: 132px; min-width: 215px; padding: 14px; }
+.ddd-boundary.aggregate { background: #f6efe0; }
+.ddd-boundary.context { background: #eef4e8; border-style: solid; }
+.ddd-boundary .root, .communication { background: var(--active); border-radius: 12px; color: var(--accent); display: inline-block; font-size: 11px; margin-top: 8px; padding: 3px 9px; }
+.ddd-canvas { height: 580px; }
+.ddd-slice { max-width: 740px; min-width: 280px; }
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -8,11 +8,14 @@ const app = {
   requirementsChangeSet: null,
   stageTab: "requirements",
   eventSelectedUc: null,
+  dddSelectedUc: null,
+  dddSelectedStep: "entity_vo",
   workflowRecovered: false,
   busy: false,
   busyLabel: "",
   error: "",
   canvas: { scale: 1, x: 0, y: 0 },
+  dddCanvas: { scale: 1, x: 0, y: 0 },
 };
 
 const escapeHtml = (value) => String(value ?? "")
@@ -148,7 +151,9 @@ function render() {
     app.openDocument = null;
     app.error = "";
     app.eventSelectedUc = null;
+    app.dddSelectedUc = null;
     app.canvas = { scale: 1, x: 0, y: 0 };
+    app.dddCanvas = { scale: 1, x: 0, y: 0 };
     app.view = "dashboard";
     render();
   });
@@ -162,6 +167,7 @@ function render() {
     detail.innerHTML = renderRequirementsWorkspace();
     if (app.stageTab === "requirements") renderEditor();
     if (app.stageTab === "eventStorming") renderEventDocumentEditor();
+    if (app.stageTab === "dddArchitecture") renderDddDocumentEditor();
     const requirementForm = document.querySelector("#grill-form");
     if (requirementForm) requirementForm.onsubmit = submitRequirementAnswer;
     const useCaseForm = document.querySelector("#use-case-form");
@@ -174,8 +180,20 @@ function render() {
     if (advanceEventStorming) advanceEventStorming.onclick = continueEventStormingDefinition;
     const eventForm = document.querySelector("#event-storming-form");
     if (eventForm) eventForm.onsubmit = submitEventStormingAnswer;
+    const startDdd = document.querySelector("#start-ddd-architecture");
+    if (startDdd) startDdd.onclick = startDddArchitecture;
+    const advanceDdd = document.querySelector("#advance-ddd-architecture");
+    if (advanceDdd) advanceDdd.onclick = continueDddArchitecture;
+    const dddForm = document.querySelector("#ddd-architecture-form");
+    if (dddForm) dddForm.onsubmit = submitDddArchitectureAnswer;
     document.querySelectorAll("[data-event-uc]").forEach((node) => {
       node.onclick = () => selectEventUseCase(node.dataset.eventUc);
+    });
+    document.querySelectorAll("[data-ddd-uc]").forEach((node) => {
+      node.onclick = () => selectDddUseCase(node.dataset.dddUc);
+    });
+    document.querySelectorAll("[data-ddd-step]").forEach((node) => {
+      node.onclick = () => { app.dddSelectedStep = node.dataset.dddStep; render(); };
     });
     document.querySelectorAll("[data-stage-tab]").forEach((node) => {
       node.onclick = () => selectStageTab(node.dataset.stageTab);
@@ -244,7 +262,9 @@ function renderRequirementsWorkspace() {
   const title = selected?.title || "";
   const busy = app.busy ? renderBusyState() : "";
   const tabs = renderStageTabs();
-  const body = app.stageTab === "eventStorming"
+  const body = app.stageTab === "dddArchitecture"
+    ? renderDddArchitectureWorkspace()
+    : app.stageTab === "eventStorming"
     ? renderEventStormingWorkspace()
     : app.stageTab === "useCases" ? renderUseCaseWorkspace() : renderRequirementsTab();
   return `<section class="workflow-page">
@@ -260,6 +280,7 @@ function renderStageTabs() {
   const requirementsDone = app.harvest?.requirements_gate_passed;
   const useCasesDone = app.harvest?.use_cases_ready;
   const eventsDone = app.harvest?.event_storming?.complete;
+  const dddDone = app.harvest?.ddd_architecture?.complete;
   return `<nav class="stage-tabs" aria-label="Workflow stages">
     <button class="stage-tab ${app.stageTab === "requirements" ? "selected" : ""}" data-stage-tab="requirements">
       <span class="progress-dot ${requirementsDone ? "complete" : "active"}"></span>Requirements
@@ -269,6 +290,9 @@ function renderStageTabs() {
     </button>
     <button class="stage-tab ${app.stageTab === "eventStorming" ? "selected" : ""}" data-stage-tab="eventStorming" ${!useCasesDone ? "disabled" : ""}>
       <span class="progress-dot ${eventsDone ? "complete" : useCasesDone ? "active" : ""}"></span>Event Storming
+    </button>
+    <button class="stage-tab ${app.stageTab === "dddArchitecture" ? "selected" : ""}" data-stage-tab="dddArchitecture" ${!eventsDone ? "disabled" : ""}>
+      <span class="progress-dot ${dddDone ? "complete" : eventsDone ? "active" : ""}"></span>DDD Architecture
     </button>
   </nav>`;
 }
@@ -343,7 +367,7 @@ function renderEventStormingWorkspace() {
     </form>`;
   } else if (state.complete) {
     interaction = `<p class="completion">Event storming complete.</p>
-      <button class="primary next-stage" type="button" disabled title="DDD Architecture UI is next implementation slice.">Continue to DDD Architecture (next slice)</button>`;
+      <button class="primary next-stage" id="start-ddd-architecture" type="button" ${app.busy ? "disabled" : ""}>Continue to DDD Architecture</button>`;
   } else if (state.status === "error") {
     interaction = `<p class="error">${escapeHtml(item?.error || app.harvest?.runtime_error || "Event storming failed.")}</p>
       <button class="primary next-stage" id="start-event-storming" type="button">Retry Event Storming</button>`;
@@ -358,6 +382,42 @@ function renderEventStormingWorkspace() {
     <section class="panel event-document"><h3>${escapeHtml(currentId || "Event Storming")} Document</h3><div id="event-document-editor"></div></section>
     <section class="panel event-live-preview"><h3>Sticky Notes Preview</h3><div id="event-live-board"></div></section>
     <section class="panel grill-panel"><h3>Oracle Questions</h3>${interaction}</section>`;
+}
+
+function renderDddArchitectureWorkspace() {
+  const state = app.harvest?.ddd_architecture || { items: {}, uc_ids: [], status: "not_started", step_order: [] };
+  const currentId = app.dddSelectedUc || state.current_uc || state.uc_ids.find((id) => state.items[id]?.status === "complete");
+  const item = currentId ? state.items[currentId] : null;
+  const steps = state.step_order || [];
+  const ucProgress = state.uc_ids.map((id) => `<button type="button" data-ddd-uc="${escapeHtml(id)}" class="event-progress-item ${escapeHtml(state.items[id]?.status || "pending")}">${escapeHtml(id)}: ${escapeHtml(state.items[id]?.status || "pending")}</button>`).join("");
+  const stepTabs = steps.map((step) => {
+    const status = item?.steps?.[step.id]?.status || "pending";
+    const unlocked = status === "complete" || step.id === state.current_step || step.id === app.dddSelectedStep;
+    return `<button type="button" data-ddd-step="${escapeHtml(step.id)}" class="ddd-step ${escapeHtml(status)} ${app.dddSelectedStep === step.id ? "selected" : ""}" ${!unlocked ? "disabled" : ""}>${escapeHtml(step.label)}</button>`;
+  }).join("");
+  let interaction = "";
+  const currentStep = item?.steps?.[state.current_step];
+  if (currentStep?.status === "needs_input" && currentStep.current_question) {
+    interaction = `<form id="ddd-architecture-form" class="grill-form">
+      <p class="question">${escapeHtml(currentStep.current_question.question)}</p>
+      ${currentStep.current_question.recommended ? `<p class="recommended">Recommended answer: ${escapeHtml(currentStep.current_question.recommended)}</p>` : ""}
+      <label for="ddd-architecture-answer">Your answer</label>
+      <textarea id="ddd-architecture-answer" required></textarea>
+      <button class="primary" type="submit" ${app.busy ? "disabled" : ""}>Submit answer</button>
+    </form>`;
+  } else if (state.complete) {
+    interaction = '<p class="completion">DDD architecture complete.</p><button class="primary next-stage" type="button" disabled>Continue to Technical Decisions (next slice)</button>';
+  } else if (state.status === "not_started") {
+    interaction = `<button class="primary next-stage" id="start-ddd-architecture" type="button" ${app.busy ? "disabled" : ""}>Start DDD Architecture</button>`;
+  } else if (state.status === "error") {
+    interaction = `<p class="error">${escapeHtml(currentStep?.error || app.harvest?.runtime_error || "DDD architecture failed.")}</p><button class="primary next-stage" id="advance-ddd-architecture" type="button">Retry DDD Substep</button>`;
+  } else {
+    interaction = `<p class="small">Review completed visualization, then continue explicitly.</p><button class="primary next-stage" id="advance-ddd-architecture" type="button" ${app.busy ? "disabled" : ""}>Continue DDD Architecture</button>`;
+  }
+  return `<section class="panel"><h3>DDD Architecture Progress</h3><p class="small">Completed ${escapeHtml(state.completed_count || 0)} / ${escapeHtml(state.total_count || 0)} substeps</p><div class="event-progress">${ucProgress}</div><nav class="ddd-steps">${stepTabs}</nav></section>
+    <section class="panel"><h3>${escapeHtml(currentId || "DDD")} Design Document</h3><div id="ddd-document-editor"></div></section>
+    <section class="panel ddd-live-preview"><h3>Design Visualization</h3><div id="ddd-live-board"></div></section>
+    <section class="panel grill-panel"><h3>DDD Architect Questions</h3>${interaction}</section>`;
 }
 
 async function openRequirementsDocument() {
@@ -401,12 +461,14 @@ async function submitRequirementAnswer(event) {
 async function selectStageTab(tab) {
   if (tab === "useCases" && !app.harvest?.requirements_gate_passed) return;
   if (tab === "eventStorming" && !app.harvest?.use_cases_ready) return;
+  if (tab === "dddArchitecture" && !app.harvest?.event_storming?.complete) return;
   app.stageTab = tab;
   if (tab === "requirements") {
     if (app.workflowRecovered) setRecoveredRequirementsDocument();
     else await openRequirementsDocument();
   }
   if (tab === "eventStorming") await openCurrentEventDocument();
+  if (tab === "dddArchitecture") await openCurrentDddDocument();
   render();
 }
 
@@ -538,6 +600,77 @@ async function selectEventUseCase(ucId) {
   render();
 }
 
+async function startDddArchitecture() {
+  app.stageTab = "dddArchitecture";
+  app.dddSelectedUc = null;
+  app.dddSelectedStep = "entity_vo";
+  await runDddTurn("/api/ddd-architecture/start", "Starting DDD Architecture");
+}
+
+async function continueDddArchitecture() {
+  await runDddTurn("/api/ddd-architecture/advance", "Processing DDD substep");
+}
+
+async function submitDddArchitectureAnswer(event) {
+  event.preventDefault();
+  const answer = document.querySelector("#ddd-architecture-answer").value.trim();
+  if (!answer) return;
+  await runDddTurn("/api/ddd-architecture/answer", "Submitting DDD answer", {
+    uc_id: app.harvest.ddd_architecture.current_uc,
+    step_id: app.harvest.ddd_architecture.current_step,
+    answer,
+  });
+}
+
+async function runDddTurn(endpoint, label, extra = {}) {
+  app.busy = true;
+  app.busyLabel = label;
+  app.error = "";
+  render();
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ change_set_id: app.requirementsChangeSet, ...extra }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Unable to run DDD architecture.");
+    app.harvest = result.harvest;
+    const state = app.harvest.ddd_architecture;
+    if (state.current_uc) app.dddSelectedUc = state.current_uc;
+    if (state.current_step) app.dddSelectedStep = state.current_step;
+    await openCurrentDddDocument();
+    await loadDashboard();
+  } catch (error) {
+    app.error = error.message;
+  }
+  app.busy = false;
+  app.busyLabel = "";
+  render();
+}
+
+async function openCurrentDddDocument() {
+  const state = app.harvest?.ddd_architecture;
+  const ucId = app.dddSelectedUc || state?.current_uc || state?.uc_ids?.find((id) => state.items[id]?.status === "complete");
+  const item = state?.items?.[ucId];
+  if (!ucId || !Object.values(item?.steps || {}).some((step) => step.status === "complete")) {
+    app.openDocument = null;
+    return;
+  }
+  const id = `ddd-design:${app.requirementsChangeSet}:${ucId}`;
+  const response = await fetch(`/api/dashboard/documents/${encodeURIComponent(id)}`);
+  if (response.ok) {
+    app.openDocument = await response.json();
+    app.editorMode = "preview";
+  }
+}
+
+async function selectDddUseCase(ucId) {
+  app.dddSelectedUc = ucId;
+  await openCurrentDddDocument();
+  render();
+}
+
 function renderDetail(change) {
   const stages = change.stages.map((stage) => `
     <div class="stage ${stage.status}">
@@ -569,6 +702,7 @@ function renderDetail(change) {
     <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div></section>
     ${documents ? `<section class="panel"><h3>Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
     ${renderCanvasBoard(change.event_storming_board)}
+    ${renderDddCanvasBoard(change.ddd_architecture_board)}
     ${workItems}
     <details class="panel"><summary>Runtime history</summary><ul>${runs || "<li>No recorded runs.</li>"}</ul></details>`;
 }
@@ -604,6 +738,24 @@ function renderSticky(note) {
   </article>`;
 }
 
+function renderDddCanvasBoard(board) {
+  if (!board?.slices?.length) return "";
+  const stepLabels = new Map([
+    ["entity_vo", "Entity / VO"],
+    ["behaviors", "Behaviors"],
+    ["application_flow", "Application Flow"],
+    ["aggregates", "Aggregates"],
+    ["bounded_contexts", "Bounded Contexts"],
+  ]);
+  const contents = board.slices.map((slice) => {
+    const sections = (slice.completed_steps || []).map((stepId) => `<div class="ddd-canvas-section"><h5>${escapeHtml(stepLabels.get(stepId) || stepId)}</h5>${renderDddVisualization(slice, stepId)}</div>`).join("");
+    return `<section class="canvas-slice ddd-slice"><h4>${escapeHtml(slice.uc_id)}</h4>${sections}</section>`;
+  }).join("");
+  return `<section class="panel"><div class="canvas-header"><h3>DDD Architecture Canvas</h3><div><span id="ddd-canvas-zoom-label">100%</span><button id="ddd-canvas-reset" type="button">Reset view</button></div></div>
+    <p class="small">Completed scoped design substeps only. Drag canvas to pan. Scroll to zoom.</p>
+    <div id="ddd-canvas" class="event-canvas ddd-canvas"><div id="ddd-canvas-content" class="event-canvas-content">${contents}</div></div></section>`;
+}
+
 function stickyText(text) {
   return String(text || "").replace(/`([^`]*)`/g, "$1");
 }
@@ -618,6 +770,7 @@ function bindDetail(change) {
     renderEditor();
   }
   bindCanvas();
+  bindDddCanvas();
 }
 
 async function loadWorkflowResults(changeSetId) {
@@ -630,11 +783,16 @@ async function loadWorkflowResults(changeSetId) {
   }
   app.requirementsChangeSet = changeSetId;
   app.harvest = result.harvest;
-  app.stageTab = result.harvest.active_stage === "eventStorming"
+  app.stageTab = result.harvest.active_stage === "dddArchitecture"
+    ? "dddArchitecture" : result.harvest.active_stage === "eventStorming"
     ? "eventStorming" : result.harvest.active_stage === "useCases" ? "useCases" : "requirements";
   app.workflowRecovered = true;
   app.view = "requirements";
-  if (app.stageTab === "eventStorming") {
+  if (app.stageTab === "dddArchitecture") {
+    app.dddSelectedUc = result.harvest.ddd_architecture?.current_uc;
+    app.dddSelectedStep = result.harvest.ddd_architecture?.current_step || "entity_vo";
+    await openCurrentDddDocument();
+  } else if (app.stageTab === "eventStorming") {
     app.eventSelectedUc = result.harvest.event_storming?.current_uc;
     await openCurrentEventDocument();
   } else {
@@ -810,6 +968,99 @@ function renderEventDocumentEditor(message = "") {
   }
 }
 
+function parseDddMarkdown(content) {
+  return {
+    impact: dddRows(content, "## Impact Assessment"),
+    entity_vo: dddRows(content, "## Entity / Value Objects"),
+    behaviors: dddRows(content, "## Behaviors"),
+    application_flow: dddRows(content, "## Application Flow"),
+    aggregates: dddRows(content, "## Aggregates"),
+    bounded_contexts: dddRows(content, "## Bounded Contexts"),
+  };
+}
+
+function dddRows(content, heading) {
+  const lines = String(content || "").split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start < 0) return [];
+  const section = lines.slice(start + 1);
+  const end = section.findIndex((line) => line.startsWith("## "));
+  const body = end < 0 ? section : section.slice(0, end);
+  const tableIndex = body.findIndex((line, index) => splitTableRow(line) && isTableDivider(body[index + 1], splitTableRow(line).length));
+  if (tableIndex < 0) return [];
+  const headers = splitTableRow(body[tableIndex]).map(stickyText);
+  const rows = [];
+  for (const line of body.slice(tableIndex + 2)) {
+    const cells = splitTableRow(line);
+    if (!cells || cells.length !== headers.length) break;
+    rows.push(Object.fromEntries(headers.map((header, index) => [header, stickyText(cells[index])])));
+  }
+  return rows;
+}
+
+function renderDddVisualization(board, stepId) {
+  if (!board) return '<p class="small">No completed DDD design substep.</p>';
+  const step = stepId || "entity_vo";
+  if (step === "entity_vo") {
+    return `<div class="ddd-grid">${(board.entity_vo || []).map((row) => {
+      const status = String(row.Status || "").toLowerCase();
+      return `<article class="sticky ddd-entity"><div class="sticky-type">${escapeHtml(row.Status || "entity")}</div><strong>${escapeHtml(row.Entity || "")}</strong><p>${escapeHtml(row["Attributes / VOs"] || "")}</p>${status === "modify" ? `<p><del>${escapeHtml(row["Previous Definition"] || "")}</del><br>${escapeHtml(row["Proposed Definition"] || "")}</p>` : ""}</article>`;
+    }).join("")}</div>${renderDddEvidence(board.entity_vo || [], "Evidence")}`;
+  }
+  if (step === "behaviors") {
+    return `<div class="ddd-grid">${(board.behaviors || []).map((row) => `<article class="sticky ddd-behavior"><div class="sticky-type">${escapeHtml(row.Placement || "behavior")}</div><strong>${escapeHtml(row["Owner / Service"] || "")}</strong><p>${escapeHtml(row.Signature || "")}</p><p>${escapeHtml(row.Participants || "")}</p></article>`).join("")}</div>${renderDddEvidence(board.behaviors || [], "Policy Evidence")}`;
+  }
+  if (step === "application_flow") {
+    return `<div class="ddd-flow">${(board.application_flow || []).map((row) => `<article class="ddd-service"><strong>${escapeHtml(row["Application Service"] || "")}</strong><code>${escapeHtml(row.Signature || "")}</code><p>${escapeHtml(row.Pseudocode || "")}</p><p>${escapeHtml(row.Calls || "")}</p></article>`).join("")}</div>${renderDddEvidence(board.application_flow || [], "Evidence")}`;
+  }
+  if (step === "aggregates") {
+    return `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<article class="ddd-boundary aggregate"><strong>${escapeHtml(row.Aggregate || "")}</strong><span class="root">Root: ${escapeHtml(row["Aggregate Root"] || "")}</span><p>${escapeHtml(row.Members || "")}</p><p>${escapeHtml(row["Atomic Invariant"] || "")}</p></article>`).join("")}</div>${renderDddEvidence(board.aggregates || [], "Evidence")}`;
+  }
+  return `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${escapeHtml(row["Bounded Context"] || "")}</strong><p>${escapeHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${escapeHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${escapeHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>${renderDddEvidence(board.bounded_contexts || [], "Evidence")}`;
+}
+
+function renderDddEvidence(rows, key) {
+  if (!rows.length) return "";
+  return `<div class="ddd-evidence">${rows.map((row) => `<p><strong>${escapeHtml(row.Entity || row["Owner / Service"] || row.Aggregate || row["Bounded Context"] || row["Application Service"] || "")}</strong>: ${escapeHtml(row[key] || "")}</p>`).join("")}</div>`;
+}
+
+function renderDddDocumentEditor(message = "") {
+  const target = document.querySelector("#ddd-document-editor");
+  const preview = document.querySelector("#ddd-live-board");
+  if (!target) return;
+  if (!app.openDocument?.id?.startsWith("ddd-design:")) {
+    target.innerHTML = '<p class="small">A DDD design document appears after the first completed substep.</p>';
+    if (preview) preview.innerHTML = '<p class="small">Complete Entity / Value Objects to visualize design.</p>';
+    return;
+  }
+  const editing = app.editorMode === "edit";
+  target.innerHTML = `<div class="doc-actions"><button id="ddd-preview-mode">Preview</button><button id="ddd-edit-mode">Edit</button>${editing ? '<button class="primary" id="ddd-save-doc">Save</button>' : ""}</div>
+    ${message ? `<p class="error">${escapeHtml(message)}</p>` : ""}
+    ${editing ? `<textarea id="ddd-doc-content">${escapeHtml(app.openDocument.content)}</textarea>` : `<div class="markdown-preview">${markdownPreview(app.openDocument.content)}</div>`}`;
+  const update = (content) => {
+    if (preview) preview.innerHTML = renderDddVisualization(parseDddMarkdown(content), app.dddSelectedStep);
+  };
+  update(app.openDocument.content);
+  document.querySelector("#ddd-preview-mode").onclick = () => { app.editorMode = "preview"; renderDddDocumentEditor(); };
+  document.querySelector("#ddd-edit-mode").onclick = () => { app.editorMode = "edit"; renderDddDocumentEditor(); };
+  if (editing) {
+    document.querySelector("#ddd-doc-content").oninput = (event) => update(event.target.value);
+    document.querySelector("#ddd-save-doc").onclick = async () => {
+      const content = document.querySelector("#ddd-doc-content").value;
+      const response = await fetch(`/api/dashboard/documents/${encodeURIComponent(app.openDocument.id)}`, {
+        method: "PUT", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content, revision: app.openDocument.revision }),
+      });
+      const result = await response.json();
+      if (!response.ok) { renderDddDocumentEditor(result.error); return; }
+      app.openDocument = result;
+      app.editorMode = "preview";
+      await loadDashboard();
+      renderDddDocumentEditor();
+    };
+  }
+}
+
 function bindCanvas() {
   const canvas = document.querySelector("#event-canvas");
   const content = document.querySelector("#event-canvas-content");
@@ -842,6 +1093,43 @@ function bindCanvas() {
   };
   document.querySelector("#canvas-reset").onclick = () => {
     app.canvas = { scale: 1, x: 0, y: 0 };
+    apply();
+  };
+  apply();
+}
+
+function bindDddCanvas() {
+  const canvas = document.querySelector("#ddd-canvas");
+  const content = document.querySelector("#ddd-canvas-content");
+  if (!canvas || !content) return;
+  const apply = () => {
+    content.style.transform = `translate(${app.dddCanvas.x}px, ${app.dddCanvas.y}px) scale(${app.dddCanvas.scale})`;
+    document.querySelector("#ddd-canvas-zoom-label").textContent = `${Math.round(app.dddCanvas.scale * 100)}%`;
+  };
+  let dragging = false;
+  let previous = null;
+  canvas.onpointerdown = (event) => {
+    if (event.target.closest(".sticky, .ddd-boundary, .ddd-service")) return;
+    event.preventDefault();
+    dragging = true;
+    previous = { x: event.clientX, y: event.clientY };
+    canvas.setPointerCapture(event.pointerId);
+  };
+  canvas.onpointermove = (event) => {
+    if (!dragging) return;
+    app.dddCanvas.x += event.clientX - previous.x;
+    app.dddCanvas.y += event.clientY - previous.y;
+    previous = { x: event.clientX, y: event.clientY };
+    apply();
+  };
+  canvas.onpointerup = () => { dragging = false; };
+  canvas.onwheel = (event) => {
+    event.preventDefault();
+    app.dddCanvas.scale = Math.max(0.4, Math.min(2.5, app.dddCanvas.scale + (event.deltaY < 0 ? 0.1 : -0.1)));
+    apply();
+  };
+  document.querySelector("#ddd-canvas-reset").onclick = () => {
+    app.dddCanvas = { scale: 1, x: 0, y: 0 };
     apply();
   };
   apply();

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -73,6 +73,9 @@ def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
                     "event_storming_board": _scoped_event_storming_board(
                         root, change_set.change_set_id, lifecycle, workflow_state
                     ),
+                    "ddd_architecture_board": _scoped_ddd_architecture_board(
+                        root, change_set.change_set_id, lifecycle, workflow_state
+                    ),
                     "latest_run": run_payloads[0] if run_payloads else None,
                     "run_history": run_payloads,
                 }
@@ -136,6 +139,12 @@ def save_dashboard_document(
     change_path.write_text(change_text, encoding="utf-8")
     if document["kind"] == "generated-use-case":
         _invalidate_scoped_event_storming(root, document_id.split(":")[1], document_id.split(":")[2])
+    elif document["kind"] == "event-storming":
+        _invalidate_scoped_ddd_architecture(root, document_id.split(":")[1], document_id.split(":")[2])
+    elif document["kind"] == "ddd-design":
+        _stale_ddd_steps_after_edit(
+            root, document_id.split(":")[1], document_id.split(":")[2], current, normalized
+        )
     return _document_payload(root, document, normalized)
 
 
@@ -254,6 +263,20 @@ def _document_summaries(
                     "editable": True,
                 }
             )
+    ddd_state = (workflow_state or {}).get("ddd_architecture") or {}
+    for uc_id in ddd_state.get("uc_ids", []):
+        item = ddd_state.get("items", {}).get(uc_id, {})
+        path = scoped_root / "docs/use-cases" / uc_id / "ddd-design.md"
+        if any(step.get("status") == "complete" for step in item.get("steps", {}).values()) and path.exists():
+            summaries.append(
+                {
+                    "id": f"ddd-design:{change_set.change_set_id}:{uc_id}",
+                    "kind": "ddd-design",
+                    "label": f"{uc_id} DDD Design",
+                    "path": _relative_path(root, path),
+                    "editable": True,
+                }
+            )
     for item in change_set.ordered_work_items():
         if item.work_item_type is WorkItemType.USE_CASE:
             path = root / "docs/use-cases" / item.work_item_id / "use-case.md"
@@ -334,7 +357,37 @@ def _invalidate_scoped_event_storming(root: Path, change_set_id: str, uc_id: str
     output = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "event-storming.md"
     if output.exists():
         output.unlink()
+    _invalidate_scoped_ddd_architecture(root, change_set_id, uc_id, state=state)
     session_path.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _invalidate_scoped_ddd_architecture(
+    root: Path, change_set_id: str, uc_id: str, *, state: dict[str, Any] | None = None
+) -> None:
+    session_path = root / SCOPED_UI_STATE_ROOT / change_set_id / "harvest-session.json"
+    state = state or _scoped_workflow_state(root, change_set_id, "active")
+    ddd_state = (state or {}).get("ddd_architecture")
+    if not isinstance(ddd_state, dict) or uc_id not in ddd_state.get("items", {}):
+        return
+    item = ddd_state["items"][uc_id]
+    for step in item.get("steps", {}).values():
+        step.update({"status": "stale", "current_question": None, "error": ""})
+    item["status"] = "stale"
+    ddd_state["complete"] = False
+    ddd_state["status"] = "pending"
+    ddd_state["current_uc"] = uc_id
+    ddd_state["current_step"] = "entity_vo"
+    ddd_state["completed_count"] = sum(
+        1
+        for candidate in ddd_state["items"].values()
+        for step in candidate.get("steps", {}).values()
+        if step.get("status") == "complete"
+    )
+    output = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "ddd-design.md"
+    if output.exists():
+        output.unlink()
+    if state is not None and session_path.exists():
+        session_path.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def _project_workflow_stages(
@@ -349,6 +402,8 @@ def _project_workflow_stages(
         completed.add("use-case-definition")
     if (workflow_state.get("event_storming") or {}).get("complete"):
         completed.add("event-storming")
+    if (workflow_state.get("ddd_architecture") or {}).get("complete"):
+        completed.add("ddd-architecture-definition")
     for stage in stages:
         if stage["id"] in completed:
             stage["status"] = "verified"
@@ -398,6 +453,16 @@ def _resolve_editable_document(root: Path, document_id: str) -> dict[str, Any]:
             raise DashboardDocumentNotFound("Event storming is not complete for this use case.")
         path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "event-storming.md"
         label = f"{uc_id} Event Storming"
+    elif kind == "ddd-design" and len(parts) == 3:
+        uc_id = parts[2]
+        state = _scoped_workflow_state(root, change_set_id, "active") or {}
+        item = (state.get("ddd_architecture") or {}).get("items", {}).get(uc_id, {})
+        if not re.fullmatch(r"UC-\d+", uc_id) or not any(
+            step.get("status") == "complete" for step in item.get("steps", {}).values()
+        ):
+            raise DashboardDocumentNotFound("DDD architecture has no completed substep for this use case.")
+        path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "ddd-design.md"
+        label = f"{uc_id} DDD Design"
     else:
         raise DashboardDocumentNotFound("Unknown editable document.")
     if not path.exists():
@@ -444,6 +509,12 @@ def _validate_document(document: dict[str, Any], content: str) -> None:
             ("🟧",),
             ("🟪",),
         )
+    elif document["kind"] == "ddd-design":
+        required_groups = (
+            ("## Impact Assessment",),
+            ("## Entity / Value Objects",),
+            ("Evidence",),
+        )
     else:
         uc_id = document["id"].split(":")[-1]
         required_groups = (
@@ -477,6 +548,8 @@ def _stale_stage_ids(kind: str) -> tuple[str, ...]:
             "plan-writing",
             "implementation",
         )
+    if kind == "ddd-design":
+        return ("technical-decisions", "plan-writing", "implementation")
     return (
         "event-storming",
         "ddd-architecture-definition",
@@ -630,6 +703,108 @@ def _domain_element_score(
         + (2 if previous and element["trigger"] == previous else 0)
         + (2 if following and element["result"] == following else 0)
     )
+
+
+DDD_SECTION_HEADINGS = (
+    ("entity_vo", "## Entity / Value Objects"),
+    ("behaviors", "## Behaviors"),
+    ("application_flow", "## Application Flow"),
+    ("aggregates", "## Aggregates"),
+    ("bounded_contexts", "## Bounded Contexts"),
+)
+
+
+def _scoped_ddd_architecture_board(
+    root: Path,
+    change_set_id: str,
+    lifecycle: str,
+    workflow_state: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if lifecycle != "active" or not workflow_state:
+        return {"slices": []}
+    state = workflow_state.get("ddd_architecture") or {}
+    slices: list[dict[str, Any]] = []
+    for uc_id in state.get("uc_ids", []):
+        item = state.get("items", {}).get(uc_id, {})
+        completed = [
+            step_id for step_id, _heading in DDD_SECTION_HEADINGS
+            if item.get("steps", {}).get(step_id, {}).get("status") == "complete"
+        ]
+        path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "ddd-design.md"
+        if completed and path.exists():
+            slices.append({"uc_id": uc_id, "completed_steps": completed, **_parse_ddd_design(path.read_text(encoding="utf-8"))})
+    return {"slices": slices}
+
+
+def _parse_ddd_design(text: str) -> dict[str, Any]:
+    return {
+        "impact": _ddd_table_rows(text, "## Impact Assessment"),
+        "entity_vo": _ddd_table_rows(text, "## Entity / Value Objects"),
+        "behaviors": _ddd_table_rows(text, "## Behaviors"),
+        "application_flow": _ddd_table_rows(text, "## Application Flow"),
+        "aggregates": _ddd_table_rows(text, "## Aggregates"),
+        "bounded_contexts": _ddd_table_rows(text, "## Bounded Contexts"),
+    }
+
+
+def _ddd_table_rows(text: str, heading: str) -> list[dict[str, str]]:
+    section = _section_text(text, heading)
+    rows = [line for line in section.splitlines() if line.strip().startswith("|")]
+    if len(rows) < 3:
+        return []
+    headers = [_clean_cell(cell) for cell in rows[0].strip().strip("|").split("|")]
+    parsed: list[dict[str, str]] = []
+    for line in rows[2:]:
+        cells = [_clean_cell(cell) for cell in line.strip().strip("|").split("|")]
+        if len(cells) == len(headers):
+            parsed.append(dict(zip(headers, cells)))
+    return parsed
+
+
+def _clean_cell(value: str) -> str:
+    return _sticky_text(value).replace("~~", "").strip()
+
+
+def _stale_ddd_steps_after_edit(
+    root: Path, change_set_id: str, uc_id: str, before: str, after: str
+) -> None:
+    state = _scoped_workflow_state(root, change_set_id, "active")
+    ddd_state = (state or {}).get("ddd_architecture")
+    if not isinstance(ddd_state, dict):
+        return
+    item = ddd_state.get("items", {}).get(uc_id)
+    if not isinstance(item, dict):
+        return
+    changed_index = next(
+        (
+            index for index, (_step_id, heading) in enumerate(DDD_SECTION_HEADINGS)
+            if _section_text(before, heading) != _section_text(after, heading)
+        ),
+        None,
+    )
+    if changed_index is None:
+        return
+    staled = False
+    for step_id, _heading in DDD_SECTION_HEADINGS[changed_index + 1:]:
+        step = item.get("steps", {}).get(step_id, {})
+        if step.get("status") == "complete":
+            step["status"] = "stale"
+            staled = True
+    if not staled:
+        return
+    item["status"] = "pending"
+    ddd_state["complete"] = False
+    ddd_state["status"] = "pending"
+    ddd_state["current_uc"] = uc_id
+    ddd_state["current_step"] = DDD_SECTION_HEADINGS[min(changed_index + 1, len(DDD_SECTION_HEADINGS) - 1)][0]
+    ddd_state["completed_count"] = sum(
+        1
+        for candidate in ddd_state["items"].values()
+        for step in candidate.get("steps", {}).values()
+        if step.get("status") == "complete"
+    )
+    session_path = root / SCOPED_UI_STATE_ROOT / change_set_id / "harvest-session.json"
+    session_path.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def _run_payload(run: DashboardRun) -> dict[str, Any]:

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -29,6 +29,16 @@ USE_CASE_DEFINITION_TIMEOUT_SEC = 3600
 EVENT_STORMING_AGENT_CONFIG_PATH = Path(".codex/agents/oracle.toml")
 EVENT_STORMING_SKILL_PATH = Path(".codex/skills/harness-event-storming/SKILL.md")
 EVENT_STORMING_TIMEOUT_SEC = 3600
+DDD_AGENT_CONFIG_PATH = Path(".codex/agents/ddd_architect.toml")
+DDD_SKILL_PATH = Path(".codex/skills/harness-ddd-design/SKILL.md")
+DDD_TIMEOUT_SEC = 3600
+DDD_STEPS = (
+    ("entity_vo", "Entity / Value Objects"),
+    ("behaviors", "Behaviors"),
+    ("application_flow", "Application Flow"),
+    ("aggregates", "Aggregates"),
+    ("bounded_contexts", "Bounded Contexts"),
+)
 
 
 @dataclass(frozen=True)
@@ -44,6 +54,7 @@ class HarvestUiResult:
     requirements_gate_passed: bool
     use_cases_ready: bool
     event_storming: dict[str, Any]
+    ddd_architecture: dict[str, Any]
     runtime_error: str
     workflow: dict[str, Any]
 
@@ -232,6 +243,72 @@ def answer_event_storming(
     return _result(root_path, session)
 
 
+def start_ddd_architecture(root: Path | str, change_set_id: str) -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    event_state = session.get("event_storming")
+    if not isinstance(event_state, dict) or not event_state.get("complete"):
+        raise ValueError("event-storming gate has not passed")
+    uc_ids = [
+        uc_id for uc_id in event_state.get("uc_ids", [])
+        if event_state.get("items", {}).get(uc_id, {}).get("status") == "complete"
+    ]
+    if not uc_ids:
+        raise ValueError("no completed event-storming slices are available for DDD architecture")
+    state = session.get("ddd_architecture")
+    if not isinstance(state, dict) or state.get("uc_ids") != uc_ids:
+        state = _new_ddd_architecture_state(uc_ids)
+        session["ddd_architecture"] = state
+    session["active_stage"] = "dddArchitecture"
+    if not state.get("complete") and not _current_ddd_question(session):
+        _advance_ddd_architecture(root_path, session, change_set_id)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
+def advance_ddd_architecture(root: Path | str, change_set_id: str) -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    state = session.get("ddd_architecture")
+    if not isinstance(state, dict):
+        raise ValueError("DDD architecture has not started")
+    if _current_ddd_question(session):
+        raise ValueError("answer the current DDD architecture question before continuing")
+    _advance_ddd_architecture(root_path, session, change_set_id)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
+def answer_ddd_architecture(
+    root: Path | str,
+    change_set_id: str,
+    uc_id: str,
+    step_id: str,
+    answer: str,
+) -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    state = session.get("ddd_architecture")
+    if not isinstance(state, dict) or state.get("current_uc") != uc_id:
+        raise ValueError("no active DDD architecture question for use case")
+    item = state.get("items", {}).get(uc_id, {})
+    step = item.get("steps", {}).get(step_id, {})
+    question = step.get("current_question")
+    normalized_answer = answer.strip()
+    if step_id != state.get("current_step") or not isinstance(question, dict) or not normalized_answer:
+        raise ValueError("answer is required for the current DDD architecture question")
+    step.setdefault("clarifications", []).append(
+        {
+            "questions": [{"question": str(question.get("question", "")), "recommended": str(question.get("recommended", ""))}],
+            "answer": normalized_answer,
+        }
+    )
+    step["current_question"] = None
+    _advance_ddd_architecture(root_path, session, change_set_id, uc_id=uc_id, step_id=step_id)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
 def load_harvest_ui(root: Path | str) -> HarvestUiResult:
     root_path = Path(root)
     session = _load_session(root_path)
@@ -273,6 +350,8 @@ def _write_changeset_harvest_snapshot(root: Path, change_set_id: str, session: d
     if use_cases_started:
         _copy_optional_artifact(root / USE_CASES_PATH, scoped_root / USE_CASES_PATH)
         _copy_scoped_use_case_outputs(root, scoped_root, session)
+        if isinstance(session.get("ddd_architecture"), dict):
+            _copy_optional_artifact(root / "ARCHITECTURE.md", scoped_root / "ARCHITECTURE.md")
     else:
         use_case_document = scoped_root / USE_CASES_PATH
         if use_case_document.exists():
@@ -330,6 +409,7 @@ def _new_session(prompt: str) -> dict[str, Any]:
         "use_case_current_questions": [],
         "use_case_pending_questions": [],
         "event_storming": None,
+        "ddd_architecture": None,
     }
 
 
@@ -339,6 +419,7 @@ def _workflow_projection() -> dict[str, Any]:
             {"id": "requirements", "label": "Requirements", "document": str(REQUIREMENTS_PATH)},
             {"id": "useCases", "label": "Use Cases", "document": str(USE_CASES_PATH)},
             {"id": "eventStorming", "label": "Event Storming", "document": ""},
+            {"id": "dddArchitecture", "label": "DDD Architecture", "document": ""},
         ]
     }
 
@@ -367,6 +448,7 @@ def _normalize_session(session: dict[str, Any]) -> None:
     session.setdefault("use_case_current_questions", [])
     session.setdefault("use_case_pending_questions", [])
     session.setdefault("event_storming", None)
+    session.setdefault("ddd_architecture", None)
     current = session.get("current_question")
     current_questions = session.get("current_questions") or []
     if current is None and current_questions:
@@ -391,6 +473,15 @@ def _normalize_session(session: dict[str, Any]) -> None:
         state.setdefault("completed_count", 0)
         state.setdefault("complete", False)
         state.setdefault("status", "pending")
+    ddd_state = session.get("ddd_architecture")
+    if isinstance(ddd_state, dict):
+        ddd_state.setdefault("uc_ids", [])
+        ddd_state.setdefault("items", {})
+        ddd_state.setdefault("current_uc", None)
+        ddd_state.setdefault("current_step", None)
+        ddd_state.setdefault("completed_count", 0)
+        ddd_state.setdefault("complete", False)
+        ddd_state.setdefault("status", "pending")
 
 
 def _load_session(root: Path) -> dict[str, Any] | None:
@@ -442,6 +533,7 @@ def _session_from_requirements_doc(root: Path) -> dict[str, Any] | None:
         "use_case_current_questions": [],
         "use_case_pending_questions": [],
         "event_storming": None,
+        "ddd_architecture": None,
     }
     if session["use_cases_ready"]:
         session["active_stage"] = "useCases"
@@ -541,12 +633,15 @@ def _result(root: Path, session: dict[str, Any], *, artifact_root: Path | None =
     )
     gate_passed = bool(session["requirements_gate_passed"])
     event_storming = _event_storming_payload(documents_root, session)
+    ddd_architecture = _ddd_architecture_payload(documents_root, session)
     status = "idle" if not session_started else (
+        "ddd_architecture_ready" if ddd_architecture.get("complete") else (
+        "ddd_architecture_running" if session.get("active_stage") == "dddArchitecture" else (
         "event_storming_ready" if event_storming.get("complete") else (
         "event_storming_running" if session.get("active_stage") == "eventStorming" else (
         "use_cases_ready" if session.get("use_cases_ready") else (
             "requirements_passed" if gate_passed else "requirements_running"
-        )))
+        )))))
     )
     if session_started and not gate_passed:
         current_question = _current_question(session)
@@ -554,6 +649,8 @@ def _result(root: Path, session: dict[str, Any], *, artifact_root: Path | None =
         current_question = _current_use_case_question(session)
     elif session_started and session.get("active_stage") == "eventStorming":
         current_question = _current_event_storming_question(session)
+    elif session_started and session.get("active_stage") == "dddArchitecture":
+        current_question = _current_ddd_question(session)
     else:
         current_question = None
     current_questions = (current_question,) if current_question else ()
@@ -569,6 +666,7 @@ def _result(root: Path, session: dict[str, Any], *, artifact_root: Path | None =
         requirements_gate_passed=gate_passed,
         use_cases_ready=bool(session.get("use_cases_ready")),
         event_storming=event_storming,
+        ddd_architecture=ddd_architecture,
         runtime_error=str(session.get("runtime_error", "")),
         workflow=_workflow_projection(),
     )
@@ -618,6 +716,7 @@ def _copy_scoped_use_case_outputs(root: Path, scoped_root: Path, session: dict[s
         shutil.rmtree(target_root)
     uc_ids = _parse_canonical_use_case_ids(_read_optional(root / USE_CASES_PATH))
     event_items = (session.get("event_storming") or {}).get("items", {})
+    ddd_items = (session.get("ddd_architecture") or {}).get("items", {})
     for uc_id in uc_ids:
         for name in ("use-case.md", "e2e-goal.md"):
             _copy_optional_artifact(
@@ -629,6 +728,14 @@ def _copy_scoped_use_case_outputs(root: Path, scoped_root: Path, session: dict[s
                 root / USE_CASE_SLICE_ROOT / uc_id / "event-storming.md",
                 target_root / uc_id / "event-storming.md",
             )
+        if any(
+            step.get("status") == "complete"
+            for step in ddd_items.get(uc_id, {}).get("steps", {}).values()
+        ):
+            _copy_optional_artifact(
+                root / USE_CASE_SLICE_ROOT / uc_id / "ddd-design.md",
+                target_root / uc_id / "ddd-design.md",
+            )
 
 
 def _normalize_resumed_stage(session: dict[str, Any]) -> None:
@@ -636,7 +743,9 @@ def _normalize_resumed_stage(session: dict[str, Any]) -> None:
         session["active_stage"] = "requirements"
         session["use_cases_ready"] = False
         return
-    if isinstance(session.get("event_storming"), dict):
+    if isinstance(session.get("ddd_architecture"), dict):
+        session["active_stage"] = "dddArchitecture"
+    elif isinstance(session.get("event_storming"), dict):
         session["active_stage"] = "eventStorming"
     elif (
         session.get("use_cases_ready")
@@ -675,6 +784,16 @@ def _current_event_storming_question(session: dict[str, Any]) -> dict[str, Any] 
         return None
     item = state.get("items", {}).get(state.get("current_uc"), {})
     current = item.get("current_question")
+    return current if isinstance(current, dict) and current.get("question") else None
+
+
+def _current_ddd_question(session: dict[str, Any]) -> dict[str, Any] | None:
+    state = session.get("ddd_architecture")
+    if not isinstance(state, dict):
+        return None
+    item = state.get("items", {}).get(state.get("current_uc"), {})
+    step = item.get("steps", {}).get(state.get("current_step"), {})
+    current = step.get("current_question")
     return current if isinstance(current, dict) and current.get("question") else None
 
 
@@ -753,6 +872,7 @@ def _advance_use_case_harvest(root: Path, session: dict[str, Any], idea: str) ->
         session["use_case_current_questions"] = []
         session["use_case_pending_questions"] = []
         session["event_storming"] = None
+        session["ddd_architecture"] = None
         session["runtime_error"] = ""
         return
     if status == "blocked":
@@ -836,6 +956,7 @@ def _advance_event_storming(
         session["runtime_error"] = ""
         return
     item = state["items"][target_id]
+    session["ddd_architecture"] = None
     state["current_uc"] = target_id
     state["status"] = "running"
     item["status"] = "running"
@@ -893,6 +1014,181 @@ def _validate_event_storming_slice(path: Path) -> tuple[bool, str]:
     for marker, label in (("🟦", "command"), ("🟧", "event"), ("🟪", "policy")):
         if marker not in text:
             return False, f"missing {label} sticky in {path}"
+    return True, ""
+
+
+def _new_ddd_architecture_state(uc_ids: list[str]) -> dict[str, Any]:
+    return {
+        "uc_ids": uc_ids,
+        "items": {
+            uc_id: {
+                "status": "pending",
+                "impact": {},
+                "steps": {
+                    step_id: {
+                        "label": label,
+                        "status": "pending",
+                        "current_question": None,
+                        "clarifications": [],
+                        "error": "",
+                    }
+                    for step_id, label in DDD_STEPS
+                },
+            }
+            for uc_id in uc_ids
+        },
+        "current_uc": uc_ids[0] if uc_ids else None,
+        "current_step": DDD_STEPS[0][0] if uc_ids else None,
+        "completed_count": 0,
+        "complete": False,
+        "status": "pending",
+    }
+
+
+def _ddd_architecture_payload(documents_root: Path, session: dict[str, Any]) -> dict[str, Any]:
+    state = session.get("ddd_architecture")
+    if not isinstance(state, dict):
+        return {
+            "uc_ids": [],
+            "items": {},
+            "current_uc": None,
+            "current_step": None,
+            "completed_count": 0,
+            "total_count": 0,
+            "complete": False,
+            "status": "not_started",
+            "step_order": [{"id": step_id, "label": label} for step_id, label in DDD_STEPS],
+        }
+    payload = json.loads(json.dumps(state, ensure_ascii=False))
+    payload["total_count"] = len(payload.get("uc_ids", [])) * len(DDD_STEPS)
+    payload["step_order"] = [{"id": step_id, "label": label} for step_id, label in DDD_STEPS]
+    for uc_id, item in payload.get("items", {}).items():
+        if any(step.get("status") == "complete" for step in item.get("steps", {}).values()):
+            item["document_id"] = f"ddd-design:{uc_id}"
+            item["markdown"] = _read_optional(
+                documents_root / USE_CASE_SLICE_ROOT / uc_id / "ddd-design.md"
+            )
+    return payload
+
+
+def _advance_ddd_architecture(
+    root: Path,
+    session: dict[str, Any],
+    change_set_id: str,
+    *,
+    uc_id: str | None = None,
+    step_id: str | None = None,
+) -> None:
+    state = session["ddd_architecture"]
+    target_uc = uc_id
+    target_step = step_id
+    if target_uc is None:
+        for candidate_uc in state["uc_ids"]:
+            candidate = state["items"][candidate_uc]
+            next_step = next(
+                (
+                    current_id for current_id, _label in DDD_STEPS
+                    if candidate["steps"][current_id]["status"] in {"pending", "error", "stale"}
+                ),
+                None,
+            )
+            if next_step:
+                target_uc, target_step = candidate_uc, next_step
+                break
+    if target_uc is None or target_step is None:
+        state["complete"] = True
+        state["status"] = "complete"
+        state["current_uc"] = None
+        state["current_step"] = None
+        session["runtime_error"] = ""
+        return
+    item = state["items"][target_uc]
+    step = item["steps"][target_step]
+    state["current_uc"] = target_uc
+    state["current_step"] = target_step
+    state["status"] = "running"
+    item["status"] = "running"
+    step["status"] = "running"
+    step["error"] = ""
+    if target_step == DDD_STEPS[0][0] and not any(
+        value.get("status") == "complete" for value in item["steps"].values()
+    ):
+        for output in (root / USE_CASE_SLICE_ROOT / target_uc / "ddd-design.md", root / "ARCHITECTURE.md"):
+            if output.exists():
+                output.unlink()
+    try:
+        result = _run_ddd_architecture(root, session, change_set_id, target_uc, target_step)
+        status = str(result.get("status", "")).strip().lower()
+        if status == "complete":
+            ready, error = _validate_ddd_design_slice(
+                root / USE_CASE_SLICE_ROOT / target_uc / "ddd-design.md",
+                target_step,
+            )
+            if not ready:
+                raise ValueError(f"DDD architecture reported complete but {error}")
+            step["status"] = "complete"
+            step["current_question"] = None
+            step["error"] = ""
+            if result.get("impact"):
+                item["impact"] = result["impact"]
+            all_done = all(value.get("status") == "complete" for value in item["steps"].values())
+            item["status"] = "complete" if all_done else "pending"
+            state["completed_count"] = sum(
+                1
+                for value in state["items"].values()
+                for current in value["steps"].values()
+                if current.get("status") == "complete"
+            )
+            state["complete"] = state["completed_count"] == len(state["uc_ids"]) * len(DDD_STEPS)
+            state["status"] = "complete" if state["complete"] else "pending"
+            session["runtime_error"] = ""
+            return
+        if status == "blocked":
+            raise ValueError(str(result.get("blocker", "") or "DDD architecture blocked"))
+        questions = result.get("questions", [])
+        if not isinstance(questions, list) or not questions:
+            raise ValueError("DDD architecture needs input but returned no question")
+        question = questions[0]
+        step["status"] = "needs_input"
+        step["current_question"] = {
+            "question": str(question.get("question", "")).strip(),
+            "recommended": str(question.get("recommended", "") or "").strip(),
+        }
+        item["status"] = "needs_input"
+        state["status"] = "needs_input"
+        session["runtime_error"] = ""
+    except ValueError as exc:
+        step["status"] = "error"
+        step["error"] = str(exc)
+        step["current_question"] = None
+        item["status"] = "error"
+        state["status"] = "error"
+        state["complete"] = False
+        session["runtime_error"] = str(exc)
+
+
+def _validate_ddd_design_slice(path: Path, completed_step: str) -> tuple[bool, str]:
+    if not path.is_file():
+        return False, f"missing output: {path}"
+    text = path.read_text(encoding="utf-8")
+    if _looks_like_placeholder(text):
+        return False, f"unverified placeholder in {path}"
+    required = {
+        "entity_vo": ("## Impact Assessment", "## Entity / Value Objects", "Evidence"),
+        "behaviors": ("## Behaviors", "Signature", "Policy Evidence"),
+        "application_flow": ("## Application Flow", "Pseudocode", "Application Service"),
+        "aggregates": ("## Aggregates", "Aggregate Root", "Atomic"),
+        "bounded_contexts": ("## Bounded Contexts", "Communication Type"),
+    }
+    index = next(index for index, (step_id, _label) in enumerate(DDD_STEPS) if step_id == completed_step)
+    terms = tuple(term for step_id, _label in DDD_STEPS[: index + 1] for term in required[step_id])
+    missing = [term for term in terms if term not in text]
+    if missing:
+        return False, f"missing DDD structure in {path}: {', '.join(missing)}"
+    if completed_step == "bounded_contexts" and not any(
+        value in text for value in ("internal_http", "domain_event", "shared_database", "None")
+    ):
+        return False, f"missing allowed communication type in {path}"
     return True, ""
 
 
@@ -1273,6 +1569,146 @@ def _parse_event_storming_json(text: str) -> dict[str, Any]:
         "questions": questions,
         "changed_files": [str(item) for item in data.get("changed_files", [])],
         "blocker": str(data.get("blocker", "") or ""),
+    }
+
+
+def _run_ddd_architecture(
+    root: Path,
+    session: dict[str, Any],
+    change_set_id: str,
+    uc_id: str,
+    step_id: str,
+) -> dict[str, Any]:
+    agent_config_path = root / DDD_AGENT_CONFIG_PATH
+    skill_path = root / DDD_SKILL_PATH
+    if not agent_config_path.exists():
+        raise ValueError(f"missing DDD agent config: {DDD_AGENT_CONFIG_PATH}")
+    if not skill_path.exists():
+        raise ValueError(f"missing DDD skill config: {DDD_SKILL_PATH}")
+    with agent_config_path.open("rb") as file:
+        agent_config = tomllib.load(file)
+    run_id = f"interactive-ddd-{uuid4().hex[:12]}"
+    run_dir = root / ".harness/ui/ddd-runs" / run_id
+    step_dir = run_dir / "step"
+    step_dir.mkdir(parents=True, exist_ok=True)
+    final_message_path = step_dir / "final-message.md"
+    output_path = USE_CASE_SLICE_ROOT / uc_id / "ddd-design.md"
+    step = Step(
+        id=f"ddd-{uc_id}-{step_id}",
+        kind=StepKind.AGENT,
+        name=f"Derive DDD {step_id} for {uc_id}",
+        agent_id="ddd_architect",
+        skill_id="harness-ddd-design",
+        inputs=(
+            Path("docs/changes/active") / f"{change_set_id}.md",
+            USE_CASE_SLICE_ROOT / uc_id / "use-case.md",
+            USE_CASE_SLICE_ROOT / uc_id / "event-storming.md",
+            USE_CASE_SLICE_ROOT / uc_id / "e2e-goal.md",
+        ),
+        outputs=(output_path, Path("ARCHITECTURE.md")),
+        timeout_sec=DDD_TIMEOUT_SEC,
+        metadata={"stage": "ddd-architecture", "scope": uc_id, "substep": step_id, "interactive": True},
+    )
+    context = RunContext(
+        run_id=run_id,
+        workflow_name="ddd-architecture-workflow",
+        mode=RunMode.APPLY,
+        repo_root=root,
+        workdir=root,
+        run_dir=run_dir,
+        metadata={"stage": "ddd_architecture", "change_set_id": change_set_id, "uc_id": uc_id, "substep": step_id},
+    )
+    prompt = build_agent_prompt(
+        step=step,
+        context=context,
+        agent_config=agent_config,
+        agent_config_path=DDD_AGENT_CONFIG_PATH,
+        skill_path=skill_path,
+        skill_body=skill_path.read_text(encoding="utf-8"),
+    )
+    item = session["ddd_architecture"]["items"][uc_id]
+    prompt = f"{prompt}\n\n{_ddd_turn_contract(change_set_id, uc_id, step_id, item)}"
+    (step_dir / "prompt.md").write_text(prompt, encoding="utf-8")
+    command = [
+        "codex", "exec", "--cd", str(root), "--skip-git-repo-check",
+        "-c", 'approval_policy="never"', "--sandbox", "workspace-write",
+        "--output-last-message", str(final_message_path),
+    ]
+    model = agent_config.get("model")
+    if isinstance(model, str) and model:
+        command.extend(["--model", model])
+    effort = agent_config.get("model_reasoning_effort")
+    if isinstance(effort, str) and effort:
+        command.extend(["-c", f'model_reasoning_effort="{effort}"'])
+    command.append("-")
+    (step_dir / "command.json").write_text(json.dumps(command, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    try:
+        completed = subprocess.run(
+            command, cwd=root, input=prompt, text=True, capture_output=True,
+            timeout=DDD_TIMEOUT_SEC, check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(
+            f"DDD architecture timed out after {DDD_TIMEOUT_SEC} seconds. "
+            "Retry to continue from this substep."
+        ) from exc
+    (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
+    (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    if completed.returncode != 0:
+        error = completed.stderr.strip() or completed.stdout.strip()
+        raise ValueError(f"DDD architecture execution failed: {error}")
+    return _parse_ddd_json(final_message_path.read_text(encoding="utf-8"))
+
+
+def _ddd_turn_contract(change_set_id: str, uc_id: str, step_id: str, item: dict[str, Any]) -> str:
+    return f"""## Interactive Phased DDD Architecture Turn
+
+Target ChangeSet: {change_set_id}
+Target Use Case: {uc_id}
+Target Substep: {step_id}
+
+Execute exactly this substep. Do not implement code or advance to another substep.
+Update `docs/use-cases/{uc_id}/ddd-design.md` as one evolving document. Preserve prior completed sections.
+For `bounded_contexts`, also update `ARCHITECTURE.md` with approved boundary constraints.
+Return only JSON with keys: status, questions, changed_files, blocker, impact.
+- `needs_input`: exactly one modeling question.
+- `complete`: current substep sections written with event-storming evidence.
+- `blocked`: inputs cannot be corrected by one DDD answer.
+
+Substep requirements:
+- `entity_vo`: write `## Impact Assessment` and `## Entity / Value Objects`; classify new/modify/reuse using completed design docs and `ARCHITECTURE.md` first, read-only implementation fallback; include `Evidence`.
+- `behaviors`: write `## Behaviors`; include entity/domain-service `Signature` and `Policy Evidence`.
+- `application_flow`: write `## Application Flow`; include `Application Service`, `Pseudocode`, loads, saves, and delegated method/service calls only.
+- `aggregates`: write `## Aggregates`; include `Aggregate Root`, contained models, `Atomic` invariant evidence.
+- `bounded_contexts`: write `## Bounded Contexts`; include `Communication Type` using only `internal_http`, `domain_event`, or `shared_database`; internal HTTP is a public client/API boundary, never internal-model access.
+
+Prior step state:
+{json.dumps(item, ensure_ascii=False, indent=2)}
+"""
+
+
+def _parse_ddd_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", stripped, flags=re.DOTALL)
+        if match is None:
+            raise ValueError(f"DDD architecture returned non-JSON output: {stripped}")
+        data = json.loads(match.group(0))
+    status = str(data.get("status", "") or "").strip().lower()
+    if status not in {"needs_input", "complete", "blocked"}:
+        raise ValueError(f"DDD architecture returned invalid status: {status or '<empty>'}")
+    questions = data.get("questions", [])
+    if not isinstance(questions, list):
+        raise ValueError("DDD architecture returned invalid questions")
+    impact = data.get("impact", {})
+    return {
+        "status": status,
+        "questions": questions,
+        "changed_files": [str(item) for item in data.get("changed_files", [])],
+        "blocker": str(data.get("blocker", "") or ""),
+        "impact": impact if isinstance(impact, dict) else {},
     }
 
 
@@ -1681,7 +2117,9 @@ def _sync_use_case_readiness(root: Path, session: dict[str, Any]) -> None:
     ready, _ = _validate_runtime_ready_use_case_slices(root)
     was_ready = bool(session.get("use_cases_ready"))
     session["use_cases_ready"] = ready
-    if ready and isinstance(session.get("event_storming"), dict):
+    if ready and isinstance(session.get("ddd_architecture"), dict):
+        session["active_stage"] = "dddArchitecture"
+    elif ready and isinstance(session.get("event_storming"), dict):
         session["active_stage"] = "eventStorming"
     elif ready:
         session["active_stage"] = "useCases"

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -23,7 +24,9 @@ from harness_codex.runtime.document_dashboard import (
 )
 from harness_codex.runtime.harvest_ui import (
     activate_changeset_harvest_ui,
+    advance_ddd_architecture,
     advance_event_storming,
+    answer_ddd_architecture,
     answer_event_storming,
     answer_use_cases,
     answer_requirements,
@@ -31,6 +34,7 @@ from harness_codex.runtime.harvest_ui import (
     load_harvest_ui,
     save_changeset_harvest_ui,
     start_requirements,
+    start_ddd_architecture,
     start_event_storming,
     start_use_case_generation,
     start_use_cases,
@@ -129,6 +133,52 @@ def answer_event_storming_changeset(
     result = answer_event_storming(root, change_set_id, uc_id, answer)
     save_changeset_harvest_ui(root, change_set_id)
     return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def start_ddd_architecture_changeset(repo_root: Path | str, change_set_id: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    _activate_scoped_ddd_inputs(root, change_set_id)
+    result = start_ddd_architecture(root, change_set_id)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def advance_ddd_architecture_changeset(repo_root: Path | str, change_set_id: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    _activate_scoped_ddd_inputs(root, change_set_id)
+    result = advance_ddd_architecture(root, change_set_id)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def answer_ddd_architecture_changeset(
+    repo_root: Path | str,
+    change_set_id: str,
+    uc_id: str,
+    step_id: str,
+    answer: str,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    _activate_scoped_ddd_inputs(root, change_set_id)
+    result = answer_ddd_architecture(root, change_set_id, uc_id, step_id, answer)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def _activate_scoped_ddd_inputs(root: Path, change_set_id: str) -> None:
+    scoped_root = root / ".harness/ui/change-sets" / change_set_id
+    for source in (scoped_root / "docs/use-cases").glob("UC-*"):
+        target = root / "docs/use-cases" / source.name
+        for name in ("event-storming.md", "ddd-design.md"):
+            if (source / name).exists():
+                target.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source / name, target / name)
+    architecture = scoped_root / "ARCHITECTURE.md"
+    if architecture.exists():
+        shutil.copyfile(architecture, root / "ARCHITECTURE.md")
 
 
 def _required_change_set_id(body: dict[str, Any]) -> str:
@@ -249,6 +299,30 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
                     self.repo_root,
                     _required_change_set_id(body),
                     str(body.get("uc_id", "")).strip(),
+                    str(body.get("answer", "")),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path == "/api/ddd-architecture/start":
+                payload = start_ddd_architecture_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path == "/api/ddd-architecture/advance":
+                payload = advance_ddd_architecture_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path == "/api/ddd-architecture/answer":
+                payload = answer_ddd_architecture_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                    str(body.get("uc_id", "")).strip(),
+                    str(body.get("step_id", "")).strip(),
                     str(body.get("answer", "")),
                 )
                 self._write_json(HTTPStatus.OK, payload)

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -92,6 +92,40 @@ EVENT_STORMING_MARKDOWN = """# UC-001 Event Storming
 |`Browser Store`|Persist draft|
 """
 
+DDD_DESIGN_MARKDOWN = """# UC-001. DDD Design
+
+## Impact Assessment
+|Element Type|Element|Status|Baseline Evidence|Event Storming Evidence|
+|---|---|---|---|---|
+|Aggregate|Note|new|No existing design|Save Fleeting Note command|
+
+## Entity / Value Objects
+|Entity|Attributes / VOs|Status|Previous Definition|Proposed Definition|Evidence|
+|---|---|---|---|---|---|
+|Note|NoteId, Content|new|-|NoteId, Content|Save Fleeting Note command|
+|Draft|Title|Modify|~~OldTitle~~|Title|Persisted Note event|
+
+## Behaviors
+|Owner / Service|Signature|Participants|Placement|Policy Evidence|
+|---|---|---|---|---|
+|Note|save(NoteId id, Content content)|Note|entity method|Display Saved Note policy|
+
+## Application Flow
+|Application Service|Signature|Pseudocode|Calls|Evidence|
+|---|---|---|---|---|
+|SaveNoteApplicationService|save(NoteId id, Content content)|load note -> call save -> persist note|Note.save(id, content)|Save Fleeting Note command|
+
+## Aggregates
+|Aggregate|Aggregate Root|Members|Atomic Invariant|Evidence|
+|---|---|---|---|---|
+|Note|Note|Note, NoteId, Content|Save note atomically|Persisted Note event|
+
+## Bounded Contexts
+|Bounded Context|Owned Aggregates / Entities|Boundary Reason|Communication Type|Target BC|Evidence|
+|---|---|---|---|---|---|
+|Notes|Note|Owns note lifecycle|internal_http|Search|Display Saved Note policy|
+"""
+
 
 def _write_change_set(root: Path, lifecycle: str = "active", *, with_use_case: bool = True) -> Path:
     path = root / "docs/changes" / lifecycle / "CHG-001.md"
@@ -155,6 +189,30 @@ def _write_completed_event_storming_workflow(root: Path) -> None:
     session_path.write_text(json.dumps(session), encoding="utf-8")
     path = root / ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/event-storming.md"
     path.write_text(EVENT_STORMING_MARKDOWN, encoding="utf-8")
+
+
+def _write_completed_ddd_architecture_workflow(root: Path) -> None:
+    _write_completed_event_storming_workflow(root)
+    session_path = root / ".harness/ui/change-sets/CHG-001/harvest-session.json"
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    step_ids = ["entity_vo", "behaviors", "application_flow", "aggregates", "bounded_contexts"]
+    session["ddd_architecture"] = {
+        "uc_ids": ["UC-001"],
+        "items": {
+            "UC-001": {
+                "status": "complete",
+                "steps": {step_id: {"status": "complete", "clarifications": []} for step_id in step_ids},
+            }
+        },
+        "current_uc": None,
+        "current_step": "bounded_contexts",
+        "completed_count": len(step_ids),
+        "complete": True,
+        "status": "complete",
+    }
+    session_path.write_text(json.dumps(session), encoding="utf-8")
+    path = root / ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/ddd-design.md"
+    path.write_text(DDD_DESIGN_MARKDOWN, encoding="utf-8")
 
 
 def test_document_dashboard_projects_docs_board_and_folder_lifecycle(tmp_path: Path) -> None:
@@ -298,6 +356,61 @@ def test_dashboard_exposes_completed_event_storming_document_and_aggregate_board
     assert "|ddd-architecture-definition|DDD Architecture Definition|stale|" in change_path.read_text(
         encoding="utf-8"
     )
+
+
+def test_dashboard_exposes_completed_ddd_document_and_visual_board(tmp_path: Path) -> None:
+    _write_change_set(tmp_path, with_use_case=False)
+    _write_documents(tmp_path)
+    _write_completed_ddd_architecture_workflow(tmp_path)
+
+    change_set = document_dashboard_state(tmp_path)["change_sets"][0]
+    statuses = {stage["id"]: stage["status"] for stage in change_set["stages"]}
+    documents = {document["id"]: document for document in change_set["documents"]}
+    board = change_set["ddd_architecture_board"]
+
+    assert statuses["ddd-architecture-definition"] == "verified"
+    assert documents["ddd-design:CHG-001:UC-001"]["editable"] is True
+    assert documents["ddd-design:CHG-001:UC-001"]["path"] == (
+        ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/ddd-design.md"
+    )
+    assert board["slices"][0]["uc_id"] == "UC-001"
+    assert board["slices"][0]["completed_steps"] == [
+        "entity_vo",
+        "behaviors",
+        "application_flow",
+        "aggregates",
+        "bounded_contexts",
+    ]
+    assert board["slices"][0]["entity_vo"][0]["Entity"] == "Note"
+    assert board["slices"][0]["behaviors"][0]["Signature"] == "save(NoteId id, Content content)"
+    assert board["slices"][0]["application_flow"][0]["Application Service"] == "SaveNoteApplicationService"
+    assert board["slices"][0]["aggregates"][0]["Aggregate Root"] == "Note"
+    assert board["slices"][0]["bounded_contexts"][0]["Communication Type"] == "internal_http"
+
+
+def test_saving_ddd_design_stales_later_completed_substeps(tmp_path: Path) -> None:
+    change_path = _write_change_set(tmp_path, with_use_case=False)
+    _write_documents(tmp_path)
+    _write_completed_ddd_architecture_workflow(tmp_path)
+    loaded = read_dashboard_document(tmp_path, "ddd-design:CHG-001:UC-001")
+
+    saved = save_dashboard_document(
+        tmp_path,
+        "ddd-design:CHG-001:UC-001",
+        content=loaded["content"].replace("NoteId, Content", "NoteId, Content, SavedAt", 1),
+        revision=loaded["revision"],
+    )
+
+    assert "SavedAt" in saved["content"]
+    session = json.loads(
+        (tmp_path / ".harness/ui/change-sets/CHG-001/harvest-session.json").read_text(encoding="utf-8")
+    )
+    steps = session["ddd_architecture"]["items"]["UC-001"]["steps"]
+    assert steps["entity_vo"]["status"] == "complete"
+    assert steps["behaviors"]["status"] == "stale"
+    assert steps["bounded_contexts"]["status"] == "stale"
+    assert session["ddd_architecture"]["complete"] is False
+    assert "|technical-decisions|Technical Decisions|stale|" in change_path.read_text(encoding="utf-8")
 
 
 def test_editing_generated_use_case_invalidates_scoped_event_storming_output(tmp_path: Path) -> None:
@@ -477,6 +590,13 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "Continue Event Storming" in javascript
         assert '"/api/event-storming/start"' in javascript
         assert "renderEventDocumentEditor" in javascript
+        assert "Continue to DDD Architecture" in javascript
+        assert '"/api/ddd-architecture/start"' in javascript
+        assert '"/api/ddd-architecture/advance"' in javascript
+        assert '"/api/ddd-architecture/answer"' in javascript
+        assert "renderDddVisualization" in javascript
+        assert "renderDddCanvasBoard" in javascript
+        assert "ddd-canvas-section" in javascript
         assert "bindCanvas" in javascript
         assert "function stickyText" in javascript
         assert "function applyDomainElementLabels" in javascript
@@ -489,6 +609,8 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "stage-tabs" in stylesheet
         assert ".markdown-preview code" in stylesheet
         assert ".event-canvas" in stylesheet
+        assert ".ddd-grid" in stylesheet
+        assert ".ddd-canvas" in stylesheet
         assert "user-select: none" in stylesheet
     finally:
         server.shutdown()

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -9,7 +9,9 @@ from harness_codex.runtime.harvest_ui import (
     REQUIREMENTS_PATH,
     USE_CASES_PATH,
     activate_changeset_harvest_ui,
+    advance_ddd_architecture,
     advance_event_storming,
+    answer_ddd_architecture,
     answer_event_storming,
     answer_use_cases,
     answer_requirements,
@@ -17,6 +19,7 @@ from harness_codex.runtime.harvest_ui import (
     load_harvest_ui,
     save_changeset_harvest_ui,
     start_requirements,
+    start_ddd_architecture,
     start_event_storming,
     start_use_case_generation,
     start_use_cases,
@@ -163,6 +166,62 @@ def write_event_storming_slice(root: Path, uc_id: str) -> None:
 """,
         encoding="utf-8",
     )
+
+
+def write_ddd_slice(root: Path, uc_id: str, step_id: str) -> None:
+    sections = {
+        "entity_vo": """## Impact Assessment
+|Element Type|Element|Status|Baseline Evidence|Event Storming Evidence|
+|---|---|---|---|---|
+|Aggregate|Note|new|No existing design|Start UC|
+
+## Entity / Value Objects
+|Entity|Attributes / VOs|Status|Previous Definition|Proposed Definition|Evidence|
+|---|---|---|---|---|---|
+|Note|NoteId, Content|new|-|NoteId, Content|Start UC|
+""",
+        "behaviors": """## Behaviors
+|Owner / Service|Signature|Participants|Placement|Policy Evidence|
+|---|---|---|---|---|
+|Note|open(NoteId id)|Note|entity method|UC is valid|
+""",
+        "application_flow": """## Application Flow
+|Application Service|Signature|Pseudocode|Calls|Evidence|
+|---|---|---|---|---|
+|OpenNoteApplicationService|open(NoteId id)|load -> call -> save|Note.open(id)|Start UC|
+""",
+        "aggregates": """## Aggregates
+|Aggregate|Aggregate Root|Members|Atomic Invariant|Evidence|
+|---|---|---|---|---|
+|Note|Note|Note, NoteId|Note opens atomically|UC was started|
+""",
+        "bounded_contexts": """## Bounded Contexts
+|Bounded Context|Owned Aggregates / Entities|Boundary Reason|Communication Type|Target BC|Evidence|
+|---|---|---|---|---|---|
+|Notes|Note|Consistent note meaning|None|-|UC is valid|
+""",
+    }
+    order = ["entity_vo", "behaviors", "application_flow", "aggregates", "bounded_contexts"]
+    end = order.index(step_id) + 1
+    path = root / f"docs/use-cases/{uc_id}/ddd-design.md"
+    path.write_text(f"# {uc_id}. DDD Design\n\n" + "\n".join(sections[current] for current in order[:end]), encoding="utf-8")
+
+
+def mark_event_storming_complete(root: Path, uc_ids: list[str]) -> None:
+    session_path = root / ".harness/ui/harvest-session.json"
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    session["event_storming"] = {
+        "uc_ids": uc_ids,
+        "items": {uc_id: {"status": "complete"} for uc_id in uc_ids},
+        "current_uc": None,
+        "completed_count": len(uc_ids),
+        "complete": True,
+        "status": "complete",
+    }
+    session["active_stage"] = "eventStorming"
+    session_path.write_text(json.dumps(session), encoding="utf-8")
+    for uc_id in uc_ids:
+        write_event_storming_slice(root, uc_id)
 
 
 def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
@@ -820,3 +879,66 @@ def test_changeset_resume_restores_event_storming_question_without_runtime_call(
 
     assert result.active_stage == "eventStorming"
     assert result.current_question["question"] == "Confirm policy?"
+
+
+def test_ddd_architecture_requires_explicit_substeps_and_resumes_answer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_passed_requirements(tmp_path)
+    write_runtime_ready_use_cases(tmp_path)
+    start_use_cases(tmp_path)
+    mark_event_storming_complete(tmp_path, ["UC-001"])
+    calls: list[tuple[str, int]] = []
+
+    def fake_ddd(_root: Path, session: dict, _change_set_id: str, uc_id: str, step_id: str) -> dict:
+        step = session["ddd_architecture"]["items"][uc_id]["steps"][step_id]
+        calls.append((step_id, len(step["clarifications"])))
+        if step_id == "behaviors" and not step["clarifications"]:
+            return {"status": "needs_input", "questions": [{"question": "Own policy?", "recommended": "Entity."}], "changed_files": [], "blocker": "", "impact": {}}
+        write_ddd_slice(tmp_path, uc_id, step_id)
+        return {"status": "complete", "questions": [], "changed_files": [], "blocker": "", "impact": {"aggregate": "new"}}
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_ddd_architecture", fake_ddd)
+
+    entity = start_ddd_architecture(tmp_path, "CHG-001")
+    paused = advance_ddd_architecture(tmp_path, "CHG-001")
+    behavior = answer_ddd_architecture(tmp_path, "CHG-001", "UC-001", "behaviors", "Entity.")
+    application = advance_ddd_architecture(tmp_path, "CHG-001")
+    aggregate = advance_ddd_architecture(tmp_path, "CHG-001")
+    complete = advance_ddd_architecture(tmp_path, "CHG-001")
+
+    assert entity.ddd_architecture["items"]["UC-001"]["steps"]["entity_vo"]["status"] == "complete"
+    assert entity.ddd_architecture["items"]["UC-001"]["steps"]["behaviors"]["status"] == "pending"
+    assert paused.current_question["question"] == "Own policy?"
+    assert behavior.ddd_architecture["items"]["UC-001"]["steps"]["behaviors"]["status"] == "complete"
+    assert application.ddd_architecture["items"]["UC-001"]["steps"]["application_flow"]["status"] == "complete"
+    assert aggregate.ddd_architecture["items"]["UC-001"]["steps"]["aggregates"]["status"] == "complete"
+    assert complete.ddd_architecture["complete"] is True
+    assert calls == [("entity_vo", 0), ("behaviors", 0), ("behaviors", 1), ("application_flow", 0), ("aggregates", 0), ("bounded_contexts", 0)]
+
+
+def test_changeset_resume_restores_ddd_question_without_agent_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_passed_requirements(tmp_path)
+    write_runtime_ready_use_cases(tmp_path)
+    start_use_cases(tmp_path)
+    mark_event_storming_complete(tmp_path, ["UC-001"])
+    write_active_changeset(tmp_path, "CHG-001")
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_ddd_architecture",
+        lambda *_args: {"status": "needs_input", "questions": [{"question": "New aggregate?", "recommended": "Reuse."}], "changed_files": [], "blocker": "", "impact": {}},
+    )
+    start_ddd_architecture(tmp_path, "CHG-001")
+    save_changeset_harvest_ui(tmp_path, "CHG-001")
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_ddd_architecture",
+        lambda *_args: pytest.fail("resume must not execute ddd_architect"),
+    )
+
+    result = load_changeset_harvest_ui(tmp_path, "CHG-001")
+
+    assert result.active_stage == "dddArchitecture"
+    assert result.current_question["question"] == "New aggregate?"

--- a/tests/runtime/test_harvest_ui_grill_me_command.py
+++ b/tests/runtime/test_harvest_ui_grill_me_command.py
@@ -5,6 +5,9 @@ from pathlib import Path
 import pytest
 
 from harness_codex.runtime.harvest_ui import (
+    DDD_AGENT_CONFIG_PATH,
+    DDD_SKILL_PATH,
+    DDD_TIMEOUT_SEC,
     EVENT_STORMING_AGENT_CONFIG_PATH,
     EVENT_STORMING_SKILL_PATH,
     EVENT_STORMING_TIMEOUT_SEC,
@@ -13,6 +16,7 @@ from harness_codex.runtime.harvest_ui import (
     USE_CASE_AGENT_CONFIG_PATH,
     USE_CASE_SKILL_PATH,
     _run_grill_me,
+    _run_ddd_architecture,
     _run_event_storming,
     _run_use_case_harvest,
 )
@@ -102,3 +106,31 @@ def test_event_storming_timeout_returns_actionable_error(tmp_path: Path, monkeyp
         )
 
     assert EVENT_STORMING_TIMEOUT_SEC == 3600
+
+
+def test_ddd_architecture_timeout_returns_actionable_error(tmp_path: Path, monkeypatch) -> None:
+    agent_config = tmp_path / DDD_AGENT_CONFIG_PATH
+    agent_config.parent.mkdir(parents=True)
+    agent_config.write_text('name = "ddd_architect"\n', encoding="utf-8")
+    skill_path = tmp_path / DDD_SKILL_PATH
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# DDD Design\n", encoding="utf-8")
+
+    def time_out(*_args, **kwargs):
+        raise subprocess.TimeoutExpired(["codex", "exec"], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", time_out)
+
+    with pytest.raises(
+        ValueError,
+        match="DDD architecture timed out after 3600 seconds. Retry to continue from this substep.",
+    ):
+        _run_ddd_architecture(
+            tmp_path,
+            {"ddd_architecture": {"items": {"UC-001": {"steps": {"entity_vo": {"clarifications": []}}}}}},
+            "CHG-001",
+            "UC-001",
+            "entity_vo",
+        )
+
+    assert DDD_TIMEOUT_SEC == 3600

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -87,8 +87,19 @@ def test_ddd_stage_and_agent_use_sliced_event_storming_first() -> None:
     )
     assert "docs/use-cases/<UC-ID>/event-storming.md" in agent_text
     assert "read the selected slice documents first" in agent_text
+    assert "entity_vo" in agent_text
+    assert "behaviors" in agent_text
+    assert "application_flow" in agent_text
+    assert "aggregates" in agent_text
+    assert "bounded_contexts" in agent_text
+    assert "Impact Assessment" in agent_text
+    assert "internal_http" in agent_text
+    assert "domain_event" in agent_text
+    assert "shared_database" in agent_text
+    assert "Direct calls into another BC's internal model are forbidden." in agent_text
     assert "If docs/design/이벤트 스토밍.md does not exist" not in agent_text
     assert "Required input:\n- docs/design/이벤트 스토밍.md" not in agent_text
+    assert "docs/use-cases/<UC-ID>/application-service.md" not in agent_text
 
 
 def test_procedure_stage_order_requires_technical_decisions_before_planning() -> None:


### PR DESCRIPTION
## Implementation intent
- Event Storming 완료 뒤 실행되는 ChangeSet 스코프 DDD Architecture UI 단계를 추가합니다.
- `ddd_architect`와 `harness-ddd-design` 계약을 확장해 Entity/VO, Behaviors, Application Flow, Aggregates, Bounded Contexts 5개 게이트를 명시합니다.
- 생성 코드 없이 클래스/메서드 시그니처, 의사코드, 근거, 시각화용 구조만 산출합니다.
- DDD agent instruction을 substep 계약 중심으로 압축하고 Entity/VO 단계에서 typed attribute/VO field 정의를 강제합니다.
- 완료되었거나 진행 중인 ChangeSet의 DDD Architecture를 UI에서 명시적으로 재시작할 수 있게 합니다.
- Event Storming canvas에서 `Basic flow`/normal-flow 계열 heading을 정상 흐름으로 표시합니다.
- Agent가 생성한 `Model | Kind | Proposed Identity / State` 형식의 Entity/VO 표도 typed design output으로 수용하고 dashboard 표준 board row로 정규화합니다.
- Closes #222
- Stacked on #223

## Implementation approach
- `harvest-session.json`에 `ddd_architecture` 상태를 추가하고 UC별 substep 상태, pending question, answer history, completion gate를 저장합니다.
- `/api/ddd-architecture/start`, `/restart`, `/advance`, `/answer`를 추가해 시작, 전체 DDD 재시작, 명시적 다음 substep 진행, 질문 답변만 런타임을 호출하게 했습니다. Resume은 저장 상태와 문서만 읽습니다.
- Restart는 선택 ChangeSet의 scoped DDD 상태와 `ddd-design.md`/`ARCHITECTURE.md` 출력을 초기화한 뒤 첫 Entity/VO substep부터 다시 실행합니다.
- scoped `.harness/ui/change-sets/<CHG-ID>/docs/use-cases/<UC-ID>/ddd-design.md`를 DDD 문서 원본으로 사용하고, dashboard는 선택 ChangeSet의 completed substep만 board로 파싱합니다.
- DDD Markdown 편집/저장, live preview, substep tab, 진행 상태, 질문 UI, restart control, pan/zoom dashboard canvas를 기존 dashboard 컴포넌트 패턴으로 연결했습니다.
- Entity/VO validator는 exact contract table과 generated variant table의 typed identity/state columns를 모두 검사합니다.
- Event Storming slice 저장 시 해당 UC의 DDD 상태를 invalidation하고, DDD 이전 substep 편집 시 이후 completed substep을 stale로 낮춥니다.
- Event Storming parser는 `main`, `basic`, `normal`, `happy`, `success`, `primary`, `default`, `기본`, `정상`, `성공`, `주요`, `표준`을 main flow로 정규화합니다.
- DDD agent instruction은 이전 20-section template을 제거하고 concise substep contract로 교체했습니다.

## Verification method
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_harvest_ui.py tests/runtime/test_harvest_ui_grill_me_command.py tests/runtime/test_document_dashboard.py tests/runtime/test_procedure_stage_runtime.py` -> 66 passed
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` -> 21 passed
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/runtime/harvest_ui.py harness_codex/runtime/ui_server.py harness_codex/runtime/document_dashboard.py`
- `git diff --check`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> 300 passed

## Risks and rollback
- Runtime calls depend on `ddd_architect` producing the required JSON turn contract and parseable DDD Markdown sections. If output quality is poor, rollback can remove the DDD API/UI wiring while keeping Event Storming intact.
- Typed Entity/VO validation may reject vague DDD documents that list only names. This is intentional for execution readiness; rollback is to relax `_ddd_entity_vo_has_typed_definition`.
- Restart intentionally replaces scoped DDD output for the selected ChangeSet only. Rollback is to remove `/api/ddd-architecture/restart` and the UI restart control.
- Flow-label normalization may classify broad success-like headings as main flow. Rollback is to narrow `_event_flow_kind` and `eventFlowKind` markers.
- Entity/VO table-variant normalization may accept non-standard agent output when it still contains typed identity/state values. Rollback is to require only exact table columns.
- This PR is stacked on #223 because it reuses the post-merge Event Storming dashboard fixes. Merge #223 first or rebase this branch onto main after #223 lands.