### PR TITLE
[codex] DDD 설계 시각화 개선

### DIFF
--- a/.codex/agents/ddd_architect.toml
+++ b/.codex/agents/ddd_architect.toml
@@ -55,6 +55,7 @@ Substep contract:
    - Classify each relevant BC, aggregate, entity, and VO as new, modify, or reuse.
    - Evidence order: completed DDD/ARCHITECTURE.md, then read-only implementation fallback, then event-storming evidence.
    - Define new entity attributes and new VO fields, types, required/optional state, validation/normalization rule, and command/event/policy evidence.
+   - Every attribute and VO field must choose an explicit type.
    - For modified entity/VO definitions, show previous definition and proposed replacement.
    - Every entity/VO row must map to one Impact Assessment row whose Element Type is only Entity or Value Object.
    - Status is lifecycle classification only; never use new/modify/reuse as a visual model tag.
@@ -73,6 +74,7 @@ Substep contract:
 4. aggregates
    - Aggregate is transaction/atomic consistency boundary.
    - Choose an explicit aggregate name for each aggregate.
+   - Never leave the aggregate name empty and never use the literal placeholder `Aggregate`.
    - Exactly one root entity per aggregate.
    - External code mutates aggregate only through root methods.
    - Include atomic invariant and command/event/policy evidence.
@@ -106,15 +108,20 @@ Required headings and table columns:
 Entity / VO cell format:
 - New entity attribute: `attributeName: Type (required|optional, rule/evidence)`.
 - New VO definition: `VOName { fieldName: Type, ... } (validation/normalization rule)`.
+- Write each attribute/field on its own line when multiple attributes/fields exist.
 - For modified attributes or VOs, put previous values in Previous Definition with `~~old~~` and replacements in Proposed Definition.
 - Proposed Definition must include final entity attributes and VO field definitions, not names only.
 
 Visualization contract:
-- Entity/value-object cards show only the model tag (`entity` or `vo`), model name, attribute names, and method signatures.
+- Entity/value-object cards show only the model tag (`entity` or `vo`), model name, typed attributes rendered as `Type attributeName`, and method signatures.
+- Use small section tags inside each model card to label the attributes and methods sections.
 - Attribute detail/prose remains in the markdown table, not in the visual card.
 - Entity/value-object method signatures come from the Behaviors table and are displayed inside the matching model card.
 - Do not visualize `Status` values such as `new`, `modify`, or `reuse`.
 - Do not visualize entity/value-object methods as separate cards.
+- The bottom area is an Application Service method list, not a relationship/property mapping area.
+- Do not render property mapping rows such as `Entity.property -> ValueObject`.
+- For each application service method, render one separate rectangle containing the method name and brief responsibility/description.
 
 Minimal docs/use-cases/<UC-ID>/ddd-design.md skeleton:
 

--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -125,24 +125,25 @@ details { margin-top: 10px; }
 .ddd-rerun-buttons { display: flex; flex-wrap: wrap; gap: 7px; }
 .ddd-grid { display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0; }
 .ddd-evolved-design { display: grid; gap: 18px; min-width: 1020px; }
