### PR TITLE
[codex] DDD 단계 재실행 프롬프트 지원

### DIFF
--- a/.codex/agents/ddd_architect.toml
+++ b/.codex/agents/ddd_architect.toml
@@ -63,9 +63,11 @@ Substep contract:
 3. application_flow
    - Application service may load, save, call entity methods, call domain services, call external/BC ports, compose result.
    - Application service must not contain business rules.
-   - Use pseudocode, not implementation code.
+   - Include the service signature and a short prose description of the orchestration flow.
+   - Do not write pseudocode or implementation code.
 4. aggregates
    - Aggregate is transaction/atomic consistency boundary.
+   - Choose an explicit aggregate name for each aggregate.
    - Exactly one root entity per aggregate.
    - External code mutates aggregate only through root methods.
    - Include atomic invariant and command/event/policy evidence.
@@ -92,7 +94,7 @@ Required headings and table columns:
 - `## Impact Assessment`: `Element Type | Element | Status | Baseline Evidence | Event Storming Evidence`
 - `## Entity / Value Objects`: `Entity | Attributes / VOs | Status | Previous Definition | Proposed Definition | Evidence`
 - `## Behaviors`: `Owner / Service | Signature | Participants | Placement | Policy Evidence`
-- `## Application Flow`: `Application Service | Signature | Pseudocode | Calls | Evidence`
+- `## Application Flow`: `Application Service | Signature | Description | Calls | Evidence`
 - `## Aggregates`: `Aggregate | Aggregate Root | Members | Atomic Invariant | Evidence`
 - `## Bounded Contexts`: `Bounded Context | Owned Aggregates / Entities | Boundary Reason | Communication Type | Target BC | Evidence`
 
@@ -119,7 +121,7 @@ Minimal docs/use-cases/<UC-ID>/ddd-design.md skeleton:
 |---|---|---|---|---|
 
 ## Application Flow
-|Application Service|Signature|Pseudocode|Calls|Evidence|
+|Application Service|Signature|Description|Calls|Evidence|
 |---|---|---|---|---|
 
 ## Aggregates

--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -119,6 +119,10 @@ details { margin-top: 10px; }
 .ddd-step.complete { background: var(--active); color: var(--accent); }
 .ddd-step.needs_input, .ddd-step.stale { background: var(--stale); }
 .ddd-step.selected { border-color: var(--accent); font-weight: 600; }
+.ddd-rerun-controls { border-top: 1px solid var(--line); display: grid; gap: 8px; margin-top: 14px; padding-top: 12px; }
+.ddd-rerun-controls label { color: var(--muted); font-size: 12px; font-weight: 600; text-transform: uppercase; }
+.ddd-rerun-controls textarea { min-height: 76px; }
+.ddd-rerun-buttons { display: flex; flex-wrap: wrap; gap: 7px; }
 .ddd-grid { display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0; }
 .ddd-evolved-design { display: grid; gap: 14px; min-width: 1020px; }
 .ddd-entity-layer { border-top: 1px dashed var(--line); padding-top: 14px; }
