### PR TITLE
[codex] 완료 계획 이동 검증 추가

### DIFF
--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -7,7 +7,9 @@ apply_serena_mcp_patch()
 from harness_codex.runtime.completion import (
     ChangeSetCompletionBlocked,
     ChangeSetCompletionResult,
+    PlanCompletionBlocked,
     complete_change_set_if_ready,
+    validate_plan_completion,
 )
 from harness_codex.runtime.engine import (
     ExecutionPlan,
@@ -105,6 +107,7 @@ __all__ = [
     "PolicyDecision",
     "PolicyEffect",
     "PolicyEngine",
+    "PlanCompletionBlocked",
     "RunContext",
     "RunMode",
     "RunResult",
@@ -140,4 +143,5 @@ __all__ = [
     "complete_change_set_if_ready",
     "decide_resume_target",
     "file_checksum",
+    "validate_plan_completion",
 ]

--- a/harness_codex/runtime/completion.py
+++ b/harness_codex/runtime/completion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,6 +14,14 @@ from harness_codex.runtime.changes.models import ChangeSet
 
 class ChangeSetCompletionBlocked(RuntimeError):
     """Raised when a ChangeSet is not ready for final completion."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+class PlanCompletionBlocked(RuntimeError):
+    """Raised when a work-item plan is not ready for completion."""
 
     def __init__(self, reason: str) -> None:
         self.reason = reason
@@ -31,6 +40,90 @@ class ChangeSetCompletionResult:
     completed_plan_paths: tuple[Path, ...]
     run_id: str | None = None
     already_completed: bool = False
+
+
+_REQUIRED_RESULT_LABELS = (
+    "Build",
+    "Tests",
+    "E2E 또는 maintenance verification",
+    "Test gate",
+    "Runtime server verification",
+    "Static analysis",
+)
+
+
+def validate_plan_completion(
+    repo_root: Path | str,
+    plan_path: Path | str,
+    *,
+    run_id: str | None = None,
+    change_set_id: str | None = None,
+    work_item_id: str | None = None,
+) -> None:
+    """Block plan completion until checklist, results, and evidence are complete."""
+
+    root = Path(repo_root)
+    relative_plan_path = Path(plan_path)
+    absolute_plan_path = root / relative_plan_path
+    if not absolute_plan_path.exists():
+        raise PlanCompletionBlocked(f"plan does not exist: {relative_plan_path}")
+
+    text = absolute_plan_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    unchecked = _first_unchecked_checkbox(lines)
+    if unchecked is not None:
+        line_number, line = unchecked
+        raise PlanCompletionBlocked(
+            f"unchecked checkbox remains at line {line_number}: {line.strip()}"
+        )
+
+    for section_name in ("검증 방법", "완료 조건", "검증 결과"):
+        if not _has_section(text, section_name):
+            raise PlanCompletionBlocked(f"missing required section: {section_name}")
+
+    if change_set_id and change_set_id not in text:
+        raise PlanCompletionBlocked(
+            f"plan does not reference active ChangeSet: {change_set_id}"
+        )
+    if work_item_id and work_item_id not in text:
+        raise PlanCompletionBlocked(
+            f"plan does not reference selected work item: {work_item_id}"
+        )
+
+    result_section = _section_body(text, "검증 결과")
+    if result_section is None:
+        raise PlanCompletionBlocked("missing required section: 검증 결과")
+
+    evidence_paths: list[Path] = []
+    for label in _REQUIRED_RESULT_LABELS:
+        entry = _result_entry(result_section, label)
+        if entry is None:
+            raise PlanCompletionBlocked(f"missing verification result: {label}")
+        if _is_empty_result(entry):
+            raise PlanCompletionBlocked(f"empty verification result: {label}")
+
+        not_applicable_error = _not_applicable_error(label, entry)
+        if not_applicable_error is not None:
+            raise PlanCompletionBlocked(not_applicable_error)
+
+        if _is_not_applicable(entry):
+            continue
+
+        entry_paths = _evidence_paths(entry, run_id=run_id)
+        if not entry_paths:
+            raise PlanCompletionBlocked(
+                f"missing evidence path for verification result: {label}"
+            )
+        evidence_paths.extend(entry_paths)
+
+    if not evidence_paths:
+        raise PlanCompletionBlocked("missing verification evidence under .harness/runs")
+
+    for path in evidence_paths:
+        absolute = root / path
+        if not absolute.exists():
+            raise PlanCompletionBlocked(f"missing evidence artifact: {path}")
 
 
 def complete_change_set_if_ready(
@@ -166,6 +259,83 @@ def complete_change_set_if_ready(
         completed_plan_paths=completed_plan_paths,
         run_id=effective_run_id,
     )
+
+
+def _first_unchecked_checkbox(lines: list[str]) -> tuple[int, str] | None:
+    for index, line in enumerate(lines, start=1):
+        if re.match(r"^\s*-\s*\[\s\]", line):
+            return index, line
+    return None
+
+
+def _has_section(text: str, section_name: str) -> bool:
+    return (
+        re.search(rf"^##+\s+.*{re.escape(section_name)}.*$", text, re.MULTILINE)
+        is not None
+    )
+
+
+def _section_body(text: str, section_name: str) -> str | None:
+    match = re.search(
+        rf"^##+\s+.*{re.escape(section_name)}.*$([\s\S]*?)(?=^##+\s+|\Z)",
+        text,
+        re.MULTILINE,
+    )
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _result_entry(section: str, label: str) -> str | None:
+    labels = "|".join(re.escape(item) for item in _REQUIRED_RESULT_LABELS)
+    pattern = (
+        rf"(?ms)^\s*-\s*{re.escape(label)}\s*:\s*(.*?)"
+        rf"(?=^\s*-\s*(?:{labels})\s*:|^##+\s+|\Z)"
+    )
+    match = re.search(pattern, section)
+    if match is None:
+        return None
+    return match.group(1).strip()
+
+
+def _is_empty_result(entry: str) -> bool:
+    return not entry or entry in {"-", "`-`", "none", "None", "없음"}
+
+
+def _is_not_applicable(entry: str) -> bool:
+    return bool(
+        re.search(r"\b(?:n/a|not applicable)\b|해당\s*없음", entry, re.IGNORECASE)
+    )
+
+
+def _not_applicable_error(label: str, entry: str) -> str | None:
+    if not _is_not_applicable(entry):
+        return None
+    if label == "Runtime server verification":
+        if re.search(
+            r"\b(?:because|reason|no runnable|no runtime|no server|no ui)\b|이유|사유",
+            entry,
+            re.IGNORECASE,
+        ):
+            return None
+        return "runtime server verification is not applicable without a reason"
+    if label == "Static analysis":
+        if re.search(r"\bpolicy\b|정책", entry, re.IGNORECASE):
+            return None
+        return "static analysis is not applicable without plan policy"
+    return f"{label} cannot be marked not applicable"
+
+
+def _evidence_paths(entry: str, *, run_id: str | None) -> tuple[Path, ...]:
+    raw_paths = re.findall(r"(?:`|\b)(\.harness/runs/[^\s`)]+)", entry)
+    paths: list[Path] = []
+    for raw_path in raw_paths:
+        cleaned = raw_path.rstrip(".,;:")
+        path = Path(cleaned)
+        if run_id and path.parts[:3] != (".harness", "runs", run_id):
+            continue
+        paths.append(path)
+    return tuple(dict.fromkeys(paths))
 
 
 def _latest_run_id_for_change_set(repo_root: Path, change_set_id: str) -> str | None:

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -11,6 +11,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Protocol, Sequence
 
+from harness_codex.runtime.completion import (
+    PlanCompletionBlocked,
+    validate_plan_completion,
+)
 from harness_codex.runtime.models import (
     FailureKind,
     RunContext,
@@ -361,6 +365,21 @@ class BasicStepRunner:
             target = context.repo_root / step.outputs[0]
             if not source.exists():
                 return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error=f"missing source: {step.inputs[0]}")
+            if _is_plan_completion_move(step.inputs[0], step.outputs[0]):
+                try:
+                    validate_plan_completion(
+                        context.repo_root,
+                        step.inputs[0],
+                        run_id=context.run_id,
+                        change_set_id=_context_string(context, "change_set_id"),
+                        work_item_id=_work_item_id_from_plan_path(step.inputs[0]),
+                    )
+                except PlanCompletionBlocked as exc:
+                    return StepResult(
+                        step_id=step.id,
+                        status=StepStatus.BLOCKED,
+                        error=f"plan completion blocked: {exc.reason}",
+                    )
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(source), str(target))
             return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
@@ -374,6 +393,29 @@ def _relative_to_repo(path: Path | None, context: RunContext) -> Path:
         return path.relative_to(context.repo_root)
     except ValueError:
         return path
+
+
+def _is_plan_completion_move(source: Path, target: Path) -> bool:
+    return (
+        len(source.parts) == 5
+        and len(target.parts) == 5
+        and source.parts[:3] == ("docs", "plans", "active")
+        and target.parts[:3] == ("docs", "plans", "completed")
+        and source.parts[3] == target.parts[3]
+        and source.name == "plan.md"
+        and target.name == "plan.md"
+    )
+
+
+def _work_item_id_from_plan_path(path: Path) -> str | None:
+    if len(path.parts) >= 5 and path.parts[:3] == ("docs", "plans", "active"):
+        return path.parts[3]
+    return None
+
+
+def _context_string(context: RunContext, key: str) -> str | None:
+    value = context.metadata.get(key)
+    return value if isinstance(value, str) and value else None
 
 
 def _load_agent_config(path: Path) -> Mapping[str, Any]:

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -98,6 +98,82 @@ def write_skill(repo_root: Path, skill_id: str = "harness-code-planner") -> None
     )
 
 
+def write_completed_plan(
+    repo_root: Path,
+    *,
+    unchecked: bool = False,
+    empty_result: str | None = None,
+    missing_evidence: bool = False,
+) -> Path:
+    plan_path = repo_root / "docs/plans/active/UC-001/plan.md"
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_dir = repo_root / ".harness/runs/run-001/steps/final-verification"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    evidence_files = {
+        "build": ".harness/runs/run-001/steps/final-verification/build.txt",
+        "tests": ".harness/runs/run-001/steps/final-verification/tests.txt",
+        "e2e": ".harness/runs/run-001/steps/final-verification/e2e.txt",
+        "gate": ".harness/runs/run-001/steps/final-verification/test-gate.txt",
+        "runtime": ".harness/runs/run-001/steps/final-verification/runtime.txt",
+        "static": ".harness/runs/run-001/steps/final-verification/static-analysis.txt",
+    }
+    for path in evidence_files.values():
+        if missing_evidence and path.endswith("static-analysis.txt"):
+            continue
+        target = repo_root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("pass\n", encoding="utf-8")
+
+    checkbox = "- [ ] Remaining task" if unchecked else "- [x] Implemented task"
+    results = {
+        "Build": f"PASS `{evidence_files['build']}`",
+        "Tests": f"PASS `{evidence_files['tests']}`",
+        "E2E 또는 maintenance verification": f"PASS `{evidence_files['e2e']}`",
+        "Test gate": f"PASS `{evidence_files['gate']}`",
+        "Runtime server verification": f"PASS `{evidence_files['runtime']}`",
+        "Static analysis": f"PASS `{evidence_files['static']}`",
+    }
+    if empty_result is not None:
+        results[empty_result] = ""
+
+    plan_path.write_text(
+        "\n".join(
+            [
+                "# Implementation Plan",
+                "",
+                "## 1. 구현 목표",
+                "- ChangeSet: CHG-001",
+                "- Work item: UC-001",
+                "",
+                "## 6. 구현 계획",
+                checkbox,
+                "",
+                "## 8. 검증 방법",
+                "- [x] Build:",
+                "- [x] Tests:",
+                "- [x] E2E 또는 maintenance verification:",
+                "- [x] Test gate:",
+                "- [x] Runtime server verification:",
+                "- [x] Static analysis:",
+                "",
+                "## 9. 완료 조건",
+                "- 모든 체크박스가 `- [x]` 상태다.",
+                "",
+                "## 10. 검증 결과",
+                f"- Build: {results['Build']}",
+                f"- Tests: {results['Tests']}",
+                f"- E2E 또는 maintenance verification: {results['E2E 또는 maintenance verification']}",
+                f"- Test gate: {results['Test gate']}",
+                f"- Runtime server verification: {results['Runtime server verification']}",
+                f"- Static analysis: {results['Static analysis']}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return plan_path
+
+
 def agent_request(tmp_path: Path, agent_config: dict) -> AgentRunRequest:
     return AgentRunRequest(
         step=Step(
@@ -255,6 +331,87 @@ def test_basic_step_runner_fails_when_required_use_case_slices_are_missing(tmp_p
 
     assert result.status == StepStatus.FAILED
     assert result.error == "missing required use-case slices under docs/use-cases"
+
+
+def test_basic_step_runner_blocks_plan_completion_with_unchecked_checkbox(
+    tmp_path: Path,
+) -> None:
+    write_completed_plan(tmp_path, unchecked=True)
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="complete-use-case-plan",
+        kind=StepKind.GIT,
+        name="Complete plan",
+        inputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        outputs=(Path("docs/plans/completed/UC-001/plan.md"),),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "unchecked checkbox remains" in (result.error or "")
+    assert (tmp_path / "docs/plans/active/UC-001/plan.md").exists()
+
+
+def test_basic_step_runner_blocks_plan_completion_with_empty_result(tmp_path: Path) -> None:
+    write_completed_plan(tmp_path, empty_result="Tests")
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="complete-use-case-plan",
+        kind=StepKind.GIT,
+        name="Complete plan",
+        inputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        outputs=(Path("docs/plans/completed/UC-001/plan.md"),),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.error == "plan completion blocked: empty verification result: Tests"
+    assert (tmp_path / "docs/plans/active/UC-001/plan.md").exists()
+
+
+def test_basic_step_runner_blocks_plan_completion_with_missing_evidence(
+    tmp_path: Path,
+) -> None:
+    write_completed_plan(tmp_path, missing_evidence=True)
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="complete-use-case-plan",
+        kind=StepKind.GIT,
+        name="Complete plan",
+        inputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        outputs=(Path("docs/plans/completed/UC-001/plan.md"),),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "missing evidence artifact" in (result.error or "")
+    assert ".harness/runs/run-001/steps/final-verification/static-analysis.txt" in (
+        result.error or ""
+    )
+    assert (tmp_path / "docs/plans/active/UC-001/plan.md").exists()
+
+
+def test_basic_step_runner_moves_completed_plan_after_completion_validation(
+    tmp_path: Path,
+) -> None:
+    write_completed_plan(tmp_path)
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="complete-use-case-plan",
+        kind=StepKind.GIT,
+        name="Complete plan",
+        inputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        outputs=(Path("docs/plans/completed/UC-001/plan.md"),),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert not (tmp_path / "docs/plans/active/UC-001/plan.md").exists()
+    assert (tmp_path / "docs/plans/completed/UC-001/plan.md").exists()
 
 
 def test_basic_step_runner_blocks_implementation_executor_on_gradle_workspace_sandbox(


### PR DESCRIPTION
## 구현 의도

`complete-work-item-plan`이 활성 계획을 완료 계획으로 이동하기 전에 계획 완료 조건을 런타임에서 결정적으로 검증하도록 합니다. 체크박스, 검증 결과, 실행 증거가 부족한 계획이 완료 처리되는 문제를 막습니다.

Closes #249

## 구현 접근

- `validate_plan_completion`을 추가해 `docs/plans/active/<WORK-ITEM-ID>/plan.md`의 미완료 체크박스, 필수 검증 섹션, 비어 있는 검증 결과, `.harness/runs/<RUN-ID>/...` 증거 파일 존재 여부를 검사합니다.
- `BasicStepRunner`의 git input/output 이동 경계에서 `docs/plans/active/.../plan.md` -> `docs/plans/completed/.../plan.md` 패턴을 감지하고 이동 전에 검증기를 실행합니다.
- 검증 실패 시 파일을 이동하지 않고 `StepStatus.BLOCKED`와 구체적인 누락 항목 메시지를 반환합니다.
- 정상 계획만 기존처럼 completed 경로로 이동합니다.

## 검증 방법

- `python3 -m py_compile harness_codex/runtime/completion.py harness_codex/runtime/runner.py tests/runtime/test_agent_runner.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/runtime/test_models.py tests/runtime/test_engine.py tests/runtime/test_workflow_loader.py tests/runtime/test_workflow_materializer.py tests/test_cli_commands.py` -> 84 passed
- `./venv/bin/python3 -m pytest -q -s` -> 311 passed, 1 failed. 실패는 이번 변경과 무관한 기존 `ddd_architect.toml` 길이 제한 테스트입니다: 기대 `< 9000`, 실제 `9448`.

## 위험 및 롤백

- 위험: 기존 완료 계획 문서가 `.harness/runs/<RUN-ID>/...` 증거 경로를 기록하지 않으면 완료 이동이 차단됩니다. 의도된 안전 장치지만 기존 작업 방식에는 추가 기록이 필요할 수 있습니다.
- 롤백: `validate_plan_completion` 호출과 관련 검증 코드를 되돌리면 이전 단순 파일 이동 동작으로 복구됩니다.
