### PR TITLE
[codex] 워크아이템 검증 게이트를 제품 검증으로 교체

### DIFF
--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -55,11 +55,16 @@ steps:
     kind: validator
     name: Verify work item against E2E or maintenance verification goal
     needs: [execute-work-item]
-    command: ./venv/bin/python3 -m pytest -q -s tests/runtime
+    command: python3 -m harness_codex.runtime.verify_work_item --change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>
     timeout_sec: 600
     inputs:
       - docs/plans/active/<WORK-ITEM-ID>/plan.md
+      - docs/use-cases/<UC-ID>/e2e-goal.md
+      - docs/maintenance/<MAINT-ID>/verification-goal.md
       - .codex/test-gate.yaml
+    outputs:
+      - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json
+      - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/verification.md
     metadata:
       stage: verification
       scope: work_item

--- a/harness_codex/runtime/verify_work_item.py
+++ b/harness_codex/runtime/verify_work_item.py
@@ -1,0 +1,427 @@
+"""Work-item product verification command.
+
+The runtime uses this module as the ChangeSet work-item verification gate. It
+reads the active plan, the E2E or maintenance verification goal, and the project
+test gate, then records command evidence under `.harness/runs/<RUN-ID>/`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+import yaml
+
+
+@dataclass(frozen=True)
+class VerificationCommand:
+    name: str
+    command: str
+    source: str
+
+
+@dataclass(frozen=True)
+class WorkItemCommandResult:
+    name: str
+    command: str
+    source: str
+    exit_code: int
+    stdout_path: Path
+    stderr_path: Path
+
+    @property
+    def passed(self) -> bool:
+        return self.exit_code == 0
+
+
+@dataclass(frozen=True)
+class WorkItemVerificationResult:
+    change_set_id: str
+    work_item_id: str
+    plan_path: Path
+    verification_goal_path: Path
+    test_gate_path: Path
+    evidence_dir: Path
+    command_results: tuple[WorkItemCommandResult, ...]
+    missing_obligations: tuple[str, ...] = ()
+    blocker: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.blocker is None
+            and not self.missing_obligations
+            and bool(self.command_results)
+            and all(result.passed for result in self.command_results)
+        )
+
+
+_BACKTICK_COMMAND = re.compile(r"`([^`]+)`")
+_CHECKBOX = re.compile(r"^\s*[-*]\s+\[[xX ]\]\s*(?P<body>.+)$")
+_OBLIGATION_KEYWORDS = {
+    "build": ("build",),
+    "tests": ("test", "unit", "integration"),
+    "e2e": ("e2e", "end-to-end"),
+    "runtime-server": (
+        "runtime server",
+        "server verification",
+        "bootrun",
+        "http",
+        "ui check",
+    ),
+    "static-analysis": ("static", "lint", "semgrep", "architecture"),
+}
+
+
+def verify_work_item(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    run_id: str,
+) -> WorkItemVerificationResult:
+    root = Path(repo_root)
+    plan_path = Path("docs/plans/active") / work_item_id / "plan.md"
+    goal_path = _verification_goal_path(root, work_item_id)
+    test_gate_path = Path(".codex/test-gate.yaml")
+    evidence_dir = (
+        Path(".harness/runs") / run_id / "work-items" / work_item_id / "verification"
+    )
+    absolute_evidence_dir = root / evidence_dir
+    absolute_evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    missing_files = _missing_required_files(root, (plan_path, goal_path))
+    if missing_files:
+        result = WorkItemVerificationResult(
+            change_set_id=change_set_id,
+            work_item_id=work_item_id,
+            plan_path=plan_path,
+            verification_goal_path=goal_path,
+            test_gate_path=test_gate_path,
+            evidence_dir=evidence_dir,
+            command_results=(),
+            blocker="missing required verification files: " + ", ".join(missing_files),
+        )
+        _write_reports(root, result)
+        return result
+
+    plan_text = (root / plan_path).read_text(encoding="utf-8")
+    goal_text = (root / goal_path).read_text(encoding="utf-8")
+    missing_obligations = _missing_plan_obligations(plan_text)
+    commands = _dedupe_commands(
+        (
+            *_commands_from_markdown(plan_text, str(plan_path)),
+            *_commands_from_markdown(goal_text, str(goal_path)),
+            *_commands_from_test_gate(root / test_gate_path),
+        )
+    )
+
+    if not commands:
+        result = WorkItemVerificationResult(
+            change_set_id=change_set_id,
+            work_item_id=work_item_id,
+            plan_path=plan_path,
+            verification_goal_path=goal_path,
+            test_gate_path=test_gate_path,
+            evidence_dir=evidence_dir,
+            command_results=(),
+            missing_obligations=missing_obligations,
+            blocker="no product verification commands found in plan, verification goal, or test gate",
+        )
+        _write_reports(root, result)
+        return result
+
+    command_results = tuple(
+        _run_command(root, absolute_evidence_dir, index, command)
+        for index, command in enumerate(commands, start=1)
+    )
+    result = WorkItemVerificationResult(
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        plan_path=plan_path,
+        verification_goal_path=goal_path,
+        test_gate_path=test_gate_path,
+        evidence_dir=evidence_dir,
+        command_results=command_results,
+        missing_obligations=missing_obligations,
+        blocker=(
+            "plan verification obligations are missing executable command evidence"
+            if missing_obligations
+            else None
+        ),
+    )
+    _write_reports(root, result)
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify one ChangeSet work item against product verification gates."
+    )
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--change-set", required=True)
+    parser.add_argument("--work-item", required=True)
+    parser.add_argument("--run-id", required=True)
+    args = parser.parse_args(argv)
+
+    result = verify_work_item(
+        args.repo_root,
+        change_set_id=args.change_set,
+        work_item_id=args.work_item,
+        run_id=args.run_id,
+    )
+    status = "PASS" if result.passed else "FAIL"
+    print(f"{status} work-item verification: {result.evidence_dir / 'report.json'}")
+    if result.blocker:
+        print(result.blocker)
+    for obligation in result.missing_obligations:
+        print(f"missing: {obligation}")
+    return 0 if result.passed else 1
+
+
+def _verification_goal_path(repo_root: Path, work_item_id: str) -> Path:
+    use_case_goal = Path("docs/use-cases") / work_item_id / "e2e-goal.md"
+    if (repo_root / use_case_goal).exists():
+        return use_case_goal
+    return Path("docs/maintenance") / work_item_id / "verification-goal.md"
+
+
+def _missing_required_files(repo_root: Path, paths: Iterable[Path]) -> list[str]:
+    return [str(path) for path in paths if not (repo_root / path).is_file()]
+
+
+def _commands_from_markdown(text: str, source: str) -> tuple[VerificationCommand, ...]:
+    commands: list[VerificationCommand] = []
+    for line in text.splitlines():
+        lowered = line.lower()
+        if "required" not in lowered and _CHECKBOX.match(line) is None:
+            continue
+        for raw_command in _BACKTICK_COMMAND.findall(line):
+            command = raw_command.strip()
+            if _is_executable_verification_command(command):
+                commands.append(
+                    VerificationCommand(
+                        name=_command_name_from_line(line, fallback=command),
+                        command=command,
+                        source=source,
+                    )
+                )
+    return tuple(commands)
+
+
+def _commands_from_test_gate(path: Path) -> tuple[VerificationCommand, ...]:
+    if not path.exists():
+        return ()
+    document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(document, Mapping):
+        return ()
+
+    commands: list[VerificationCommand] = []
+    for section in ("full", "required", "required_stages"):
+        items = document.get(section)
+        if not isinstance(items, list):
+            continue
+        for index, item in enumerate(items, start=1):
+            parsed = _gate_item_command(item, default_name=f"{section}-{index}")
+            if parsed is not None:
+                commands.append(parsed)
+    return tuple(commands)
+
+
+def _gate_item_command(item: object, *, default_name: str) -> VerificationCommand | None:
+    if isinstance(item, str):
+        command = item.strip()
+        name = default_name
+    elif isinstance(item, Mapping):
+        raw_command = item.get("command")
+        if not isinstance(raw_command, str):
+            return None
+        command = raw_command.strip()
+        raw_name = item.get("stage") or item.get("name") or default_name
+        name = str(raw_name)
+    else:
+        return None
+
+    if not _is_executable_verification_command(command):
+        return None
+    return VerificationCommand(
+        name=name,
+        command=command,
+        source=".codex/test-gate.yaml",
+    )
+
+
+def _missing_plan_obligations(plan_text: str) -> tuple[str, ...]:
+    missing: list[str] = []
+    for line in plan_text.splitlines():
+        checkbox = _CHECKBOX.match(line)
+        if checkbox is None:
+            continue
+        body = checkbox.group("body").strip()
+        lowered = body.lower()
+        obligation = _obligation_name(lowered)
+        if obligation is None:
+            continue
+        commands = [
+            command
+            for command in _BACKTICK_COMMAND.findall(line)
+            if _is_executable_verification_command(command)
+        ]
+        gate_references = [
+            command
+            for command in _BACKTICK_COMMAND.findall(line)
+            if command.strip() == ".codex/test-gate.yaml"
+        ]
+        if not commands and not gate_references:
+            missing.append(f"{obligation}: {body}")
+    return tuple(missing)
+
+
+def _obligation_name(line: str) -> str | None:
+    for name, keywords in _OBLIGATION_KEYWORDS.items():
+        if any(keyword in line for keyword in keywords):
+            return name
+    return None
+
+
+def _is_executable_verification_command(command: str) -> bool:
+    stripped = command.strip()
+    if not stripped:
+        return False
+    if stripped.startswith(".codex/") or stripped.endswith((".yaml", ".yml", ".md")):
+        return False
+    if stripped.startswith("docs/"):
+        return False
+    return True
+
+
+def _command_name_from_line(line: str, *, fallback: str) -> str:
+    cells = [cell.strip(" `") for cell in line.strip().strip("|").split("|")]
+    if len(cells) >= 2 and cells[0] and "---" not in cells[0]:
+        return cells[0]
+    checkbox = _CHECKBOX.match(line)
+    if checkbox is not None:
+        return checkbox.group("body").split(":", 1)[0].strip()
+    return fallback
+
+
+def _dedupe_commands(
+    commands: Iterable[VerificationCommand],
+) -> tuple[VerificationCommand, ...]:
+    seen: set[str] = set()
+    deduped: list[VerificationCommand] = []
+    for command in commands:
+        if command.command in seen:
+            continue
+        seen.add(command.command)
+        deduped.append(command)
+    return tuple(deduped)
+
+
+def _run_command(
+    repo_root: Path,
+    evidence_dir: Path,
+    index: int,
+    command: VerificationCommand,
+) -> WorkItemCommandResult:
+    command_dir = evidence_dir / f"command-{index:02d}"
+    command_dir.mkdir(parents=True, exist_ok=True)
+    (command_dir / "command.json").write_text(
+        json.dumps(
+            {
+                "name": command.name,
+                "command": command.command,
+                "source": command.source,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        command.command,
+        cwd=repo_root,
+        shell=True,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    stdout_path = command_dir / "stdout.txt"
+    stderr_path = command_dir / "stderr.txt"
+    stdout_path.write_text(completed.stdout, encoding="utf-8")
+    stderr_path.write_text(completed.stderr, encoding="utf-8")
+    return WorkItemCommandResult(
+        name=command.name,
+        command=command.command,
+        source=command.source,
+        exit_code=completed.returncode,
+        stdout_path=stdout_path.relative_to(repo_root),
+        stderr_path=stderr_path.relative_to(repo_root),
+    )
+
+
+def _write_reports(repo_root: Path, result: WorkItemVerificationResult) -> None:
+    evidence_dir = repo_root / result.evidence_dir
+    payload = {
+        "change_set_id": result.change_set_id,
+        "work_item_id": result.work_item_id,
+        "status": "PASS" if result.passed else "FAIL",
+        "blocker": result.blocker,
+        "plan_path": str(result.plan_path),
+        "verification_goal_path": str(result.verification_goal_path),
+        "test_gate_path": str(result.test_gate_path),
+        "evidence_dir": str(result.evidence_dir),
+        "missing_obligations": list(result.missing_obligations),
+        "commands": [
+            {
+                "name": command.name,
+                "command": command.command,
+                "source": command.source,
+                "exit_code": command.exit_code,
+                "stdout_path": str(command.stdout_path),
+                "stderr_path": str(command.stderr_path),
+            }
+            for command in result.command_results
+        ],
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (evidence_dir / "report.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    lines = [
+        f"# Work Item Verification: {result.work_item_id}",
+        "",
+        f"- Status: {'PASS' if result.passed else 'FAIL'}",
+        f"- ChangeSet: `{result.change_set_id}`",
+        f"- Plan: `{result.plan_path}`",
+        f"- Verification goal: `{result.verification_goal_path}`",
+        f"- Test gate: `{result.test_gate_path}`",
+    ]
+    if result.blocker:
+        lines.append(f"- Blocker: {result.blocker}")
+    if result.missing_obligations:
+        lines.append("")
+        lines.append("## Missing Obligations")
+        lines.extend(f"- {item}" for item in result.missing_obligations)
+    if result.command_results:
+        lines.append("")
+        lines.append("## Commands")
+        for command in result.command_results:
+            state = "PASS" if command.passed else "FAIL"
+            lines.append(f"- {state}: `{command.command}` ({command.source})")
+    (evidence_dir / "verification.md").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -217,12 +217,15 @@ TBD
 copy_file_if_missing "$TARGET_DIR/.codex/repository-settings.md" '# Repository Settings
 
 ## Test Command
-./venv/bin/python3 -m pytest -q -s tests/runtime
+Configure the product build, test, E2E, runtime, and static-analysis commands for this repository.
 '
 
-copy_file_if_missing "$TARGET_DIR/.codex/test-gate.yaml" 'required:
-  - name: runtime
-    command: ./venv/bin/python3 -m pytest -q -s tests/runtime
+copy_file_if_missing "$TARGET_DIR/.codex/test-gate.yaml" '# Product verification gates for ChangeSet work items.
+# Example:
+# required:
+#   - name: unit
+#     command: ./gradlew test
+required: []
 '
 
 restore_preserved_paths() { restore_paths "$@"; }

--- a/tests/runtime/test_verify_work_item.py
+++ b/tests/runtime/test_verify_work_item.py
@@ -1,0 +1,117 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.verify_work_item import verify_work_item
+from harness_codex.runtime.workflows import load_named_workflow
+
+
+def test_verify_work_item_workflow_uses_product_verifier_command() -> None:
+    workflow = load_named_workflow("changeset-use-case-workflow")
+
+    verification = workflow.step_by_id("verify-work-item")
+
+    assert verification.command is not None
+    assert "harness_codex.runtime.verify_work_item" in verification.command
+    assert "tests/runtime" not in verification.command
+    assert (
+        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json")
+        in verification.outputs
+    )
+
+
+def test_work_item_verifier_fails_when_plan_claims_complete_without_command_evidence(
+    tmp_path: Path,
+) -> None:
+    _write_work_item_files(
+        tmp_path,
+        plan="- [x] Build: completed by executor\n",
+        goal="|Step|Command|Success|Required|\n|---|---|---|---|\n",
+    )
+
+    result = verify_work_item(
+        tmp_path,
+        change_set_id="CHG-1",
+        work_item_id="UC-1",
+        run_id="run-001",
+    )
+
+    assert result.passed is False
+    assert result.missing_obligations == ("build: Build: completed by executor",)
+    report = json.loads(
+        (
+            tmp_path
+            / ".harness/runs/run-001/work-items/UC-1/verification/report.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert report["status"] == "FAIL"
+    assert report["commands"] == []
+
+
+def test_work_item_verifier_runs_product_command_and_writes_structured_evidence(
+    tmp_path: Path,
+) -> None:
+    _write_work_item_files(
+        tmp_path,
+        plan="- [x] Tests: `python3 -c \"print('plan-ok')\"`\n",
+        goal=(
+            "|Step|Command|Success|Required|\n"
+            "|---|---|---|---|\n"
+            "|E2E|`python3 -c \"print('goal-ok')\"`|exit code 0|required|\n"
+        ),
+    )
+
+    result = verify_work_item(
+        tmp_path,
+        change_set_id="CHG-1",
+        work_item_id="UC-1",
+        run_id="run-001",
+    )
+
+    assert result.passed is True
+    assert [command.command for command in result.command_results] == [
+        "python3 -c \"print('plan-ok')\"",
+        "python3 -c \"print('goal-ok')\"",
+    ]
+    report_path = tmp_path / result.evidence_dir / "report.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["status"] == "PASS"
+    assert len(report["commands"]) == 2
+
+
+def test_work_item_verifier_runs_test_gate_when_plan_and_goal_reference_gate(
+    tmp_path: Path,
+) -> None:
+    _write_work_item_files(
+        tmp_path,
+        plan="- [x] Tests: `.codex/test-gate.yaml`\n",
+        goal="|Step|Command|Success|Required|\n|Test gate|`.codex/test-gate.yaml`|PASS|required|\n",
+    )
+    gate_dir = tmp_path / ".codex"
+    gate_dir.mkdir(exist_ok=True)
+    (gate_dir / "test-gate.yaml").write_text(
+        "required:\n"
+        "  - name: unit\n"
+        "    command: python3 -c \"print('gate-ok')\"\n",
+        encoding="utf-8",
+    )
+
+    result = verify_work_item(
+        tmp_path,
+        change_set_id="CHG-1",
+        work_item_id="UC-1",
+        run_id="run-001",
+    )
+
+    assert result.passed is True
+    assert [command.command for command in result.command_results] == [
+        "python3 -c \"print('gate-ok')\"",
+    ]
+
+
+def _write_work_item_files(tmp_path: Path, *, plan: str, goal: str) -> None:
+    plan_dir = tmp_path / "docs/plans/active/UC-1"
+    goal_dir = tmp_path / "docs/use-cases/UC-1"
+    plan_dir.mkdir(parents=True)
+    goal_dir.mkdir(parents=True)
+    plan_dir.joinpath("plan.md").write_text(plan, encoding="utf-8")
+    goal_dir.joinpath("e2e-goal.md").write_text(goal, encoding="utf-8")

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -124,7 +124,10 @@ def test_default_changeset_work_item_workflow_loads() -> None:
     assert workflow.step_by_id("execute-work-item").skill_id == (
         "harness-plan-executor"
     )
-    assert workflow.step_by_id("verify-work-item").command
+    assert workflow.step_by_id("verify-work-item").command == (
+        "python3 -m harness_codex.runtime.verify_work_item "
+        "--change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>"
+    )
     remediation = workflow.step_by_id("remediate-work-item")
     assert remediation.needs == ("classify-verification-result",)
     assert remediation.metadata["loop_target"] == "execute-work-item"


### PR DESCRIPTION
Closes #239

## Implementation intent (구현 의도)
`verify-work-item` 단계가 `tests/runtime` 자체 테스트를 제품 검증 게이트로 사용하던 문제를 제거하고, 선택된 work item의 계획과 E2E/maintenance 검증 목표를 기준으로 실제 제품 검증 명령을 실행하도록 바꿉니다.

## Implementation approach (구현 방식)
`harness_codex.runtime.verify_work_item` 모듈을 추가해 `docs/plans/active/<WORK-ITEM-ID>/plan.md`, 해당 E2E 또는 maintenance 검증 목표, `.codex/test-gate.yaml`을 읽습니다. 계획/목표/테스트 게이트에서 실행 가능한 검증 명령을 수집하고 중복 제거 후 실행하며, 결과를 `.harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/` 아래 `report.json`, `verification.md`, stdout/stderr 증거로 남깁니다. 워크플로의 `verify-work-item` 명령은 새 모듈 호출로 교체했고, installer 기본 `.codex/test-gate.yaml`은 harness runtime self-test 대신 비어 있는 제품 게이트 템플릿을 생성하도록 바꿨습니다.

## Verification method (검증 방법)
- `./venv/bin/python3 -m py_compile harness_codex/runtime/verify_work_item.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_verify_work_item.py tests/runtime/test_workflow_loader.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime` -> 266 passed
- `git diff --check`

## Risks and rollback (위험 및 롤백)
기존 대상 저장소가 `.codex/test-gate.yaml`에 harness runtime 테스트만 넣어둔 경우, 새 검증기는 해당 명령을 계속 실행할 수 있습니다. 필요한 경우 대상 저장소의 product gate를 명시적으로 갱신해야 합니다. 롤백은 워크플로 명령을 이전 `./venv/bin/python3 -m pytest -q -s tests/runtime` 값으로 되돌리고 새 verifier 모듈과 테스트를 제거하면 됩니다.