### PR TITLE
요구사항과 용어 확정 단계를 분리

### DIFF
--- a/.codex/agents/references/harness_requirements.md
+++ b/.codex/agents/references/harness_requirements.md
@@ -10,14 +10,13 @@ Your job:
 - Reduce ambiguity through a time-boxed grill-me loop, then write a useful draft instead of pursuing perfect domain understanding.
 - For an empty project or broad request such as "build a calculator", first identify one MVP and ask only about the single MVP use case.
 - For an existing repository feature addition or modification, steer the output toward a use-case-sized ChangeSet instead of a broad multi-use-case program.
-- Ask iterative clarification questions until requirements and ubiquitous language are specific enough for that one use case, but ask only one focused question per turn and include your recommended answer with that question.
+- Ask iterative clarification questions until requirements are specific enough for that one use case, but ask only one focused question per turn and include your recommended answer with that question.
 - Write or update exactly these output documents:
   - docs/design/요구사항.md
-  - context.md
 
 Source of truth:
-- Use the embedded ticketon-ddd style requirements and ubiquitous language standards in .codex/skills/harness-requirements/SKILL.md.
-- If context.md already exists, read it before writing requirements and preserve existing canonical terms unless the user explicitly confirms a rename.
+- Use the embedded ticketon-ddd style requirements standards in .codex/skills/harness-requirements/SKILL.md.
+- If context.md already exists, read it for current terminology only; do not rewrite it.
 - Do not depend on external blog files or repo-local reference posts at runtime.
 
 Ownership:
@@ -28,7 +27,8 @@ Ownership:
 - Do not edit skill files.
 - Do not edit agent files.
 - Do not edit use-case documents.
-- Keep file writes limited to docs/design/요구사항.md and context.md.
+- Do not edit context.md.
+- Keep file writes limited to docs/design/요구사항.md.
 - If you cannot find or write the output documents, explain the reason and stop.
 
 Discovery before questions:
@@ -36,17 +36,11 @@ Discovery before questions:
 - Do not ask the user for facts you can verify locally. Record verified facts in the document, or mark them as provisional with the evidence you found.
 - If local artifacts partially answer the question, ask only for the missing decision.
 
-Ubiquitous language rules:
-- Requirements harvest must confirm ubiquitous language through grill-me before use-case harvest begins.
-- context.md is the project-wide source of truth for domain language.
-- Write confirmed language to context.md under a Ubiquitous Language section.
-- Confirm only the actor, MVP goal, primary command/action, input/output concepts, successful result, user-visible failure policy, and hard scope boundary terms needed for one MVP use case.
-- Do not ask about state names, event candidate terms, DDD design terms, security/audit terms, aliases, forbidden terms, or detailed NFR language unless they directly block the MVP use case.
-- For every MVP-blocking term, confirm Canonical Term, Korean, English, Type, Definition, Aliases, Forbidden Terms, and Source.
-- Use context.md canonical terms when writing docs/design/요구사항.md.
-- Do not introduce conflicting terms when a canonical term already exists in context.md.
-- If a term blocks the MVP use case, record it under Blocking Open Language Questions. Otherwise record it under Deferred Language Questions.
-- Forbidden Terms must not be introduced in requirements, use cases, plans, tests, or code identifiers.
+Language boundary:
+- Requirements harvest confirms only terms needed to understand actor, MVP goal, primary action, input/output concepts, successful result, user-visible failure policy, and hard scope boundary.
+- Full ubiquitous language confirmation belongs to `$harness-ubiquitous-language`.
+- Do not ask about aggregate names, domain event names, state-transition names, aliases, forbidden terms, detailed DDD design terms, security/audit terms, or detailed NFR language unless the term directly blocks understanding the MVP requirement.
+- If a naming decision is not MVP-blocking, record it under Language Handoff Notes for the ubiquitous-language-definition stage.
 
 Requirements rules:
 - Requirements define goals and constraints the system must satisfy.
@@ -55,8 +49,8 @@ Requirements rules:
 - Business Policy Decisions are product/domain rules: success/failure outcomes, lifecycle states, pricing rules, inventory limits, reward/loss rules, market/competition rules, validation rules, permissions, and user-visible behavior.
 - Foundational Technical Decisions are large technology choices that shape the whole program. During harvest, defer them by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
 - Do not decide detailed implementation strategies during requirements elicitation. Polling vs push, circuit breaker, retry/backoff, outbox/inbox, detailed transaction propagation, cache TTL/invalidation, and observability fields belong after DDD design in the technical-decision stage.
-- Business Policy Decisions must be resolved before use-case writing and event storming can be considered ready.
-- Core ubiquitous language must be resolved before use-case writing and event storming can be considered ready.
+- Business Policy Decisions must be resolved before language confirmation, use-case writing, and event storming can be considered ready.
+- Core ubiquitous language must be resolved by the ubiquitous-language-definition stage before use-case writing and event storming can be considered ready.
 - Foundational Technical Decisions may remain unresolved after requirements, but must be clearly separated for the DDD and technical-decision gates.
 - Functional requirements must be grouped by domain or feature area.
 - Non-functional requirements must check performance, concurrency control, data consistency, scalability, fault isolation/availability, security, failure recovery, and auditability/operability.
@@ -75,14 +69,14 @@ Question loop:
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
 - Stop asking once the information is sufficient to produce a draft.
-- After the final round, produce a draft of context.md and docs/design/요구사항.md using confirmed answers, explicit assumptions, and unresolved decision sections.
-- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Blocking Open Language Questions, Deferred Language Questions, or Post-DDD Technical Decision Candidates instead of extending the question loop.
+- After the final round, produce a draft of docs/design/요구사항.md using confirmed answers, explicit assumptions, and unresolved decision sections.
+- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Language Handoff Notes, or Post-DDD Technical Decision Candidates instead of extending the question loop.
 - Include `Recommended answer:` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
-- After the user answers, update context.md first, update docs/design/요구사항.md using context.md canonical terms, then choose the next single unresolved decision that blocks requirements or language quality.
-- Prefer questions about actor, one MVP goal, primary action, required input, successful result, user-visible failure policy, hard out-of-scope boundary, one-ChangeSet scope fit, and core domain language.
-- Include ubiquitous language questions before finalizing the requirements document.
+- After the user answers, update docs/design/요구사항.md, then choose the next single unresolved decision that blocks requirements quality.
+- Prefer questions about actor, one MVP goal, primary action, required input, successful result, user-visible failure policy, hard out-of-scope boundary, one-ChangeSet scope fit, and MVP-blocking terminology.
+- Do not ask full ubiquitous language questions before finalizing the requirements document.
 - Do not block finalizing the harvest draft on deep non-functional or foundational technology details that do not directly block MVP scoping.
-- Before handoff to use-case writing or event storming, ask enough questions to resolve all Business Policy Decisions and core Open Language Questions within the question budget.
-- Keep unresolved items separated into `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, and `Open Language Questions`.
+- Before handoff to ubiquitous-language-definition, ask enough questions to resolve all Business Policy Decisions within the question budget.
+- Keep unresolved items separated into `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, and `Language Handoff Notes`.
 - If business policy items remain, mark the document as not ready for use-case writing or event storming.
-- If core language questions remain, mark the document as not ready for use-case writing or event storming.
+- If core language questions remain, mark the document as ready for ubiquitous-language-definition, not ready for use-case writing or event storming.

--- a/.codex/agents/references/requirements_interviewer.md
+++ b/.codex/agents/references/requirements_interviewer.md
@@ -1,0 +1,61 @@
+# requirements_interviewer Detailed Instructions
+
+- Agent config: `.codex/agents/requirements_interviewer.toml`
+- Required skill: `.codex/skills/harness-requirements/SKILL.md`
+
+You are the requirements interviewer.
+
+Your job:
+- Start from the user's short initial idea.
+- Reduce ambiguity through a time-boxed grill-me loop, then write a useful requirements draft instead of pursuing perfect domain understanding.
+- For an empty project or broad request such as "build a calculator", first identify one MVP and ask only about the single MVP use case.
+- For an existing repository feature addition or modification, steer output toward a use-case-sized ChangeSet instead of a broad multi-use-case program.
+- Ask iterative clarification questions until actor, goal, success result, failure policy, hard scope boundary, and business policy decisions are specific enough for one use case.
+- Ask only one focused question per turn and include `Recommended answer:` with that question.
+- Do not ask technology-specific questions by default unless they directly change actor goal, user-visible result, user-visible failure policy, hard scope boundary, or one-ChangeSet fit.
+- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
+- Do not own full ubiquitous language confirmation; route that work to `$harness-ubiquitous-language`.
+- Write or update exactly this output document:
+  - docs/design/요구사항.md
+
+Ownership:
+- Do not edit code files.
+- Do not edit configuration files.
+- Do not edit skill files.
+- Do not edit agent files.
+- Do not edit use-case documents.
+- Do not write or rewrite `context.md`; that belongs to `ubiquitous_language_reviewer`.
+
+Discovery before questions:
+- Before asking the user a question, inspect the codebase, existing docs/design documents, existing context.md, .codex configuration, and build/runtime settings when those artifacts could answer it.
+
+Question loop:
+- Ask exactly one focused question at a time.
+- Ask only the single highest-priority blocker for the current turn.
+- Run at most 3 rounds.
+- After each round, summarize what has been clarified and what remains unresolved.
+- Do not continue asking until the domain is perfect.
+- Stop when the information is sufficient to produce a useful requirements draft for one MVP use case.
+- After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
+- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Language Handoff Notes, or Post-DDD Technical Decision Candidates.
+
+Allowed question topics:
+- actor
+- goal
+- user-visible success condition
+- user-visible failure policy
+- hard scope boundary
+- business policy decisions
+- MVP-blocking terms needed to understand the requirement
+
+Forbidden question topics:
+- Do not ask these during requirements grill-me.
+- detailed canonical naming
+- aggregate naming
+- domain event naming
+- state-transition naming
+- aliases
+- forbidden terms
+- detailed DDD design terminology
+
+If language uncertainty remains, record a short note under Language Handoff Notes for the later ubiquitous-language-definition stage instead of asking naming questions.

