### PR TITLE
[codex] 런타임 보정 루프 강제

### DIFF
--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -77,6 +77,19 @@ steps:
         - scope conflict
         - environment blocker
         - verification goal unclear
+      on_implementation_failure: remediate-work-item
+
+  - id: remediate-work-item
+    kind: record
+    name: Append remediation task and retry execution
+    needs: [classify-verification-result]
+    outputs:
+      - docs/plans/active/<WORK-ITEM-ID>/plan.md
+    metadata:
+      stage: remediation
+      scope: work_item
+      loop_target: execute-work-item
+      max_retry_count: 2
 
   - id: complete-work-item-plan
     kind: git

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -13,12 +13,14 @@ from harness_codex.runtime import (
     AgentContextBootstrapResult,
     BasicStepRunner,
     ChangeSetCompletionBlocked,
+    FailureKind,
     ReportWriter,
     ResumeDisposition,
     RunnerEngine,
     RunContext,
     RunMode,
     RunReport,
+    RunFailureKind,
     RunState,
     RunStateStore,
     RunStatus,
@@ -1238,6 +1240,7 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
 
     result_by_work_item = {}
     final_result = None
+    final_scope = None
     for scope in scopes:
         materialized_workflow = materialize_workflow_for_scope(workflow, change_set, scope)
         write_materialized_workflow_manifest(
@@ -1291,12 +1294,14 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
         scope_result = RunnerEngine(BasicStepRunner()).run(materialized_workflow, context)
         result_by_work_item[scope.display_id] = scope_result
         final_result = scope_result
+        final_scope = scope
         if scope_result.status != RunStatus.SUCCEEDED:
             break
 
     if final_result is None:
         raise RuntimeError("workflow execution requires at least one ChangeSet work item")
 
+    current_scope = final_scope or scopes[0]
     state = RunState(
         run_id=run_id,
         change_set_id=change_set.change_set_id,
@@ -1304,9 +1309,12 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
         mode=RunMode.APPLY,
         affected_use_cases=affected_use_cases,
         affected_work_items=affected_work_items,
-        current_use_case_id=affected_use_cases[0] if affected_use_cases else None,
-        current_work_item_id=affected_work_items[0] if affected_work_items else None,
+        current_use_case_id=(
+            current_scope.use_case.uc_id if current_scope.use_case is not None else None
+        ),
+        current_work_item_id=current_scope.display_id,
         status=final_result.status,
+        failure_kind=_run_failure_kind(final_result.failure_kind),
         work_item_states=tuple(
             WorkItemLoopState(
                 work_item_id=scope.display_id,
@@ -1316,6 +1324,10 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
                 status=result_by_work_item.get(scope.display_id, final_result).status,
                 current_step_id=scope.current_stage,
                 verification_status=result_by_work_item.get(scope.display_id, final_result).status.value,
+                retry_count=result_by_work_item.get(scope.display_id, final_result).retry_count,
+                failure_kind=_run_failure_kind(
+                    result_by_work_item.get(scope.display_id, final_result).failure_kind
+                ),
                 blocker=result_by_work_item.get(scope.display_id, final_result).blocker,
             )
             for scope in scopes
@@ -1326,6 +1338,10 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
                 active_plan_path=scope.plan_path
                 or Path(f"docs/plans/active/{scope.use_case.uc_id}/plan.md"),
                 status=result_by_work_item.get(scope.display_id, final_result).status,
+                retry_count=result_by_work_item.get(scope.display_id, final_result).retry_count,
+                failure_kind=_run_failure_kind(
+                    result_by_work_item.get(scope.display_id, final_result).failure_kind
+                ),
                 blocker=result_by_work_item.get(scope.display_id, final_result).blocker,
             )
             for scope in scopes
@@ -1360,6 +1376,18 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
         )
     )
     return state, final_result
+
+
+def _run_failure_kind(failure_kind: FailureKind | None) -> RunFailureKind | None:
+    if failure_kind == FailureKind.IMPLEMENTATION:
+        return RunFailureKind.IMPLEMENTATION_FAILURE
+    if failure_kind == FailureKind.UPSTREAM_DESIGN:
+        return RunFailureKind.UPSTREAM_DESIGN_CONFLICT
+    if failure_kind == FailureKind.ENVIRONMENT_BLOCKER:
+        return RunFailureKind.ENVIRONMENT_BLOCKER
+    if failure_kind == FailureKind.UNKNOWN:
+        return RunFailureKind.UNCLEAR_E2E_GOAL
+    return None
 
 
 def _latest_run_id_for_change_set(repo_root: Path, change_set_id: str) -> str | None:

--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -11,6 +11,7 @@ from collections import deque
 from dataclasses import dataclass, replace
 
 from harness_codex.runtime.models import (
+    FailureKind,
     RunContext,
     RunResult,
     RunStatus,
@@ -39,6 +40,13 @@ class ExecutionPlan:
         """Return step IDs in execution order."""
 
         return tuple(step.id for step in self.steps)
+
+
+@dataclass(frozen=True)
+class _RemediationPath:
+    decision_step: Step
+    remediation_step: Step
+    loop_target_step: Step
 
 
 class RunnerEngine:
@@ -71,8 +79,25 @@ class RunnerEngine:
             return self._dry_run_result(execution_plan, context)
 
         results: list[StepResult] = []
+        retry_count = 0
+        max_retries = self._max_remediation_retries(workflow, context)
+        previous_failure_signature: tuple[str, str, str] | None = None
+        next_index = 0
+        skipped_runtime_steps: set[str] = set()
+        step_index = {
+            step.id: index for index, step in enumerate(execution_plan.steps)
+        }
 
-        for step in execution_plan.steps:
+        while next_index < len(execution_plan.steps):
+            step = execution_plan.steps[next_index]
+            next_index += 1
+
+            if step.id in skipped_runtime_steps:
+                continue
+
+            if self._is_runtime_remediation_step(step):
+                continue
+
             decision = self._evaluate_command_policy(step, context)
             if decision is not None and not decision.allowed:
                 result = StepResult(
@@ -90,6 +115,7 @@ class RunnerEngine:
                     mode=context.mode,
                     failed_step_id=step.id,
                     blocker=decision.reason,
+                    retry_count=retry_count,
                     metadata=self._result_metadata(
                         execution_plan,
                         context,
@@ -109,13 +135,120 @@ class RunnerEngine:
             results.append(result)
 
             if result.status == StepStatus.FAILED:
+                remediation = self._remediation_path(execution_plan, step, result)
+                if remediation is not None:
+                    signature = (
+                        step.id,
+                        result.failure_kind.value if result.failure_kind else "",
+                        result.error or "",
+                    )
+                    if (
+                        previous_failure_signature == signature
+                        or retry_count >= max_retries
+                    ):
+                        return RunResult(
+                            run_id=context.run_id,
+                            status=RunStatus.BLOCKED,
+                            step_results=tuple(results),
+                            mode=context.mode,
+                            failed_step_id=step.id,
+                            failure_kind=result.failure_kind,
+                            blocker=result.error,
+                            retry_count=retry_count,
+                            metadata=self._result_metadata(
+                                execution_plan,
+                                context,
+                                tuple(results),
+                                extra={
+                                    "remediation_blocked": True,
+                                    "max_remediation_retries": max_retries,
+                                    "repeated_failure": (
+                                        previous_failure_signature == signature
+                                    ),
+                                },
+                            ),
+                        )
+                    previous_failure_signature = signature
+                    retry_count += 1
+                    decision_result = self._run_runtime_step(
+                        remediation.decision_step,
+                        context,
+                        results,
+                        retry_count=retry_count,
+                        failed_step=step,
+                        failed_result=result,
+                    )
+                    if decision_result.status != StepStatus.SUCCEEDED:
+                        return self._blocked_result(
+                            execution_plan,
+                            context,
+                            tuple(results),
+                            decision_result,
+                            retry_count,
+                        )
+                    remediation_result = self._run_runtime_step(
+                        remediation.remediation_step,
+                        context,
+                        results,
+                        retry_count=retry_count,
+                        failed_step=step,
+                        failed_result=result,
+                    )
+                    if remediation_result.status != StepStatus.SUCCEEDED:
+                        return self._blocked_result(
+                            execution_plan,
+                            context,
+                            tuple(results),
+                            remediation_result,
+                            retry_count,
+                        )
+                    skipped_runtime_steps.add(remediation.remediation_step.id)
+                    next_index = step_index[remediation.loop_target_step.id]
+                    continue
+
+                decision_step = self._failure_decision_step(execution_plan, step)
+                if decision_step is not None:
+                    decision_result = self._run_runtime_step(
+                        decision_step,
+                        context,
+                        results,
+                        retry_count=retry_count,
+                        failed_step=step,
+                        failed_result=result,
+                    )
+                    if decision_result.status != StepStatus.SUCCEEDED:
+                        return self._blocked_result(
+                            execution_plan,
+                            context,
+                            tuple(results),
+                            decision_result,
+                            retry_count,
+                        )
+                    return RunResult(
+                        run_id=context.run_id,
+                        status=RunStatus.BLOCKED,
+                        step_results=tuple(results),
+                        mode=context.mode,
+                        failed_step_id=step.id,
+                        failure_kind=result.failure_kind,
+                        blocker=result.error,
+                        retry_count=retry_count,
+                        metadata=self._result_metadata(
+                            execution_plan,
+                            context,
+                            tuple(results),
+                        ),
+                    )
+
                 return RunResult(
                     run_id=context.run_id,
                     status=RunStatus.FAILED,
                     step_results=tuple(results),
                     mode=context.mode,
                     failed_step_id=step.id,
+                    failure_kind=result.failure_kind,
                     blocker=result.error,
+                    retry_count=retry_count,
                     metadata=self._result_metadata(
                         execution_plan,
                         context,
@@ -130,7 +263,9 @@ class RunnerEngine:
                     step_results=tuple(results),
                     mode=context.mode,
                     failed_step_id=step.id,
+                    failure_kind=result.failure_kind,
                     blocker=result.error,
+                    retry_count=retry_count,
                     metadata=self._result_metadata(
                         execution_plan,
                         context,
@@ -143,6 +278,7 @@ class RunnerEngine:
             status=RunStatus.SUCCEEDED,
             step_results=tuple(results),
             mode=context.mode,
+            retry_count=retry_count,
             metadata=self._result_metadata(execution_plan, context, tuple(results)),
         )
 
@@ -212,6 +348,7 @@ class RunnerEngine:
         execution_plan: ExecutionPlan,
         context: RunContext,
         step_results: tuple[StepResult, ...] = (),
+        extra: dict[str, object] | None = None,
     ) -> dict[str, object]:
         policy_decisions = tuple(
             result.metadata["policy_decision"]
@@ -219,13 +356,64 @@ class RunnerEngine:
             if "policy_decision" in result.metadata
         )
 
-        return {
+        metadata: dict[str, object] = {
             "mode": context.mode.value,
             "workflow_name": context.workflow_name,
             "planned_steps": execution_plan.step_ids(),
             "side_effects": context.mode == RunMode.APPLY,
             "policy_decisions": policy_decisions,
         }
+        if extra:
+            metadata.update(extra)
+        return metadata
+
+    def _run_runtime_step(
+        self,
+        step: Step,
+        context: RunContext,
+        results: list[StepResult],
+        *,
+        retry_count: int,
+        failed_step: Step,
+        failed_result: StepResult,
+    ) -> StepResult:
+        runtime_context = replace(
+            context,
+            metadata={
+                **dict(context.metadata),
+                "runtime_retry_count": retry_count,
+                "runtime_failed_step_id": failed_step.id,
+                "runtime_failure_kind": (
+                    failed_result.failure_kind.value
+                    if failed_result.failure_kind is not None
+                    else ""
+                ),
+                "runtime_failure_error": failed_result.error or "",
+            },
+        )
+        result = self._step_runner.run(step, runtime_context)
+        results.append(result)
+        return result
+
+    def _blocked_result(
+        self,
+        execution_plan: ExecutionPlan,
+        context: RunContext,
+        results: tuple[StepResult, ...],
+        result: StepResult,
+        retry_count: int,
+    ) -> RunResult:
+        return RunResult(
+            run_id=context.run_id,
+            status=RunStatus.BLOCKED,
+            step_results=results,
+            mode=context.mode,
+            failed_step_id=result.step_id,
+            failure_kind=result.failure_kind,
+            blocker=result.error,
+            retry_count=retry_count,
+            metadata=self._result_metadata(execution_plan, context, results),
+        )
 
     def _evaluate_command_policy(
         self,
@@ -248,6 +436,77 @@ class RunnerEngine:
                 workdir=context.workdir,
             )
         )
+
+    def _remediation_path(
+        self,
+        execution_plan: ExecutionPlan,
+        failed_step: Step,
+        failed_result: StepResult,
+    ) -> _RemediationPath | None:
+        if failed_result.failure_kind != FailureKind.IMPLEMENTATION:
+            return None
+
+        decision_step = self._failure_decision_step(execution_plan, failed_step)
+        if decision_step is None:
+            return None
+
+        steps_by_id = {step.id: step for step in execution_plan.steps}
+        remediation_steps = tuple(
+            step
+            for step in execution_plan.steps
+            if decision_step.id in step.needs and self._is_runtime_remediation_step(step)
+        )
+        if not remediation_steps:
+            return None
+
+        remediation_step = remediation_steps[0]
+        loop_target_id = str(remediation_step.metadata.get("loop_target", ""))
+        loop_target_step = steps_by_id.get(loop_target_id)
+        if loop_target_step is None:
+            return None
+
+        return _RemediationPath(
+            decision_step=decision_step,
+            remediation_step=remediation_step,
+            loop_target_step=loop_target_step,
+        )
+
+    def _failure_decision_step(
+        self,
+        execution_plan: ExecutionPlan,
+        failed_step: Step,
+    ) -> Step | None:
+        for step in execution_plan.steps:
+            if failed_step.id in step.needs and step.kind == StepKind.DECISION:
+                return step
+        return None
+
+    def _is_runtime_remediation_step(self, step: Step) -> bool:
+        return bool(step.metadata.get("loop_target"))
+
+    def _max_remediation_retries(
+        self,
+        workflow: Workflow,
+        context: RunContext,
+    ) -> int:
+        value = (
+            context.metadata.get("max_remediation_retries")
+            or workflow.metadata.get("max_remediation_retries")
+            or next(
+                (
+                    step.metadata.get("max_retry_count")
+                    for step in workflow.steps
+                    if self._is_runtime_remediation_step(step)
+                    and step.metadata.get("max_retry_count") is not None
+                ),
+                None,
+            )
+            or 2
+        )
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return 2
 
     def _index_steps(self, workflow: Workflow) -> dict[str, Step]:
         steps_by_id: dict[str, Step] = {}

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -165,7 +165,9 @@ class RunResult:
     step_results: tuple[StepResult, ...]
     mode: RunMode | None = None
     failed_step_id: str | None = None
+    failure_kind: FailureKind | None = None
     blocker: str | None = None
+    retry_count: int = 0
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
 

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -309,6 +309,9 @@ class BasicStepRunner:
         )
 
     def _run_record(self, step: Step, context: RunContext, step_dir: Path) -> StepResult:
+        if step.metadata.get("loop_target"):
+            return _append_runtime_remediation_task(step, context, step_dir)
+
         missing = tuple(path for path in step.inputs if not (context.repo_root / path).exists())
         evidence = step_dir / "record.json"
         evidence.write_text(
@@ -413,6 +416,82 @@ def _work_item_id_from_plan_path(path: Path) -> str | None:
 def _context_string(context: RunContext, key: str) -> str | None:
     value = context.metadata.get(key)
     return value if isinstance(value, str) and value else None
+
+
+def _append_runtime_remediation_task(
+    step: Step,
+    context: RunContext,
+    step_dir: Path,
+) -> StepResult:
+    plan_path = _runtime_remediation_plan_path(step, context)
+    if plan_path is None:
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.BLOCKED,
+            error="remediation plan path is required",
+            failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
+        )
+
+    absolute_plan_path = context.repo_root / plan_path
+    if not absolute_plan_path.exists():
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.BLOCKED,
+            error=f"missing remediation plan: {plan_path}",
+            failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
+        )
+
+    retry_count = _context_string(context, "runtime_retry_count") or "1"
+    failed_step_id = _context_string(context, "runtime_failed_step_id") or "verification"
+    failure_kind = _context_string(context, "runtime_failure_kind") or "implementation"
+    error = _first_line(_context_string(context, "runtime_failure_error") or "")
+    task = (
+        "\n"
+        "## Runtime Remediation\n\n"
+        f"- [ ] Retry {retry_count}: fix `{failed_step_id}` ({failure_kind})"
+    )
+    if error:
+        task += f" - {error}"
+    task += "\n"
+
+    absolute_plan_path.write_text(
+        absolute_plan_path.read_text(encoding="utf-8").rstrip() + task,
+        encoding="utf-8",
+    )
+    evidence = step_dir / "remediation.json"
+    evidence.write_text(
+        json.dumps(
+            {
+                "step_id": step.id,
+                "plan_path": str(plan_path),
+                "retry_count": retry_count,
+                "failed_step_id": failed_step_id,
+                "failure_kind": failure_kind,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return StepResult(
+        step_id=step.id,
+        status=StepStatus.SUCCEEDED,
+        output_path=_relative_to_repo(evidence, context),
+    )
+
+
+def _runtime_remediation_plan_path(step: Step, context: RunContext) -> Path | None:
+    if step.outputs:
+        return step.outputs[0]
+    active_plan = _context_string(context, "active_plan_path")
+    if active_plan:
+        return Path(active_plan)
+    return context.active_plan_path
+
+
+def _first_line(value: str) -> str:
+    return value.strip().splitlines()[0][:240] if value.strip() else ""
 
 
 def _load_agent_config(path: Path) -> Mapping[str, Any]:

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -222,6 +222,43 @@ def test_basic_step_runner_invokes_agent_adapter_and_writes_result(
     assert result_json["metadata"] == {"fake": True}
 
 
+def test_basic_step_runner_appends_runtime_remediation_task(tmp_path: Path) -> None:
+    plan_path = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan_path.parent.mkdir(parents=True)
+    plan_path.write_text("# Plan\n\n- [x] Existing task\n", encoding="utf-8")
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    run_context = RunContext(
+        run_id="run-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-001",
+        metadata={
+            "runtime_retry_count": "1",
+            "runtime_failed_step_id": "verify-work-item",
+            "runtime_failure_kind": "implementation",
+            "runtime_failure_error": "missing branch\nextra details",
+        },
+    )
+    step = Step(
+        id="remediate-work-item",
+        kind=StepKind.RECORD,
+        name="Remediate",
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        metadata={"loop_target": "execute-work-item"},
+    )
+
+    result = runner.run(step, run_context)
+
+    assert result.status == StepStatus.SUCCEEDED
+    plan_text = plan_path.read_text(encoding="utf-8")
+    assert "## Runtime Remediation" in plan_text
+    assert "- [ ] Retry 1: fix `verify-work-item` (implementation)" in plan_text
+    assert "missing branch" in plan_text
+    assert "extra details" not in plan_text
+
+
 def test_basic_step_runner_records_skill_invocation_manifest(tmp_path: Path) -> None:
     write_agent_config(tmp_path)
     write_skill(tmp_path)

--- a/tests/runtime/test_engine.py
+++ b/tests/runtime/test_engine.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from harness_codex.runtime import (
+    FailureKind,
     RunContext,
     RunMode,
     RunStatus,
@@ -28,7 +29,10 @@ class FakeStepRunner:
         self.executed_step_ids.append(step.id)
 
         if step.id in self.results_by_step_id:
-            return self.results_by_step_id[step.id]
+            result = self.results_by_step_id[step.id]
+            if isinstance(result, list):
+                return result.pop(0)
+            return result
 
         return StepResult(
             step_id=step.id,
@@ -176,6 +180,139 @@ def test_engine_stops_when_step_is_blocked() -> None:
     assert result.failed_step_id == "analyze"
     assert result.blocker == "missing plan.md"
     assert fake_runner.executed_step_ids == ["analyze"]
+
+
+def test_engine_loops_implementation_failure_through_remediation() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="plan", kind=StepKind.AGENT, name="Plan"),
+            Step(
+                id="execute",
+                kind=StepKind.AGENT,
+                name="Execute",
+                needs=("plan",),
+            ),
+            Step(
+                id="verify",
+                kind=StepKind.VALIDATOR,
+                name="Verify",
+                needs=("execute",),
+            ),
+            Step(
+                id="classify",
+                kind=StepKind.DECISION,
+                name="Classify",
+                needs=("verify",),
+            ),
+            Step(
+                id="remediate",
+                kind=StepKind.RECORD,
+                name="Remediate",
+                needs=("classify",),
+                metadata={"loop_target": "execute", "max_retry_count": 2},
+            ),
+            Step(
+                id="complete",
+                kind=StepKind.RECORD,
+                name="Complete",
+                needs=("classify",),
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner(
+        results_by_step_id={
+            "verify": [
+                StepResult(
+                    step_id="verify",
+                    status=StepStatus.FAILED,
+                    error="missing branch",
+                    failure_kind=FailureKind.IMPLEMENTATION,
+                ),
+                StepResult(step_id="verify", status=StepStatus.SUCCEEDED),
+            ],
+        }
+    )
+
+    result = RunnerEngine(fake_runner).run(workflow, context())
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.retry_count == 1
+    assert fake_runner.executed_step_ids == [
+        "plan",
+        "execute",
+        "verify",
+        "classify",
+        "remediate",
+        "execute",
+        "verify",
+        "classify",
+        "complete",
+    ]
+
+
+def test_engine_blocks_non_implementation_failure_without_remediation() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="plan", kind=StepKind.AGENT, name="Plan"),
+            Step(
+                id="execute",
+                kind=StepKind.AGENT,
+                name="Execute",
+                needs=("plan",),
+            ),
+            Step(
+                id="verify",
+                kind=StepKind.VALIDATOR,
+                name="Verify",
+                needs=("execute",),
+            ),
+            Step(
+                id="classify",
+                kind=StepKind.DECISION,
+                name="Classify",
+                needs=("verify",),
+            ),
+            Step(
+                id="remediate",
+                kind=StepKind.RECORD,
+                name="Remediate",
+                needs=("classify",),
+                metadata={"loop_target": "execute"},
+            ),
+            Step(
+                id="complete",
+                kind=StepKind.RECORD,
+                name="Complete",
+                needs=("classify",),
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner(
+        results_by_step_id={
+            "verify": StepResult(
+                step_id="verify",
+                status=StepStatus.FAILED,
+                error="database unavailable",
+                failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
+            ),
+        }
+    )
+
+    result = RunnerEngine(fake_runner).run(workflow, context())
+
+    assert result.status == RunStatus.BLOCKED
+    assert result.failure_kind == FailureKind.ENVIRONMENT_BLOCKER
+    assert result.retry_count == 0
+    assert fake_runner.executed_step_ids == [
+        "plan",
+        "execute",
+        "verify",
+        "classify",
+    ]
 
 
 def test_plan_rejects_duplicate_step_ids() -> None:

--- a/tests/runtime/test_run_state_resume.py
+++ b/tests/runtime/test_run_state_resume.py
@@ -32,6 +32,19 @@ def test_run_state_store_round_trips_json(tmp_path: Path) -> None:
                 active_plan_path=Path("docs/plans/active/UC-001/plan.md"),
                 status=RunStatus.RUNNING,
                 current_step_id=UseCaseStep.VERIFY,
+                retry_count=1,
+                failure_kind=RunFailureKind.IMPLEMENTATION_FAILURE,
+            ),
+        ),
+        work_item_states=(
+            WorkItemLoopState(
+                work_item_id="UC-001",
+                work_item_type=WorkItemType.USE_CASE,
+                active_plan_path=Path("docs/plans/active/UC-001/plan.md"),
+                status=RunStatus.RUNNING,
+                current_step_id="verify",
+                retry_count=1,
+                failure_kind=RunFailureKind.IMPLEMENTATION_FAILURE,
             ),
         ),
     )

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -125,6 +125,10 @@ def test_default_changeset_work_item_workflow_loads() -> None:
         "harness-plan-executor"
     )
     assert workflow.step_by_id("verify-work-item").command
+    remediation = workflow.step_by_id("remediate-work-item")
+    assert remediation.needs == ("classify-verification-result",)
+    assert remediation.metadata["loop_target"] == "execute-work-item"
+    assert Path("docs/plans/active/<WORK-ITEM-ID>/plan.md") in remediation.outputs
 
 
 def test_default_harvest_workflow_loads() -> None:


### PR DESCRIPTION
## 구현 의도

이 PR은 #241에서 요청한 런타임 수준 보정 루프를 구현합니다. 검증 실패 후 모델 지시문에만 의존하지 않고, 런타임이 구현 실패만 보정 대상으로 분류하고 실행 단계로 되돌아가도록 합니다.

## 구현 접근

- `changeset-use-case-workflow`에 `remediate-work-item` 단계를 추가하고 `classify-verification-result -> remediate-work-item -> execute-work-item` 루프 대상을 명시했습니다.
- `RunnerEngine`이 검증 실패를 받으면 실패 종류를 확인하고, `implementation` 실패일 때만 분류 단계와 보정 단계를 실행한 뒤 실행 단계부터 재시도합니다.
- 보정 단계는 활성 계획 파일에 런타임 보정 작업을 추가하고, 최대 재시도 수와 반복 실패 감지로 루프를 차단합니다.
- `RunResult`와 CLI 상태 저장에 `failure_kind`, `retry_count`를 반영해 재개 대상 계산이 실패 종류와 보정 횟수를 기준으로 동작하도록 했습니다.

## 검증 방법

- `./venv/bin/python3 -m py_compile harness_codex/runtime/engine.py harness_codex/runtime/runner.py harness_codex/runtime/models.py harness_codex/cli.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_engine.py tests/runtime/test_agent_runner.py tests/runtime/test_run_state_resume.py tests/runtime/test_workflow_loader.py` → 60 passed
- `./venv/bin/python3 -m pytest -q -s tests/runtime --ignore=tests/runtime/test_ui_server_restart.py` → 261 passed
- 참고: `./venv/bin/python3 -m pytest -q -s tests/runtime`는 기존 UI 서버 재시작 테스트 `tests/runtime/test_ui_server_restart.py::test_ui_server_restarts_existing_server_for_repo`에서 readiness timeout으로 실패했습니다. 변경 파일과 직접 관련 없는 서버 포트/재시작 경로입니다.

## 위험 및 롤백

- 위험: 보정 루프 조건이 잘못 분류되면 런타임이 재시도하지 않거나 불필요하게 차단될 수 있습니다.
- 완화: 구현 실패만 루프 대상으로 제한하고, 비구현 실패는 보정 작업을 추가하지 않고 차단하도록 테스트했습니다.
- 롤백: 이 커밋을 되돌리면 워크플로는 기존 선형 실행 방식으로 복귀합니다.

Closes #241
