### PR TITLE
기술 결정 승인 프리플라이트 게이트 추가

### DIFF
--- a/harness_codex/runtime/changes/resolver.py
+++ b/harness_codex/runtime/changes/resolver.py
@@ -127,6 +127,16 @@ class ChangeSetResolver:
                             "Approve or refine the E2E goal before planning."
                         ),
                     )
+                technical_blocked = _technical_decision_blocker(
+                    self.repo_root,
+                    work_item.work_item_id,
+                    use_case.slice_path / "technical-decisions.md",
+                )
+                if technical_blocked:
+                    return PlanningBlocked(
+                        change_set_id=change_set.change_set_id,
+                        reason=technical_blocked,
+                    )
                 continue
 
             missing = _missing_maintenance_documents(self.repo_root, work_item.slice_path)
@@ -210,6 +220,20 @@ def _use_case_scope(
         change_set.change_set_id,
         use_case.uc_id,
     )
+    planner_inputs = tuple(
+        dict.fromkeys(
+            (
+                *planner_inputs,
+                use_case.slice_path / "use-case.md",
+                use_case.slice_path / "event-storming.md",
+                use_case.slice_path / "ddd-design.md",
+                use_case.slice_path / "technical-decisions.md",
+                use_case.slice_path / "e2e-goal.md",
+                Path("ARCHITECTURE.md"),
+                Path(".codex/repository-settings.md"),
+            )
+        )
+    )
     e2e_goal_path = use_case.slice_path / "e2e-goal.md"
     plan_path = Path(f"docs/plans/active/{use_case.uc_id}/plan.md")
     executor_inputs = tuple(
@@ -218,6 +242,8 @@ def _use_case_scope(
                 plan_path,
                 use_case.slice_path / "use-case.md",
                 use_case.slice_path / "event-storming.md",
+                use_case.slice_path / "ddd-design.md",
+                use_case.slice_path / "technical-decisions.md",
                 e2e_goal_path,
                 change_set_path,
                 Path("ARCHITECTURE.md"),
@@ -289,6 +315,9 @@ def _missing_use_case_documents(
 ) -> tuple[Path, ...]:
     required = (
         slice_path / "use-case.md",
+        slice_path / "event-storming.md",
+        slice_path / "ddd-design.md",
+        slice_path / "technical-decisions.md",
         slice_path / "e2e-goal.md",
     )
     return tuple(path for path in required if not (repo_root / path).exists())
@@ -328,6 +357,35 @@ def _use_case_approval_status(repo_root: Path, e2e_goal_path: Path) -> tuple[boo
     return _approval_status_from_markdown(absolute_path.read_text(encoding="utf-8"))
 
 
+def _technical_decision_blocker(
+    repo_root: Path,
+    uc_id: str,
+    technical_path: Path,
+) -> str | None:
+    absolute_path = repo_root / technical_path
+    text = absolute_path.read_text(encoding="utf-8")
+    approval_found, approval_status = _approval_status_from_markdown(text)
+    normalized_status = approval_status.lower()
+    if not approval_found or normalized_status != APPROVED_STATUS:
+        status = approval_status or ("<missing>" if not approval_found else "<blank>")
+        return (
+            f"Use case work item {uc_id} is waiting for technical-decision approval: "
+            f"status={status} path={technical_path}. "
+            "Approve technical decisions before planning."
+        )
+
+    pending_items = _pending_decision_items_from_markdown(text)
+    if pending_items:
+        preview = "; ".join(pending_items[:3])
+        return (
+            f"Use case work item {uc_id} has pending technical decisions: "
+            f"path={technical_path} pending={preview}. "
+            "Resolve implementation-impacting decisions before planning."
+        )
+
+    return None
+
+
 def _approval_status_from_markdown(text: str) -> tuple[bool, str]:
     for line in text.splitlines():
         stripped = line.strip()
@@ -337,6 +395,32 @@ def _approval_status_from_markdown(text: str) -> tuple[bool, str]:
         if len(cells) >= 2 and cells[0] in {"Approval Status", "승인 상태"}:
             return True, cells[1]
     return False, ""
+
+
+def _pending_decision_items_from_markdown(text: str) -> tuple[str, ...]:
+    in_section = False
+    items: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            heading = stripped.lstrip("#").strip().lower()
+            in_section = (
+                "pending decisions" in heading
+                or "보류 결정" in heading
+                or "미결정" in heading
+            )
+            continue
+        if not in_section:
+            continue
+        if not stripped or stripped.startswith("|") or stripped.startswith("---"):
+            continue
+        item = stripped.lstrip("-*0123456789. ").strip()
+        if not item or item.lower() in {"none", "n/a", "no pending decisions"}:
+            continue
+        if item in {"없음", "해당 없음"}:
+            continue
+        items.append(item)
+    return tuple(items)
 
 
 def _replace_uc_placeholders(

--- a/tests/runtime/test_affected_use_case_resolver.py
+++ b/tests/runtime/test_affected_use_case_resolver.py
@@ -24,10 +24,15 @@ def write_use_case_slice(
     uc_id: str = "UC-001",
     *,
     approval_status: str | None = None,
+    technical_approval_status: str | None = "approved",
+    pending_decisions: str = "- None",
+    include_technical_decisions: bool = True,
 ) -> None:
     slice_dir = tmp_path / "docs/use-cases" / uc_id
     slice_dir.mkdir(parents=True)
     (slice_dir / "use-case.md").write_text("# use case\n", encoding="utf-8")
+    (slice_dir / "event-storming.md").write_text("# event storming\n", encoding="utf-8")
+    (slice_dir / "ddd-design.md").write_text("# ddd design\n", encoding="utf-8")
     if approval_status is not None:
         e2e_goal = f"""# e2e goal
 
@@ -40,6 +45,25 @@ def write_use_case_slice(
     else:
         e2e_goal = "# e2e goal\n"
     (slice_dir / "e2e-goal.md").write_text(e2e_goal, encoding="utf-8")
+    if include_technical_decisions:
+        if technical_approval_status is None:
+            metadata = "|ChangeSet|CHG-001|\n"
+        else:
+            metadata = (
+                "|ChangeSet|CHG-001|\n"
+                f"|Approval Status|{technical_approval_status}|\n"
+            )
+        (slice_dir / "technical-decisions.md").write_text(
+            "# UC-001. Technical Decisions\n\n"
+            "## 1. Metadata\n"
+            "|Item|Value|\n"
+            "|---|---|\n"
+            f"{metadata}"
+            "\n"
+            "## 7. Pending Decisions\n"
+            f"{pending_decisions}\n",
+            encoding="utf-8",
+        )
 
 
 CHANGESET = """# ChangeSet CHG-001
@@ -136,6 +160,8 @@ def test_resolver_builds_per_use_case_planning_scope(tmp_path: Path) -> None:
     assert scope.use_case.uc_id == "UC-001"
     assert Path("docs/changes/active/CHG-001.md") in scope.planner_inputs
     assert Path("docs/use-cases/UC-001/e2e-goal.md") in scope.planner_inputs
+    assert Path("docs/use-cases/UC-001/ddd-design.md") in scope.planner_inputs
+    assert Path("docs/use-cases/UC-001/technical-decisions.md") in scope.planner_inputs
     assert Path("docs/plans/active/UC-001/plan.md") in scope.executor_inputs
     assert scope.e2e_goal_path == Path("docs/use-cases/UC-001/e2e-goal.md")
 
@@ -168,6 +194,67 @@ def test_resolver_blocks_missing_use_case_documents(tmp_path: Path) -> None:
 
     assert isinstance(result, PlanningBlocked)
     assert "Use case work item UC-001 is missing required documents" in result.reason
+
+
+def test_resolver_blocks_missing_technical_decisions_before_planning(
+    tmp_path: Path,
+) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(tmp_path, include_technical_decisions=False)
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "Use case work item UC-001 is missing required documents" in result.reason
+    assert "docs/use-cases/UC-001/technical-decisions.md" in result.reason
+
+
+def test_resolver_blocks_pending_technical_decision_approval_before_planning(
+    tmp_path: Path,
+) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(tmp_path, technical_approval_status="pending")
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "Use case work item UC-001 is waiting for technical-decision approval" in result.reason
+    assert "status=pending" in result.reason
+    assert "docs/use-cases/UC-001/technical-decisions.md" in result.reason
+
+
+def test_resolver_blocks_missing_technical_decision_approval_before_planning(
+    tmp_path: Path,
+) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(tmp_path, technical_approval_status=None)
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "status=<missing>" in result.reason
+    assert "docs/use-cases/UC-001/technical-decisions.md" in result.reason
+
+
+def test_resolver_blocks_pending_technical_decision_items_before_planning(
+    tmp_path: Path,
+) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(
+        tmp_path,
+        pending_decisions="- Transaction boundary for payment confirmation is not decided.",
+    )
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "Use case work item UC-001 has pending technical decisions" in result.reason
+    assert "Transaction boundary for payment confirmation is not decided" in result.reason
+    assert "docs/use-cases/UC-001/technical-decisions.md" in result.reason
 
 
 def test_resolver_blocks_pending_e2e_approval_before_planning(tmp_path: Path) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -67,6 +67,25 @@ def write_use_case_slice(repo: Path, uc_id: str) -> None:
         f"# {uc_id} Event Storming\n",
         encoding="utf-8",
     )
+    (use_case_dir / "ddd-design.md").write_text(
+        f"# {uc_id} DDD Design\n",
+        encoding="utf-8",
+    )
+    (use_case_dir / "technical-decisions.md").write_text(
+        f"""# {uc_id}. Technical Decisions
+
+## 1. Metadata
+|Item|Value|
+|---|---|
+|ChangeSet|CHG-001|
+|Use Case|{uc_id}|
+|Approval Status|approved|
+
+## 7. Pending Decisions
+- None
+""",
+        encoding="utf-8",
+    )
     (use_case_dir / "affected-files.md").write_text(
         f"# {uc_id} Affected Files\n",
         encoding="utf-8",
@@ -318,7 +337,7 @@ def test_harvest_apply_warns_and_uses_interactive_runtime(
     assert "harvest requires one of --plan or --interactive" in captured.err
 
 
-def test_changes_create_from_design_generates_runnable_slice(
+def test_changes_create_from_design_blocks_planning_before_decision_gates(
     tmp_path: Path,
     capsys,
 ) -> None:
@@ -365,9 +384,10 @@ def test_changes_create_from_design_generates_runnable_slice(
 
     preview = capsys.readouterr().out
     assert exit_code == 0
-    assert "Mode: preview" in preview
-    assert "UC: UC-001" in preview
-    assert "docs/use-cases/UC-001/use-case.md" in preview
+    assert "BLOCKED:" in preview
+    assert "UC-001" in preview
+    assert "docs/use-cases/UC-001/ddd-design.md" in preview
+    assert "docs/use-cases/UC-001/technical-decisions.md" in preview
 
 
 def test_changes_create_from_design_prompts_for_title_and_change_set_id(


### PR DESCRIPTION
## 구현 의도 (Implementation intent)
#242에서 요구한 런타임 계획 프리플라이트 게이트를 강화합니다. 유스케이스 작업 항목은 계획 단계에 들어가기 전에 이벤트 스토밍, DDD 설계, 승인된 기술 결정 문서를 갖추고 있어야 합니다.

## 구현 방식 (Implementation approach)
`ChangeSetResolver`가 유스케이스 필수 문서에 `event-storming.md`, `ddd-design.md`, `technical-decisions.md`를 포함하도록 확장했습니다. 기술 결정 문서의 `Approval Status`가 `approved`가 아니거나 `Pending Decisions` 섹션에 구현 영향 항목이 남아 있으면 `PlanningBlocked`를 반환합니다. 계획/실행 입력에도 DDD 설계와 기술 결정 문서를 포함해 플래너가 승인된 결정을 받도록 했습니다. maintenance 작업 항목은 기존처럼 maintenance 전용 필수 문서만 요구합니다.

## 검증 방법 (Verification method)
- `./venv/bin/python3 -m py_compile harness_codex/runtime/changes/resolver.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_affected_use_case_resolver.py tests/runtime/test_procedure_stage_runtime.py tests/test_cli_commands.py`
- `./venv/bin/python3 -m pytest -q -s`

## 위험 및 롤백 (Risks and rollback)
이 변경은 계획 단계 진입 조건을 강화하므로, 기존에 기술 결정 문서 없이 바로 계획하던 유스케이스는 차단됩니다. 문제가 생기면 이 커밋을 되돌려 기존 프리플라이트 범위로 복구할 수 있습니다.

Closes #242