-.ddd-aggregate-panel { background: #fff; border: 4px solid #111; display: grid; gap: 24px; min-height: 520px; padding: 8px 36px 18px; }
-.ddd-aggregate-name { color: #111; font-size: 13px; font-weight: 600; margin: 0; text-align: center; }
+.ddd-aggregate-panel { background: #f6efe0; border: 1px solid #d8cdb8; border-radius: 8px; display: grid; gap: 22px; min-height: 500px; padding: 14px 28px 20px; }
+.ddd-aggregate-name { color: var(--text); font-size: 14px; font-weight: 700; margin: 0; text-align: center; }
 .ddd-model-board { align-items: start; display: flex; flex-wrap: wrap; gap: 16px; }
-.ddd-model-card { background: #fff; border: 4px solid #111; color: #111; display: grid; flex: 0 0 240px; grid-template-rows: 38px 82px minmax(92px, auto) minmax(118px, auto); min-height: 330px; }
-.ddd-model-header { align-items: center; border-bottom: 4px solid #111; display: flex; font-size: 13px; justify-content: space-between; padding: 0 18px; }
-.ddd-root-badge { font-size: 12px; font-weight: 600; }
-.ddd-model-name { border-bottom: 4px solid #111; font-size: 13px; padding: 14px 20px; }
-.ddd-model-properties { border-bottom: 4px solid #111; font-size: 13px; line-height: 1.8; overflow-wrap: anywhere; padding: 20px; white-space: pre-wrap; }
-.ddd-model-methods { font-size: 13px; line-height: 1.8; overflow-wrap: anywhere; padding: 24px 20px; white-space: pre-wrap; }
+.ddd-model-card { background: #d6ecff; border: 1px solid #a8cdec; border-radius: 8px; box-shadow: 0 2px 5px rgba(0,0,0,.08); color: var(--text); display: grid; flex: 0 0 240px; grid-template-rows: 38px 74px minmax(92px, auto) minmax(100px, auto); min-height: 318px; overflow: hidden; }
+.ddd-model-header { align-items: center; border-bottom: 1px solid #a8cdec; display: flex; font-size: 12px; font-weight: 700; justify-content: space-between; padding: 0 16px; text-transform: lowercase; }
+.ddd-root-badge { background: var(--active); border-radius: 12px; color: var(--accent); font-size: 11px; font-weight: 700; padding: 3px 8px; text-transform: lowercase; }
+.ddd-model-name { background: rgba(255,255,255,.42); border-bottom: 1px solid #a8cdec; font-size: 13px; font-weight: 700; padding: 14px 18px; }
+.ddd-model-section { font-size: 13px; line-height: 1.65; overflow-wrap: anywhere; padding: 12px 18px 16px; white-space: pre-wrap; }
+.ddd-model-properties { border-bottom: 1px solid #a8cdec; }
+.ddd-model-section-tag { background: rgba(255,255,255,.70); border: 1px solid rgba(79,105,130,.24); border-radius: 999px; color: var(--muted); display: inline-block; font-size: 10px; font-weight: 700; letter-spacing: 0; margin-bottom: 8px; padding: 2px 7px; text-transform: uppercase; }
+.ddd-model-section-content { min-height: 24px; }
 .ddd-vo-card { flex-basis: 145px; }
-.ddd-ownership-links { align-items: center; display: flex; flex-wrap: wrap; gap: 10px 20px; margin-top: -12px; }
-.ddd-ownership-link { align-items: center; color: #111; display: flex; font-size: 12px; gap: 8px; }
-.ddd-ownership-arrow { border-bottom: 3px solid #111; display: inline-block; min-width: 110px; position: relative; text-align: right; }
-.ddd-ownership-arrow::after { border-bottom: 5px solid transparent; border-left: 8px solid #111; border-top: 5px solid transparent; content: ""; position: absolute; right: -1px; top: 50%; transform: translateY(-45%); }
+.ddd-vo-card { background: #ead7ff; border-color: #c9abe9; }
+.ddd-vo-card .ddd-model-header, .ddd-vo-card .ddd-model-name, .ddd-vo-card .ddd-model-properties { border-color: #c9abe9; }
 .ddd-aggregate-services { display: flex; flex-wrap: wrap; gap: 12px; }
-.ddd-service-box { background: #fff; border: 4px solid #111; color: #111; flex: 0 1 290px; min-height: 92px; padding: 14px 24px; }
-.ddd-service-box p { font-size: 12px; line-height: 1.45; margin: 18px 0 0; }
-.ddd-service-type { border-bottom: 4px solid #111; font-size: 13px; margin: -14px -24px 14px; padding: 12px 24px; }
+.ddd-app-service-list { border-top: 1px dashed #d8cdb8; padding-top: 14px; }
+.ddd-service-box { background: #d5efd5; border: 1px solid #a8d0a8; border-radius: 8px; box-shadow: 0 2px 5px rgba(0,0,0,.08); color: var(--text); flex: 0 1 290px; min-height: 92px; padding: 12px 18px; }
+.ddd-service-box p { font-size: 12px; line-height: 1.45; margin: 10px 0 0; }
+.ddd-service-type { border-bottom: 1px solid #a8d0a8; color: var(--muted); font-size: 11px; font-weight: 700; margin: -12px -18px 12px; padding: 9px 18px; text-transform: uppercase; }
 .ddd-entity-layer { border-top: 1px dashed var(--line); padding-top: 14px; }
 .sticky.ddd-entity { background: #d6ecff; min-height: 130px; }
 .sticky.ddd-behavior { background: #ead7ff; min-height: 125px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -1123,6 +1123,29 @@ function dddAttributeNames(attributes) {
     .join(", ");
 }
 
+function dddAttributeDisplayLines(attributes) {
+  const text = stickyText(attributes || "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/`/g, "");
+  const parts = text
+    .split(/[,;\n]/g)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const lines = [];
+  parts.forEach((part) => {
+    const nameFirst = part.match(/^([a-z][\w?]*)\s*:\s*([A-Z][\w<>,\[\]?]*)/);
+    if (nameFirst) {
+      lines.push(`${nameFirst[2]} ${nameFirst[1]}`);
+      return;
+    }
+    const typeFirst = part.match(/^([A-Z][\w<>,\[\]?]*)\s+([a-z][\w?]*)/);
+    if (typeFirst) {
+      lines.push(`${typeFirst[1]} ${typeFirst[2]}`);
+    }
+  });
+  return lines.length ? lines.join("\n") : dddAttributeNames(attributes).replace(/,\s*/g, "\n");
+}
+
 const DDD_PRIMITIVE_TYPES = new Set(["String", "Char", "Text", "Number", "Boolean", "Bool", "Int", "Integer", "Long", "Float", "Double", "Decimal", "Date", "DateTime", "Instant", "UUID"]);
 
 function dddModelName(row) {
@@ -1162,7 +1185,7 @@ function dddVoReferenceRows(attributes) {
     add(match[1], match[2]);
   }
   for (const match of text.matchAll(/([A-Z][\w]*)\s*\{([^}]*)\}/g)) {
-    add(match[1], match[1], dddAttributeNames(match[2]));
+    add(match[1], match[1], dddAttributeDisplayLines(match[2]));
   }
   return [...refs.values()].map((ref) => ({
     name: ref.name,
@@ -1176,7 +1199,7 @@ function dddEntityPropertyNames(attributes) {
   for (const ref of dddVoReferenceRows(attributes)) {
     if (ref.property && ref.property !== ref.name) names.push(ref.property);
   }
-  return names.length ? names.join(", ") : dddAttributeNames(attributes);
+  return names.length ? names.join("\n") : dddAttributeDisplayLines(attributes);
 }
 
 function dddEntityMethodSignatures(board, entity) {
@@ -1189,7 +1212,7 @@ function dddEntityMethodSignatures(board, entity) {
     })
     .map((row) => dddMethodLabel(row.Signature))
     .filter(Boolean)
-    .join(", ");
+    .join("\n");
 }
 
 function dddAggregateMembers(row, allNames) {
@@ -1205,7 +1228,7 @@ function dddFlowTouchesMembers(row, members, aggregateName) {
 }
 
 function renderDddModelCard(kind, name, properties, methods, root = false) {
-  return `<article class="ddd-model-card ddd-${kind}-card"><div class="ddd-model-header"><span>${kind === "vo" ? "vo" : "Entity/VO"}</span>${root ? `<span class="ddd-root-badge">root</span>` : ""}</div><div class="ddd-model-name">${richTextHtml(name)}</div><div class="ddd-model-properties">${richTextHtml(properties || "")}</div><div class="ddd-model-methods">${richTextHtml(methods || "")}</div></article>`;
+  return `<article class="ddd-model-card ddd-${kind}-card"><div class="ddd-model-header"><span>${kind === "vo" ? "vo" : "entity"}</span>${root ? `<span class="ddd-root-badge">root</span>` : ""}</div><div class="ddd-model-name">${richTextHtml(name)}</div><div class="ddd-model-section ddd-model-properties"><span class="ddd-model-section-tag">attributes</span><div class="ddd-model-section-content">${richTextHtml(properties || "")}</div></div><div class="ddd-model-section ddd-model-methods"><span class="ddd-model-section-tag">methods</span><div class="ddd-model-section-content">${richTextHtml(methods || "")}</div></div></article>`;
 }
 
 function renderDddVisualization(board, stepId) {
@@ -1219,27 +1242,28 @@ function renderDddVisualization(board, stepId) {
   const explicitVoRows = modelRows.filter((row) => dddIsValueObject(board, row));
   const aggregateRows = completed("aggregates") && (board.aggregates || []).length
     ? board.aggregates
-    : [{ Aggregate: "Aggregate", "Aggregate Root": entityRows[0] ? dddModelName(entityRows[0]) : "", Members: allNames.join(", ") }];
+    : [{ Aggregate: entityRows[0] ? `${dddModelName(entityRows[0])} Aggregate` : "Unconfirmed Aggregate", "Aggregate Root": entityRows[0] ? dddModelName(entityRows[0]) : "", Members: allNames.join(", ") }];
   const aggregatePanels = aggregateRows.map((aggregateRow) => {
-    const aggregateName = aggregateRow.Aggregate || "Aggregate";
     const rootName = stickyText(aggregateRow["Aggregate Root"] || "");
+    const aggregateName = stickyText(aggregateRow.Aggregate || "");
+    const displayAggregateName = aggregateName && aggregateName.toLowerCase() !== "aggregate"
+      ? aggregateName
+      : (rootName ? `${rootName} Aggregate` : "Unconfirmed Aggregate");
     const members = dddAggregateMembers(aggregateRow, allNames);
     const aggregateEntities = entityRows.filter((row) => members.has(dddModelName(row)) || !members.size);
     const voRefs = new Map();
-    const ownershipLinks = [];
     aggregateEntities.forEach((row) => {
       const entityName = dddModelName(row);
       dddVoReferenceRows(row["Attributes / VOs"]).forEach((ref) => {
         if (ref.name === entityName) return;
         voRefs.set(ref.name, ref);
-        ownershipLinks.push({ entity: entityName, property: ref.property || ref.name, vo: ref.name });
       });
     });
     explicitVoRows.forEach((row) => {
       const name = dddModelName(row);
       if (members.has(name) || voRefs.has(name)) {
         const attributes = row["Attributes / VOs"] || row["Proposed Identity / State"] || "";
-        voRefs.set(name, { name, property: "", detail: dddAttributeNames(attributes) || stickyText(attributes) });
+        voRefs.set(name, { name, property: "", detail: dddAttributeDisplayLines(attributes) || stickyText(attributes) });
       }
     });
     const entityCards = aggregateEntities.map((row) => {
@@ -1248,14 +1272,12 @@ function renderDddVisualization(board, stepId) {
       return renderDddModelCard("entity", name, dddEntityPropertyNames(row["Attributes / VOs"]), methods, name === rootName);
     }).join("");
     const voCards = [...voRefs.values()].map((ref) => renderDddModelCard("vo", ref.name, ref.detail || ref.property, "", false)).join("");
-    const linkRows = ownershipLinks.length ? `<div class="ddd-ownership-links">${ownershipLinks.map((link) => `<div class="ddd-ownership-link"><span>${richTextHtml(link.entity)}.${richTextHtml(link.property)}</span><span class="ddd-ownership-arrow">-></span><span>${richTextHtml(link.vo)}</span></div>`).join("")}</div>` : "";
-    const domainServices = completed("behaviors") ? (board.behaviors || []).filter((row) => String(row.Placement || "").toLowerCase().includes("domain service")).filter((row) => dddFlowTouchesMembers(row, members, aggregateName)).map((row) => `<article class="ddd-service-box"><div class="ddd-service-type">domain service</div><strong>${richTextHtml(row["Owner / Service"] || "")}</strong><p>${richTextHtml(dddMethodLabel(row.Signature))}</p></article>`).join("") : "";
-    const appServices = completed("application_flow") ? (board.application_flow || []).filter((row) => dddFlowTouchesMembers(row, members, aggregateName)).map((row) => {
+    const appServices = completed("application_flow") ? (board.application_flow || []).filter((row) => dddFlowTouchesMembers(row, members, displayAggregateName)).map((row) => {
       const description = dddFlowDescription(row);
       return `<article class="ddd-service-box ddd-app-service-box"><div class="ddd-service-type">application service</div><strong>${richTextHtml(dddMethodLabel(row.Signature || row["Application Service"]))}</strong>${description ? `<p>${richTextHtml(description)}</p>` : ""}</article>`;
     }).join("") : "";
-    const services = domainServices || appServices ? `<div class="ddd-aggregate-services">${domainServices}${appServices}</div>` : "";
-    return `<section class="ddd-aggregate-panel"><h5 class="ddd-aggregate-name">${richTextHtml(aggregateName)}</h5><div class="ddd-model-board">${entityCards}${voCards}</div>${linkRows}${services}</section>`;
+    const services = appServices ? `<div class="ddd-aggregate-services ddd-app-service-list">${appServices}</div>` : "";
+    return `<section class="ddd-aggregate-panel"><h5 class="ddd-aggregate-name">${richTextHtml(displayAggregateName)}</h5><div class="ddd-model-board">${entityCards}${voCards}</div>${services}</section>`;
   }).join("");
   const contexts = completed("bounded_contexts") ? `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong><p>${richTextHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>` : "";
   const evidence = [

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -533,6 +533,8 @@ def _validate_document(document: dict[str, Any], content: str) -> None:
         raise DashboardDocumentValidationError(
             "DDD Entity / Value Objects must define typed entity or value-object attributes."
         )
+    if document["kind"] == "ddd-design" and not _ddd_aggregates_have_real_names_when_present(content):
+        raise DashboardDocumentValidationError("DDD Aggregates must define explicit aggregate names.")
 
 
 def _ddd_entity_vo_has_typed_definition(content: str) -> bool:
@@ -560,9 +562,32 @@ def _ddd_entity_vo_has_typed_definition(content: str) -> bool:
 
 
 def _looks_like_typed_ddd_value(value: str) -> bool:
-    if ":" in value:
+    if re.search(r"`?[a-z][A-Za-z0-9_]*`?\s*:\s*`?[A-Z][A-Za-z0-9_<>,\[\]?]*`?", value):
         return True
     return bool(re.search(r"`?[A-Z][A-Za-z0-9_<>]*(?:RelativePath|Path|Id|ID|String|Content|Name|List)?`?\s+[a-z][A-Za-z0-9_]*", value))
+
+
+def _ddd_aggregates_have_real_names_when_present(content: str) -> bool:
+    section = _section_text(content, "## Aggregates")
+    if not section:
+        return True
+    aggregate_index: int | None = None
+    for line in section.splitlines():
+        if not line.startswith("|") or "---" in line:
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        lowered = [cell.lower() for cell in cells]
+        if "aggregate" in lowered and ("aggregate root" in lowered or "atomic invariant" in lowered or "members" in lowered):
+            aggregate_index = lowered.index("aggregate")
+            continue
+        if aggregate_index is None or aggregate_index >= len(cells):
+            continue
+        if not any(cells):
+            continue
+        name = cells[aggregate_index].strip("` ")
+        if not name or name.lower() == "aggregate":
+            return False
+    return True
 
 
 def _stale_stage_ids(kind: str) -> tuple[str, ...]:

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -1245,6 +1245,8 @@ def _validate_ddd_design_slice(path: Path, completed_step: str) -> tuple[bool, s
         return False, f"missing DDD structure in {path}: {', '.join(missing)}"
     if index >= 0 and not _ddd_entity_vo_has_typed_definition(text):
         return False, f"missing typed entity/VO attributes in {path}"
+    if completed_step in {"aggregates", "bounded_contexts"} and not _ddd_aggregates_have_real_names(text):
+        return False, f"missing explicit aggregate name in {path}"
     if completed_step == "bounded_contexts" and not any(
         value in text for value in ("internal_http", "domain_event", "shared_database", "None")
     ):
@@ -1277,9 +1279,32 @@ def _ddd_entity_vo_has_typed_definition(text: str) -> bool:
 
 
 def _looks_like_typed_ddd_value(value: str) -> bool:
-    if ":" in value:
+    if re.search(r"`?[a-z][A-Za-z0-9_]*`?\s*:\s*`?[A-Z][A-Za-z0-9_<>,\[\]?]*`?", value):
         return True
     return bool(re.search(r"`?[A-Z][A-Za-z0-9_<>]*(?:RelativePath|Path|Id|ID|String|Content|Name|List)?`?\s+[a-z][A-Za-z0-9_]*", value))
+
+
+def _ddd_aggregates_have_real_names(text: str) -> bool:
+    section = _ddd_section_text(text, "## Aggregates")
+    aggregate_index: int | None = None
+    saw_data_row = False
+    for line in section.splitlines():
+        if not line.startswith("|") or "---" in line:
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        lowered = [cell.lower() for cell in cells]
+        if "aggregate" in lowered and ("aggregate root" in lowered or "atomic invariant" in lowered or "members" in lowered):
+            aggregate_index = lowered.index("aggregate")
+            continue
+        if aggregate_index is None or aggregate_index >= len(cells):
+            continue
+        if not any(cells):
+            continue
+        saw_data_row = True
+        name = cells[aggregate_index].strip("` ")
+        if not name or name.lower() == "aggregate":
+            return False
+    return saw_data_row
 
 
 def _ddd_section_text(text: str, heading: str) -> str:
@@ -1776,10 +1801,10 @@ Return only JSON with keys: status, questions, changed_files, blocker, impact.
 - `blocked`: inputs cannot be corrected by one DDD answer.
 
 Substep requirements:
-- `entity_vo`: write `## Impact Assessment` with exact columns `Element Type | Element | Status | Baseline Evidence | Event Storming Evidence`; every `## Entity / Value Objects` row must have one matching `Impact Assessment` row whose `Element Type` is only `Entity` or `Value Object`; write `## Entity / Value Objects` with exact columns `Entity | Attributes / VOs | Status | Previous Definition | Proposed Definition | Evidence`; classify new/modify/reuse using completed design docs and `ARCHITECTURE.md` first, read-only implementation fallback; `Status` is only lifecycle classification and must never be used as a visual model tag; include typed attributes/VO fields only, such as `notePath: WorkspaceRelativePath (required, evidence)` and `WorkspaceRelativePath {{ value: String }} (normalized inside workspace)`, without prose definitions inside the attributes cell; visualization must show only `entity` or `vo` tag above each model, then model name, attribute names, and method signatures.
+- `entity_vo`: write `## Impact Assessment` with exact columns `Element Type | Element | Status | Baseline Evidence | Event Storming Evidence`; every `## Entity / Value Objects` row must have one matching `Impact Assessment` row whose `Element Type` is only `Entity` or `Value Object`; write `## Entity / Value Objects` with exact columns `Entity | Attributes / VOs | Status | Previous Definition | Proposed Definition | Evidence`; classify new/modify/reuse using completed design docs and `ARCHITECTURE.md` first, read-only implementation fallback; `Status` is only lifecycle classification and must never be used as a visual model tag; include typed attributes/VO fields only, such as `notePath: WorkspaceRelativePath (required, evidence)` and `WorkspaceRelativePath {{ value: String }} (normalized inside workspace)`, without prose definitions inside the attributes cell; choose an explicit type for every attribute/field; write one attribute/field per line when multiple exist; visualization must show only `entity` or `vo` tag above each model, then model name, typed attributes rendered as `Type attributeName`, section tags for attributes/methods, and method signatures.
 - `behaviors`: write `## Behaviors`; include entity/value-object/domain-service `Signature` and `Policy Evidence`; entity/value-object methods stay owned by their model and must be visualized inside that model card only; do not make separate visual cards for entity/value-object methods; only domain services may appear as separate behavior nodes.
-- `application_flow`: write `## Application Flow` with exact columns `Application Service | Signature | Description | Calls | Evidence`; include the application service signature and a short prose description of logic flow; do not write pseudocode.
-- `aggregates`: write `## Aggregates`; choose explicit aggregate names; include `Aggregate Root`, contained models, `Atomic` invariant evidence.
+- `application_flow`: write `## Application Flow` with exact columns `Application Service | Signature | Description | Calls | Evidence`; include the application service signature and a short prose description of logic flow; do not write pseudocode; bottom visualization area is an Application Service method list only, not relationship/property mapping; each application service method is one separate rectangle with method name and brief responsibility/description.
+- `aggregates`: write `## Aggregates`; choose explicit aggregate names; never leave the aggregate name empty and never use the literal placeholder `Aggregate`; include `Aggregate Root`, contained models, `Atomic` invariant evidence.
 - `bounded_contexts`: write `## Bounded Contexts`; include `Communication Type` using only `internal_http`, `domain_event`, or `shared_database`; internal HTTP is a public client/API boundary, never internal-model access.
 
 Additional user prompts for rerun:

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -526,6 +526,24 @@ def test_saving_ddd_design_requires_typed_entity_value_object_attributes(tmp_pat
         )
 
 
+def test_saving_ddd_design_rejects_placeholder_aggregate_name(tmp_path: Path) -> None:
+    _write_change_set(tmp_path, with_use_case=False)
+    _write_documents(tmp_path)
+    _write_completed_ddd_architecture_workflow(tmp_path)
+    loaded = read_dashboard_document(tmp_path, "ddd-design:CHG-001:UC-001")
+
+    with pytest.raises(DashboardDocumentValidationError, match="explicit aggregate names"):
+        save_dashboard_document(
+            tmp_path,
+            "ddd-design:CHG-001:UC-001",
+            content=loaded["content"].replace(
+                "|Note|Note|Note, NoteId, Content|Save note atomically|Persisted Note event|",
+                "|Aggregate|Note|Note, NoteId, Content|Save note atomically|Persisted Note event|",
+            ),
+            revision=loaded["revision"],
+        )
+
+
 def test_editing_generated_use_case_invalidates_scoped_event_storming_output(tmp_path: Path) -> None:
     _write_change_set(tmp_path, with_use_case=False)
     _write_documents(tmp_path)
@@ -722,10 +740,17 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "ddd-aggregate-name" in javascript
         assert "ddd-model-card" in javascript
         assert "ddd-root-badge" in javascript
-        assert "ddd-ownership-arrow" in javascript
         assert "ddd-service-box" in javascript
         assert "ddd-aggregate-services" in javascript
+        assert "ddd-app-service-list" in javascript
+        assert "ddd-model-section-tag" in javascript
+        assert "attributes" in javascript
+        assert "methods" in javascript
+        assert "application service" in javascript
+        assert "Entity/VO" not in javascript
+        assert '? "vo" : "entity"' in javascript
         assert "dddVoReferenceRows" in javascript
+        assert "dddAttributeDisplayLines" in javascript
         assert "matchAll(/([A-Za-z_][\\w?]*)\\s*:\\s*([A-Z][\\w]*)/g)" in javascript
         assert "matchAll(/([A-Z][\\w]*)\\s*\\{([^}]*)\\}/g)" in javascript
         assert "voRefs.set(ref.name, ref)" in javascript
@@ -734,7 +759,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "dddFlowDescription" in javascript
         assert "calls: " not in javascript
         assert "calls ->" not in javascript
-        assert "domain service" in javascript
+        assert "dddFlowTouchesMembers(row, members, displayAggregateName)" in javascript
         assert "entity method" not in javascript
         assert "bindCanvas" in javascript
         assert "function stickyText" in javascript
@@ -756,7 +781,8 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert ".ddd-aggregate-panel" in stylesheet
         assert ".ddd-model-card" in stylesheet
         assert ".ddd-vo-card" in stylesheet
-        assert ".ddd-ownership-arrow::after" in stylesheet
+        assert ".ddd-model-section-tag" in stylesheet
+        assert ".ddd-app-service-list" in stylesheet
         assert ".ddd-service-box" in stylesheet
         assert ".ddd-grid" in stylesheet
         assert ".ddd-canvas { height: 720px; }" in stylesheet

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -1096,3 +1096,77 @@ def test_ddd_entity_vo_validation_accepts_proposed_identity_state_table(tmp_path
     )
 
     assert _validate_ddd_design_slice(path, "entity_vo") == (True, "")
+
+
+def test_ddd_entity_vo_validation_accepts_type_first_attributes(tmp_path: Path) -> None:
+    from harness_codex.runtime.harvest_ui import _validate_ddd_design_slice
+
+    path = tmp_path / "docs/use-cases/UC-001/ddd-design.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """# UC-001 DDD Design
+
+## Impact Assessment
+|Element Type|Element|Status|Baseline Evidence|Event Storming Evidence|
+|---|---|---|---|---|
+|Entity|MarkdownNote|new|No existing design|Open selected Markdown Note|
+
+## Entity / Value Objects
+|Entity|Attributes / VOs|Status|Previous Definition|Proposed Definition|Evidence|
+|---|---|---|---|---|---|
+|MarkdownNote|WorkspaceRelativePath path|new|-|WorkspaceRelativePath path|Open selected Markdown Note|
+""",
+        encoding="utf-8",
+    )
+
+    assert _validate_ddd_design_slice(path, "entity_vo") == (True, "")
+
+
+def test_ddd_aggregate_validation_rejects_placeholder_name(tmp_path: Path) -> None:
+    from harness_codex.runtime.harvest_ui import _validate_ddd_design_slice
+
+    path = tmp_path / "docs/use-cases/UC-001/ddd-design.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """# UC-001 DDD Design
+
+## Impact Assessment
+|Element Type|Element|Status|Baseline Evidence|Event Storming Evidence|
+|---|---|---|---|---|
+|Entity|MarkdownNote|new|No existing design|Open selected Markdown Note|
+
+## Entity / Value Objects
+|Entity|Attributes / VOs|Status|Previous Definition|Proposed Definition|Evidence|
+|---|---|---|---|---|---|
+|MarkdownNote|path: WorkspaceRelativePath|required|-|path: WorkspaceRelativePath|Open selected Markdown Note|
+
+## Behaviors
+|Owner / Service|Signature|Participants|Placement|Policy Evidence|
+|---|---|---|---|---|
+|MarkdownNote|open(path: WorkspaceRelativePath)|MarkdownNote|entity method|Open selected Markdown Note|
+
+## Application Flow
+|Application Service|Signature|Description|Calls|Evidence|
+|---|---|---|---|---|
+|OpenNoteApplicationService|open(path: WorkspaceRelativePath)|Load note and delegate opening.|MarkdownNote.open(path)|Open selected Markdown Note|
+
+## Aggregates
+|Aggregate|Aggregate Root|Members|Atomic Invariant|Evidence|
+|---|---|---|---|---|
+|Aggregate|MarkdownNote|MarkdownNote|Open atomically|Open selected Markdown Note|
+""",
+        encoding="utf-8",
+    )
+
+    ready, error = _validate_ddd_design_slice(path, "aggregates")
+
+    assert ready is False
+    assert "explicit aggregate name" in error
+
+
+def test_ddd_instruction_mentions_aggregate_name_and_bottom_app_service_methods() -> None:
+    text = Path("harness_codex/runtime/harvest_ui.py").read_text(encoding="utf-8")
+
+    assert "never use the literal placeholder `Aggregate`" in text
+    assert "bottom visualization area is an Application Service method list only" in text
+    assert "typed attributes rendered as `Type attributeName`" in text

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -95,6 +95,9 @@ def test_ddd_stage_and_agent_use_sliced_event_storming_first() -> None:
     assert "Impact Assessment" in agent_text
     assert "Entity/value-object methods stay inside the owning model in visualization" in agent_text
     assert "Do not visualize entity/value-object methods as separate cards" in agent_text
+    assert "Never leave the aggregate name empty and never use the literal placeholder `Aggregate`" in agent_text
+    assert "typed attributes rendered as `Type attributeName`" in agent_text
+    assert "bottom area is an Application Service method list" in agent_text
     assert "internal_http" in agent_text
     assert "domain_event" in agent_text
     assert "shared_database" in agent_text


### PR DESCRIPTION
## 구현 의도
DDD Architecture Design 시각화에서 자리표시자와 모호한 모델 표기를 제거하고, 실제 Aggregate 이름, Entity/VO 구분, 타입이 포함된 속성, Application Service 메서드 목록이 보이도록 개선합니다.

## 구현 방식
- ddd_architect 지시문과 UI rerun 프롬프트에 Aggregate 이름 선택, 타입 지정, 속성 1줄 1개, Application Service bottom area 규칙을 추가했습니다.
- dashboard.js 렌더러가 Entity/VO 태그를 실제 `entity`/`vo`로 표시하고, 속성을 `Type attributeName` 형식으로 변환하며, 속성/메서드 영역 태그를 렌더링하도록 변경했습니다.
- bottom area에서 관계 매핑/도메인 서비스 박스를 제거하고 Application Service 메서드 박스만 렌더링하도록 변경했습니다.
- ddd-design 저장 및 단계 검증에서 `Aggregate` 자리표시자 이름을 거부하도록 검증을 강화했습니다.

## 검증 방법
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `python3 -m py_compile harness_codex/runtime/harvest_ui.py harness_codex/runtime/document_dashboard.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_dashboard.py tests/runtime/test_harvest_ui.py tests/runtime/test_procedure_stage_runtime.py` -> 68 passed

## 위험 및 롤백
시각화 파서가 기존 DDD 설계 문서의 느슨한 속성 형식 일부를 간단히 표시할 수 있습니다. 문제가 있으면 이 PR을 되돌리면 기존 흑백 시각화와 느슨한 검증 동작으로 복구됩니다.