### PR TITLE
[codex] ui-server 재실행 동작 추가

### DIFF
--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
+import os
+import signal
 import shutil
+import threading
+import time
 from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -41,6 +46,47 @@ from harness_codex.runtime.harvest_ui import (
     start_use_cases,
 )
 from harness_codex.runtime.procedure_stages import render_initial_changeset
+
+
+def _ui_server_pid_path(repo_root: Path) -> Path:
+    return repo_root / ".harness" / "ui-server.pid"
+
+
+def _terminate_previous_ui_server(repo_root: Path) -> bool:
+    pid_path = _ui_server_pid_path(repo_root)
+    try:
+        pid = int(pid_path.read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, ValueError):
+        return False
+    if pid <= 0 or pid == os.getpid():
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pid_path.unlink(missing_ok=True)
+        return False
+    return True
+
+
+def _create_http_server(
+    host: str,
+    port: int,
+    handler: type[BaseHTTPRequestHandler],
+    *,
+    wait_for_restart: bool,
+) -> ThreadingHTTPServer:
+    deadline = time.monotonic() + 3
+    while True:
+        try:
+            return ThreadingHTTPServer((host, port), handler)
+        except OSError as exc:
+            if not wait_for_restart or exc.errno != errno.EADDRINUSE or time.monotonic() >= deadline:
+                raise
+            time.sleep(0.05)
+
+
+def _exit_on_terminate(_signum: int, _frame: object) -> None:
+    raise SystemExit(0)
 
 
 def _suggest_change_set_id(repo_root: Path) -> str:
@@ -209,8 +255,25 @@ def run_ui_server(
     class Handler(HarvestUiRequestHandler):
         repo_root = root
 
-    server = ThreadingHTTPServer((host, port), Handler)
-    server.serve_forever()
+    restart_pending = _terminate_previous_ui_server(root)
+    server = _create_http_server(host, port, Handler, wait_for_restart=restart_pending)
+    pid_path = _ui_server_pid_path(root)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    previous_sigterm_handler: Any | None = None
+    if threading.current_thread() is threading.main_thread():
+        previous_sigterm_handler = signal.signal(signal.SIGTERM, _exit_on_terminate)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+        if previous_sigterm_handler is not None:
+            signal.signal(signal.SIGTERM, previous_sigterm_handler)
+        try:
+            if pid_path.read_text(encoding="utf-8").strip() == str(os.getpid()):
+                pid_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 class HarvestUiRequestHandler(BaseHTTPRequestHandler):

--- a/tests/runtime/test_ui_server_restart.py
+++ b/tests/runtime/test_ui_server_restart.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.request import urlopen
+
+
+def _available_port() -> int:
+    with socket.socket() as candidate:
+        candidate.bind(("127.0.0.1", 0))
+        return int(candidate.getsockname()[1])
+
+
+def _wait_for_dashboard(port: int, expected_pid_path: Path, expected_pid: int) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            current_pid = int(expected_pid_path.read_text(encoding="utf-8").strip())
+            with urlopen(f"http://127.0.0.1:{port}/api/dashboard", timeout=0.2) as response:
+                if current_pid == expected_pid and response.status == 200:
+                    return
+        except (FileNotFoundError, OSError, ValueError):
+            pass
+        time.sleep(0.05)
+    raise AssertionError("UI server did not become ready")
+
+
+def _start_server(repo_root: Path, port: int) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "harness_codex",
+            "--repo-root",
+            str(repo_root),
+            "ui-server",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def test_ui_server_restarts_existing_server_for_repo(tmp_path: Path) -> None:
+    port = _available_port()
+    pid_path = tmp_path / ".harness" / "ui-server.pid"
+    first = _start_server(tmp_path, port)
+    second: subprocess.Popen[bytes] | None = None
+    try:
+        _wait_for_dashboard(port, pid_path, first.pid)
+
+        second = _start_server(tmp_path, port)
+        _wait_for_dashboard(port, pid_path, second.pid)
+
+        assert first.wait(timeout=2) == 0
+    finally:
+        if second is not None and second.poll() is None:
+            second.terminate()
+            second.wait(timeout=2)
+            assert not pid_path.exists()
+        if first.poll() is None:
+            first.terminate()
+            first.wait(timeout=2)


### PR DESCRIPTION
## 구현 의도

`harness ui-server`를 다시 실행할 때 같은 저장소에서 이미 실행 중인 UI 서버를 종료하고 새 프로세스로 교체하도록 한다.

## 구현 접근

- 서버 시작 시 `.harness/ui-server.pid`에서 기존 관리 프로세스 PID를 읽고 `SIGTERM`을 전송한다.
- 종료 과정에서 포트 반환이 지연될 수 있으므로 최대 3초 동안 바인딩을 재시도한 뒤 새 HTTP 서버를 시작한다.
- 실행 중인 서버는 자신의 PID를 기록하고 종료 시 자신이 소유한 PID 파일만 제거한다.
- 다른 프로세스가 PID 파일 없이 포트를 사용하는 경우 임의 종료하지 않고 기존 바인딩 오류를 유지한다.
- 통합 테스트는 첫 서버 시작, 두 번째 실행에 의한 교체, 종료 후 PID 파일 정리를 검증한다.

## 검증 방법

- `git diff --check`
- `./venv/bin/python3 -m pytest -q -s` -> `301 passed in 60.81s`

## 위험 및 롤백

- PID 파일이 잘못된 PID를 가리키면 해당 PID에 종료 신호가 전달될 수 있다. 파일은 저장소 로컬 서버가 생성하고 정상 종료 시 제거한다.
- 회귀 발생 시 이 커밋을 되돌리면 기존의 단순 포트 바인딩 동작으로 복원된다.