### PR TITLE
[codex] DDD 시각화 타입 배지 표시 수정

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -1043,9 +1043,10 @@ function renderEventDocumentEditor(message = "") {
 }
 
 function parseDddMarkdown(content) {
+  const impact = dddRows(content, "## Impact Assessment");
   return {
-    impact: dddRows(content, "## Impact Assessment"),
-    entity_vo: normalizeDddEntityVoRows(dddRows(content, "## Entity / Value Objects")),
+    impact,
+    entity_vo: normalizeDddEntityVoRows(dddRows(content, "## Entity / Value Objects"), impact),
     behaviors: dddRows(content, "## Behaviors"),
     application_flow: dddRows(content, "## Application Flow"),
     aggregates: dddRows(content, "## Aggregates"),
@@ -1073,14 +1074,32 @@ function dddRows(content, heading) {
   return rows;
 }
 
-function normalizeDddEntityVoRows(rows) {
+function dddModelKindLabel(kind) {
+  const normalized = String(kind || "").toLowerCase();
+  if (normalized.includes("value object") || normalized === "vo") return "vo";
+  if (normalized.includes("entity")) return "entity";
+  return "";
+}
+
+function dddModelKindFromImpact(board, entity) {
+  const target = stickyText(entity || "");
+  if (!target) return "";
+  const impact = (board?.impact || []).find((row) => stickyText(row.Element || row.Model || "") === target);
+  return impact?.["Element Type"] || impact?.Kind || impact?.Type || "";
+}
+
+function normalizeDddEntityVoRows(rows, impactRows = []) {
+  const impactKinds = new Map(impactRows.map((row) => [stickyText(row.Element || row.Model || ""), row["Element Type"] || row.Kind || row.Type || ""]).filter(([model, kind]) => model && kind));
   return rows.map((row) => {
-    if ("Entity" in row && "Attributes / VOs" in row) return row;
+    if ("Entity" in row && "Attributes / VOs" in row) {
+      return { ...row, "Model Type": row["Model Type"] || impactKinds.get(stickyText(row.Entity || "")) || "" };
+    }
     const model = row.Model || "";
     if (!model) return row;
     return {
       Entity: model,
       "Attributes / VOs": row["Core attributes"] || row["Proposed Identity / State"] || "",
+      "Model Type": row.Kind || row.Type || impactKinds.get(stickyText(model)) || "",
       Status: row.Classification || row.Kind || "",
       "Previous Definition": "",
       "Proposed Definition": row["Proposed Identity / State"] || row["Core attributes"] || "",
@@ -1097,7 +1116,8 @@ function renderDddVisualization(board, stepId) {
   const entityTargets = (board.entity_vo || []).map((row) => row.Entity).filter(Boolean).join(", ");
   const entities = `<div class="ddd-grid ddd-entity-layer">${(board.entity_vo || []).map((row) => {
     const status = String(row.Status || "").toLowerCase();
-    return `<article class="sticky ddd-entity"><div class="sticky-type">${escapeHtml(row.Status || "entity")}</div><strong>${richTextHtml(row.Entity || "")}</strong><p>${richTextHtml(row["Attributes / VOs"] || "")}</p>${status === "modify" ? `<p><del>${richTextHtml(row["Previous Definition"] || "")}</del><br>${richTextHtml(row["Proposed Definition"] || "")}</p>` : ""}</article>`;
+    const modelType = dddModelKindLabel(row["Model Type"] || dddModelKindFromImpact(board, row.Entity));
+    return `<article class="sticky ddd-entity"><div class="sticky-type">${escapeHtml(modelType || row.Status || "entity")}</div><strong>${richTextHtml(row.Entity || "")}</strong><p>${richTextHtml(row["Attributes / VOs"] || "")}</p>${status === "modify" ? `<p><del>${richTextHtml(row["Previous Definition"] || "")}</del><br>${richTextHtml(row["Proposed Definition"] || "")}</p>` : ""}</article>`;
   }).join("")}</div>`;
   const behaviors = completed("behaviors") ? `<div class="ddd-relations">${(board.behaviors || []).map((row) => {
     const service = String(row.Placement || "").toLowerCase().includes("domain service");

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -781,9 +781,10 @@ def _scoped_ddd_architecture_board(
 
 
 def _parse_ddd_design(text: str) -> dict[str, Any]:
+    impact = _ddd_table_rows(text, "## Impact Assessment")
     return {
-        "impact": _ddd_table_rows(text, "## Impact Assessment"),
-        "entity_vo": _normalize_ddd_entity_vo_rows(_ddd_table_rows(text, "## Entity / Value Objects")),
+        "impact": impact,
+        "entity_vo": _normalize_ddd_entity_vo_rows(_ddd_table_rows(text, "## Entity / Value Objects"), impact),
         "behaviors": _ddd_table_rows(text, "## Behaviors"),
         "application_flow": _ddd_table_rows(text, "## Application Flow"),
         "aggregates": _ddd_table_rows(text, "## Aggregates"),
@@ -791,11 +792,18 @@ def _parse_ddd_design(text: str) -> dict[str, Any]:
     }
 
 
-def _normalize_ddd_entity_vo_rows(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+def _normalize_ddd_entity_vo_rows(
+    rows: list[dict[str, str]], impact_rows: list[dict[str, str]] | None = None
+) -> list[dict[str, str]]:
+    impact_kinds = {
+        row.get("Element") or row.get("Model", ""): row.get("Element Type") or row.get("Kind") or row.get("Type", "")
+        for row in impact_rows or []
+        if row.get("Element") or row.get("Model")
+    }
     normalized: list[dict[str, str]] = []
     for row in rows:
         if "Entity" in row and "Attributes / VOs" in row:
-            normalized.append(row)
+            normalized.append({**row, "Model Type": row.get("Model Type") or impact_kinds.get(row.get("Entity", ""), "")})
             continue
         model = row.get("Model", "")
         if not model:
@@ -805,6 +813,7 @@ def _normalize_ddd_entity_vo_rows(rows: list[dict[str, str]]) -> list[dict[str, 
             {
                 "Entity": model,
                 "Attributes / VOs": row.get("Core attributes") or row.get("Proposed Identity / State", ""),
+                "Model Type": row.get("Kind") or row.get("Type") or impact_kinds.get(model, ""),
                 "Status": row.get("Classification") or row.get("Kind", ""),
                 "Previous Definition": "",
                 "Proposed Definition": row.get("Proposed Identity / State") or row.get("Core attributes", ""),

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -520,6 +520,7 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
         data = path.read_bytes()
         self.send_response(HTTPStatus.OK.value)
         self.send_header("content-type", content_type)
+        self.send_header("cache-control", "no-store")
         self.send_header("content-length", str(len(data)))
         self.end_headers()
         self.wfile.write(data)

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -437,7 +437,37 @@ def test_dashboard_normalizes_generated_entity_vo_table_variant(tmp_path: Path) 
 
     assert len(change_set["ddd_architecture_board"]["slices"][0]["entity_vo"]) == 2
     assert row["Entity"] == "MarkdownNote"
+    assert row["Model Type"] == "Entity"
     assert row["Attributes / VOs"] == "WorkspaceRelativePath path, openable file content loaded from that path"
+
+
+def test_dashboard_derives_entity_vo_model_type_from_impact_assessment(tmp_path: Path) -> None:
+    _write_change_set(tmp_path, with_use_case=False)
+    _write_documents(tmp_path)
+    _write_completed_ddd_architecture_workflow(tmp_path)
+    path = tmp_path / ".harness/ui/change-sets/CHG-001/docs/use-cases/UC-001/ddd-design.md"
+    path.write_text(
+        """# UC-001. DDD Design
+
+## Impact Assessment
+| Element Type | Element | Status | Baseline Evidence | Event Storming Evidence |
+| --- | --- | --- | --- | --- |
+| Value Object | `NoteWorkspace` | new | No existing design | Workspace is fixed |
+| Entity | `MarkdownNote` | new | No existing design | Open selected Markdown Note |
+
+## Entity / Value Objects
+| Entity | Attributes / VOs | Status | Previous Definition | Proposed Definition | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| `NoteWorkspace` | `rootPath: WorkspaceRelativePath` | new | - | Boundary value object. | Workspace is fixed |
+| `MarkdownNote` | `notePath: WorkspaceRelativePath` | new | - | File-backed note entity. | Open selected Markdown Note |
+""",
+        encoding="utf-8",
+    )
+
+    rows = document_dashboard_state(tmp_path)["change_sets"][0]["ddd_architecture_board"]["slices"][0]["entity_vo"]
+
+    assert rows[0]["Model Type"] == "Value Object"
+    assert rows[1]["Model Type"] == "Entity"
 
 
 def test_saving_ddd_design_stales_later_completed_substeps(tmp_path: Path) -> None:


### PR DESCRIPTION
## 구현 의도

DDD Entity / Value Objects 시각화에서 라이프사이클 상태인 `new`를 카드 배지로 표시하지 않고, 모델 종류인 `entity` 또는 `vo`를 표시하도록 수정합니다. Resume workflow 화면과 메인 대시보드의 DDD Architecture Canvas가 같은 표시 규칙을 사용하게 합니다.

## 구현 접근

프런트엔드 렌더러는 `Model Type`을 우선 사용하고, 기존 메인 대시보드 payload처럼 `Model Type`이 없는 경우 `Impact Assessment`의 `Element Type`에서 모델 종류를 찾아 `entity` 또는 `vo` 배지로 정규화합니다. 문서 대시보드 백엔드는 DDD 설계 문서를 파싱할 때 `Impact Assessment` 정보를 함께 넘겨 `entity_vo` 행에 `Model Type`을 채웁니다. 대시보드 정적 에셋 응답에는 `Cache-Control: no-store`를 추가해 오래된 JS가 남아 잘못된 배지가 보이는 문제를 줄였습니다.

## 검증 방법

- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `./venv/bin/python3 -m pytest -q tests/runtime/test_document_dashboard.py -k "ddd_document_and_visual_board or normalizes_generated_entity_vo_table_variant or derives_entity_vo_model_type" -s`
- `./venv/bin/python3 -m pytest -q tests/runtime/test_harvest_ui.py -k "ddd_entity_vo_validation" -s`
- 기존 메인 대시보드 형태의 stale JSON 렌더 스모크에서 `vo=true`, `entity=true`, `new=false` 확인

## 위험 및 롤백

위험은 DDD 설계 문서의 표 헤더 변형에서 모델 종류를 찾지 못하면 기존 fallback 배지가 표시될 수 있다는 점입니다. 문제 발생 시 이 커밋을 되돌리면 기존 `Status` 기반 표시로 복구됩니다.