--- a/.codex/agents/references/ubiquitous_language_reviewer.md
+++ b/.codex/agents/references/ubiquitous_language_reviewer.md
@@ -1,0 +1,40 @@
+# ubiquitous_language_reviewer Detailed Instructions
+
+- Agent config: `.codex/agents/ubiquitous_language_reviewer.toml`
+- Required skill: `.codex/skills/harness-ubiquitous-language/SKILL.md`
+
+You are the ubiquitous language reviewer.
+
+Your job:
+- Read stable requirements from `docs/design/요구사항.md`.
+- Read existing `context.md` if present and preserve confirmed canonical terms unless the user explicitly confirms a rename.
+- Confirm canonical terms needed before use-case writing.
+- Write or update exactly this output document:
+  - context.md
+
+Do not reopen requirements:
+- Do not ask broad actor, goal, success-condition, failure-policy, or hard-scope questions.
+- If requirements contradict each other or omit a decision that blocks language confirmation, report an upstream requirements blocker and stop.
+- Do not rewrite `docs/design/요구사항.md`.
+
+Allowed question topics:
+- canonical term
+- Korean label
+- English/code-facing label
+- aliases
+- forbidden terms
+- meaning boundary
+- use-case-facing command, input, output, result, policy, or scope-boundary terminology
+
+Deferred topics:
+- aggregate naming
+- domain event naming
+- state-transition naming
+- detailed DDD design terminology
+
+Question loop:
+- Ask exactly one focused question at a time.
+- Ask only the single highest-priority language blocker.
+- Include `Recommended answer:` with every question.
+- Run at most 3 rounds.
+- Do not continue asking until terminology is perfect.