@@ -139,6 +143,8 @@ details { margin-top: 10px; }
 .ddd-link-target { background: #d6ecff; border-radius: 12px; color: var(--accent); padding: 5px 10px; }
 .ddd-boundary { border: 2px dashed #8fa598; border-radius: 9px; min-height: 132px; min-width: 215px; padding: 14px; }
 .ddd-boundary.aggregate { background: #f6efe0; }
+.ddd-aggregate-card { display: grid; gap: 6px; }
+.ddd-aggregate-name { color: #394034; font-size: 13px; }
 .ddd-boundary.context { background: #eef4e8; border-style: solid; }
 .ddd-boundary .root, .communication { background: var(--active); border-radius: 12px; color: var(--accent); display: inline-block; font-size: 11px; margin-top: 8px; padding: 3px 9px; }
 .ddd-canvas { height: 580px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -206,6 +206,9 @@ function render() {
     document.querySelectorAll("[data-ddd-step]").forEach((node) => {
       node.onclick = () => { app.dddSelectedStep = node.dataset.dddStep; render(); };
     });
+    document.querySelectorAll("[data-ddd-rerun-step]").forEach((node) => {
+      node.onclick = () => rerunDddArchitectureStep(node.dataset.dddRerunStep);
+    });
     document.querySelectorAll("[data-stage-tab]").forEach((node) => {
       node.onclick = () => selectStageTab(node.dataset.stageTab);
     });
@@ -406,6 +409,17 @@ function renderDddArchitectureWorkspace() {
     const unlocked = status === "complete" || step.id === state.current_step || step.id === app.dddSelectedStep;
     return `<button type="button" data-ddd-step="${escapeHtml(step.id)}" class="ddd-step ${escapeHtml(status)} ${app.dddSelectedStep === step.id ? "selected" : ""}" ${!unlocked ? "disabled" : ""}>${escapeHtml(step.label)}</button>`;
   }).join("");
+  const rerunControls = currentId && steps.length
+    ? `<div class="ddd-rerun-controls">
+        <label for="ddd-rerun-prompt">Additional rerun prompt</label>
+        <textarea id="ddd-rerun-prompt" placeholder="Add correction or emphasis for the selected rerun..." ${app.busy ? "disabled" : ""}></textarea>
+        <div class="ddd-rerun-buttons">${steps.map((step) => {
+          const status = item?.steps?.[step.id]?.status || "pending";
+          const enabled = status !== "pending" && !app.busy;
+          return `<button type="button" class="secondary" data-ddd-rerun-step="${escapeHtml(step.id)}" ${enabled ? "" : "disabled"}>Rerun ${escapeHtml(step.label)}</button>`;
+        }).join("")}</div>
+      </div>`
+    : "";
   let interaction = "";
   const currentStep = item?.steps?.[state.current_step];
   if (currentStep?.status === "needs_input" && currentStep.current_question) {
@@ -428,7 +442,7 @@ function renderDddArchitectureWorkspace() {
   const restartAction = state.status === "not_started"
     ? ""
     : `<button class="secondary" id="restart-ddd-architecture" type="button" ${app.busy ? "disabled" : ""}>Restart DDD Architecture</button>`;
-  return `<section class="panel"><h3>DDD Architecture Progress</h3><p class="small">Completed ${escapeHtml(state.completed_count || 0)} / ${escapeHtml(state.total_count || 0)} substeps</p>${restartAction}<div class="event-progress">${ucProgress}</div><nav class="ddd-steps">${stepTabs}</nav></section>
+  return `<section class="panel"><h3>DDD Architecture Progress</h3><p class="small">Completed ${escapeHtml(state.completed_count || 0)} / ${escapeHtml(state.total_count || 0)} substeps</p>${restartAction}<div class="event-progress">${ucProgress}</div><nav class="ddd-steps">${stepTabs}</nav>${rerunControls}</section>
     <section class="panel"><h3>${escapeHtml(currentId || "DDD")} Design Document</h3><div id="ddd-document-editor"></div></section>
     <section class="panel ddd-live-preview"><h3>Design Visualization</h3><div id="ddd-live-board"></div></section>
     <section class="panel grill-panel"><h3>DDD Architect Questions</h3>${interaction}</section>`;
@@ -632,6 +646,27 @@ async function restartDddArchitecture() {
 
 async function continueDddArchitecture() {
   await runDddTurn("/api/ddd-architecture/advance", "Processing DDD substep");
+}
+
+async function rerunDddArchitectureStep(stepId) {
+  const prompt = document.querySelector("#ddd-rerun-prompt")?.value.trim() || "";
+  const ucId = app.dddSelectedUc || app.harvest?.ddd_architecture?.current_uc;
+  if (!ucId) {
+    app.error = "Select a DDD use case before rerunning a substep.";
+    render();
+    return;
+  }
+  if (!prompt) {
+    app.error = "Additional rerun prompt is required.";
+    render();
+    return;
+  }
+  app.dddSelectedStep = stepId;
+  await runDddTurn("/api/ddd-architecture/rerun-step", `Rerunning ${stepId}`, {
+    uc_id: ucId,
+    step_id: stepId,
+    user_prompt: prompt,
+  });
 }
 
 async function submitDddArchitectureAnswer(event) {
@@ -1072,7 +1107,7 @@ function renderDddVisualization(board, stepId) {
     const description = dddFlowDescription(row);
     return `<article class="ddd-service"><div class="sticky-type">application service</div><p><strong>${richTextHtml(dddMethodLabel(row.Signature || row["Application Service"]))}</strong>${description ? ` ${richTextHtml(description)}` : ""}</p></article>`;
   }).join("")}</div>` : "";
-  const aggregates = completed("aggregates") ? `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<article class="ddd-boundary aggregate"><strong>${richTextHtml(row.Aggregate || "")}</strong><span class="root">Root: ${richTextHtml(row["Aggregate Root"] || "")}</span><p>${richTextHtml(row.Members || "")}</p><p>${richTextHtml(row["Atomic Invariant"] || "")}</p></article>`).join("")}</div>` : "";
+  const aggregates = completed("aggregates") ? `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<div class="ddd-aggregate-card"><strong class="ddd-aggregate-name">${richTextHtml(row.Aggregate || "")}</strong><article class="ddd-boundary aggregate"><span class="root">Root: ${richTextHtml(row["Aggregate Root"] || "")}</span><p>${richTextHtml(row.Members || "")}</p><p>${richTextHtml(row["Atomic Invariant"] || "")}</p></article></div>`).join("")}</div>` : "";
   const contexts = completed("bounded_contexts") ? `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong><p>${richTextHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>` : "";
   const evidence = [
     renderDddEvidence(board.entity_vo || [], "Evidence"),
@@ -1090,7 +1125,7 @@ function dddMethodLabel(signature) {
 }
 
 function dddFlowDescription(row) {
-  const text = stickyText(row.Pseudocode || row.Evidence || "")
+  const text = stickyText(row.Description || row.Pseudocode || row.Evidence || "")
     .replace(/<br\s*\/?>/gi, " ")
     .replace(/([A-Za-z_][\w.]*)\s*\([^)]*\)/g, "$1()")
     .replace(/\s*->\s*/g, ". ")

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -307,6 +307,43 @@ def advance_ddd_architecture(root: Path | str, change_set_id: str) -> HarvestUiR
     return _result(root_path, session)
 
 
+def rerun_ddd_architecture_step(
+    root: Path | str,
+    change_set_id: str,
+    uc_id: str,
+    step_id: str,
+    user_prompt: str,
+) -> HarvestUiResult:
+    root_path = Path(root)
+    session = _load_or_recover_session(root_path)
+    state = session.get("ddd_architecture")
+    if not isinstance(state, dict):
+        raise ValueError("DDD architecture has not started")
+    if _current_ddd_question(session):
+        raise ValueError("answer the current DDD architecture question before rerunning a substep")
+    item = state.get("items", {}).get(uc_id)
+    if not isinstance(item, dict) or step_id not in item.get("steps", {}):
+        raise ValueError("unknown DDD architecture substep")
+    normalized_prompt = user_prompt.strip()
+    if not normalized_prompt:
+        raise ValueError("rerun prompt is required")
+    step_ids = [current_id for current_id, _label in DDD_STEPS]
+    target_index = step_ids.index(step_id)
+    for current_id in step_ids[target_index + 1 :]:
+        current = item["steps"][current_id]
+        if current.get("status") == "complete":
+            current["status"] = "stale"
+    item["steps"][step_id].setdefault("rerun_prompts", []).append(normalized_prompt)
+    item["steps"][step_id]["current_question"] = None
+    state["complete"] = False
+    state["status"] = "running"
+    item["status"] = "running"
+    session["active_stage"] = "dddArchitecture"
+    _advance_ddd_architecture(root_path, session, change_set_id, uc_id=uc_id, step_id=step_id)
+    _write_session(root_path, session)
+    return _result(root_path, session)
+
+
 def answer_ddd_architecture(
     root: Path | str,
     change_set_id: str,
@@ -1204,7 +1241,7 @@ def _validate_ddd_design_slice(path: Path, completed_step: str) -> tuple[bool, s
     required = {
         "entity_vo": ("## Impact Assessment", "## Entity / Value Objects", "Evidence"),
         "behaviors": ("## Behaviors", "Signature", "Policy Evidence"),
-        "application_flow": ("## Application Flow", "Pseudocode", "Application Service"),
+        "application_flow": ("## Application Flow", "Signature", "Description", "Application Service"),
         "aggregates": ("## Aggregates", "Aggregate Root", "Atomic"),
         "bounded_contexts": ("## Bounded Contexts", "Communication Type"),
     }
@@ -1748,9 +1785,12 @@ Return only JSON with keys: status, questions, changed_files, blocker, impact.
 Substep requirements:
 - `entity_vo`: write `## Impact Assessment` with exact columns `Element Type | Element | Status | Baseline Evidence | Event Storming Evidence`; write `## Entity / Value Objects` with exact columns `Entity | Attributes / VOs | Status | Previous Definition | Proposed Definition | Evidence`; classify new/modify/reuse using completed design docs and `ARCHITECTURE.md` first, read-only implementation fallback; include typed attributes/VO fields such as `notePath: WorkspaceRelativePath (required, evidence)` and `WorkspaceRelativePath {{ value: String }} (normalized inside workspace)`.
 - `behaviors`: write `## Behaviors`; include entity/domain-service `Signature` and `Policy Evidence`.
-- `application_flow`: write `## Application Flow`; include `Application Service`, `Pseudocode`, loads, saves, and delegated method/service calls only.
-- `aggregates`: write `## Aggregates`; include `Aggregate Root`, contained models, `Atomic` invariant evidence.
+- `application_flow`: write `## Application Flow` with exact columns `Application Service | Signature | Description | Calls | Evidence`; include the application service signature and a short prose description of logic flow; do not write pseudocode.
+- `aggregates`: write `## Aggregates`; choose explicit aggregate names; include `Aggregate Root`, contained models, `Atomic` invariant evidence.
 - `bounded_contexts`: write `## Bounded Contexts`; include `Communication Type` using only `internal_http`, `domain_event`, or `shared_database`; internal HTTP is a public client/API boundary, never internal-model access.
+
+Additional user prompts for rerun:
+{json.dumps(item.get("steps", {}).get(step_id, {}).get("rerun_prompts", []), ensure_ascii=False, indent=2)}
 
 Prior step state:
 {json.dumps(item, ensure_ascii=False, indent=2)}

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -37,6 +37,7 @@ from harness_codex.runtime.harvest_ui import (
     answer_requirements,
     load_changeset_harvest_ui,
     load_harvest_ui,
+    rerun_ddd_architecture_step,
     restart_ddd_architecture,
     save_changeset_harvest_ui,
     start_requirements,
@@ -205,6 +206,21 @@ def advance_ddd_architecture_changeset(repo_root: Path | str, change_set_id: str
     activate_changeset_harvest_ui(root, change_set_id)
     _activate_scoped_ddd_inputs(root, change_set_id)
     result = advance_ddd_architecture(root, change_set_id)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {"change_set_id": change_set_id, "harvest": result.as_dict()}
+
+
+def rerun_ddd_architecture_step_changeset(
+    repo_root: Path | str,
+    change_set_id: str,
+    uc_id: str,
+    step_id: str,
+    user_prompt: str,
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    activate_changeset_harvest_ui(root, change_set_id)
+    _activate_scoped_ddd_inputs(root, change_set_id)
+    result = rerun_ddd_architecture_step(root, change_set_id, uc_id, step_id, user_prompt)
     save_changeset_harvest_ui(root, change_set_id)
     return {"change_set_id": change_set_id, "harvest": result.as_dict()}
 
@@ -394,6 +410,16 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
                 payload = advance_ddd_architecture_changeset(
                     self.repo_root,
                     _required_change_set_id(body),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path == "/api/ddd-architecture/rerun-step":
+                payload = rerun_ddd_architecture_step_changeset(
+                    self.repo_root,
+                    _required_change_set_id(body),
+                    str(body.get("uc_id", "")).strip(),
+                    str(body.get("step_id", "")).strip(),
+                    str(body.get("user_prompt", "")),
                 )
                 self._write_json(HTTPStatus.OK, payload)
                 return

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -111,9 +111,9 @@ DDD_DESIGN_MARKDOWN = """# UC-001. DDD Design
 |Note|save(NoteId id, Content content)|Note|entity method|Display Saved Note policy|
 
 ## Application Flow
-|Application Service|Signature|Pseudocode|Calls|Evidence|
+|Application Service|Signature|Description|Calls|Evidence|
 |---|---|---|---|---|
-|SaveNoteApplicationService|save(NoteId id, Content content)|load note -> call save -> persist note|Note.save(id, content)|Save Fleeting Note command|
+|SaveNoteApplicationService|save(NoteId id, Content content)|Load the note, call the aggregate save behavior, persist the changed note, and return save result data.|Note.save(id, content)|Save Fleeting Note command|
 
 ## Aggregates
 |Aggregate|Aggregate Root|Members|Atomic Invariant|Evidence|
@@ -677,14 +677,18 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert '"/api/ddd-architecture/start"' in javascript
         assert '"/api/ddd-architecture/restart"' in javascript
         assert '"/api/ddd-architecture/advance"' in javascript
+        assert '"/api/ddd-architecture/rerun-step"' in javascript
         assert '"/api/ddd-architecture/answer"' in javascript
         assert "Restart DDD Architecture" in javascript
+        assert "Additional rerun prompt" in javascript
+        assert "Rerun ${escapeHtml(step.label)}" in javascript
         assert "renderDddVisualization" in javascript
         assert "function richTextHtml" in javascript
         assert "function tableColumnClass" in javascript
         assert "function normalizeDddEntityVoRows" in javascript
         assert "renderDddCanvasBoard" in javascript
         assert "ddd-evolved-design" in javascript
+        assert "ddd-aggregate-name" in javascript
         assert "dddMethodLabel" in javascript
         assert "dddFlowDescription" in javascript
         assert "calls: " not in javascript

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -17,6 +17,7 @@ from harness_codex.runtime.harvest_ui import (
     answer_requirements,
     load_changeset_harvest_ui,
     load_harvest_ui,
+    rerun_ddd_architecture_step,
     restart_ddd_architecture,
     save_changeset_harvest_ui,
     start_requirements,
@@ -187,9 +188,9 @@ def write_ddd_slice(root: Path, uc_id: str, step_id: str) -> None:
 |Note|open(NoteId id)|Note|entity method|UC is valid|
 """,
         "application_flow": """## Application Flow
-|Application Service|Signature|Pseudocode|Calls|Evidence|
+|Application Service|Signature|Description|Calls|Evidence|
 |---|---|---|---|---|
-|OpenNoteApplicationService|open(NoteId id)|load -> call -> save|Note.open(id)|Start UC|
+|OpenNoteApplicationService|open(NoteId id)|Load the note, delegate opening to the aggregate, save state, and return opened-note view data.|Note.open(id)|Start UC|
 """,
         "aggregates": """## Aggregates
 |Aggregate|Aggregate Root|Members|Atomic Invariant|Evidence|
@@ -917,6 +918,51 @@ def test_ddd_architecture_requires_explicit_substeps_and_resumes_answer(
     assert aggregate.ddd_architecture["items"]["UC-001"]["steps"]["aggregates"]["status"] == "complete"
     assert complete.ddd_architecture["complete"] is True
     assert calls == [("entity_vo", 0), ("behaviors", 0), ("behaviors", 1), ("application_flow", 0), ("aggregates", 0), ("bounded_contexts", 0)]
+
+
+def test_rerun_ddd_architecture_step_records_prompt_and_stales_later_steps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_passed_requirements(tmp_path)
+    write_runtime_ready_use_cases(tmp_path)
+    start_use_cases(tmp_path)
+    mark_event_storming_complete(tmp_path, ["UC-001"])
+    application_flow_calls = 0
+
+    def fake_ddd(_root: Path, session: dict, _change_set_id: str, uc_id: str, step_id: str) -> dict:
+        nonlocal application_flow_calls
+        if step_id == "application_flow":
+            application_flow_calls += 1
+            prompts = session["ddd_architecture"]["items"][uc_id]["steps"][step_id].get("rerun_prompts", [])
+            if application_flow_calls == 2:
+                assert prompts == ["Use prose only and keep service signature visible."]
+        write_ddd_slice(tmp_path, uc_id, step_id)
+        return {"status": "complete", "questions": [], "changed_files": [], "blocker": "", "impact": {}}
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_ddd_architecture", fake_ddd)
+
+    start_ddd_architecture(tmp_path, "CHG-001")
+    advance_ddd_architecture(tmp_path, "CHG-001")
+    advance_ddd_architecture(tmp_path, "CHG-001")
+    advance_ddd_architecture(tmp_path, "CHG-001")
+    complete = advance_ddd_architecture(tmp_path, "CHG-001")
+    assert complete.ddd_architecture["complete"] is True
+
+    result = rerun_ddd_architecture_step(
+        tmp_path,
+        "CHG-001",
+        "UC-001",
+        "application_flow",
+        "Use prose only and keep service signature visible.",
+    )
+
+    steps = result.ddd_architecture["items"]["UC-001"]["steps"]
+    assert steps["application_flow"]["status"] == "complete"
+    assert steps["application_flow"]["rerun_prompts"] == ["Use prose only and keep service signature visible."]
+    assert steps["aggregates"]["status"] == "stale"
+    assert steps["bounded_contexts"]["status"] == "stale"
+    assert result.ddd_architecture["complete"] is False
 
 
 def test_changeset_resume_restores_ddd_question_without_agent_call(


### PR DESCRIPTION
## 구현 의도
DDD 설계 단계에서 애플리케이션 서비스 흐름을 의사코드 대신 시그니처와 짧은 서술형 설명으로 작성하게 하고, 각 DDD 서브스텝을 추가 사용자 프롬프트와 함께 다시 실행할 수 있게 합니다.

## 구현 접근
DDD architect 에이전트 설정과 런타임 턴 계약을 `Application Service | Signature | Description | Calls | Evidence` 형식으로 맞췄습니다. 대시보드에는 서브스텝별 재실행 버튼과 추가 프롬프트 입력란을 추가했고, `/api/ddd-architecture/rerun-step` 런타임 경로가 프롬프트를 step state에 기록한 뒤 대상 단계를 재실행합니다. 이전 단계를 재실행하면 이후 완료 단계는 stale 처리되어 다시 이어서 검증할 수 있습니다. Aggregate 시각화는 aggregate 이름을 경계 사각형 위에 표시하도록 변경했습니다.

## 검증 방법
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest tests/runtime/test_harvest_ui.py tests/runtime/test_document_dashboard.py -q -s` → 54 passed
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` → 302 passed
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `git diff --check`

## 위험 및 롤백
주요 위험은 DDD 설계 문서의 Application Flow 테이블 컬럼 변경으로 기존 수동 문서가 새 검증 규칙과 맞지 않을 수 있다는 점입니다. 문제가 생기면 이 PR을 revert하면 기존 Pseudocode 계약과 단계 진행 방식으로 돌아갑니다.