### PR TITLE
[codex] DDD 캔버스 누적 시각화 및 워크플로 너비 개선

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -25,7 +25,7 @@ h1 { margin-bottom: 0; font-size: 31px; }
 .layout { display: grid; grid-template-columns: 280px minmax(600px, 1fr); min-height: calc(100vh - 100px); }
 .layout.workflow-layout { display: block; }
 .layout.workflow-layout .sidebar { display: none; }
-.layout.workflow-layout .detail { margin: 0 auto; max-width: 1080px; }
+.layout.workflow-layout .detail { margin: 0 auto; max-width: 1480px; }
 .sidebar { border-right: 1px solid var(--line); padding: 26px 20px; }
 .detail { padding: 27px 34px; max-width: 1240px; }
 .change-button { background: transparent; border: 1px solid var(--line); border-radius: 10px; display: block; margin-bottom: 10px; padding: 12px; text-align: left; width: 100%; }
@@ -68,7 +68,7 @@ textarea { border: 1px solid var(--line); border-radius: 7px; font: 13px/1.48 "S
 .markdown-table tbody tr:nth-child(even) { background: #f6f7f1; }
 .error { color: #9c2d20; }
 details { margin-top: 10px; }
-.workflow-page { margin: 0 auto; max-width: 1000px; }
+.workflow-page { margin: 0 auto; max-width: 1380px; }
 .workflow-page > h2 { font-size: 30px; margin-bottom: 10px; }
 .lead { color: var(--muted); font-size: 15px; }
 .prompt-form, .grill-form { display: grid; gap: 12px; }
@@ -117,14 +117,23 @@ details { margin-top: 10px; }
 .ddd-step.needs_input, .ddd-step.stale { background: var(--stale); }
 .ddd-step.selected { border-color: var(--accent); font-weight: 600; }
 .ddd-grid { display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0; }
+.ddd-evolved-design { display: grid; gap: 14px; min-width: 660px; }
+.ddd-entity-layer { border-top: 1px dashed var(--line); padding-top: 14px; }
 .sticky.ddd-entity { background: #d6ecff; min-height: 130px; }
 .sticky.ddd-behavior { background: #ead7ff; min-height: 125px; }
+.sticky.ddd-domain-service { background: #d5efd5; }
 .sticky p { font-size: 12px; margin: 7px 0 0; }
 .ddd-evidence { border-top: 1px dashed var(--line); font-size: 12px; margin-top: 12px; padding-top: 10px; }
 .ddd-evidence p { margin: 5px 0; }
 .ddd-flow { display: flex; gap: 13px; margin: 14px 0; }
 .ddd-service { background: #d5efd5; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,.10); max-width: 310px; padding: 13px; }
 .ddd-service code { display: block; font-size: 12px; margin-top: 8px; }
+.ddd-relations { display: grid; gap: 10px; }
+.ddd-link-row { align-items: center; display: flex; gap: 12px; }
+.ddd-link-row .ddd-behavior { flex: 0 0 210px; min-height: 86px; }
+.ddd-method { color: var(--accent); font: 12px "SFMono-Regular", Consolas, monospace; }
+.ddd-connector { border-bottom: 2px solid #8fa598; color: var(--muted); font-size: 11px; min-width: 62px; padding-bottom: 3px; text-align: center; }
+.ddd-link-target { background: #d6ecff; border-radius: 12px; color: var(--accent); padding: 5px 10px; }
 .ddd-boundary { border: 2px dashed #8fa598; border-radius: 9px; min-height: 132px; min-width: 215px; padding: 14px; }
 .ddd-boundary.aggregate { background: #f6efe0; }
 .ddd-boundary.context { background: #eef4e8; border-style: solid; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -754,19 +754,13 @@ function renderSticky(note) {
 
 function renderDddCanvasBoard(board) {
   if (!board?.slices?.length) return "";
-  const stepLabels = new Map([
-    ["entity_vo", "Entity / VO"],
-    ["behaviors", "Behaviors"],
-    ["application_flow", "Application Flow"],
-    ["aggregates", "Aggregates"],
-    ["bounded_contexts", "Bounded Contexts"],
-  ]);
   const contents = board.slices.map((slice) => {
-    const sections = (slice.completed_steps || []).map((stepId) => `<div class="ddd-canvas-section"><h5>${escapeHtml(stepLabels.get(stepId) || stepId)}</h5>${renderDddVisualization(slice, stepId)}</div>`).join("");
-    return `<section class="canvas-slice ddd-slice"><h4>${escapeHtml(slice.uc_id)}</h4>${sections}</section>`;
+    const completedSteps = slice.completed_steps || [];
+    const latestStep = completedSteps[completedSteps.length - 1] || "entity_vo";
+    return `<section class="canvas-slice ddd-slice"><h4>${escapeHtml(slice.uc_id)}</h4>${renderDddVisualization(slice, latestStep)}</section>`;
   }).join("");
   return `<section class="panel"><div class="canvas-header"><h3>DDD Architecture Canvas</h3><div><span id="ddd-canvas-zoom-label">100%</span><button id="ddd-canvas-reset" type="button">Reset view</button></div></div>
-    <p class="small">Completed scoped design substeps only. Drag canvas to pan. Scroll to zoom.</p>
+    <p class="small">Design evolves as scoped substeps complete. Drag canvas to pan. Scroll to zoom.</p>
     <div id="ddd-canvas" class="event-canvas ddd-canvas"><div id="ddd-canvas-content" class="event-canvas-content">${contents}</div></div></section>`;
 }
 
@@ -1032,23 +1026,38 @@ function dddRows(content, heading) {
 
 function renderDddVisualization(board, stepId) {
   if (!board) return '<p class="small">No completed DDD design substep.</p>';
-  const step = stepId || "entity_vo";
-  if (step === "entity_vo") {
-    return `<div class="ddd-grid">${(board.entity_vo || []).map((row) => {
-      const status = String(row.Status || "").toLowerCase();
-      return `<article class="sticky ddd-entity"><div class="sticky-type">${escapeHtml(row.Status || "entity")}</div><strong>${escapeHtml(row.Entity || "")}</strong><p>${escapeHtml(row["Attributes / VOs"] || "")}</p>${status === "modify" ? `<p><del>${escapeHtml(row["Previous Definition"] || "")}</del><br>${escapeHtml(row["Proposed Definition"] || "")}</p>` : ""}</article>`;
-    }).join("")}</div>${renderDddEvidence(board.entity_vo || [], "Evidence")}`;
-  }
-  if (step === "behaviors") {
-    return `<div class="ddd-grid">${(board.behaviors || []).map((row) => `<article class="sticky ddd-behavior"><div class="sticky-type">${escapeHtml(row.Placement || "behavior")}</div><strong>${escapeHtml(row["Owner / Service"] || "")}</strong><p>${escapeHtml(row.Signature || "")}</p><p>${escapeHtml(row.Participants || "")}</p></article>`).join("")}</div>${renderDddEvidence(board.behaviors || [], "Policy Evidence")}`;
-  }
-  if (step === "application_flow") {
-    return `<div class="ddd-flow">${(board.application_flow || []).map((row) => `<article class="ddd-service"><strong>${escapeHtml(row["Application Service"] || "")}</strong><code>${escapeHtml(row.Signature || "")}</code><p>${escapeHtml(row.Pseudocode || "")}</p><p>${escapeHtml(row.Calls || "")}</p></article>`).join("")}</div>${renderDddEvidence(board.application_flow || [], "Evidence")}`;
-  }
-  if (step === "aggregates") {
-    return `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<article class="ddd-boundary aggregate"><strong>${escapeHtml(row.Aggregate || "")}</strong><span class="root">Root: ${escapeHtml(row["Aggregate Root"] || "")}</span><p>${escapeHtml(row.Members || "")}</p><p>${escapeHtml(row["Atomic Invariant"] || "")}</p></article>`).join("")}</div>${renderDddEvidence(board.aggregates || [], "Evidence")}`;
-  }
-  return `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${escapeHtml(row["Bounded Context"] || "")}</strong><p>${escapeHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${escapeHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${escapeHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>${renderDddEvidence(board.bounded_contexts || [], "Evidence")}`;
+  const stepOrder = ["entity_vo", "behaviors", "application_flow", "aggregates", "bounded_contexts"];
+  const stepIndex = Math.max(0, stepOrder.indexOf(stepId || "entity_vo"));
+  const completed = (step) => stepIndex >= stepOrder.indexOf(step);
+  const entityTargets = (board.entity_vo || []).map((row) => row.Entity).filter(Boolean).join(", ");
+  const entities = `<div class="ddd-grid ddd-entity-layer">${(board.entity_vo || []).map((row) => {
+    const status = String(row.Status || "").toLowerCase();
+    return `<article class="sticky ddd-entity"><div class="sticky-type">${escapeHtml(row.Status || "entity")}</div><strong>${escapeHtml(row.Entity || "")}</strong><p>${escapeHtml(row["Attributes / VOs"] || "")}</p>${status === "modify" ? `<p><del>${escapeHtml(row["Previous Definition"] || "")}</del><br>${escapeHtml(row["Proposed Definition"] || "")}</p>` : ""}</article>`;
+  }).join("")}</div>`;
+  const behaviors = completed("behaviors") ? `<div class="ddd-relations">${(board.behaviors || []).map((row) => {
+    const service = String(row.Placement || "").toLowerCase().includes("domain service");
+    return `<div class="ddd-link-row"><article class="sticky ddd-behavior ${service ? "ddd-domain-service" : ""}"><div class="sticky-type">${service ? "domain service" : "entity method"}</div><strong>${escapeHtml(row["Owner / Service"] || "")}</strong><p class="ddd-method">${escapeHtml(dddMethodLabel(row.Signature))}</p></article><span class="ddd-connector">calls -></span><span class="ddd-link-target">${escapeHtml(row.Participants || entityTargets || "Entity")}</span></div>`;
+  }).join("")}</div>` : "";
+  const flow = completed("application_flow") ? `<div class="ddd-flow">${(board.application_flow || []).map((row) => `<article class="ddd-service"><div class="sticky-type">application service</div><strong>${escapeHtml(row["Application Service"] || "")}</strong><code class="ddd-method">${escapeHtml(dddMethodLabel(row.Signature))}</code><p>${escapeHtml(row.Pseudocode || "")}</p><p>calls: ${escapeHtml(dddCallsLabel(row.Calls))}</p></article>`).join("")}</div>` : "";
+  const aggregates = completed("aggregates") ? `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<article class="ddd-boundary aggregate"><strong>${escapeHtml(row.Aggregate || "")}</strong><span class="root">Root: ${escapeHtml(row["Aggregate Root"] || "")}</span><p>${escapeHtml(row.Members || "")}</p><p>${escapeHtml(row["Atomic Invariant"] || "")}</p></article>`).join("")}</div>` : "";
+  const contexts = completed("bounded_contexts") ? `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${escapeHtml(row["Bounded Context"] || "")}</strong><p>${escapeHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${escapeHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${escapeHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>` : "";
+  const evidence = [
+    renderDddEvidence(board.entity_vo || [], "Evidence"),
+    completed("behaviors") ? renderDddEvidence(board.behaviors || [], "Policy Evidence") : "",
+    completed("application_flow") ? renderDddEvidence(board.application_flow || [], "Evidence") : "",
+    completed("aggregates") ? renderDddEvidence(board.aggregates || [], "Evidence") : "",
+    completed("bounded_contexts") ? renderDddEvidence(board.bounded_contexts || [], "Evidence") : "",
+  ].join("");
+  return `<div class="ddd-evolved-design">${flow}${behaviors}${entities}${aggregates}${contexts}</div>${evidence}`;
+}
+
+function dddMethodLabel(signature) {
+  const name = stickyText(signature).split("(", 1)[0].trim();
+  return name ? `${name}()` : "method";
+}
+
+function dddCallsLabel(calls) {
+  return stickyText(calls).replace(/([A-Za-z_][\w.]*)\s*\([^)]*\)/g, "$1()");
 }
 
 function renderDddEvidence(rows, key) {

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -679,7 +679,10 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "Restart DDD Architecture" in javascript
         assert "renderDddVisualization" in javascript
         assert "renderDddCanvasBoard" in javascript
-        assert "ddd-canvas-section" in javascript
+        assert "ddd-evolved-design" in javascript
+        assert "dddMethodLabel" in javascript
+        assert "dddCallsLabel" in javascript
+        assert "domain service" in javascript
         assert "bindCanvas" in javascript
         assert "function stickyText" in javascript
         assert "function eventFlowKind" in javascript
@@ -695,6 +698,9 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert ".event-canvas" in stylesheet
         assert ".ddd-grid" in stylesheet
         assert ".ddd-canvas" in stylesheet
+        assert ".ddd-relations" in stylesheet
+        assert ".ddd-link-target" in stylesheet
+        assert "max-width: 1380px" in stylesheet
         assert "user-select: none" in stylesheet
     finally:
         server.shutdown()


### PR DESCRIPTION
## 구현 의도

대시보드의 DDD Architecture Canvas가 단계별 결과를 분리해 반복 표시하지 않고, 설계가 단계 진행에 따라 확장되는 하나의 시각화로 보이도록 개선한다. Domain Service와 Entity의 관계를 드러내고, 메서드 표시에서 불필요한 파라미터 시그니처를 제거하며, ChangeSet Workflow 화면의 좁은 컨텐츠 영역을 넓힌다.

## 구현 접근

- 각 유스케이스의 완료된 마지막 DDD 단계를 기준으로 단일 누적 시각화를 렌더링한다.
- `Entity / VO` 기반 뷰 위에 완료된 `Behaviors`, `Application Flow`, `Aggregates`, `Bounded Contexts` 레이어를 차례로 추가한다.
- Behavior/Domain Service 노드를 Entity 대상과 연결하는 행 및 커넥터 표현을 추가해 호출 관계를 표시한다.
- Behavior와 Application Service의 `Signature`/`Calls` 값은 메서드명만 `save()` 형태로 정규화해 파라미터 내용을 시각화에서 숨긴다.
- 워크플로 컨텐츠 최대 너비를 `1380px`, 워크플로 상세 래퍼 최대 너비를 `1480px`로 확대한다.
- 자산 제공 테스트를 새 캔버스 렌더링 헬퍼, 관계 스타일, 확대된 레이아웃 기대값에 맞춰 갱신한다.

## 검증 방법

- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- Node 렌더러 검증: Domain Service 연결과 `calculate()`/`place()` 표시, 파라미터 문자열 미표시 확인
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` -> `22 passed in 9.98s`
- `git diff --check`
- `./venv/bin/python3 -m pytest -q -s` -> `301 passed in 65.06s`

## 위험 및 롤백

- 현재 연결 대상은 DDD 표의 `Participants` 또는 Entity 목록에 의존하므로, 생성 문서가 관계 정보를 누락하면 연결 라벨이 일반 Entity 목록으로 표시된다.
- 누적 시각화가 기존 단계별 비교 사용성보다 부적합하면 이 커밋을 되돌려 단계별 렌더링과 기존 너비로 복원할 수 있다.