### PR TITLE
DDD 어그리거트 시각화 개편

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -124,7 +124,25 @@ details { margin-top: 10px; }
 .ddd-rerun-controls textarea { min-height: 76px; }
 .ddd-rerun-buttons { display: flex; flex-wrap: wrap; gap: 7px; }
 .ddd-grid { display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0; }
-.ddd-evolved-design { display: grid; gap: 14px; min-width: 1020px; }
+.ddd-evolved-design { display: grid; gap: 18px; min-width: 1020px; }
+.ddd-aggregate-panel { background: #fff; border: 4px solid #111; display: grid; gap: 24px; min-height: 520px; padding: 8px 36px 18px; }
+.ddd-aggregate-name { color: #111; font-size: 13px; font-weight: 600; margin: 0; text-align: center; }
+.ddd-model-board { align-items: start; display: flex; flex-wrap: wrap; gap: 16px; }
+.ddd-model-card { background: #fff; border: 4px solid #111; color: #111; display: grid; flex: 0 0 240px; grid-template-rows: 38px 82px minmax(92px, auto) minmax(118px, auto); min-height: 330px; }
+.ddd-model-header { align-items: center; border-bottom: 4px solid #111; display: flex; font-size: 13px; justify-content: space-between; padding: 0 18px; }
+.ddd-root-badge { font-size: 12px; font-weight: 600; }
+.ddd-model-name { border-bottom: 4px solid #111; font-size: 13px; padding: 14px 20px; }
+.ddd-model-properties { border-bottom: 4px solid #111; font-size: 13px; line-height: 1.8; overflow-wrap: anywhere; padding: 20px; white-space: pre-wrap; }
+.ddd-model-methods { font-size: 13px; line-height: 1.8; overflow-wrap: anywhere; padding: 24px 20px; white-space: pre-wrap; }
+.ddd-vo-card { flex-basis: 145px; }
+.ddd-ownership-links { align-items: center; display: flex; flex-wrap: wrap; gap: 10px 20px; margin-top: -12px; }
+.ddd-ownership-link { align-items: center; color: #111; display: flex; font-size: 12px; gap: 8px; }
+.ddd-ownership-arrow { border-bottom: 3px solid #111; display: inline-block; min-width: 110px; position: relative; text-align: right; }
+.ddd-ownership-arrow::after { border-bottom: 5px solid transparent; border-left: 8px solid #111; border-top: 5px solid transparent; content: ""; position: absolute; right: -1px; top: 50%; transform: translateY(-45%); }
+.ddd-aggregate-services { display: flex; flex-wrap: wrap; gap: 12px; }
+.ddd-service-box { background: #fff; border: 4px solid #111; color: #111; flex: 0 1 290px; min-height: 92px; padding: 14px 24px; }
+.ddd-service-box p { font-size: 12px; line-height: 1.45; margin: 18px 0 0; }
+.ddd-service-type { border-bottom: 4px solid #111; font-size: 13px; margin: -14px -24px 14px; padding: 12px 24px; }
 .ddd-entity-layer { border-top: 1px dashed var(--line); padding-top: 14px; }
 .sticky.ddd-entity { background: #d6ecff; min-height: 130px; }
 .sticky.ddd-behavior { background: #ead7ff; min-height: 125px; }
@@ -144,9 +162,8 @@ details { margin-top: 10px; }
 .ddd-boundary { border: 2px dashed #8fa598; border-radius: 9px; min-height: 132px; min-width: 215px; padding: 14px; }
 .ddd-boundary.aggregate { background: #f6efe0; }
 .ddd-aggregate-card { display: grid; gap: 6px; }
-.ddd-aggregate-name { color: #394034; font-size: 13px; }
 .ddd-boundary.context { background: #eef4e8; border-style: solid; }
 .ddd-boundary .root, .communication { background: var(--active); border-radius: 12px; color: var(--accent); display: inline-block; font-size: 11px; margin-top: 8px; padding: 3px 9px; }
-.ddd-canvas { height: 580px; }
+.ddd-canvas { height: 720px; }
 .ddd-slice { max-width: none; min-width: 1020px; }
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -1123,6 +1123,62 @@ function dddAttributeNames(attributes) {
     .join(", ");
 }
 
+const DDD_PRIMITIVE_TYPES = new Set(["String", "Char", "Text", "Number", "Boolean", "Bool", "Int", "Integer", "Long", "Float", "Double", "Decimal", "Date", "DateTime", "Instant", "UUID"]);
+
+function dddModelName(row) {
+  return stickyText(row.Entity || row.Model || "").trim();
+}
+
+function dddModelType(board, row) {
+  return dddModelKindLabel(row["Model Type"] || row.Kind || row.Type || dddModelKindFromImpact(board, dddModelName(row)));
+}
+
+function dddIsValueObject(board, row) {
+  return dddModelType(board, row) === "vo";
+}
+
+function dddSplitNames(text) {
+  return stickyText(text)
+    .split(/[,;\n]/g)
+    .map((part) => part.trim().replace(/^`|`$/g, ""))
+    .filter(Boolean);
+}
+
+function dddVoReferenceRows(attributes) {
+  const text = stickyText(attributes || "");
+  const refs = new Map();
+  const add = (name, property = "", detail = "") => {
+    if (!name || DDD_PRIMITIVE_TYPES.has(name)) return;
+    if (!/^[A-Z][\w]*$/.test(name)) return;
+    if (!refs.has(name)) refs.set(name, { name, properties: new Set(), details: [] });
+    const ref = refs.get(name);
+    if (property) ref.properties.add(property);
+    if (detail) ref.details.push(detail);
+  };
+  for (const match of text.matchAll(/([A-Za-z_][\w?]*)\s*:\s*([A-Z][\w]*)/g)) {
+    add(match[2], match[1]);
+  }
+  for (const match of text.matchAll(/([A-Z][\w]*)\s+([a-z][\w?]*)/g)) {
+    add(match[1], match[2]);
+  }
+  for (const match of text.matchAll(/([A-Z][\w]*)\s*\{([^}]*)\}/g)) {
+    add(match[1], match[1], dddAttributeNames(match[2]));
+  }
+  return [...refs.values()].map((ref) => ({
+    name: ref.name,
+    property: [...ref.properties].join(", "),
+    detail: ref.details.filter(Boolean).join(", "),
+  }));
+}
+
+function dddEntityPropertyNames(attributes) {
+  const names = [];
+  for (const ref of dddVoReferenceRows(attributes)) {
+    if (ref.property && ref.property !== ref.name) names.push(ref.property);
+  }
+  return names.length ? names.join(", ") : dddAttributeNames(attributes);
+}
+
 function dddEntityMethodSignatures(board, entity) {
   const target = stickyText(entity || "");
   if (!target) return "";
@@ -1136,28 +1192,71 @@ function dddEntityMethodSignatures(board, entity) {
     .join(", ");
 }
 
+function dddAggregateMembers(row, allNames) {
+  const members = new Set(dddSplitNames(row.Members || row["Owned Aggregates / Entities"] || ""));
+  if (!members.size) allNames.forEach((name) => members.add(name));
+  return members;
+}
+
+function dddFlowTouchesMembers(row, members, aggregateName) {
+  const haystack = stickyText([row.Calls, row.Description, row.Pseudocode, row["Application Service"], row.Signature].filter(Boolean).join(" "));
+  const candidates = [aggregateName, ...members].filter(Boolean);
+  return !candidates.length || candidates.some((name) => haystack.includes(name));
+}
+
+function renderDddModelCard(kind, name, properties, methods, root = false) {
+  return `<article class="ddd-model-card ddd-${kind}-card"><div class="ddd-model-header"><span>${kind === "vo" ? "vo" : "Entity/VO"}</span>${root ? `<span class="ddd-root-badge">root</span>` : ""}</div><div class="ddd-model-name">${richTextHtml(name)}</div><div class="ddd-model-properties">${richTextHtml(properties || "")}</div><div class="ddd-model-methods">${richTextHtml(methods || "")}</div></article>`;
+}
+
 function renderDddVisualization(board, stepId) {
   if (!board) return '<p class="small">No completed DDD design substep.</p>';
   const stepOrder = ["entity_vo", "behaviors", "application_flow", "aggregates", "bounded_contexts"];
   const stepIndex = Math.max(0, stepOrder.indexOf(stepId || "entity_vo"));
   const completed = (step) => stepIndex >= stepOrder.indexOf(step);
-  const entityTargets = (board.entity_vo || []).map((row) => row.Entity).filter(Boolean).join(", ");
-  const entities = `<div class="ddd-grid ddd-entity-layer">${(board.entity_vo || []).map((row) => {
-    const modelType = dddModelKindLabel(row["Model Type"] || dddModelKindFromImpact(board, row.Entity));
-    const methods = completed("behaviors") ? dddEntityMethodSignatures(board, row.Entity) : "";
-    return `<article class="sticky ddd-entity"><div class="sticky-type">${escapeHtml(modelType || "entity")}</div><strong>${richTextHtml(row.Entity || "")}</strong><p>${richTextHtml(dddAttributeNames(row["Attributes / VOs"]))}</p>${methods ? `<p class="ddd-method">${richTextHtml(methods)}</p>` : ""}</article>`;
-  }).join("")}</div>`;
-  const behaviors = completed("behaviors") ? `<div class="ddd-relations">${(board.behaviors || []).filter((row) => {
-    return String(row.Placement || "").toLowerCase().includes("domain service");
-  }).map((row) => {
-    const service = String(row.Placement || "").toLowerCase().includes("domain service");
-    return `<div class="ddd-link-row"><article class="sticky ddd-behavior ${service ? "ddd-domain-service" : ""}"><div class="sticky-type">domain service</div><strong>${richTextHtml(row["Owner / Service"] || "")}</strong><p class="ddd-method">${richTextHtml(dddMethodLabel(row.Signature))}</p></article><span class="ddd-connector">calls -></span><span class="ddd-link-target">${richTextHtml(row.Participants || entityTargets || "Entity")}</span></div>`;
-  }).join("")}</div>` : "";
-  const flow = completed("application_flow") ? `<div class="ddd-flow">${(board.application_flow || []).map((row) => {
-    const description = dddFlowDescription(row);
-    return `<article class="ddd-service"><div class="sticky-type">application service</div><p><strong>${richTextHtml(dddMethodLabel(row.Signature || row["Application Service"]))}</strong>${description ? ` ${richTextHtml(description)}` : ""}</p></article>`;
-  }).join("")}</div>` : "";
-  const aggregates = completed("aggregates") ? `<div class="ddd-grid">${(board.aggregates || []).map((row) => `<div class="ddd-aggregate-card"><strong class="ddd-aggregate-name">${richTextHtml(row.Aggregate || "")}</strong><article class="ddd-boundary aggregate"><span class="root">Root: ${richTextHtml(row["Aggregate Root"] || "")}</span><p>${richTextHtml(row.Members || "")}</p><p>${richTextHtml(row["Atomic Invariant"] || "")}</p></article></div>`).join("")}</div>` : "";
+  const modelRows = board.entity_vo || [];
+  const allNames = modelRows.map(dddModelName).filter(Boolean);
+  const entityRows = modelRows.filter((row) => !dddIsValueObject(board, row));
+  const explicitVoRows = modelRows.filter((row) => dddIsValueObject(board, row));
+  const aggregateRows = completed("aggregates") && (board.aggregates || []).length
+    ? board.aggregates
+    : [{ Aggregate: "Aggregate", "Aggregate Root": entityRows[0] ? dddModelName(entityRows[0]) : "", Members: allNames.join(", ") }];
+  const aggregatePanels = aggregateRows.map((aggregateRow) => {
+    const aggregateName = aggregateRow.Aggregate || "Aggregate";
+    const rootName = stickyText(aggregateRow["Aggregate Root"] || "");
+    const members = dddAggregateMembers(aggregateRow, allNames);
+    const aggregateEntities = entityRows.filter((row) => members.has(dddModelName(row)) || !members.size);
+    const voRefs = new Map();
+    const ownershipLinks = [];
+    aggregateEntities.forEach((row) => {
+      const entityName = dddModelName(row);
+      dddVoReferenceRows(row["Attributes / VOs"]).forEach((ref) => {
+        if (ref.name === entityName) return;
+        voRefs.set(ref.name, ref);
+        ownershipLinks.push({ entity: entityName, property: ref.property || ref.name, vo: ref.name });
+      });
+    });
+    explicitVoRows.forEach((row) => {
+      const name = dddModelName(row);
+      if (members.has(name) || voRefs.has(name)) {
+        const attributes = row["Attributes / VOs"] || row["Proposed Identity / State"] || "";
+        voRefs.set(name, { name, property: "", detail: dddAttributeNames(attributes) || stickyText(attributes) });
+      }
+    });
+    const entityCards = aggregateEntities.map((row) => {
+      const name = dddModelName(row);
+      const methods = completed("behaviors") ? dddEntityMethodSignatures(board, name) : "";
+      return renderDddModelCard("entity", name, dddEntityPropertyNames(row["Attributes / VOs"]), methods, name === rootName);
+    }).join("");
+    const voCards = [...voRefs.values()].map((ref) => renderDddModelCard("vo", ref.name, ref.detail || ref.property, "", false)).join("");
+    const linkRows = ownershipLinks.length ? `<div class="ddd-ownership-links">${ownershipLinks.map((link) => `<div class="ddd-ownership-link"><span>${richTextHtml(link.entity)}.${richTextHtml(link.property)}</span><span class="ddd-ownership-arrow">-></span><span>${richTextHtml(link.vo)}</span></div>`).join("")}</div>` : "";
+    const domainServices = completed("behaviors") ? (board.behaviors || []).filter((row) => String(row.Placement || "").toLowerCase().includes("domain service")).filter((row) => dddFlowTouchesMembers(row, members, aggregateName)).map((row) => `<article class="ddd-service-box"><div class="ddd-service-type">domain service</div><strong>${richTextHtml(row["Owner / Service"] || "")}</strong><p>${richTextHtml(dddMethodLabel(row.Signature))}</p></article>`).join("") : "";
+    const appServices = completed("application_flow") ? (board.application_flow || []).filter((row) => dddFlowTouchesMembers(row, members, aggregateName)).map((row) => {
+      const description = dddFlowDescription(row);
+      return `<article class="ddd-service-box ddd-app-service-box"><div class="ddd-service-type">application service</div><strong>${richTextHtml(dddMethodLabel(row.Signature || row["Application Service"]))}</strong>${description ? `<p>${richTextHtml(description)}</p>` : ""}</article>`;
+    }).join("") : "";
+    const services = domainServices || appServices ? `<div class="ddd-aggregate-services">${domainServices}${appServices}</div>` : "";
+    return `<section class="ddd-aggregate-panel"><h5 class="ddd-aggregate-name">${richTextHtml(aggregateName)}</h5><div class="ddd-model-board">${entityCards}${voCards}</div>${linkRows}${services}</section>`;
+  }).join("");
   const contexts = completed("bounded_contexts") ? `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong><p>${richTextHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>` : "";
   const evidence = [
     renderDddEvidence(board.entity_vo || [], "Evidence"),
@@ -1166,7 +1265,7 @@ function renderDddVisualization(board, stepId) {
     completed("aggregates") ? renderDddEvidence(board.aggregates || [], "Evidence") : "",
     completed("bounded_contexts") ? renderDddEvidence(board.bounded_contexts || [], "Evidence") : "",
   ].join("");
-  return `<div class="ddd-evolved-design">${flow}${behaviors}${entities}${aggregates}${contexts}</div>${evidence}`;
+  return `<div class="ddd-evolved-design">${aggregatePanels}${contexts}</div>${evidence}`;
 }
 
 function dddMethodLabel(signature) {
@@ -1275,7 +1374,7 @@ function bindDddCanvas() {
   let dragging = false;
   let previous = null;
   canvas.onpointerdown = (event) => {
-    if (event.target.closest(".sticky, .ddd-boundary, .ddd-service")) return;
+    if (event.target.closest(".sticky, .ddd-boundary, .ddd-service, .ddd-model-card, .ddd-service-box")) return;
     event.preventDefault();
     dragging = true;
     previous = { x: event.clientX, y: event.clientY };

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -718,11 +718,22 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "function normalizeDddEntityVoRows" in javascript
         assert "renderDddCanvasBoard" in javascript
         assert "ddd-evolved-design" in javascript
+        assert "ddd-aggregate-panel" in javascript
         assert "ddd-aggregate-name" in javascript
+        assert "ddd-model-card" in javascript
+        assert "ddd-root-badge" in javascript
+        assert "ddd-ownership-arrow" in javascript
+        assert "ddd-service-box" in javascript
+        assert "ddd-aggregate-services" in javascript
+        assert "dddVoReferenceRows" in javascript
+        assert "matchAll(/([A-Za-z_][\\w?]*)\\s*:\\s*([A-Z][\\w]*)/g)" in javascript
+        assert "matchAll(/([A-Z][\\w]*)\\s*\\{([^}]*)\\}/g)" in javascript
+        assert "voRefs.set(ref.name, ref)" in javascript
         assert "dddMethodLabel" in javascript
         assert "dddEntityMethodSignatures" in javascript
         assert "dddFlowDescription" in javascript
         assert "calls: " not in javascript
+        assert "calls ->" not in javascript
         assert "domain service" in javascript
         assert "entity method" not in javascript
         assert "bindCanvas" in javascript
@@ -742,8 +753,13 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "max-height: 180px" in stylesheet
         assert "max-width: min(1720px, calc(100vw - 48px))" in stylesheet
         assert ".event-canvas" in stylesheet
+        assert ".ddd-aggregate-panel" in stylesheet
+        assert ".ddd-model-card" in stylesheet
+        assert ".ddd-vo-card" in stylesheet
+        assert ".ddd-ownership-arrow::after" in stylesheet
+        assert ".ddd-service-box" in stylesheet
         assert ".ddd-grid" in stylesheet
-        assert ".ddd-canvas" in stylesheet
+        assert ".ddd-canvas { height: 720px; }" in stylesheet
         assert ".ddd-relations" in stylesheet
         assert ".ddd-link-target" in stylesheet
         assert "min-width: 1020px" in stylesheet


### PR DESCRIPTION
## 구현 의도
DDD 설계 캔버스를 스티키 카드 나열 대신 어그리거트 경계 안에서 엔티티, VO, 애플리케이션 서비스를 한눈에 볼 수 있는 구조로 개편합니다.

## 구현 접근
기존 DDD 마크다운 테이블을 그대로 사용해 어그리거트별 패널을 만들고, 엔티티 속성의 VO 타입 참조와 명시적 VO 행을 합쳐 VO 박스를 분리 렌더링합니다. 엔티티 속성에서 VO로 향하는 소유 관계 화살표를 표시하고, 애플리케이션 서비스와 도메인 서비스 박스는 어그리거트 패널 내부 하단에 배치합니다. 기존 증거 출력과 DDD 캔버스 pan/zoom 동작은 유지했습니다.

## 검증 방법
- node --check harness_codex/runtime/dashboard_assets/dashboard.js
- /home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py

## 위험 및 롤백
시각화 레이아웃 변경이므로 기존 카드형 DDD 캔버스에 익숙한 사용자는 화면 구조가 달라질 수 있습니다. 문제 발생 시 이 커밋을 되돌리면 기존 렌더러와 스타일로 복구됩니다.