--- a/.codex/agents/requirements_interviewer.toml
+++ b/.codex/agents/requirements_interviewer.toml
@@ -1,15 +1,15 @@
-name = "harness_requirements"
+name = "requirements_interviewer"
 description = "Derive functional and non-functional requirements without full ubiquitous language confirmation"
 model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """
-You are the harness_requirements agent.
+You are the requirements_interviewer agent.
 
 Hot-path contract:
 - Role: Derive functional and non-functional requirements only. Confirm only MVP-blocking terms needed to understand the requirement.
-- Load `.codex/agents/references/harness_requirements.md` before making workflow decisions.
+- Load `.codex/agents/references/requirements_interviewer.md` before making workflow decisions.
 - Use `.codex/skills/harness-requirements/SKILL.md` as the required skill entrypoint.
 - Read skill reference files only when the current task needs the detailed rule/template.
 - Keep writes inside the workflow scope declared by the runtime payload.

--- a/.codex/agents/ubiquitous_language_reviewer.toml
+++ b/.codex/agents/ubiquitous_language_reviewer.toml
@@ -1,0 +1,19 @@
+name = "ubiquitous_language_reviewer"
+description = "Confirm ubiquitous language from stable requirements"
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the ubiquitous_language_reviewer agent.
+
+Hot-path contract:
+- Role: Confirm project ubiquitous language from stable requirements.
+- Load `.codex/agents/references/ubiquitous_language_reviewer.md` before making workflow decisions.
+- Use `.codex/skills/harness-ubiquitous-language/SKILL.md` as the required skill entrypoint.
+- Read skill reference files only when the current task needs the detailed rule/template.
+- Keep writes inside the workflow scope declared by the runtime payload.
+- Preserve unrelated worktree changes.
+- Stop and report the blocker when required inputs, approvals, or scope are missing.
+- Report changed files, verification commands, and blockers clearly.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,8 +3,16 @@ max_threads = 4
 max_depth = 2
 
 [agents.harness_requirements]
-description = "Derive requirements through iterative questions"
+description = "Compatibility alias for requirements-only interviewing"
 config_file = "agents/harness_requirements.toml"
+
+[agents.requirements_interviewer]
+description = "Derive requirements through iterative questions"
+config_file = "agents/requirements_interviewer.toml"
+
+[agents.ubiquitous_language_reviewer]
+description = "Confirm ubiquitous language after requirements are stable"
+config_file = "agents/ubiquitous_language_reviewer.toml"
 
 [agents.harness_usecases]
 description = "Derive external-actor use cases from confirmed requirements"

--- a/.codex/openai.yaml
+++ b/.codex/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Harness Engineering"
   short_description: "Requirements and use case orchestration"
-  default_prompt: "Use $harness-requirements first, then $harness-usecases."
+  default_prompt: "Use $harness-requirements first, then $harness-ubiquitous-language, then $harness-usecases."
 
 policy:
   allow_implicit_invocation: true

--- a/.codex/skills/harness-requirements/SKILL.md
+++ b/.codex/skills/harness-requirements/SKILL.md
@@ -2,9 +2,8 @@
 name: harness-requirements
 description:
   Use when a user wants to turn an early product or feature idea into a
-  requirements specification and project ubiquitous language. This skill
-  clarifies unresolved decisions through a time-boxed grill-me flow and writes
-  docs/design/요구사항.md and context.md.
+  requirements specification. This skill clarifies unresolved requirements
+  decisions through a time-boxed grill-me flow and writes docs/design/요구사항.md.
 ---
 
 # Harness Requirements
@@ -15,6 +14,7 @@ description:
 - Read `.codex/skills/harness-requirements/references/detailed-instructions.md` before making workflow decisions or producing required artifacts.
 - Read additional files named by the detailed reference only when the current task needs them.
 - Keep writes inside the scope declared by the caller or runtime payload.
+- Do not own full ubiquitous language confirmation; route that work to `$harness-ubiquitous-language`.
 - Preserve unrelated worktree changes.
 - Stop and report the blocker when required inputs, approvals, or scope are missing.
 - Report changed files, verification commands, and blockers clearly.

--- a/.codex/skills/harness-requirements/references/agent-prompt.md
+++ b/.codex/skills/harness-requirements/references/agent-prompt.md
@@ -5,13 +5,12 @@ Use this prompt when spawning a worker agent for `$harness-requirements`.
 ```text
 You are the harness requirements documentation agent.
 
-Start from the user's initial idea and ask iterative questions until one MVP use case, requirements, and ubiquitous language are specific enough to document.
-Follow the ticketon-ddd style requirements, language, and template standards embedded in the skill.
+Start from the user's initial idea and ask iterative questions until one MVP use case and its requirements are specific enough to document.
+Follow the ticketon-ddd style requirements standards embedded in the skill.
 Do not depend on external blog files or repo-local reference posts at runtime.
 
 Owned files:
 - docs/design/요구사항.md
-- context.md
 
 Rules:
 - Do not revert edits made by others.
@@ -29,13 +28,13 @@ Rules:
 - Do not continue asking until the domain is perfect.
 - Stop when the information is sufficient to produce a useful draft for one MVP use case.
 - After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
-- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Blocking Open Language Questions, Deferred Language Questions, or Post-DDD Technical Decision Candidates.
-- Confirm ubiquitous language through grill-me before use-case harvest.
-- Update context.md first with confirmed canonical terms, Korean names, English code-facing names, definitions, aliases, Forbidden Terms, and open language questions.
-- Use context.md canonical terms when updating docs/design/요구사항.md.
-- After the user answers, update context.md and docs/design/요구사항.md, then ask the next most important unresolved requirement or language decision within the question budget.
+- If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Language Handoff Notes, or Post-DDD Technical Decision Candidates.
+- Do not own full ubiquitous language confirmation; route that work to `$harness-ubiquitous-language`.
+- Confirm only MVP-blocking terms needed to understand the requirement.
+- Do not ask detailed canonical naming, alias, forbidden-term, aggregate naming, domain event naming, or state-transition naming questions.
+- After the user answers, update docs/design/요구사항.md, then ask the next most important unresolved requirements decision within the question budget.
 - Split functional and non-functional requirements.
-- Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, and Open Language Questions.
+- Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, and Language Handoff Notes.
 - Do not ask technology-specific questions by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
 - Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
 - Do not write use cases.

--- a/.codex/skills/harness-requirements/references/detailed-instructions.md
+++ b/.codex/skills/harness-requirements/references/detailed-instructions.md
@@ -1,372 +1,140 @@
 # harness-requirements Detailed Instructions
 
 - Skill entrypoint: `.codex/skills/harness-requirements/SKILL.md`
+- Agent config: `.codex/agents/requirements_interviewer.toml`
+- Compatibility agent config: `.codex/agents/harness_requirements.toml`
 
----
-name: harness-requirements
-description:
-  Use when a user wants to turn an early product or feature idea into a
-  requirements specification and project ubiquitous language. This skill
-  clarifies unresolved decisions through a time-boxed grill-me flow and writes
-  docs/design/요구사항.md and context.md.
----
+## Role
 
-# Harness Requirements
+Turn an early idea into a requirements specification for one MVP use case.
 
-## Agent Context Bootstrap
+This stage does not own full ubiquitous language confirmation. It may confirm only MVP-blocking terms needed to understand the requirement. Full canonical term review belongs to `$harness-ubiquitous-language`.
 
-Before harvesting a new target repository, ensure repo-local agent context exists:
+## Inputs
 
-```bash
-python3 -m harness_codex agent-context init --description "<repo description>"
-```
+- User idea or existing requirements draft.
+- Existing docs, settings, and code relevant to the requested product behavior.
+- Existing `context.md` as read-only terminology context when present.
 
-If `docs/agent/` exists, read only the smallest relevant file. Preserve compact
-`AGENTS.md` and avoid moving long reference context back into the hot path.
+## Outputs
 
-Before running this skill, ensure required external skills are installed under
-`.codex/skills/`.
+- `docs/design/요구사항.md`
 
-Required external skill:
+Do not write `context.md`. Do not write use cases.
 
-- `grill-me`
+## Required Skill Use
 
-If `grill-me` is missing, stop and report that the external skill must be
-installed first.
+- Use `$grill-me` only as the questioning method.
+- Pass a brief that restricts questions to requirements clarification.
+- The `$grill-me` result is an intermediate decision record used to write `docs/design/요구사항.md`.
 
-## Purpose
+## Discovery Before Questions
 
-This skill turns an early idea into a requirements specification and a project
-ubiquitous language source of truth.
+- Before asking the user a question, inspect the codebase, existing docs/design documents, existing context.md, .codex configuration, and build/runtime settings when those artifacts could answer it.
+- If local artifacts could answer it, inspect them first.
+- Do not ask the user for facts you can verify locally.
+- If local artifacts partially answer the question, ask only for the missing decision.
 
-For an empty project or a broad request such as "build a calculator", harvest
-must first narrow the work to one MVP and one external-actor use case. For an
-existing repository feature addition or modification, harvest should steer the
-output toward one use-case-sized ChangeSet instead of a broad multi-use-case
-program.
+## Question Loop
 
-Responsibilities are split as follows.
-
-- `$grill-me`: clarifies unresolved requirement and language decisions through a bounded question loop.
-- `harness-requirements`: validates confirmed decisions and writes `docs/design/요구사항.md` and `context.md`.
-- `harness-usecases`: later reads confirmed requirements and `context.md`, then writes `docs/design/유스케이스.md`.
-
-`$grill-me` only provides the questioning method. The requirements and ubiquitous
-language standards belong to this skill's `Embedded Standards`. Therefore, when
-running `$grill-me`, pass a `Grill-Me Brief` that summarizes this skill's
-standards and the bounded questioning rule.
-
-The `$grill-me` result is not the final deliverable. It is an intermediate
-decision record used to write `docs/design/요구사항.md` and `context.md`.
-
-If business policies are incomplete, do not report that the work is ready for
-use-case writing or Event Storming. If foundational technology choices are
-incomplete, leave them under `Foundational Technology Decisions Needed`.
-
-If MVP-blocking ubiquitous language is incomplete, do not report that the work
-is ready for use-case writing, Event Storming, planning, or implementation.
-Leave unresolved MVP blockers under `Blocking Open Language Questions` in
-`context.md`. Leave non-blocking language questions under `Deferred Language
-Questions`.
-
-When this skill is invoked, delegate the work to the dedicated agent defined in
-`.codex/agents/harness_requirements.toml`. If the dedicated agent cannot be
-found or cannot run, do not perform a fallback implementation. Explain the
-reason and stop.
-
-## Embedded Standards
-
-Use the following standards as the source of truth for the instructions.
-
-### Requirements Standards
-
-- A requirement defines a goal or constraint that the system must satisfy.
-- Separate requirements into functional requirements and non-functional requirements.
-- Functional requirements describe the functional goals that actors achieve through the system, grouped by domain or feature area.
-- Non-functional requirements must cover only the minimal candidate constraints needed for the MVP use case. Detailed performance, concurrency, consistency, scalability, availability, security, recovery, and operability decisions can be deferred when they do not block the use case.
-- Items that depend on numbers or conditions must be written in measurable form. If unknown, mark them as `Needs confirmation`.
-- Do not confirm requirements that the user has not explicitly stated or that cannot be verified from local artifacts.
-- Separate unresolved items into `Business Policy Decisions Needed` and `Foundational Technology Decisions Needed`.
-- Business policies include success/failure outcomes, state transitions, validation rules, compensation, authorization, and user-visible behavior.
-- Do not confirm technology choices before the problem, actors, scope, and core business policies are understood.
-- Do not ask technology-specific questions by default. Ask them only when they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
-- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
-- Foundational technologies may remain unresolved after harvest and should usually be recorded under `Foundational Technology Decisions Needed`.
-- Detailed technical strategies that can be decided after design must not be confirmed during the requirements phase. Leave them under `Post-DDD Technical Decision Candidates`.
-- Before moving to use-case writing or Event Storming, there must be no unresolved business policy decisions.
-
-### Ubiquitous Language Standards
-
-- Requirements harvest must confirm ubiquitous language through `$grill-me` before use-case harvest begins.
-- Store the confirmed language in root-level `context.md` under `## 1. Ubiquitous Language` or `## Ubiquitous Language`.
-- `context.md` is the project-wide source of truth for domain language.
-- Confirm only the actor, one MVP goal, primary command/action, input/output concepts, successful result, user-visible failure policy, and hard scope boundary terms required for one use case.
-- Defer state names, event candidate terms, DDD terms, security/audit concepts, aliases, forbidden terms, external system names, and technology names unless they directly block the MVP use case.
-- For every MVP-blocking term, confirm the canonical term, Korean label, English code-facing label, type, definition, aliases, forbidden terms, and source.
-- The same concept must not have multiple canonical terms.
-- Aliases may be recorded only as aliases; generated requirements, use cases, plans, tests, and code identifiers must use canonical terms.
-- Forbidden terms must not appear in newly generated docs or code identifiers.
-- Do not mix implementation technology terms with domain terms unless the business explicitly uses the same term.
-- If an MVP-blocking term is missing or contested, do not invent it. Record it under `Blocking Open Language Questions` in `context.md`. Record non-blocking terms under `Deferred Language Questions`.
-
-## Grill-Me Brief Contract
-
-`$grill-me` only provides the questioning method. When running it, pass a brief
-that summarizes this skill's standards.
-
-### Question Budget and Completion Rule
-
-The grill-me phase must reduce ambiguity enough to produce a useful draft. It
-must not continue asking until the domain is perfect.
-
-Rules:
-
-- Run at most 3 rounds.
-- Ask one focused question at a time when interacting with the user.
+- Ask exactly one focused question at a time.
 - Ask only the single highest-priority blocker for the current turn.
 - Do not queue non-blocking follow-up questions.
-- After each round, summarize what has been clarified and what remains unresolved.
-- Stop once one actor, one MVP goal, the primary action, inputs, success result, failure policy, and hard scope boundary are clear enough to produce a draft.
-- If the question budget is exhausted, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
-- If uncertainty remains, record it under `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Blocking Open Language Questions`, `Deferred Language Questions`, or `Post-DDD Technical Decision Candidates` instead of extending the question loop.
-- After the final round, produce a draft of `context.md` and `docs/design/요구사항.md`.
-
-### Brief Contents
-
-```text
-You are conducting an interview to clarify requirements and confirm ubiquitous language.
-
-Questioning method:
-- Use a time-boxed questioning loop, not an unbounded interview.
 - Run at most 3 rounds.
-- Ask one focused question at a time when interacting with the user.
-- Ask only the single highest-priority blocker for the current turn.
-- Do not queue non-blocking follow-up questions.
-- Include `Recommended answer:` with each question.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
-- Stop when the information is sufficient to produce a useful draft.
-- After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
-- If uncertainty remains, record it under `Business Policy Decisions Needed`, `Foundational Technology Decisions Needed`, `Blocking Open Language Questions`, `Deferred Language Questions`, or `Post-DDD Technical Decision Candidates`.
-- If the answer can be found in the codebase, existing documents, or settings, inspect them first.
-- Follow decision dependencies and resolve the most important unresolved item first.
+- Stop once the information is sufficient to produce a draft.
+- Include `Recommended answer:` with every question.
+- The recommendation must reflect current evidence and should say whether it is based on local artifacts or inference.
 
-Judgment standards:
-- Follow the Embedded Standards from harness-requirements.
-- Business policies must be confirmed before use-case writing and DDD/Event Storming.
-- Ubiquitous language must be confirmed before use-case writing and DDD/Event Storming.
-- Foundational technologies are confirmed in the later part of the requirements phase.
-- Detailed technical strategies must not be confirmed as requirements; separate them as post-DDD candidates.
-- Do not write use cases in this phase.
+## Allowed Requirement Questions
 
-Question priority:
-1. Problem situation
-2. Goal
-3. Scope
-4. Actors
-5. Goals per actor
-6. Core domain terms and concept names
-7. State names
-8. Command/event/policy candidate terms
-9. Alias and forbidden-term cleanup
-10. Core features
-11. Success/failure outcomes
-12. Business policies
-13. Hard out-of-scope boundary
-14. External systems only when user-visible behavior depends on them
-15. Non-functional requirements only when they block MVP scoping
-16. Foundational technologies only when they block MVP scoping
+Requirements grill-me should clarify:
+- actor
+- goal
+- success condition
+- failure policy
+- hard scope boundary
+- business policy decisions
+- MVP-blocking terminology needed to understand the requirement
 
-Ubiquitous language confirmation criteria:
-- Same concept has exactly one canonical term.
-- Korean and English/code-facing names are confirmed.
-- Term type is clear: Actor, Goal, Domain Concept, State, Command Candidate, Event Candidate, Policy, External System, or Other.
-- Aliases and forbidden terms are recorded.
-- MVP-blocking missing terms are recorded in `Blocking Open Language Questions` instead of invented.
-- Non-blocking missing terms are recorded in `Deferred Language Questions`.
+## Forbidden Requirement Questions
 
-Completion criteria:
-- Main actors and their goals are separated enough for functional requirements.
-- Functional and non-functional requirement candidates can be written.
-- There are no unresolved core business policies, or the remaining items are explicitly recorded as not-ready blockers.
-- Foundational technologies are either unnecessary for MVP scoping or separated as needing confirmation.
-- Core ubiquitous language is confirmed and can be written to `context.md`, or unresolved terms are explicitly recorded under `Open Language Questions`.
+Requirements grill-me must not ask:
+- detailed canonical naming
+- alias decisions
+- forbidden term decisions
+- aggregate naming
+- domain event naming
+- state-transition naming
+- DDD design terminology
+- implementation strategy
 
-Output format:
-## Confirmed Decisions
-- ...
+Do not ask technology-specific questions by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
 
-## Confirmed Ubiquitous Language
-| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
-|---|---|---|---|---|---|---|---|
-| ... | ... | ... | ... | ... | ... | ... | grill-me |
+Do not ask about authentication, authorization, cache, Redis, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
 
-## Needs Confirmation
-### Business Policy Decisions Needed
-- ...
-### Foundational Technology Decisions Needed
-- ...
-### Blocking Open Language Questions
-- ...
-### Deferred Language Questions
-- ...
-### Post-DDD Technical Decision Candidates
-- ...
+## Requirements Rules
 
-## Documentation Input
-### Content for requirements.md
-- ...
-### Content for context.md
-- ...
-```
+- Requirements define goals and constraints the system must satisfy.
+- Split functional requirements and non-functional requirements.
+- Classify unresolved decisions as either Business Policy Decisions Needed, Foundational Technology Decisions Needed, or Language Handoff Notes.
+- Business Policy Decisions are product/domain rules: success/failure outcomes, validation rules, compensation, permissions, and user-visible behavior.
+- Foundational Technical Decisions are large technology choices that shape the whole program. During harvest, defer them by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+- Do not decide detailed implementation strategies during requirements elicitation. Polling vs push, circuit breaker, retry/backoff, outbox/inbox, detailed transaction propagation, cache TTL/invalidation, and observability fields belong after DDD design in the technical-decision stage.
+- Business Policy Decisions must be resolved before ubiquitous language confirmation can pass.
+- Foundational Technical Decisions may remain unresolved after requirements, but must be clearly separated for DDD and technical-decision gates.
+- If a measurable non-functional target is missing, mark it as confirmation needed instead of inventing it.
 
-## Invocation
+## Language Boundary
 
-When the user invokes `$harness-requirements` with an early idea or a `$grill-me`
-result, treat it as a request to write requirements and project language only.
-
-Dedicated agent:
-
-- agent id: `harness_requirements`
-- config: `.codex/agents/harness_requirements.toml`
-- output files:
-  - `docs/design/요구사항.md`
-  - `context.md`
-
-Execution rules:
-
-- If the dedicated agent cannot be found or cannot run, the current agent must not perform the work as a fallback.
-- Explain the reason for the failure and stop.
-- The dedicated agent must not modify code, settings, skill files, agent files, or use-case documents.
-- The dedicated agent may only write to `docs/design/요구사항.md` and `context.md`.
-
-## Workflow
-
-1. **Confirm standards**
-   Use `Embedded Standards`, `Grill-Me Brief Contract`, and the document templates as the working standards.
-
-2. **Inspect inputs**
-   Review the early idea, `$grill-me` result, existing requirements, existing `context.md`, relevant code, docs, and settings.
-
-3. **Decide whether to run Grill-Me**
-   If requirement or language decisions are missing, create a brief that follows the `Grill-Me Brief Contract` and run `$grill-me` within the question budget.
-
-4. **Validate decisions**
-   Split the `$grill-me` result into confirmed decisions, needs-confirmation items, confirmed language, open language questions, and post-DDD candidates.
-   Do not confirm items that fail the standards.
-
-5. **Write requirements and language**
-   Write or update `context.md` first, then write or update `docs/design/요구사항.md` using the canonical terms from `context.md`.
-
-6. **Confirm completion**
-   If business policies are unresolved, do not report readiness for use-case writing or Event Storming.
-   If ubiquitous language has unresolved MVP-blocking terms, do not report readiness for use-case writing or Event Storming.
-   Collect remaining unresolved items in needs-confirmation sections instead of continuing the question loop beyond the budget.
-
-## Context Document Template
-
-`context.md` must follow this structure.
-
-```markdown
-# Project Context
-
-## 1. Ubiquitous Language
-
-| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
-|---|---|---|---|---|---|---|---|
-| ... | ... | ... | ... | ... | ... | ... | grill-me |
-
-## 2. Naming Rules
-
-- Documents must use `Canonical Term`.
-- Code class, method, package, command, event, and policy identifiers must use `English`.
-- User-facing text should use `Korean`.
-- `Forbidden Terms` must not be used in new documents, plans, tests, or code identifiers.
-- Aliases are recorded only for migration/search context and must not be introduced as new canonical language.
-
-## 3. Blocking Open Language Questions
-
-- ...
-
-## 4. Deferred Language Questions
-
-- ...
-```
+- Record MVP-blocking terms only enough for the later ubiquitous-language-definition stage to confirm canonical language.
+- Do not ask full ubiquitous language questions before finalizing the requirements document.
+- If a naming decision is not needed to understand the requirement, record it under `Language Handoff Notes`.
+- If language uncertainty blocks use-case writing, mark the document as ready for ubiquitous-language-definition and not ready for use-case writing.
 
 ## Requirements Document Template
 
-`docs/design/요구사항.md` must follow this structure.
-
 ```markdown
-# Requirements Specification
+# 요구사항
 
-## 1. Overview
-- Initial idea:
-- Problem situation:
+## 1. Scope
+
+- MVP use case:
+- Actor:
 - Goal:
-- Scope:
+- Hard out-of-scope boundary:
 
-## 2. Actors and Stakeholders
-- Main actors:
-- Supporting actors:
-- Stakeholders:
+## 2. Functional Requirements
 
-## 3. Functional Requirements
-### 3.1 <Domain/Feature Group>
-- FR-001. ...
+### FR-001
 
-## 4. Non-Functional Requirements
-> Items not confirmed by the user must be marked as `Candidate` or `Needs confirmation`.
+- Requirement:
+- Success condition:
+- Failure policy:
 
-### 4.1 Performance
-- NFR-001. ...
+## 3. Non-Functional Requirements
 
-### 4.2 Concurrency Control
-- NFR-...
+### NFR-001
 
-### 4.3 Data Consistency
-- NFR-...
+- Candidate requirement:
+- Confirmation status:
 
-### 4.4 Scalability
-- NFR-...
+## 4. Business Policy Decisions Needed
 
-### 4.5 Fault Isolation and Availability
-- NFR-...
+- None.
 
-### 4.6 Security
-- NFR-...
+## 5. Foundational Technology Decisions Needed
 
-### 4.7 Failure Handling and Recovery
-- NFR-...
+- None.
 
-### 4.8 Auditability and Operability
-- NFR-...
+## 6. Language Handoff Notes
 
-## 5. Constraints and Assumptions
-- ...
+- None.
 
-## 6. Foundational Technology Decisions
-> In the requirements phase, record only foundational stack or infrastructure choices that directly block MVP scoping. Otherwise defer them.
+## 7. Readiness
 
-- Programming language:
-- Main framework:
-- Database/storage:
-- Cache/distributed state infrastructure:
-- Messaging broker/framework:
-- Runtime/deployment constraints:
-- Build tool:
-
-## 7. Post-DDD Technical Decision Candidates
-- Polling/push/scheduling approach:
-- Circuit breaker/retry/backoff:
-- Outbox/inbox/idempotency:
-- Transaction propagation/consistency implementation:
-- Cache policy:
-- Logging/metrics/tracing fields:
-
-## 8. Business Policy Decisions Needed
-- ...
-
-## 9. Foundational Technology Decisions Needed
-- ...
+- Requirements gate:
+- Ubiquitous language gate:
+- Use-case writing:
 ```

--- a/.codex/skills/harness-ubiquitous-language/SKILL.md
+++ b/.codex/skills/harness-ubiquitous-language/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: harness-ubiquitous-language
+description:
+  Use after requirements are stable to confirm project ubiquitous language in
+  context.md before use-case generation.
+---
+
+# Harness Ubiquitous Language
+
+## Hot Path
+
+- Use this skill only after `docs/design/요구사항.md` exists.
+- Read `.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md` before making workflow decisions or producing required artifacts.
+- Read additional files named by the detailed reference only when the current task needs them.
+- Keep writes inside the scope declared by the caller or runtime payload.
+- Preserve unrelated worktree changes.
+- Stop and report an upstream requirements blocker if actor, goal, success condition, failure policy, or scope boundary is missing or contradictory.
+- Report changed files, verification commands, and blockers clearly.

--- a/.codex/skills/harness-ubiquitous-language/agents/openai.yaml
+++ b/.codex/skills/harness-ubiquitous-language/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Harness Ubiquitous Language"
+  short_description: "Confirm context.md terminology after requirements"
+  default_prompt: "Use $harness-ubiquitous-language to confirm context.md from stable requirements."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/harness-ubiquitous-language/references/agent-prompt.md
+++ b/.codex/skills/harness-ubiquitous-language/references/agent-prompt.md
@@ -1,0 +1,30 @@
+# Harness Ubiquitous Language Agent Prompt
+
+Use this prompt when spawning a worker agent for `$harness-ubiquitous-language`.
+
+```text
+You are the harness ubiquitous language reviewer.
+
+Start from stable requirements in docs/design/요구사항.md and confirm only language decisions needed before use-case writing.
+Do not reopen requirements unless a contradiction blocks terminology.
+
+Owned files:
+- context.md
+
+Rules:
+- Do not revert edits made by others.
+- Do not edit code, settings, skill files, agent files, requirements documents, or use-case documents.
+- Inspect existing context.md before asking the user a question.
+- Preserve existing canonical terms unless the user explicitly confirms a rename.
+- Ask one focused question at a time when interacting with the user.
+- Ask only the single highest-priority language blocker for the current turn.
+- Include `Recommended answer:` with every question.
+- Run at most 3 rounds.
+- After each round, summarize what has been clarified and what remains unresolved.
+- Do not continue asking until terminology is perfect.
+- Clarify canonical term, Korean label, English/code-facing label, aliases, forbidden terms, and meaning boundary.
+- Do not ask broad requirements questions about actor, goal, success condition, failure policy, or hard scope unless reporting an upstream requirements blocker.
+- Do not ask aggregate, domain event, or state-transition naming questions in this stage.
+- After the final round, update context.md with confirmed terms and explicit open language questions.
+- If the dedicated agent cannot be found or cannot run, explain the reason and stop.
+```

--- a/.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md
+++ b/.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md
@@ -1,0 +1,90 @@
+# harness-ubiquitous-language Detailed Instructions
+
+- Skill entrypoint: `.codex/skills/harness-ubiquitous-language/SKILL.md`
+- Agent config: `.codex/agents/ubiquitous_language_reviewer.toml`
+- Agent reference: `.codex/agents/references/ubiquitous_language_reviewer.md`
+
+## Role
+
+Confirm project ubiquitous language after requirements are stable and before use-case writing.
+
+## Required Inputs
+
+- `docs/design/요구사항.md`
+- Existing `context.md` when present
+
+If `docs/design/요구사항.md` is missing, stop and ask the user to run `$harness-requirements` first.
+
+## Outputs
+
+- `context.md`
+
+Do not edit `docs/design/요구사항.md`. Do not write use cases.
+
+## Stage Boundary
+
+Requirements-definition owns:
+- actor
+- goal
+- user-visible success condition
+- user-visible failure policy
+- hard scope boundary
+- business policy decisions
+- only MVP-blocking terms needed to understand the requirement
+
+Ubiquitous-language-definition owns:
+- canonical term
+- Korean label
+- English/code-facing label
+- aliases
+- forbidden terms
+- meaning boundary
+- use-case-facing command, input, output, result, policy, and scope-boundary terminology
+
+Do not ask broad requirements questions unless a contradiction blocks language confirmation. If blocked, report an upstream requirements blocker and stop.
+
+## Deferred Naming
+
+Do not ask aggregate naming, domain event naming, or state-transition naming questions during this stage. Record those as deferred DDD or event-storming questions if they appear.
+
+## Question Loop
+
+- Ask exactly one focused question at a time.
+- Ask only the single highest-priority language blocker for the current turn.
+- Do not queue non-blocking follow-up questions.
+- Run at most 3 rounds.
+- Include `Recommended answer:` with every question.
+- After each round, summarize what has been clarified and what remains unresolved.
+- Do not continue asking until terminology is perfect.
+
+## context.md Contract
+
+Use this structure:
+
+```markdown
+# Project Context
+
+## 1. Ubiquitous Language
+
+| Canonical Term | Korean | English | Type | Definition | Aliases | Forbidden Terms | Source |
+|---|---|---|---|---|---|---|---|
+| ... | ... | ... | ... | ... | ... | ... | grill-me |
+
+## 2. Naming Rules
+
+- Documents must use `Canonical Term`.
+- Code class, method, package, command, event, and policy identifiers must use `English`.
+- User-facing text should use `Korean`.
+- `Forbidden Terms` must not be used in new documents, plans, tests, or code identifiers.
+- Aliases are recorded only for migration/search context and must not be introduced as new canonical language.
+
+## 3. Blocking Open Language Questions
+
+- None.
+
+## 4. Deferred Language Questions
+
+- None.
+```
+
+Use `Source` value `grill-me` for confirmed terms from clarification.

--- a/.harness/workflows/harvest-workflow.yaml
+++ b/.harness/workflows/harvest-workflow.yaml
@@ -3,7 +3,7 @@ version: 1
 workflow:
   name: harness-harvest-workflow
   mode: apply
-  description: Harvest product intent into canonical requirements, ubiquitous language, then runtime-ready use-case documents.
+  description: Harvest product intent into canonical requirements, confirmed ubiquitous language, then runtime-ready use-case documents.
 
 sandbox:
   kind: worktree
@@ -12,15 +12,14 @@ steps:
   - id: harvest-requirements
     kind: agent
     name: Derive requirements from the initial product idea
-    agent_id: harness_requirements
+    agent_id: requirements_interviewer
     skill_id: harness-requirements
     outputs:
       - docs/design/요구사항.md
-      - context.md
     timeout_sec: 3600
     metadata:
       stage: harvest
-      scope: canonical_requirements_and_language
+      scope: canonical_requirements
       bootstrap_outputs:
         - AGENTS.md
         - docs/agent/context.md
@@ -29,13 +28,30 @@ steps:
         - docs/agent/token-reduction-report.md
       output_gate:
         - docs/design/요구사항.md
+
+  - id: harvest-ubiquitous-language
+    kind: agent
+    name: Confirm ubiquitous language from stable requirements
+    agent_id: ubiquitous_language_reviewer
+    skill_id: harness-ubiquitous-language
+    needs:
+      - harvest-requirements
+    inputs:
+      - docs/design/요구사항.md
+    outputs:
+      - context.md
+    timeout_sec: 3600
+    metadata:
+      stage: harvest
+      scope: canonical_language
+      output_gate:
         - context.md
 
   - id: validate-context-language
     kind: validator
     name: Validate confirmed ubiquitous language before use-case harvest
     needs:
-      - harvest-requirements
+      - harvest-ubiquitous-language
     command: python3 -m harness_codex.context_language --repo-root .
     timeout_sec: 300
     inputs:

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -398,6 +398,7 @@ def _project_workflow_stages(
     completed = set()
     if workflow_state.get("requirements_gate_passed"):
         completed.add("requirements-definition")
+        completed.add("ubiquitous-language-definition")
     if workflow_state.get("use_cases_ready"):
         completed.add("use-case-definition")
     if (workflow_state.get("event_storming") or {}).get("complete"):
@@ -593,6 +594,7 @@ def _ddd_aggregates_have_real_names_when_present(content: str) -> bool:
 def _stale_stage_ids(kind: str) -> tuple[str, ...]:
     if kind == "requirements":
         return (
+            "ubiquitous-language-definition",
             "use-case-definition",
             "event-storming",
             "ddd-architecture-definition",

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -23,6 +23,7 @@ USE_CASES_PATH = Path("docs/design/유스케이스.md")
 USE_CASE_SLICE_ROOT = Path("docs/use-cases")
 GRILL_ME_SKILL_PATH = Path(".codex/skills/grill-me/SKILL.md")
 REQUIREMENTS_SKILL_PATH = Path(".codex/skills/harness-requirements/SKILL.md")
+LANGUAGE_SKILL_PATH = Path(".codex/skills/harness-ubiquitous-language/SKILL.md")
 USE_CASE_AGENT_CONFIG_PATH = Path(".codex/agents/harness_usecases.toml")
 USE_CASE_SKILL_PATH = Path(".codex/skills/harness-usecases/SKILL.md")
 USE_CASE_DEFINITION_TIMEOUT_SEC = 3600
@@ -1901,7 +1902,7 @@ def _run_grill_me_finalizer(
 ) -> dict[str, Any]:
     step_dir = run_dir / "finalize"
     step_dir.mkdir(parents=True, exist_ok=True)
-    prompt = _grill_me_finalization_prompt(session, requirements_skill_path)
+    prompt = _grill_me_finalization_prompt(session, requirements_skill_path, root / LANGUAGE_SKILL_PATH)
     final_message = _exec_codex_prompt(root, step_dir, prompt, "Grill-Me finalization")
     result = _parse_grill_me_json(final_message)
     if not result["requirements_markdown"] or not result["context_markdown"]:
@@ -1972,7 +1973,8 @@ Question rules:
 - Generate questions only from unresolved decisions.
 - Ask only the single highest-priority blocker.
 - Do not queue non-blocking follow-up questions.
-- Return complete=true once the confirmed decisions are sufficient for a separate writer step to draft context.md and docs/design/요구사항.md.
+- Do not ask detailed canonical naming, alias, forbidden-term, aggregate naming, domain event naming, or state-transition naming questions.
+- Return complete=true once the confirmed decisions are sufficient for separate writer steps to draft docs/design/요구사항.md and context.md.
 
 Initial prompt:
 {session["initial_prompt"]}
@@ -1982,7 +1984,11 @@ Compact Q/A history:
 """
 
 
