### PR TITLE
[codex] DDD 대시보드 스티키 렌더링 수정

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -125,9 +125,9 @@ details { margin-top: 10px; }
 .sticky p { font-size: 12px; margin: 7px 0 0; }
 .ddd-evidence { border-top: 1px dashed var(--line); font-size: 12px; margin-top: 12px; padding-top: 10px; }
 .ddd-evidence p { margin: 5px 0; }
-.ddd-flow { display: flex; gap: 13px; margin: 14px 0; }
-.ddd-service { background: #d5efd5; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,.10); max-width: 310px; padding: 13px; }
-.ddd-service code { display: block; font-size: 12px; margin-top: 8px; }
+.ddd-flow { display: flex; flex-wrap: wrap; gap: 13px; margin: 14px 0; }
+.ddd-service { background: #d5efd5; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,.10); max-width: 310px; overflow-wrap: anywhere; padding: 13px; }
+.ddd-service code { display: block; font-size: 12px; margin-top: 8px; white-space: normal; }
 .ddd-relations { display: grid; gap: 10px; }
 .ddd-link-row { align-items: center; display: flex; gap: 12px; }
 .ddd-link-row .ddd-behavior { flex: 0 0 210px; min-height: 86px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -728,7 +728,7 @@ function renderBoard(board) {
     <div class="flow-lane">${flow.notes.map((note) => `
       <article class="sticky ${escapeHtml(note.type)}">
         <div class="sticky-type">${escapeHtml(note.type.replace("_", " "))}</div>
-        ${escapeHtml(stickyText(note.text))}
+        ${richTextHtml(note.text)}
       </article>`).join("")}</div>`).join("")}`;
 }
 
@@ -748,7 +748,7 @@ function renderCanvasBoard(board) {
 
 function renderSticky(note) {
   return `<article class="sticky ${escapeHtml(note.type)}">
-    <div class="sticky-type">${escapeHtml(note.type.replace("_", " "))}</div>${escapeHtml(stickyText(note.text))}
+    <div class="sticky-type">${escapeHtml(note.type.replace("_", " "))}</div>${richTextHtml(note.text)}
   </article>`;
 }
 
@@ -766,6 +766,10 @@ function renderDddCanvasBoard(board) {
 
 function stickyText(text) {
   return String(text || "").replace(/`([^`]*)`/g, "$1");
+}
+
+function richTextHtml(text) {
+  return escapeHtml(stickyText(text)).replace(/&lt;br\s*\/?&gt;/gi, "<br>");
 }
 
 function bindDetail(change) {
@@ -997,7 +1001,7 @@ function renderEventDocumentEditor(message = "") {
 function parseDddMarkdown(content) {
   return {
     impact: dddRows(content, "## Impact Assessment"),
-    entity_vo: dddRows(content, "## Entity / Value Objects"),
+    entity_vo: normalizeDddEntityVoRows(dddRows(content, "## Entity / Value Objects")),
     behaviors: dddRows(content, "## Behaviors"),
     application_flow: dddRows(content, "## Application Flow"),
     aggregates: dddRows(content, "## Aggregates"),
@@ -1019,9 +1023,26 @@ function dddRows(content, heading) {
   for (const line of body.slice(tableIndex + 2)) {
     const cells = splitTableRow(line);
     if (!cells || cells.length !== headers.length) break;
+    if (!cells.some((cell) => stickyText(cell).trim())) continue;
     rows.push(Object.fromEntries(headers.map((header, index) => [header, stickyText(cells[index])])));
   }
   return rows;
+}
+
+function normalizeDddEntityVoRows(rows) {
+  return rows.map((row) => {
+    if ("Entity" in row && "Attributes / VOs" in row) return row;
+    const model = row.Model || "";
+    if (!model) return row;
+    return {
+      Entity: model,
+      "Attributes / VOs": row["Core attributes"] || row["Proposed Identity / State"] || "",
+      Status: row.Classification || row.Kind || "",
+      "Previous Definition": "",
+      "Proposed Definition": row["Proposed Identity / State"] || row["Core attributes"] || "",
+      Evidence: row.Evidence || row["Why new"] || "",
+    };
+  }).filter((row) => row.Entity || row["Attributes / VOs"] || row.Status);
 }
 
 function renderDddVisualization(board, stepId) {
@@ -1032,15 +1053,15 @@ function renderDddVisualization(board, stepId) {
   const entityTargets = (board.entity_vo || []).map((row) => row.Entity).filter(Boolean).join(", ");
   const entities = `<div class="ddd-grid ddd-entity-layer">${(board.entity_vo || []).map((row) => {
     const status = String(row.Status || "").toLowerCase();
-    return `<article class="sticky ddd-entity"><div class="sticky-type">${escapeHtml(row.Status || "entity")}</div><strong>${escapeHtml(row.Entity || "")}</strong><p>${escapeHtml(row["Attributes / VOs"] || "")}</p>${status === "modify" ? `<p><del>${escapeHtml(row["Previous Definition"] || "")}</del><br>${escapeHtml(row["Proposed Definition"] || "")}</p>` : ""}</article>`;
+    return `<article class="sticky ddd-entity"><div class="sticky-type">${escapeHtml(row.Status || "entity")}</div><strong>${richTextHtml(row.Entity || "")}</strong><p>${richTextHtml(row["Attributes / VOs"] || "")}</p>${status === "modify" ? `<p><del>${richTextHtml(row["Previous Definition"] || "")}</del><br>${richTextHtml(row["Proposed Definition"] || "")}</p>` : ""}</article>`;
   }).join("")}</div>`;
   const behaviors = completed("behaviors") ? `<div class="ddd-relations">${(board.behaviors || []).map((row) => {
     const service = String(row.Placement || "").toLowerCase().includes("domain service");
-    return `<div class="ddd-link-row"><article class="sticky ddd-behavior ${service ? "ddd-domain-service" : ""}"><div class="sticky-type">${service ? "domain service" : "entity method"}</div><strong>${escapeHtml(row["Owner / Service"] || "")}</strong><p class="ddd-method">${escapeHtml(dddMethodLabel(row.Signature))}</p></article><span class="ddd-connector">calls -></span><span class="ddd-link-target">${escapeHtml(row.Participants || entityTargets || "Entity")}</span></div>`;
+    return `<div class="ddd-link-row"><article class="sticky ddd-behavior ${service ? "ddd-domain-service" : ""}"><div class="sticky-type">${service ? "domain service" : "entity method"}</div><strong>${richTextHtml(row["Owner / Service"] || "")}</strong><p class="ddd-method">${richTextHtml(dddMethodLabel(row.Signature))}</p></article><span class="ddd-connector">calls -></span><span class="ddd-link-target">${richTextHtml(row.Participants || entityTargets || "Entity")}</span></div>`;
   }).join("")}</div>` : "";
-  const flow = completed("application_flow") ? `<div class="ddd-flow">${(board.application_flow || []).map((row) => `<article class="ddd-service"><div class="sticky-type">application service</div><strong>${escapeHtml(row["Application Service"] || "")}</strong><code class="ddd-method">${escapeHtml(dddMethodLabel(row.Signature))}</code><p>${escapeHtml(row.Pseudocode || "")}</p><p>calls: ${escapeHtml(dddCallsLabel(row.Calls))}</p></article>`).join("")}</div>` : "";
-  const aggregates = completed("aggregates") ? `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<article class="ddd-boundary aggregate"><strong>${escapeHtml(row.Aggregate || "")}</strong><span class="root">Root: ${escapeHtml(row["Aggregate Root"] || "")}</span><p>${escapeHtml(row.Members || "")}</p><p>${escapeHtml(row["Atomic Invariant"] || "")}</p></article>`).join("")}</div>` : "";
-  const contexts = completed("bounded_contexts") ? `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${escapeHtml(row["Bounded Context"] || "")}</strong><p>${escapeHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${escapeHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${escapeHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>` : "";
+  const flow = completed("application_flow") ? `<div class="ddd-flow">${(board.application_flow || []).map((row) => `<article class="ddd-service"><div class="sticky-type">application service</div><strong>${richTextHtml(row["Application Service"] || "")}</strong><code class="ddd-method">${richTextHtml(dddMethodLabel(row.Signature))}</code><p>${richTextHtml(row.Pseudocode || "")}</p><p>calls: ${richTextHtml(dddCallsLabel(row.Calls))}</p></article>`).join("")}</div>` : "";
+  const aggregates = completed("aggregates") ? `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<article class="ddd-boundary aggregate"><strong>${richTextHtml(row.Aggregate || "")}</strong><span class="root">Root: ${richTextHtml(row["Aggregate Root"] || "")}</span><p>${richTextHtml(row.Members || "")}</p><p>${richTextHtml(row["Atomic Invariant"] || "")}</p></article>`).join("")}</div>` : "";
+  const contexts = completed("bounded_contexts") ? `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong><p>${richTextHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>` : "";
   const evidence = [
     renderDddEvidence(board.entity_vo || [], "Evidence"),
     completed("behaviors") ? renderDddEvidence(board.behaviors || [], "Policy Evidence") : "",
@@ -1062,7 +1083,7 @@ function dddCallsLabel(calls) {
 
 function renderDddEvidence(rows, key) {
   if (!rows.length) return "";
-  return `<div class="ddd-evidence">${rows.map((row) => `<p><strong>${escapeHtml(row.Entity || row["Owner / Service"] || row.Aggregate || row["Bounded Context"] || row["Application Service"] || "")}</strong>: ${escapeHtml(row[key] || "")}</p>`).join("")}</div>`;
+  return `<div class="ddd-evidence">${rows.map((row) => `<p><strong>${richTextHtml(row.Entity || row["Owner / Service"] || row.Aggregate || row["Bounded Context"] || row["Application Service"] || "")}</strong>: ${richTextHtml(row[key] || "")}</p>`).join("")}</div>`;
 }
 
 function renderDddDocumentEditor(message = "") {

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -824,6 +824,8 @@ def _ddd_table_rows(text: str, heading: str) -> list[dict[str, str]]:
     for line in rows[2:]:
         cells = [_clean_cell(cell) for cell in line.strip().strip("|").split("|")]
         if len(cells) == len(headers):
+            if not any(cells):
+                continue
             parsed.append(dict(zip(headers, cells)))
     return parsed
 

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -423,6 +423,7 @@ def test_dashboard_normalizes_generated_entity_vo_table_variant(tmp_path: Path) 
 | Model | Kind | Proposed Identity / State | Why new |
 | --- | --- | --- | --- |
 | `MarkdownNote` | Entity | `WorkspaceRelativePath path`, openable file content loaded from that path | Path identity matters. |
+| | | | |
 | `WorkspaceRelativePath` | Value Object | Normalized relative path constrained beneath `NoteWorkspace` | Prevents escaping root. |
 
 ### Evidence
@@ -434,6 +435,7 @@ def test_dashboard_normalizes_generated_entity_vo_table_variant(tmp_path: Path) 
     change_set = document_dashboard_state(tmp_path)["change_sets"][0]
     row = change_set["ddd_architecture_board"]["slices"][0]["entity_vo"][0]
 
+    assert len(change_set["ddd_architecture_board"]["slices"][0]["entity_vo"]) == 2
     assert row["Entity"] == "MarkdownNote"
     assert row["Attributes / VOs"] == "WorkspaceRelativePath path, openable file content loaded from that path"
 
@@ -678,6 +680,8 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert '"/api/ddd-architecture/answer"' in javascript
         assert "Restart DDD Architecture" in javascript
         assert "renderDddVisualization" in javascript
+        assert "function richTextHtml" in javascript
+        assert "function normalizeDddEntityVoRows" in javascript
         assert "renderDddCanvasBoard" in javascript
         assert "ddd-evolved-design" in javascript
         assert "dddMethodLabel" in javascript
@@ -691,6 +695,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert 'app.view === "dashboard" && !isEditingDashboardDocument()' in javascript
         assert 'if (event.target.closest(".sticky")) return;\n    event.preventDefault();' in javascript
         assert "function renderInline" in javascript
+        assert ".ddd-flow { display: flex; flex-wrap: wrap;" in stylesheet
         assert "listItems.map" in javascript
         assert "runtime-progress" in stylesheet
         assert "stage-tabs" in stylesheet


### PR DESCRIPTION
## 구현 의도
DDD 아키텍처 캔버스와 라이브 미리보기에서 빈 스티키 노트가 표시되고 `<br>` 태그가 텍스트로 노출되는 문제를 수정합니다.

## 구현 방식
- 스티키/DDD 렌더링 경로에서 기존 HTML 이스케이프를 유지한 뒤 허용된 `<br>` 표기만 실제 줄바꿈으로 변환합니다.
- DDD 테이블 파서가 빈 행을 건너뛰도록 하여 빈 스티키 노트 생성을 막습니다.
- 브라우저 라이브 미리보기에서도 서버와 동일하게 `Model | Kind` 형태의 Entity/VO 테이블을 표준 컬럼으로 정규화합니다.
- Application Flow 카드가 긴 서비스명과 메서드 라벨을 넘치지 않게 줄바꿈하도록 CSS를 조정합니다.

## 검증 방법
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`

## 위험 및 롤백
위험은 낮습니다. 변경 범위는 대시보드 렌더링/파싱 보정과 관련 테스트로 제한됩니다. 문제가 발생하면 이 커밋을 되돌리면 기존 렌더링 동작으로 복구됩니다.