### PR TITLE
[codex] 대시보드 설계 시각화 추가

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -140,4 +140,28 @@ details { margin-top: 10px; }
 .ddd-boundary .root, .communication { background: var(--active); border-radius: 12px; color: var(--accent); display: inline-block; font-size: 11px; margin-top: 8px; padding: 3px 9px; }
 .ddd-canvas { height: 580px; }
 .ddd-slice { max-width: 740px; min-width: 280px; }
+.design-visualization { overflow: hidden; }
+.design-section { border-top: 1px solid var(--line); margin-top: 18px; padding-top: 18px; }
+.design-section h4 { margin: 0 0 12px; }
+.design-section-heading { align-items: center; display: flex; justify-content: space-between; gap: 12px; }
+.design-stage-map { display: grid; gap: 10px; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.design-stage { background: #f1f2ec; border: 1px solid var(--line); border-radius: 9px; min-height: 86px; padding: 11px; position: relative; }
+.design-stage::after { color: var(--muted); content: "→"; position: absolute; right: -11px; top: 32px; }
+.design-stage:last-child::after { content: ""; }
+.design-stage.verified { background: var(--active); border-color: #acc4b0; }
+.design-stage.stale { background: var(--stale); }
+.design-stage strong { display: block; font-size: 12px; margin-bottom: 10px; }
+.design-status-table .pill { text-transform: none; }
+.design-tabs { display: flex; flex-wrap: wrap; gap: 8px; margin: 10px 0 14px; }
+.selected-chip { background: var(--accent); border-color: var(--accent); color: white; }
+.process-model-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); }
+.process-lane { border: 1px solid var(--line); border-radius: 10px; padding: 12px; }
+.process-lane h5, .trace-links h5 { color: var(--muted); font-size: 12px; margin: 0 0 10px; text-transform: uppercase; }
+.process-lane .flow-lane { flex-wrap: wrap; margin: 0; overflow: visible; }
+.process-lane .sticky { flex-basis: 158px; min-height: 82px; }
+.process-flow-strip { border-top: 1px dashed var(--line); margin-top: 16px; padding-top: 12px; }
+.software-design-board { overflow-x: auto; padding-bottom: 6px; }
+.trace-links { background: #f7f8f2; border-radius: 9px; margin-top: 12px; padding: 12px; }
+.trace-links ul { margin: 0; padding-left: 18px; }
+.trace-links li { margin: 7px 0; }
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -715,8 +715,9 @@ function renderDetail(change) {
     </div>` : ""}
     <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div></section>
     ${documents ? `<section class="panel"><h3>Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
-    ${renderCanvasBoard(change.event_storming_board)}
-    ${renderDddCanvasBoard(change.ddd_architecture_board)}
+    ${renderDesignVisualization(change)}
+    ${change.design_visualization ? "" : renderCanvasBoard(change.event_storming_board)}
+    ${change.design_visualization ? "" : renderDddCanvasBoard(change.ddd_architecture_board)}
     ${workItems}
     <details class="panel"><summary>Runtime history</summary><ul>${runs || "<li>No recorded runs.</li>"}</ul></details>`;
 }
@@ -752,6 +753,85 @@ function renderSticky(note) {
   </article>`;
 }
 
+function renderDesignVisualization(change) {
+  const visualization = change.design_visualization;
+  if (!visualization) return "";
+  return `<section class="panel design-visualization">
+    <div class="canvas-header"><div><p class="eyebrow">Design Visualization</p><h3>Big Picture Event Storming -> Process Modeling -> Software Design</h3></div></div>
+    ${renderDesignOverview(visualization.overview)}
+    ${renderProcessModel(visualization.process_model)}
+    ${renderSoftwareDesign(visualization.software_design)}
+  </section>`;
+}
+
+function renderDesignOverview(overview) {
+  const stages = (overview?.stages || []).map((stage) => `
+    <article class="design-stage ${escapeHtml(stage.status)}">
+      <strong>${escapeHtml(stage.label)}</strong>
+      <span class="pill ${escapeHtml(stage.status)}">${escapeHtml(stage.status)}</span>
+    </article>`).join("");
+  const useCases = (overview?.use_cases || []).map((item) => `
+    <tr>
+      <td><strong>${escapeHtml(item.uc_id)}</strong><br><span class="small">${escapeHtml(item.name)}</span></td>
+      ${renderVisualStateCell(item.use_case)}
+      ${renderVisualStateCell(item.event_storming)}
+      ${renderVisualStateCell(item.software_design)}
+      ${renderVisualStateCell(item.technical_decisions)}
+    </tr>`).join("");
+  return `<div class="design-section">
+    <h4>1. Big Picture Event Storming</h4>
+    <div class="design-stage-map">${stages}</div>
+    <div class="markdown-table design-status-table"><table>
+      <thead><tr><th>Use Case</th><th>Use Case</th><th>Event Storming</th><th>Software Design</th><th>Technical Decisions</th></tr></thead>
+      <tbody>${useCases || '<tr><td colspan="5">No use-case work items.</td></tr>'}</tbody>
+    </table></div>
+  </div>`;
+}
+
+function renderVisualStateCell(state) {
+  const status = state?.status || "missing";
+  return `<td><span class="pill ${escapeHtml(status)}">${escapeHtml(status)}</span>${state?.path ? `<br><span class="small">${escapeHtml(state.path)}</span>` : ""}</td>`;
+}
+
+function renderProcessModel(processModel) {
+  const slices = processModel?.slices || [];
+  if (!slices.length) return `<div class="design-section"><h4>2. Process Modeling</h4><p class="small">No completed event-storming document yet.</p></div>`;
+  const selected = slices.find((slice) => slice.uc_id === app.eventSelectedUc) || slices[0];
+  const tabs = slices.map((slice) => `<button type="button" data-process-uc="${escapeHtml(slice.uc_id)}" class="${selected.uc_id === slice.uc_id ? "selected-chip" : ""}">${escapeHtml(slice.uc_id)}</button>`).join("");
+  const lanes = (selected.lanes || []).map((lane) => `
+    <section class="process-lane ${escapeHtml(lane.type)}">
+      <h5>${escapeHtml(lane.type.replace("_", " "))}</h5>
+      <div class="flow-lane">${lane.nodes.map(renderSticky).join("")}</div>
+    </section>`).join("");
+  const flows = (selected.flows || []).map((flow) => `<div class="canvas-lane"><strong>${escapeHtml(flow.name)}</strong><div class="flow-lane">${flow.notes.map(renderSticky).join("")}</div></div>`).join("");
+  return `<div class="design-section">
+    <div class="design-section-heading"><h4>2. Process Modeling</h4>${selected.document_id ? `<button type="button" data-document="${escapeHtml(selected.document_id)}">Edit Event Storming</button>` : ""}</div>
+    <div class="design-tabs">${tabs}</div>
+    <div class="process-model-grid">${lanes}</div>
+    <div class="process-flow-strip">${flows}</div>
+  </div>`;
+}
+
+function renderSoftwareDesign(softwareDesign) {
+  const slices = softwareDesign?.slices || [];
+  if (!slices.length) return `<div class="design-section"><h4>3. Software Design</h4><p class="small">No completed DDD design document yet.</p></div>`;
+  const selected = slices.find((slice) => slice.uc_id === app.dddSelectedUc) || slices[0];
+  const selectedStep = selected.completed_steps?.includes(app.dddSelectedStep)
+    ? app.dddSelectedStep
+    : selected.completed_steps?.[selected.completed_steps.length - 1] || "entity_vo";
+  const tabs = slices.map((slice) => `<button type="button" data-software-uc="${escapeHtml(slice.uc_id)}" class="${selected.uc_id === slice.uc_id ? "selected-chip" : ""}">${escapeHtml(slice.uc_id)}</button>`).join("");
+  const steps = (selected.completed_steps || []).map((step) => `<button type="button" data-software-step="${escapeHtml(step)}" class="${selectedStep === step ? "selected-chip" : ""}">${escapeHtml(step.replaceAll("_", " "))}</button>`).join("");
+  const traces = (selected.trace_links || []).map((link) => `
+    <li><span class="pill ${escapeHtml(link.source_type)}">${escapeHtml(link.source_type)}</span> ${richTextHtml(link.source_text)} -> <strong>${richTextHtml(link.target_text)}</strong></li>`).join("");
+  return `<div class="design-section">
+    <div class="design-section-heading"><h4>3. Software Design</h4>${selected.document_id ? `<button type="button" data-document="${escapeHtml(selected.document_id)}">Edit DDD Design</button>` : ""}</div>
+    <div class="design-tabs">${tabs}</div>
+    <div class="design-tabs">${steps}</div>
+    <div class="software-design-board">${renderDddVisualization(selected, selectedStep)}</div>
+    <div class="trace-links"><h5>Trace Links</h5><ul>${traces || "<li>No direct event-to-design matches.</li>"}</ul></div>
+  </div>`;
+}
+
 function renderDddCanvasBoard(board) {
   if (!board?.slices?.length) return "";
   const contents = board.slices.map((slice) => {
@@ -774,6 +854,24 @@ function richTextHtml(text) {
 
 function bindDetail(change) {
   document.querySelectorAll("[data-document]").forEach((node) => node.onclick = () => openDocument(node.dataset.document));
+  document.querySelectorAll("[data-process-uc]").forEach((node) => {
+    node.onclick = () => {
+      app.eventSelectedUc = node.dataset.processUc;
+      render();
+    };
+  });
+  document.querySelectorAll("[data-software-uc]").forEach((node) => {
+    node.onclick = () => {
+      app.dddSelectedUc = node.dataset.softwareUc;
+      render();
+    };
+  });
+  document.querySelectorAll("[data-software-step]").forEach((node) => {
+    node.onclick = () => {
+      app.dddSelectedStep = node.dataset.softwareStep;
+      render();
+    };
+  });
   const deleteButton = document.querySelector("[data-delete-change-set]");
   if (deleteButton) deleteButton.onclick = () => deleteActiveChangeSet(change);
   const resumeWorkflow = document.querySelector("[data-resume-workflow]");

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -57,6 +57,14 @@ def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
             )
             run_payloads = [_run_payload(run) for run in runs]
             workflow_state = _scoped_workflow_state(root, change_set.change_set_id, lifecycle)
+            parsed_stages = _parse_procedure_stages(text)
+            projected_stages = _project_workflow_stages(parsed_stages, workflow_state)
+            event_storming_board = _scoped_event_storming_board(
+                root, change_set.change_set_id, lifecycle, workflow_state
+            )
+            ddd_architecture_board = _scoped_ddd_architecture_board(
+                root, change_set.change_set_id, lifecycle, workflow_state
+            )
             change_sets.append(
                 {
                     "id": change_set.change_set_id,
@@ -64,17 +72,23 @@ def document_dashboard_state(repo_root: Path | str) -> dict[str, Any]:
                     "lifecycle": lifecycle,
                     "intent": change_set.intent_summary,
                     "path": _relative_path(root, path),
-                    "stages": _project_workflow_stages(_parse_procedure_stages(text), workflow_state),
+                    "stages": projected_stages,
                     "work_items": [
                         _work_item_payload(root, change_set.change_set_id, lifecycle, item)
                         for item in change_set.ordered_work_items()
                     ],
                     "documents": _document_summaries(root, change_set, lifecycle, path, workflow_state),
-                    "event_storming_board": _scoped_event_storming_board(
-                        root, change_set.change_set_id, lifecycle, workflow_state
-                    ),
-                    "ddd_architecture_board": _scoped_ddd_architecture_board(
-                        root, change_set.change_set_id, lifecycle, workflow_state
+                    "event_storming_board": event_storming_board,
+                    "ddd_architecture_board": ddd_architecture_board,
+                    "design_visualization": _design_visualization(
+                        root,
+                        change_set.change_set_id,
+                        lifecycle,
+                        change_set.ordered_work_items(),
+                        projected_stages,
+                        workflow_state,
+                        event_storming_board,
+                        ddd_architecture_board,
                     ),
                     "latest_run": run_payloads[0] if run_payloads else None,
                     "run_history": run_payloads,
@@ -701,7 +715,7 @@ def _scoped_event_storming_board(
         if not path.exists():
             continue
         board = _parse_event_storming(path.read_text(encoding="utf-8"))
-        slices.append({"uc_id": uc_id, **board})
+        slices.append({"uc_id": uc_id, "document_id": f"event-storming:{change_set_id}:{uc_id}", **board})
     return {"slices": slices}
 
 
@@ -776,8 +790,268 @@ def _scoped_ddd_architecture_board(
         ]
         path = root / SCOPED_UI_STATE_ROOT / change_set_id / "docs/use-cases" / uc_id / "ddd-design.md"
         if completed and path.exists():
-            slices.append({"uc_id": uc_id, "completed_steps": completed, **_parse_ddd_design(path.read_text(encoding="utf-8"))})
+            slices.append(
+                {
+                    "uc_id": uc_id,
+                    "document_id": f"ddd-design:{change_set_id}:{uc_id}",
+                    "completed_steps": completed,
+                    **_parse_ddd_design(path.read_text(encoding="utf-8")),
+                }
+            )
     return {"slices": slices}
+
+
+def _design_visualization(
+    root: Path,
+    change_set_id: str,
+    lifecycle: str,
+    work_items: list[Any],
+    stages: list[dict[str, str]],
+    workflow_state: dict[str, Any] | None,
+    event_storming_board: dict[str, Any],
+    ddd_architecture_board: dict[str, Any],
+) -> dict[str, Any]:
+    process_model = _process_model_visualization(event_storming_board)
+    software_design = _software_design_visualization(ddd_architecture_board, process_model)
+    return {
+        "overview": _overview_visualization(
+            root,
+            change_set_id,
+            lifecycle,
+            work_items,
+            stages,
+            workflow_state,
+        ),
+        "process_model": process_model,
+        "software_design": software_design,
+    }
+
+
+def _overview_visualization(
+    root: Path,
+    change_set_id: str,
+    lifecycle: str,
+    work_items: list[Any],
+    stages: list[dict[str, str]],
+    workflow_state: dict[str, Any] | None,
+) -> dict[str, Any]:
+    stage_rows = [
+        {
+            "id": stage["id"],
+            "label": stage["procedure"],
+            "status": stage["status"],
+            "notes": stage["notes"],
+        }
+        for stage in stages
+    ]
+    use_cases: list[dict[str, Any]] = []
+    for item in work_items:
+        if item.work_item_type is not WorkItemType.USE_CASE:
+            continue
+        uc_id = item.work_item_id
+        use_cases.append(
+            {
+                "uc_id": uc_id,
+                "name": item.name,
+                "status": item.status,
+                "use_case": _visual_artifact_state(
+                    root,
+                    change_set_id,
+                    lifecycle,
+                    workflow_state,
+                    uc_id,
+                    "use-case-definition",
+                ),
+                "event_storming": _visual_artifact_state(
+                    root,
+                    change_set_id,
+                    lifecycle,
+                    workflow_state,
+                    uc_id,
+                    "event-storming",
+                ),
+                "software_design": _visual_artifact_state(
+                    root,
+                    change_set_id,
+                    lifecycle,
+                    workflow_state,
+                    uc_id,
+                    "ddd-architecture-definition",
+                ),
+                "technical_decisions": _visual_artifact_state(
+                    root,
+                    change_set_id,
+                    lifecycle,
+                    workflow_state,
+                    uc_id,
+                    "technical-decisions",
+                ),
+            }
+        )
+    return {"stages": stage_rows, "use_cases": use_cases}
+
+
+def _visual_artifact_state(
+    root: Path,
+    change_set_id: str,
+    lifecycle: str,
+    workflow_state: dict[str, Any] | None,
+    uc_id: str,
+    stage_id: str,
+) -> dict[str, str | bool]:
+    path_by_stage = {
+        "use-case-definition": root / "docs/use-cases" / uc_id / "use-case.md",
+        "event-storming": root
+        / SCOPED_UI_STATE_ROOT
+        / change_set_id
+        / "docs/use-cases"
+        / uc_id
+        / "event-storming.md",
+        "ddd-architecture-definition": root
+        / SCOPED_UI_STATE_ROOT
+        / change_set_id
+        / "docs/use-cases"
+        / uc_id
+        / "ddd-design.md",
+        "technical-decisions": root / "docs/use-cases" / uc_id / "technical-decisions.md",
+    }
+    if lifecycle != "active":
+        path_by_stage["event-storming"] = root / "docs/use-cases" / uc_id / "event-storming.md"
+        path_by_stage["ddd-architecture-definition"] = root / "docs/use-cases" / uc_id / "ddd-design.md"
+    path = path_by_stage[stage_id]
+    state_status = "missing"
+    if stage_id == "use-case-definition":
+        state_status = "complete" if (workflow_state or {}).get("use_cases_ready") or path.exists() else "pending"
+    elif stage_id == "event-storming":
+        state_status = (
+            ((workflow_state or {}).get("event_storming") or {}).get("items", {}).get(uc_id, {}).get("status")
+            or ("complete" if path.exists() else "pending")
+        )
+    elif stage_id == "ddd-architecture-definition":
+        item = ((workflow_state or {}).get("ddd_architecture") or {}).get("items", {}).get(uc_id, {})
+        state_status = item.get("status") or ("complete" if path.exists() else "pending")
+    elif stage_id == "technical-decisions":
+        state_status = "complete" if path.exists() else "pending"
+    return {
+        "status": state_status,
+        "exists": path.exists(),
+        "path": _relative_path(root, path) if path.exists() else "",
+    }
+
+
+def _process_model_visualization(event_storming_board: dict[str, Any]) -> dict[str, Any]:
+    slices = []
+    for slice_payload in event_storming_board.get("slices", []):
+        lanes: dict[str, list[dict[str, str]]] = {
+            "command": [],
+            "event": [],
+            "policy": [],
+            "system": [],
+            "external_system": [],
+        }
+        for flow in slice_payload.get("flows", []):
+            for note in flow.get("notes", []):
+                _append_unique_node(lanes.setdefault(note.get("type", ""), []), note)
+        for note in slice_payload.get("supporting_notes", []):
+            _append_unique_node(lanes.setdefault(note.get("type", ""), []), note)
+        slices.append(
+            {
+                "uc_id": slice_payload["uc_id"],
+                "document_id": slice_payload.get("document_id", ""),
+                "flows": slice_payload.get("flows", []),
+                "lanes": [{"type": key, "nodes": value} for key, value in lanes.items() if value],
+                "supporting_notes": slice_payload.get("supporting_notes", []),
+            }
+        )
+    return {"slices": slices}
+
+
+def _append_unique_node(nodes: list[dict[str, str]], note: dict[str, str]) -> None:
+    candidate = {"type": note.get("type", ""), "text": note.get("text", "")}
+    if candidate["text"] and candidate not in nodes:
+        nodes.append(candidate)
+
+
+def _software_design_visualization(
+    ddd_architecture_board: dict[str, Any],
+    process_model: dict[str, Any],
+) -> dict[str, Any]:
+    process_by_uc = {item["uc_id"]: item for item in process_model.get("slices", [])}
+    slices = []
+    for slice_payload in ddd_architecture_board.get("slices", []):
+        uc_id = slice_payload["uc_id"]
+        design_slice = {
+            "uc_id": uc_id,
+            "document_id": slice_payload.get("document_id", ""),
+            "completed_steps": slice_payload.get("completed_steps", []),
+            "entity_vo": slice_payload.get("entity_vo", []),
+            "behaviors": slice_payload.get("behaviors", []),
+            "application_flow": slice_payload.get("application_flow", []),
+            "aggregates": slice_payload.get("aggregates", []),
+            "bounded_contexts": slice_payload.get("bounded_contexts", []),
+        }
+        design_slice["trace_links"] = _trace_design_links(process_by_uc.get(uc_id, {}), design_slice)
+        slices.append(design_slice)
+    return {"slices": slices}
+
+
+def _trace_design_links(process_slice: dict[str, Any], design_slice: dict[str, Any]) -> list[dict[str, str]]:
+    event_notes = [
+        note
+        for flow in process_slice.get("flows", [])
+        for note in flow.get("notes", [])
+        if note.get("text")
+    ]
+    targets = _design_trace_targets(design_slice)
+    links: list[dict[str, str]] = []
+    for note in event_notes:
+        source_text = note["text"]
+        normalized_source = _trace_normalize(source_text)
+        if len(normalized_source) < 4:
+            continue
+        for target in targets:
+            haystack = _trace_normalize(target["haystack"])
+            if normalized_source in haystack or haystack in normalized_source:
+                link = {
+                    "source_type": note.get("type", ""),
+                    "source_text": source_text,
+                    "target_type": target["type"],
+                    "target_text": target["text"],
+                    "evidence": target["evidence"],
+                }
+                if link not in links:
+                    links.append(link)
+    return links
+
+
+def _design_trace_targets(design_slice: dict[str, Any]) -> list[dict[str, str]]:
+    row_groups = (
+        ("entity_vo", "entity", ("Entity",), ("Evidence", "Attributes / VOs", "Proposed Definition")),
+        ("behaviors", "behavior", ("Owner / Service", "Signature"), ("Policy Evidence", "Participants")),
+        ("application_flow", "application_service", ("Application Service",), ("Evidence", "Pseudocode", "Calls")),
+        ("aggregates", "aggregate", ("Aggregate",), ("Evidence", "Members", "Atomic Invariant")),
+        ("bounded_contexts", "bounded_context", ("Bounded Context",), ("Evidence", "Owned Aggregates / Entities")),
+    )
+    targets: list[dict[str, str]] = []
+    for group_key, target_type, label_keys, evidence_keys in row_groups:
+        for row in design_slice.get(group_key, []):
+            label = next((row.get(key, "") for key in label_keys if row.get(key)), "")
+            evidence = " ".join(row.get(key, "") for key in evidence_keys if row.get(key))
+            haystack = " ".join(str(value) for value in row.values())
+            if label or evidence:
+                targets.append(
+                    {
+                        "type": target_type,
+                        "text": label or evidence,
+                        "evidence": evidence,
+                        "haystack": haystack,
+                    }
+                )
+    return targets
+
+
+def _trace_normalize(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
 
 
 def _parse_ddd_design(text: str) -> dict[str, Any]:

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -75,7 +75,7 @@ def _create_http_server(
     *,
     wait_for_restart: bool,
 ) -> ThreadingHTTPServer:
-    deadline = time.monotonic() + 3
+    deadline = time.monotonic() + 6
     while True:
         try:
             return ThreadingHTTPServer((host, port), handler)

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -238,6 +238,8 @@ def test_document_dashboard_projects_docs_board_and_folder_lifecycle(tmp_path: P
     }
     flows = work_item["event_storming"]["flows"]
     assert [flow["kind"] for flow in flows] == ["main", "exception"]
+    assert change_set["design_visualization"]["process_model"]["slices"] == []
+    assert change_set["design_visualization"]["software_design"]["slices"] == []
     assert flows[0]["notes"][0] == {"type": "command", "text": "Save Fleeting Note"}
     assert flows[0]["notes"][1] == {"type": "event", "text": "Persisted Note"}
 
@@ -326,6 +328,15 @@ def test_dashboard_exposes_completed_event_storming_document_and_aggregate_board
     assert statuses["event-storming"] == "verified"
     assert document_id in {item["id"] for item in change_set["documents"]}
     assert change_set["event_storming_board"]["slices"][0]["uc_id"] == "UC-001"
+    process = change_set["design_visualization"]["process_model"]["slices"][0]
+    assert process["document_id"] == document_id
+    assert {lane["type"] for lane in process["lanes"]} == {
+        "command",
+        "event",
+        "policy",
+        "system",
+        "external_system",
+    }
     assert change_set["event_storming_board"]["slices"][0]["flows"][0]["notes"][:2] == [
         {"type": "command", "text": "Save Fleeting Note"},
         {"type": "event", "text": "Persisted Note"},
@@ -385,6 +396,7 @@ def test_dashboard_exposes_completed_ddd_document_and_visual_board(tmp_path: Pat
     statuses = {stage["id"]: stage["status"] for stage in change_set["stages"]}
     documents = {document["id"]: document for document in change_set["documents"]}
     board = change_set["ddd_architecture_board"]
+    design = change_set["design_visualization"]["software_design"]["slices"][0]
 
     assert statuses["ddd-architecture-definition"] == "verified"
     assert documents["ddd-design:CHG-001:UC-001"]["editable"] is True
@@ -404,6 +416,36 @@ def test_dashboard_exposes_completed_ddd_document_and_visual_board(tmp_path: Pat
     assert board["slices"][0]["application_flow"][0]["Application Service"] == "SaveNoteApplicationService"
     assert board["slices"][0]["aggregates"][0]["Aggregate Root"] == "Note"
     assert board["slices"][0]["bounded_contexts"][0]["Communication Type"] == "internal_http"
+    assert design["document_id"] == "ddd-design:CHG-001:UC-001"
+    assert {
+        (link["source_text"], link["target_type"], link["target_text"])
+        for link in design["trace_links"]
+    } >= {
+        ("Save Fleeting Note", "entity", "Note"),
+        ("Persisted Note", "aggregate", "Note"),
+        ("Display Saved Note", "bounded_context", "Notes"),
+    }
+
+
+def test_dashboard_design_visualization_overview_tracks_per_uc_status(tmp_path: Path) -> None:
+    _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    _write_completed_event_storming_workflow(tmp_path)
+
+    change_set = document_dashboard_state(tmp_path)["change_sets"][0]
+    overview = change_set["design_visualization"]["overview"]
+    use_case = overview["use_cases"][0]
+
+    assert [stage["id"] for stage in overview["stages"]][:3] == [
+        "requirements-definition",
+        "use-case-definition",
+        "event-storming",
+    ]
+    assert use_case["uc_id"] == "UC-001"
+    assert use_case["use_case"]["exists"] is True
+    assert use_case["event_storming"]["status"] == "complete"
+    assert use_case["software_design"]["status"] == "pending"
+    assert use_case["technical_decisions"]["exists"] is False
 
 
 def test_dashboard_normalizes_generated_entity_vo_table_variant(tmp_path: Path) -> None:
@@ -678,6 +720,11 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert '"/api/ddd-architecture/restart"' in javascript
         assert '"/api/ddd-architecture/advance"' in javascript
         assert '"/api/ddd-architecture/answer"' in javascript
+        assert "renderDesignVisualization" in javascript
+        assert "Big Picture Event Storming -> Process Modeling -> Software Design" in javascript
+        assert "Trace Links" in javascript
+        assert "design-stage-map" in stylesheet
+        assert "process-model-grid" in stylesheet
         assert "Restart DDD Architecture" in javascript
         assert "renderDddVisualization" in javascript
         assert "function richTextHtml" in javascript


### PR DESCRIPTION
## 구현 의도

- Harness 대시보드에서 MSA School 스타일의 3단계 설계 흐름을 한 화면에서 확인할 수 있게 합니다.
- Big Picture Event Storming, Process Modeling, Software Design 단계를 기존 ChangeSet/use-case 런타임 산출물 기반으로 시각화합니다.
- 사용자가 생성된 Markdown 산출물을 편집하면 기존 stale 처리 흐름을 유지하면서 대시보드 시각화가 다시 파생되도록 합니다.

## 구현 접근

- `/api/dashboard` 응답에 `design_visualization.overview`, `design_visualization.process_model`, `design_visualization.software_design`를 추가했습니다.
- 기존 `event-storming.md` 파서와 `ddd-design.md` 파서를 재사용해 커맨드, 이벤트, 정책, 시스템, 외부 시스템, 엔티티/VO, 동작, 애플리케이션 서비스, 애그리거트, 바운디드 컨텍스트를 구조화합니다.
- 대시보드 정적 자산에 3단계 섹션을 추가하고 UC 선택, DDD 단계 선택, 원본 문서 편집 버튼을 연결했습니다.
- 이벤트 스토밍 요소와 DDD 설계 행의 evidence/name 매칭으로 간단한 trace link를 생성합니다.
- 전체 테스트 중 UI 서버 재시작 테스트가 부하 상황에서 기존 3초 바인드 재시도 한계에 걸려, 재시도 시간을 6초로 늘렸습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py` → `23 passed`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_ui_server_restart.py::test_ui_server_restarts_existing_server_for_repo` → `1 passed`
- `./venv/bin/python3 -m pytest -q -s` → `302 passed`
- `git diff --check` → 통과

## 리스크 및 롤백

- 리스크: 대시보드 API 응답 크기가 기존보다 커집니다. 현재는 기존 Markdown 파생 데이터만 추가하므로 별도 저장소 변경은 없습니다.
- 리스크: trace link는 문자열 매칭 기반이므로 모든 설계 관계를 완전하게 표현하지는 않습니다.
- 롤백: 이 PR의 대시보드 API 확장, 정적 자산 변경, 테스트 변경을 되돌리면 기존 `event_storming_board`/`ddd_architecture_board` 기반 대시보드로 복귀합니다.
