### PR TITLE
[codex] DDD 단계 독립 재실행 지원

### DIFF
--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -327,15 +327,8 @@ def rerun_ddd_architecture_step(
     normalized_prompt = user_prompt.strip()
     if not normalized_prompt:
         raise ValueError("rerun prompt is required")
-    step_ids = [current_id for current_id, _label in DDD_STEPS]
-    target_index = step_ids.index(step_id)
-    for current_id in step_ids[target_index + 1 :]:
-        current = item["steps"][current_id]
-        if current.get("status") == "complete":
-            current["status"] = "stale"
     item["steps"][step_id].setdefault("rerun_prompts", []).append(normalized_prompt)
     item["steps"][step_id]["current_question"] = None
-    state["complete"] = False
     state["status"] = "running"
     item["status"] = "running"
     session["active_stage"] = "dddArchitecture"

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -920,7 +920,7 @@ def test_ddd_architecture_requires_explicit_substeps_and_resumes_answer(
     assert calls == [("entity_vo", 0), ("behaviors", 0), ("behaviors", 1), ("application_flow", 0), ("aggregates", 0), ("bounded_contexts", 0)]
 
 
-def test_rerun_ddd_architecture_step_records_prompt_and_stales_later_steps(
+def test_rerun_ddd_architecture_step_records_prompt_and_keeps_other_steps_complete(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -960,9 +960,9 @@ def test_rerun_ddd_architecture_step_records_prompt_and_stales_later_steps(
     steps = result.ddd_architecture["items"]["UC-001"]["steps"]
     assert steps["application_flow"]["status"] == "complete"
     assert steps["application_flow"]["rerun_prompts"] == ["Use prose only and keep service signature visible."]
-    assert steps["aggregates"]["status"] == "stale"
-    assert steps["bounded_contexts"]["status"] == "stale"
-    assert result.ddd_architecture["complete"] is False
+    assert steps["aggregates"]["status"] == "complete"
+    assert steps["bounded_contexts"]["status"] == "complete"
+    assert result.ddd_architecture["complete"] is True
 
 
 def test_changeset_resume_restores_ddd_question_without_agent_call(


### PR DESCRIPTION
## 구현 의도
#230 병합 이후 DDD Architecture의 각 서브스텝을 서로 독립적으로 다시 실행할 수 있게 합니다. 사용자가 aggregates만이 아니라 entity/value object, behaviors, application flow, bounded contexts도 선택한 단계만 다시 실행하기 위한 후속 변경입니다.

## 구현 접근
서브스텝 재실행 런타임에서 선택 단계 이후의 완료 단계를 stale 처리하던 로직을 제거했습니다. 추가 사용자 프롬프트는 기존처럼 선택 단계의 `rerun_prompts`에 기록하고 해당 단계 실행 프롬프트에만 반영합니다. 선택 단계가 다시 complete 되면 다른 완료 단계 상태를 유지하므로 전체 DDD 완료 상태도 모든 단계가 complete이면 유지됩니다.

## 검증 방법
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest tests/runtime/test_harvest_ui.py::test_rerun_ddd_architecture_step_records_prompt_and_keeps_other_steps_complete tests/runtime/test_harvest_ui.py::test_ddd_architecture_requires_explicit_substeps_and_resumes_answer -q -s` → 2 passed
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` → 302 passed
- `git diff --check`

## 위험 및 롤백
독립 재실행은 사용자가 이전 단계 변경의 영향을 후속 단계에 수동으로 반영하지 않을 가능성이 있습니다. 필요한 경우 후속 단계를 별도로 다시 실행하면 되고, 문제가 있으면 이 PR만 revert하면 #230의 기존 연쇄 stale 동작으로 돌아갑니다.