-def _grill_me_finalization_prompt(session: dict[str, Any], requirements_skill_path: Path) -> str:
+def _grill_me_finalization_prompt(
+    session: dict[str, Any],
+    requirements_skill_path: Path,
+    language_skill_path: Path,
+) -> str:
     return f"""Use the confirmed requirement decisions below to draft the final harvest documents.
 
 Return only JSON with keys: complete, questions, requirements_markdown, context_markdown.
@@ -1992,7 +1998,8 @@ Each question object must have keys: question, recommended.
 
 Document rules:
 - In requirements_markdown, never use a clarification table column named `Answer`; use `Response`.
-- context_markdown must follow the root context.md structure from harness-requirements and include the Ubiquitous Language table.
+- requirements_markdown must follow harness-requirements and must not own full ubiquitous language confirmation.
+- context_markdown must follow harness-ubiquitous-language and include the Ubiquitous Language table.
 - requirements_markdown must use canonical terms from context_markdown.
 - Return complete=true only when context_markdown has no unresolved entries under `## 3. Open Language Questions`.
 - If context_markdown still has any open language question, return complete=false and ask the focused follow-up question that resolves it.
@@ -2006,6 +2013,8 @@ Compact Q/A history:
 Harness requirements standards:
 - Load `{requirements_skill_path}`.
 - Then read `.codex/skills/harness-requirements/references/detailed-instructions.md`.
+- Load `{language_skill_path}`.
+- Then read `.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md`.
 - Read additional referenced files only if the current draft needs them.
 """
 

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -182,15 +182,12 @@ HARNESS_FULL_WORKFLOW = Workflow(
             id="harvest-requirements",
             kind=StepKind.AGENT,
             name="Derive requirements from the initial product idea",
-            agent_id="harness_requirements",
+            agent_id="requirements_interviewer",
             skill_id="harness-requirements",
-            outputs=(
-                Path("docs/design/요구사항.md"),
-                Path("context.md"),
-            ),
+            outputs=(Path("docs/design/요구사항.md"),),
             metadata={
                 "stage": "harvest",
-                "scope": "canonical_requirements_and_language",
+                "scope": "canonical_requirements",
                 "bootstrap_outputs": (
                     "AGENTS.md",
                     "docs/agent/context.md",
@@ -199,7 +196,24 @@ HARNESS_FULL_WORKFLOW = Workflow(
                     "docs/agent/token-reduction-report.md",
                 ),
                 "purpose": (
-                    "Produce canonical requirements before use-case derivation."
+                    "Produce canonical requirements before language confirmation."
+                ),
+            },
+        ),
+        Step(
+            id="harvest-ubiquitous-language",
+            kind=StepKind.AGENT,
+            name="Confirm ubiquitous language from stable requirements",
+            agent_id="ubiquitous_language_reviewer",
+            skill_id="harness-ubiquitous-language",
+            needs=("harvest-requirements",),
+            inputs=(Path("docs/design/요구사항.md"),),
+            outputs=(Path("context.md"),),
+            metadata={
+                "stage": "harvest",
+                "scope": "canonical_language",
+                "purpose": (
+                    "Produce confirmed ubiquitous language before use-case derivation."
                 ),
             },
         ),
@@ -209,7 +223,7 @@ HARNESS_FULL_WORKFLOW = Workflow(
             name="Derive use cases from confirmed requirements",
             agent_id="harness_usecases",
             skill_id="harness-usecases",
-            needs=("harvest-requirements",),
+            needs=("harvest-ubiquitous-language",),
             inputs=(Path("context.md"), Path("docs/design/요구사항.md")),
             outputs=(Path("docs/design/유스케이스.md"), Path("docs/use-cases")),
             metadata={

--- a/harness_codex/runtime/procedure_stages.py
+++ b/harness_codex/runtime/procedure_stages.py
@@ -25,10 +25,22 @@ PROCEDURE_STAGES: tuple[ProcedureStage, ...] = (
     ProcedureStage(
         stage_id="requirements-definition",
         display_name="Requirements Definition",
-        agent_id="harness_requirements",
+        agent_id="requirements_interviewer",
         skill_id="harness-requirements",
         inputs=(Path("docs/changes/active/<CHG-ID>.md"),),
-        outputs=(Path("context.md"), Path("docs/design/요구사항.md")),
+        outputs=(Path("docs/design/요구사항.md"),),
+        verifier_terms=("TBD from confirmed requirements",),
+    ),
+    ProcedureStage(
+        stage_id="ubiquitous-language-definition",
+        display_name="Ubiquitous Language Definition",
+        agent_id="ubiquitous_language_reviewer",
+        skill_id="harness-ubiquitous-language",
+        inputs=(
+            Path("docs/changes/active/<CHG-ID>.md"),
+            Path("docs/design/요구사항.md"),
+        ),
+        outputs=(Path("context.md"),),
         verifier_terms=("TBD from confirmed requirements",),
     ),
     ProcedureStage(

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -232,6 +232,7 @@ def test_document_dashboard_projects_docs_board_and_folder_lifecycle(tmp_path: P
         }
     ]
     assert change_set["stages"][0]["id"] == "requirements-definition"
+    assert change_set["stages"][1]["id"] == "ubiquitous-language-definition"
     work_item = change_set["work_items"][0]
     assert "docs/plans/completed/UC-001/plan.md" in {
         artifact["path"] for artifact in work_item["artifacts"]
@@ -281,6 +282,7 @@ def test_dashboard_projects_completed_ui_workflow_and_generated_use_cases_docume
     documents = {document["id"]: document for document in change_set["documents"]}
 
     assert statuses["requirements-definition"] == "verified"
+    assert statuses["ubiquitous-language-definition"] == "verified"
     assert statuses["use-case-definition"] == "verified"
     assert documents["generated-use-cases:CHG-001"]["label"] == "Use Cases (Read only)"
     loaded = read_dashboard_document(tmp_path, "generated-use-cases:CHG-001")
@@ -626,6 +628,7 @@ def test_save_requirements_requires_current_revision_and_stales_downstream_stage
     assert "Save a durable note." in saved["content"]
     change_text = change_path.read_text(encoding="utf-8")
     assert "|requirements-definition|Requirements Definition|pending|" in change_text
+    assert "|ubiquitous-language-definition|Ubiquitous Language Definition|stale|" in change_text
     assert "|use-case-definition|Use Case Definition|stale|" in change_text
     assert "|implementation|Implementation|stale|" in change_text
     assert (tmp_path / "docs/use-cases/UC-001/event-storming.md").exists()

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -612,6 +612,7 @@ def test_grill_me_finalization_prompt_uses_compact_history_and_writer_contract()
             "pending_questions": [],
         },
         Path(".codex/skills/harness-requirements/SKILL.md"),
+        Path(".codex/skills/harness-ubiquitous-language/SKILL.md"),
     )
 
     assert "Compact Q/A history" in prompt
@@ -620,6 +621,8 @@ def test_grill_me_finalization_prompt_uses_compact_history_and_writer_contract()
     assert "Harness requirements standards" in prompt
     assert ".codex/skills/harness-requirements/SKILL.md" in prompt
     assert ".codex/skills/harness-requirements/references/detailed-instructions.md" in prompt
+    assert ".codex/skills/harness-ubiquitous-language/SKILL.md" in prompt
+    assert ".codex/skills/harness-ubiquitous-language/references/detailed-instructions.md" in prompt
     assert "Return complete=true only when context_markdown has no unresolved entries" in prompt
 
 

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -112,6 +112,7 @@ def test_harness_full_workflow_models_top_level_harness_lifecycle() -> None:
 
     assert workflow.step_ids() == (
         "harvest-requirements",
+        "harvest-ubiquitous-language",
         "harvest-use-cases",
         "capture-implementation-intent",
         "create-change-set",
@@ -131,20 +132,29 @@ def test_harness_full_workflow_models_top_level_harness_lifecycle() -> None:
 
 def test_harness_full_workflow_starts_with_harvest_then_change_set_intake() -> None:
     requirements = HARNESS_FULL_WORKFLOW.step_by_id("harvest-requirements")
+    language = HARNESS_FULL_WORKFLOW.step_by_id("harvest-ubiquitous-language")
     use_cases = HARNESS_FULL_WORKFLOW.step_by_id("harvest-use-cases")
     capture = HARNESS_FULL_WORKFLOW.step_by_id("capture-implementation-intent")
     change_set = HARNESS_FULL_WORKFLOW.step_by_id("create-change-set")
     affected = HARNESS_FULL_WORKFLOW.step_by_id("identify-affected-use-cases")
 
     assert requirements.kind == StepKind.AGENT
-    assert requirements.agent_id == "harness_requirements"
+    assert requirements.agent_id == "requirements_interviewer"
     assert requirements.needs == ()
-    assert requirements.metadata["scope"] == "canonical_requirements_and_language"
-    assert requirements.outputs == (Path("docs/design/요구사항.md"), Path("context.md"))
+    assert requirements.metadata["scope"] == "canonical_requirements"
+    assert requirements.outputs == (Path("docs/design/요구사항.md"),)
+
+    assert language.kind == StepKind.AGENT
+    assert language.agent_id == "ubiquitous_language_reviewer"
+    assert language.skill_id == "harness-ubiquitous-language"
+    assert language.needs == ("harvest-requirements",)
+    assert language.inputs == (Path("docs/design/요구사항.md"),)
+    assert language.outputs == (Path("context.md"),)
+    assert language.metadata["scope"] == "canonical_language"
 
     assert use_cases.kind == StepKind.AGENT
     assert use_cases.agent_id == "harness_usecases"
-    assert use_cases.needs == ("harvest-requirements",)
+    assert use_cases.needs == ("harvest-ubiquitous-language",)
     assert use_cases.inputs == (Path("context.md"), Path("docs/design/요구사항.md"))
     assert use_cases.outputs == (Path("docs/design/유스케이스.md"), Path("docs/use-cases"))
     assert use_cases.metadata["scope"] == "canonical_use_cases"

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -32,6 +32,37 @@ def test_procedure_stage_plan_uses_explicit_process_name(
     assert "docs/use-cases/UC-001/event-storming.md" in output
 
 
+def test_procedure_stages_split_requirements_language_before_use_cases() -> None:
+    requirements = procedure_stage("requirements-definition")
+    language = procedure_stage("ubiquitous-language-definition")
+    use_cases = procedure_stage("use-case-definition")
+
+    assert requirements.agent_id == "requirements_interviewer"
+    assert requirements.skill_id == "harness-requirements"
+    assert requirements.outputs == (Path("docs/design/요구사항.md"),)
+
+    assert language.agent_id == "ubiquitous_language_reviewer"
+    assert language.skill_id == "harness-ubiquitous-language"
+    assert language.inputs == (
+        Path("docs/changes/active/<CHG-ID>.md"),
+        Path("docs/design/요구사항.md"),
+    )
+    assert language.outputs == (Path("context.md"),)
+
+    rendered = render_initial_changeset(
+        change_set_id="CHG-001",
+        title="Split language",
+        request_summary="Separate language gate",
+    )
+    assert rendered.index("|requirements-definition|") < rendered.index(
+        "|ubiquitous-language-definition|"
+    )
+    assert rendered.index("|ubiquitous-language-definition|") < rendered.index(
+        "|use-case-definition|"
+    )
+    assert Path("context.md") in use_cases.inputs
+
+
 def test_procedure_stage_preview_verifies_outputs(
     tmp_path: Path,
     capsys,
@@ -199,6 +230,7 @@ def test_changeset_stage_status_keeps_runtime_stage_order_after_added_stage() ->
 |Stage ID|Procedure|Status|Verified At|Notes|
 |---|---|---|---|---|
 |requirements-definition|Requirements Definition|verified|2026-01-01T00:00:00Z|-|
+|ubiquitous-language-definition|Ubiquitous Language Definition|verified|2026-01-01T00:00:00Z|-|
 |use-case-definition|Use Case Definition|verified|2026-01-01T00:00:00Z|-|
 |event-storming|Event Storming|verified|2026-01-01T00:00:00Z|-|
 |ddd-architecture-definition|DDD Architecture Definition|verified|2026-01-01T00:00:00Z|-|
@@ -213,5 +245,11 @@ def test_changeset_stage_status_keeps_runtime_stage_order_after_added_stage() ->
         notes="pending approval",
     )
 
+    assert updated.index("|requirements-definition|") < updated.index(
+        "|ubiquitous-language-definition|"
+    )
+    assert updated.index("|ubiquitous-language-definition|") < updated.index(
+        "|use-case-definition|"
+    )
     assert updated.index("|ddd-architecture-definition|") < updated.index("|technical-decisions|")
     assert updated.index("|technical-decisions|") < updated.index("|plan-writing|")

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -132,21 +132,29 @@ def test_default_harvest_workflow_loads() -> None:
 
     assert workflow.name == "harness-harvest-workflow"
     requirements = workflow.step_by_id("harvest-requirements")
+    language = workflow.step_by_id("harvest-ubiquitous-language")
     validate_language = workflow.step_by_id("validate-context-language")
     use_cases = workflow.step_by_id("harvest-use-cases")
 
     assert workflow.step_ids() == (
         "harvest-requirements",
+        "harvest-ubiquitous-language",
         "validate-context-language",
         "harvest-use-cases",
     )
 
-    assert requirements.agent_id == "harness_requirements"
+    assert requirements.agent_id == "requirements_interviewer"
     assert requirements.skill_id == "harness-requirements"
-    assert requirements.outputs == (Path("docs/design/요구사항.md"), Path("context.md"))
+    assert requirements.outputs == (Path("docs/design/요구사항.md"),)
+
+    assert language.agent_id == "ubiquitous_language_reviewer"
+    assert language.skill_id == "harness-ubiquitous-language"
+    assert language.needs == ("harvest-requirements",)
+    assert language.inputs == (Path("docs/design/요구사항.md"),)
+    assert language.outputs == (Path("context.md"),)
 
     assert validate_language.kind == StepKind.VALIDATOR
-    assert validate_language.needs == ("harvest-requirements",)
+    assert validate_language.needs == ("harvest-ubiquitous-language",)
     assert validate_language.command == "python3 -m harness_codex.context_language --repo-root ."
     assert validate_language.inputs == (
         Path("context.md"),

--- a/tests/test_harvester_skill_instructions.py
+++ b/tests/test_harvester_skill_instructions.py
@@ -20,15 +20,19 @@ def read_contract(path: Path) -> str:
 def test_harvester_skills_ask_one_question_with_recommendation() -> None:
     all_paths = (
         REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
-        REPO_ROOT / ".codex/agents/harness_requirements.toml",
+        REPO_ROOT / ".codex/agents/requirements_interviewer.toml",
         REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
+        REPO_ROOT / ".codex/skills/harness-ubiquitous-language/SKILL.md",
+        REPO_ROOT / ".codex/agents/ubiquitous_language_reviewer.toml",
+        REPO_ROOT / ".codex/skills/harness-ubiquitous-language/references/agent-prompt.md",
         REPO_ROOT / ".codex/skills/harness-usecases/SKILL.md",
         REPO_ROOT / ".codex/agents/harness_usecases.toml",
         REPO_ROOT / ".codex/skills/harness-usecases/references/agent-prompt.md",
     )
 
     requirement_paths = all_paths[:3]
-    usecase_paths = all_paths[3:]
+    language_paths = all_paths[3:6]
+    usecase_paths = all_paths[6:]
 
     for path in requirement_paths:
         text = read_contract(path)
@@ -38,6 +42,12 @@ def test_harvester_skills_ask_one_question_with_recommendation() -> None:
 
         assert "single highest-priority blocker" in text
 
+    for path in language_paths:
+        text = read_contract(path)
+        assert "one focused question at a time" in text
+        assert "Recommended answer" in text
+        assert "single highest-priority language blocker" in text
+
     for path in usecase_paths:
         text = read_contract(path)
         assert "one JSON needs_input question" in text or "one focused question at a time" in text
@@ -46,7 +56,7 @@ def test_harvester_skills_ask_one_question_with_recommendation() -> None:
 def test_requirements_grill_me_questioning_is_time_boxed() -> None:
     paths = (
         REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
-        REPO_ROOT / ".codex/agents/harness_requirements.toml",
+        REPO_ROOT / ".codex/agents/requirements_interviewer.toml",
         REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
     )
 
@@ -56,13 +66,13 @@ def test_requirements_grill_me_questioning_is_time_boxed() -> None:
         assert "After each round" in text
         assert "not continue asking until the domain is perfect" in text
         assert "produce a draft" in text
-        assert "Open Language Questions" in text
+        assert "Language Handoff Notes" in text
 
 
 def test_requirements_harvest_defers_technology_specific_questions() -> None:
     paths = (
         REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
-        REPO_ROOT / ".codex/agents/harness_requirements.toml",
+        REPO_ROOT / ".codex/agents/requirements_interviewer.toml",
         REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
     )
 
@@ -77,25 +87,67 @@ def test_requirements_harvest_defers_technology_specific_questions() -> None:
 
 def test_requirements_skill_explores_local_context_before_questions() -> None:
     skill = read_contract(REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md")
-    agent = read_contract(REPO_ROOT / ".codex/agents/harness_requirements.toml")
+    agent = read_contract(REPO_ROOT / ".codex/agents/requirements_interviewer.toml")
 
     assert "inspect them first" in skill
     assert "Before asking the user a question" in agent
 
 
-def test_requirements_harvest_owns_context_language() -> None:
+def test_requirements_harvest_does_not_own_full_context_language() -> None:
     paths = (
         REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
-        REPO_ROOT / ".codex/agents/harness_requirements.toml",
+        REPO_ROOT / ".codex/agents/requirements_interviewer.toml",
         REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
     )
 
     for path in paths:
         text = read_contract(path)
+        assert "harness-ubiquitous-language" in text
+        assert "Do not write `context.md`" in text or "Do not own full ubiquitous language confirmation" in text
+        assert "Language Handoff Notes" in text
+
+
+def test_ubiquitous_language_skill_owns_context_language() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-ubiquitous-language/SKILL.md",
+        REPO_ROOT / ".codex/agents/ubiquitous_language_reviewer.toml",
+        REPO_ROOT / ".codex/skills/harness-ubiquitous-language/references/agent-prompt.md",
+    )
+
+    for path in paths:
+        text = read_contract(path)
         assert "context.md" in text
-        assert "Ubiquitous Language" in text or "ubiquitous language" in text
-        assert "Forbidden Terms" in text
-        assert "Open Language Questions" in text
+        assert "canonical term" in text or "canonical" in text
+        assert "Forbidden Terms" in text or "forbidden terms" in text
+        assert "upstream requirements blocker" in text
+
+
+def test_requirements_grill_me_does_not_ask_design_naming_questions() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-requirements/SKILL.md",
+        REPO_ROOT / ".codex/agents/requirements_interviewer.toml",
+        REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md",
+    )
+
+    for path in paths:
+        text = read_contract(path)
+        assert "must not ask" in text or "Do not ask" in text
+        assert "aggregate" in text
+        assert "domain event" in text
+        assert "state-transition" in text
+
+
+def test_ubiquitous_language_grill_me_does_not_reopen_requirements() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-ubiquitous-language/SKILL.md",
+        REPO_ROOT / ".codex/agents/ubiquitous_language_reviewer.toml",
+        REPO_ROOT / ".codex/skills/harness-ubiquitous-language/references/agent-prompt.md",
+    )
+
+    for path in paths:
+        text = read_contract(path)
+        assert "Do not reopen requirements" in text or "Do not ask broad requirements questions" in text
+        assert "upstream requirements blocker" in text
 
 
 def test_usecases_consume_context_language_without_editing_it() -> None:


### PR DESCRIPTION
## 구현 의도 (Implementation intent)

이슈 #238에 따라 요구사항 grill-me와 유비쿼터스 언어 grill-me 책임을 분리합니다. 요구사항 단계는 actor, goal, success/failure policy, scope, business policy만 다루고, 용어 확정은 별도 단계에서 처리합니다.

## 구현 접근 (Implementation approach)

- `requirements_interviewer`와 `ubiquitous_language_reviewer` 에이전트를 추가했습니다.
- `harness-ubiquitous-language` 스킬을 추가하고 `context.md` 작성 책임을 이 스킬로 옮겼습니다.
- `requirements-definition -> ubiquitous-language-definition -> use-case-definition` 순서로 런타임 procedure stage와 harvest workflow를 갱신했습니다.
- use-case harvest는 language agent와 context language validator 이후에만 실행되도록 의존성을 연결했습니다.
- 정적 계약 테스트로 요구사항 grill-me의 aggregate/event/state naming 질문 금지와 language grill-me의 broad requirements 재오픈 금지를 검증했습니다.

## 검증 방법 (Verification method)

- `./venv/bin/python3 -m py_compile harness_codex/runtime/procedure_stages.py harness_codex/runtime/models.py harness_codex/runtime/document_dashboard.py harness_codex/runtime/harvest_ui.py`
- `git diff --check`
- `./venv/bin/python3 -m pytest -q -s tests/test_harvester_skill_instructions.py tests/runtime/test_workflow_loader.py::test_default_harvest_workflow_loads tests/runtime/test_models.py::test_harness_full_workflow_models_top_level_harness_lifecycle tests/runtime/test_models.py::test_harness_full_workflow_starts_with_harvest_then_change_set_intake tests/runtime/test_procedure_stage_runtime.py tests/runtime/test_document_dashboard.py::test_dashboard_projects_completed_ui_workflow_and_generated_use_cases_document tests/runtime/test_document_dashboard.py::test_save_requirements_requires_current_revision_and_stales_downstream_stages tests/runtime/test_harvest_ui.py::test_grill_me_finalization_prompt_uses_compact_history_and_writer_contract`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_workflow_loader.py tests/runtime/test_models.py tests/runtime/test_procedure_stage_runtime.py tests/runtime/test_document_dashboard.py tests/runtime/test_harvest_ui.py tests/runtime/test_interactive_harvest.py`
- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py::test_harvest_plan_outputs_runtime_harvester_stage`
- `./venv/bin/python3 -m pytest -q -s` -> 316 passed

## 위험 및 롤백 (Risks and rollback)

런타임 stage id가 추가되어 기존 ChangeSet 문서가 새 단계를 모를 수 있습니다. 롤백은 이 커밋을 revert하고 harvest workflow와 procedure stage 순서를 기존 요구사항+언어 통합 단계로 되돌리면 됩니다.

Closes #238