### PR TITLE
[codex] DDD 대시보드 캔버스 너비 개선

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -25,7 +25,7 @@ h1 { margin-bottom: 0; font-size: 31px; }
 .layout { display: grid; grid-template-columns: 280px minmax(600px, 1fr); min-height: calc(100vh - 100px); }
 .layout.workflow-layout { display: block; }
 .layout.workflow-layout .sidebar { display: none; }
-.layout.workflow-layout .detail { margin: 0 auto; max-width: 1480px; }
+.layout.workflow-layout .detail { margin: 0 auto; max-width: min(1720px, calc(100vw - 48px)); width: 100%; }
 .sidebar { border-right: 1px solid var(--line); padding: 26px 20px; }
 .detail { padding: 27px 34px; max-width: 1240px; }
 .change-button { background: transparent; border: 1px solid var(--line); border-radius: 10px; display: block; margin-bottom: 10px; padding: 12px; text-align: left; width: 100%; }
@@ -61,14 +61,17 @@ textarea { border: 1px solid var(--line); border-radius: 7px; font: 13px/1.48 "S
 .markdown-preview ul, .markdown-preview ol { margin: 8px 0 16px; padding-left: 25px; white-space: normal; }
 .markdown-preview li { margin: 4px 0; }
 .markdown-preview code { background: #eef1e8; border-radius: 4px; font: 12px "SFMono-Regular", Consolas, monospace; padding: 1px 4px; }
-.markdown-table { margin: 12px 0; overflow-x: auto; white-space: normal; }
-.markdown-table table { border-collapse: collapse; min-width: 100%; }
-.markdown-table th, .markdown-table td { border: 1px solid var(--line); padding: 7px 10px; text-align: left; vertical-align: top; }
+.markdown-table { margin: 12px 0; max-width: 100%; overflow-x: auto; white-space: normal; }
+.markdown-table table { border-collapse: collapse; min-width: 1280px; width: max-content; }
+.markdown-table th, .markdown-table td { border: 1px solid var(--line); min-width: 170px; padding: 7px 10px; text-align: left; vertical-align: top; }
 .markdown-table th { background: #eef1e8; font-weight: 600; }
 .markdown-table tbody tr:nth-child(even) { background: #f6f7f1; }
+.markdown-table .column-long { min-width: 340px; }
+.markdown-table-cell { max-width: 520px; }
+.markdown-table td.column-long .markdown-table-cell { max-height: 180px; overflow-y: auto; }
 .error { color: #9c2d20; }
 details { margin-top: 10px; }
-.workflow-page { margin: 0 auto; max-width: 1380px; }
+.workflow-page { margin: 0 auto; max-width: min(1720px, calc(100vw - 48px)); }
 .workflow-page > h2 { font-size: 30px; margin-bottom: 10px; }
 .lead { color: var(--muted); font-size: 15px; }
 .prompt-form, .grill-form { display: grid; gap: 12px; }
@@ -117,7 +120,7 @@ details { margin-top: 10px; }
 .ddd-step.needs_input, .ddd-step.stale { background: var(--stale); }
 .ddd-step.selected { border-color: var(--accent); font-weight: 600; }
 .ddd-grid { display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0; }
-.ddd-evolved-design { display: grid; gap: 14px; min-width: 660px; }
+.ddd-evolved-design { display: grid; gap: 14px; min-width: 1020px; }
 .ddd-entity-layer { border-top: 1px dashed var(--line); padding-top: 14px; }
 .sticky.ddd-entity { background: #d6ecff; min-height: 130px; }
 .sticky.ddd-behavior { background: #ead7ff; min-height: 125px; }
@@ -126,8 +129,8 @@ details { margin-top: 10px; }
 .ddd-evidence { border-top: 1px dashed var(--line); font-size: 12px; margin-top: 12px; padding-top: 10px; }
 .ddd-evidence p { margin: 5px 0; }
 .ddd-flow { display: flex; flex-wrap: wrap; gap: 13px; margin: 14px 0; }
-.ddd-service { background: #d5efd5; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,.10); max-width: 310px; overflow-wrap: anywhere; padding: 13px; }
-.ddd-service code { display: block; font-size: 12px; margin-top: 8px; white-space: normal; }
+.ddd-service { background: #d5efd5; border-radius: 5px; box-shadow: 0 2px 5px rgba(0,0,0,.10); flex: 1 1 420px; max-width: 620px; overflow-wrap: anywhere; padding: 12px; }
+.ddd-service p { font-size: 12px; line-height: 1.45; margin: 6px 0 0; }
 .ddd-relations { display: grid; gap: 10px; }
 .ddd-link-row { align-items: center; display: flex; gap: 12px; }
 .ddd-link-row .ddd-behavior { flex: 0 0 210px; min-height: 86px; }
@@ -139,5 +142,5 @@ details { margin-top: 10px; }
 .ddd-boundary.context { background: #eef4e8; border-style: solid; }
 .ddd-boundary .root, .communication { background: var(--active); border-radius: 12px; color: var(--accent); display: inline-block; font-size: 11px; margin-top: 8px; padding: 3px 9px; }
 .ddd-canvas { height: 580px; }
-.ddd-slice { max-width: 740px; min-width: 280px; }
+.ddd-slice { max-width: none; min-width: 1020px; }
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -121,9 +121,18 @@ function isTableDivider(line, columnCount) {
 }
 
 function renderTable(headers, rows) {
-  const head = headers.map((cell) => `<th>${renderInline(cell)}</th>`).join("");
-  const body = rows.map((row) => `<tr>${row.map((cell) => `<td>${renderInline(cell)}</td>`).join("")}</tr>`).join("");
+  const head = headers.map((cell) => `<th class="${tableColumnClass(cell)}">${renderInline(cell)}</th>`).join("");
+  const body = rows.map((row) => `<tr>${row.map((cell, index) => {
+    const columnClass = tableColumnClass(headers[index] || "");
+    return `<td class="${columnClass}"><div class="markdown-table-cell">${renderInline(cell)}</div></td>`;
+  }).join("")}</tr>`).join("");
   return `<div class="markdown-table"><table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>`;
+}
+
+function tableColumnClass(header) {
+  const normalized = stickyText(header).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  const tallColumns = ["evidence", "pseudocode", "calls", "baseline-evidence", "event-storming-evidence", "policy-evidence", "attributes-vos", "proposed-definition", "atomic-invariant"];
+  return tallColumns.includes(normalized) ? `column-${normalized} column-long` : `column-${normalized || "value"}`;
 }
 
 async function loadDashboard() {
@@ -1059,7 +1068,10 @@ function renderDddVisualization(board, stepId) {
     const service = String(row.Placement || "").toLowerCase().includes("domain service");
     return `<div class="ddd-link-row"><article class="sticky ddd-behavior ${service ? "ddd-domain-service" : ""}"><div class="sticky-type">${service ? "domain service" : "entity method"}</div><strong>${richTextHtml(row["Owner / Service"] || "")}</strong><p class="ddd-method">${richTextHtml(dddMethodLabel(row.Signature))}</p></article><span class="ddd-connector">calls -></span><span class="ddd-link-target">${richTextHtml(row.Participants || entityTargets || "Entity")}</span></div>`;
   }).join("")}</div>` : "";
-  const flow = completed("application_flow") ? `<div class="ddd-flow">${(board.application_flow || []).map((row) => `<article class="ddd-service"><div class="sticky-type">application service</div><strong>${richTextHtml(row["Application Service"] || "")}</strong><code class="ddd-method">${richTextHtml(dddMethodLabel(row.Signature))}</code><p>${richTextHtml(row.Pseudocode || "")}</p><p>calls: ${richTextHtml(dddCallsLabel(row.Calls))}</p></article>`).join("")}</div>` : "";
+  const flow = completed("application_flow") ? `<div class="ddd-flow">${(board.application_flow || []).map((row) => {
+    const description = dddFlowDescription(row);
+    return `<article class="ddd-service"><div class="sticky-type">application service</div><p><strong>${richTextHtml(dddMethodLabel(row.Signature || row["Application Service"]))}</strong>${description ? ` ${richTextHtml(description)}` : ""}</p></article>`;
+  }).join("")}</div>` : "";
   const aggregates = completed("aggregates") ? `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<article class="ddd-boundary aggregate"><strong>${richTextHtml(row.Aggregate || "")}</strong><span class="root">Root: ${richTextHtml(row["Aggregate Root"] || "")}</span><p>${richTextHtml(row.Members || "")}</p><p>${richTextHtml(row["Atomic Invariant"] || "")}</p></article>`).join("")}</div>` : "";
   const contexts = completed("bounded_contexts") ? `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong><p>${richTextHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>` : "";
   const evidence = [
@@ -1077,8 +1089,15 @@ function dddMethodLabel(signature) {
   return name ? `${name}()` : "method";
 }
 
-function dddCallsLabel(calls) {
-  return stickyText(calls).replace(/([A-Za-z_][\w.]*)\s*\([^)]*\)/g, "$1()");
+function dddFlowDescription(row) {
+  const text = stickyText(row.Pseudocode || row.Evidence || "")
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/([A-Za-z_][\w.]*)\s*\([^)]*\)/g, "$1()")
+    .replace(/\s*->\s*/g, ". ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.;,\s]+$/, "");
+  return text ? `${text}.` : "";
 }
 
 function renderDddEvidence(rows, key) {

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -681,11 +681,13 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "Restart DDD Architecture" in javascript
         assert "renderDddVisualization" in javascript
         assert "function richTextHtml" in javascript
+        assert "function tableColumnClass" in javascript
         assert "function normalizeDddEntityVoRows" in javascript
         assert "renderDddCanvasBoard" in javascript
         assert "ddd-evolved-design" in javascript
         assert "dddMethodLabel" in javascript
-        assert "dddCallsLabel" in javascript
+        assert "dddFlowDescription" in javascript
+        assert "calls: " not in javascript
         assert "domain service" in javascript
         assert "bindCanvas" in javascript
         assert "function stickyText" in javascript
@@ -700,12 +702,15 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "runtime-progress" in stylesheet
         assert "stage-tabs" in stylesheet
         assert ".markdown-preview code" in stylesheet
+        assert ".markdown-table .column-long" in stylesheet
+        assert "max-height: 180px" in stylesheet
+        assert "max-width: min(1720px, calc(100vw - 48px))" in stylesheet
         assert ".event-canvas" in stylesheet
         assert ".ddd-grid" in stylesheet
         assert ".ddd-canvas" in stylesheet
         assert ".ddd-relations" in stylesheet
         assert ".ddd-link-target" in stylesheet
-        assert "max-width: 1380px" in stylesheet
+        assert "min-width: 1020px" in stylesheet
         assert "user-select: none" in stylesheet
     finally:
         server.shutdown()


### PR DESCRIPTION
## 구현 의도
DDD 아키텍처 화면에서 애플리케이션 서비스 캔버스와 문서 테이블이 좁게 렌더링되어 내용이 과도하게 세로로 늘어나는 문제를 개선합니다.

## 구현 방식
- 워크플로우 상세 영역과 DDD 캔버스의 최대/최소 너비를 넓혀 넓은 화면을 더 활용하도록 조정했습니다.
- 애플리케이션 서비스 카드는 시그니처 이름과 간단한 설명만 보여주고, 카드 너비를 유연하게 확장하도록 변경했습니다.
- Markdown 테이블은 긴 열을 감지해 더 넓게 배치하고, 긴 셀 내부는 제한 높이에서 스크롤되도록 하여 특정 열이 전체 행 높이를 과도하게 키우지 않게 했습니다.

## 검증 방법
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py`

## 위험 및 롤백
위험은 낮습니다. 변경 범위는 대시보드 정적 자산과 관련 테스트로 제한됩니다. 문제가 있으면 이 커밋을 되돌려 기존 레이아웃으로 복구할 수 있습니다.