### PR TITLE
executor ChangeSet 범위 diff 검증 추가

### DIFF
--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -24,6 +24,12 @@ from harness_codex.runtime.models import (
     StepStatus,
 )
 from harness_codex.runtime.prompt import build_agent_prompt
+from harness_codex.runtime.validate_scope_diff import (
+    ScopePattern,
+    capture_git_snapshot,
+    validate_scope_diff,
+    write_snapshot,
+)
 
 
 SUCCESS_STDERR_TAIL_BYTES = 16_384
@@ -259,6 +265,11 @@ class BasicStepRunner:
             + "\n",
             encoding="utf-8",
         )
+        scope_before = None
+        if _requires_scope_diff_validation(step):
+            scope_before = capture_git_snapshot(context.repo_root)
+            write_snapshot(step_dir / "scope-diff-before.json", scope_before)
+
         result = self._agent_adapter.run(
             AgentRunRequest(
                 step=step,
@@ -269,6 +280,43 @@ class BasicStepRunner:
                 skill_path=skill_path,
             )
         )
+        if _requires_scope_diff_validation(step) and scope_before is not None:
+            scope_after = capture_git_snapshot(context.repo_root)
+            write_snapshot(step_dir / "scope-diff-after.json", scope_after)
+            scope_result = validate_scope_diff(
+                repo_root=context.repo_root,
+                run_id=context.run_id,
+                change_set_id=_context_string(context, "change_set_id") or "",
+                work_item_id=_context_string(context, "active_work_item_id") or "",
+                before=scope_before,
+                after=scope_after,
+                report_path=step_dir / "scope-diff-report.json",
+                context_metadata=context.metadata,
+                runtime_allow_patterns=_runtime_scope_allow_patterns(context, step_dir),
+            )
+            result = AgentRunResult(
+                status=(
+                    StepStatus.BLOCKED
+                    if result.status == StepStatus.SUCCEEDED
+                    and scope_result.blocked_files
+                    else result.status
+                ),
+                exit_code=result.exit_code,
+                error=(
+                    scope_result.message
+                    if result.status == StepStatus.SUCCEEDED
+                    and scope_result.blocked_files
+                    else result.error
+                ),
+                metadata={
+                    **dict(result.metadata),
+                    "scope_diff_status": scope_result.status,
+                    "scope_diff_report_path": str(
+                        _relative_to_repo(scope_result.report_path, context)
+                    ),
+                    "scope_diff_blocked_files": scope_result.blocked_files,
+                },
+            )
         result_path = step_dir / "result.json"
         validation_error = None
         if result.status == StepStatus.SUCCEEDED:
@@ -416,6 +464,27 @@ def _work_item_id_from_plan_path(path: Path) -> str | None:
 def _context_string(context: RunContext, key: str) -> str | None:
     value = context.metadata.get(key)
     return value if isinstance(value, str) and value else None
+
+
+def _requires_scope_diff_validation(step: Step) -> bool:
+    return step.kind == StepKind.AGENT and step.agent_id == "implementation_executor"
+
+
+def _runtime_scope_allow_patterns(
+    context: RunContext,
+    step_dir: Path,
+) -> tuple[ScopePattern, ...]:
+    run_dir = context.run_dir
+    return (
+        ScopePattern(
+            str(_relative_to_repo(step_dir, context)) + "/",
+            "runtime step artifacts",
+        ),
+        ScopePattern(
+            str(_relative_to_repo(run_dir, context)) + "/",
+            "runtime run artifacts",
+        ),
+    )
 
 
 def _append_runtime_remediation_task(

--- a/harness_codex/runtime/validate_scope_diff.py
+++ b/harness_codex/runtime/validate_scope_diff.py
@@ -1,0 +1,471 @@
+"""executor worktree 변경을 ChangeSet 범위와 대조한다."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+
+
+PATH_CODE_RE = re.compile(r"`([^`]+)`")
+PATH_TOKEN_RE = re.compile(r"(?<![\w.-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.*{}<>, -]+)+)")
+
+
+@dataclass(frozen=True)
+class ScopePattern:
+    pattern: str
+    source: str
+    kind: str = "allow"
+
+
+@dataclass(frozen=True)
+class ScopeDiffResult:
+    status: str
+    report_path: Path
+    blocked_files: tuple[str, ...]
+    message: str | None = None
+
+
+def capture_git_snapshot(repo_root: Path) -> dict[str, dict[str, str | None]]:
+    """변경된 worktree 파일 상태를 비교 가능한 snapshot으로 기록한다."""
+
+    if not _inside_git_work_tree(repo_root):
+        return {}
+
+    changed_paths = _git_changed_paths(repo_root)
+    snapshot: dict[str, dict[str, str | None]] = {}
+    for path in sorted(changed_paths):
+        absolute = repo_root / path
+        snapshot[path] = {
+            "path": path,
+            "state": _file_state(absolute),
+            "sha256": _sha256(absolute),
+        }
+    return snapshot
+
+
+def write_snapshot(path: Path, snapshot: Mapping[str, Mapping[str, str | None]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def validate_scope_diff(
+    *,
+    repo_root: Path,
+    run_id: str,
+    change_set_id: str,
+    work_item_id: str,
+    before: Mapping[str, Mapping[str, str | None]],
+    after: Mapping[str, Mapping[str, str | None]],
+    report_path: Path,
+    context_metadata: Mapping[str, Any] | None = None,
+    runtime_allow_patterns: Sequence[ScopePattern] = (),
+) -> ScopeDiffResult:
+    """범위 검증 report를 쓰고 범위 밖 파일 목록을 반환한다."""
+
+    metadata = context_metadata or {}
+    changed_files = _changed_between(before, after)
+    allow_patterns, block_patterns = _scope_patterns(
+        repo_root=repo_root,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        metadata=metadata,
+        runtime_allow_patterns=runtime_allow_patterns,
+    )
+
+    allowed: list[dict[str, Any]] = []
+    suspicious: list[dict[str, Any]] = []
+    blocked: list[dict[str, Any]] = []
+    changed_rows: list[dict[str, Any]] = []
+
+    for path in changed_files:
+        block_matches = _matching_sources(path, block_patterns)
+        allow_matches = _matching_sources(path, allow_patterns)
+        row = {
+            "path": path,
+            "before": before.get(path),
+            "after": after.get(path),
+            "allowed_sources": allow_matches,
+            "blocked_sources": block_matches,
+        }
+        changed_rows.append(row)
+        if block_matches or not allow_matches:
+            blocked.append(row)
+        elif _is_suspicious_path(path, allow_matches):
+            suspicious.append(row)
+        else:
+            allowed.append(row)
+
+    status = "blocked" if blocked else "passed"
+    source_summary = tuple(dict.fromkeys(pattern.source for pattern in allow_patterns))
+    report = {
+        "status": status,
+        "run_id": run_id,
+        "change_set_id": change_set_id,
+        "work_item_id": work_item_id,
+        "changed_files": changed_rows,
+        "allowed": allowed,
+        "suspicious": suspicious,
+        "blocked": blocked,
+        "allowed_scope_sources": source_summary,
+    }
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    blocked_files = tuple(row["path"] for row in blocked)
+    message = None
+    if blocked_files:
+        message = (
+            "scope diff blocked unexpected files: "
+            + ", ".join(blocked_files)
+            + ". allowed scope sources: "
+            + ", ".join(source_summary)
+        )
+    return ScopeDiffResult(
+        status=status,
+        report_path=report_path,
+        blocked_files=blocked_files,
+        message=message,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--change-set", required=True)
+    parser.add_argument("--work-item", required=True)
+    parser.add_argument("--before", required=True)
+    parser.add_argument("--after", required=True)
+    parser.add_argument("--report", required=True)
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    before = json.loads(Path(args.before).read_text(encoding="utf-8"))
+    after = json.loads(Path(args.after).read_text(encoding="utf-8"))
+    result = validate_scope_diff(
+        repo_root=repo_root,
+        run_id="manual",
+        change_set_id=args.change_set,
+        work_item_id=args.work_item,
+        before=before,
+        after=after,
+        report_path=Path(args.report),
+        context_metadata={
+            "change_set_path": f"docs/changes/active/{args.change_set}.md",
+            "active_work_item_id": args.work_item,
+            "active_plan_path": f"docs/plans/active/{args.work_item}/plan.md",
+        },
+    )
+    if result.message:
+        print(result.message)
+    else:
+        print(f"scope diff {result.status}: {result.report_path}")
+    return 1 if result.blocked_files else 0
+
+
+def _inside_git_work_tree(repo_root: Path) -> bool:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return completed.returncode == 0 and completed.stdout.strip() == "true"
+
+
+def _git_changed_paths(repo_root: Path) -> set[str]:
+    paths: set[str] = set()
+    commands = (
+        ["git", "diff", "--name-only"],
+        ["git", "diff", "--name-only", "--cached"],
+        ["git", "ls-files", "--others", "--exclude-standard"],
+    )
+    for command in commands:
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            continue
+        for line in completed.stdout.splitlines():
+            normalized = _normalize_path_token(line)
+            if not normalized:
+                continue
+            absolute = repo_root / normalized
+            if absolute.is_dir():
+                paths.update(
+                    str(path.relative_to(repo_root))
+                    for path in absolute.rglob("*")
+                    if path.is_file()
+                )
+            else:
+                paths.add(normalized)
+    return paths
+
+
+def _file_state(path: Path) -> str:
+    if path.is_file():
+        return "file"
+    if path.is_dir():
+        return "directory"
+    return "missing"
+
+
+def _sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _changed_between(
+    before: Mapping[str, Mapping[str, str | None]],
+    after: Mapping[str, Mapping[str, str | None]],
+) -> tuple[str, ...]:
+    paths = set(before) | set(after)
+    return tuple(sorted(path for path in paths if before.get(path) != after.get(path)))
+
+
+def _scope_patterns(
+    *,
+    repo_root: Path,
+    change_set_id: str,
+    work_item_id: str,
+    metadata: Mapping[str, Any],
+    runtime_allow_patterns: Sequence[ScopePattern],
+) -> tuple[tuple[ScopePattern, ...], tuple[ScopePattern, ...]]:
+    allow: list[ScopePattern] = list(runtime_allow_patterns)
+    block: list[ScopePattern] = []
+
+    active_plan_path = _metadata_path(metadata, "active_plan_path")
+    if active_plan_path:
+        allow.append(ScopePattern(str(active_plan_path), "active plan output"))
+        allow.extend(_patterns_from_markdown(repo_root / active_plan_path, "active plan"))
+
+    change_set_path = _metadata_path(metadata, "change_set_path") or Path(
+        f"docs/changes/active/{change_set_id}.md"
+    )
+    for pattern in _patterns_from_changeset(repo_root / change_set_path):
+        if pattern.kind == "block":
+            block.append(pattern)
+        else:
+            allow.append(pattern)
+
+    for path in _affected_file_docs(repo_root, work_item_id, metadata):
+        file_allow, file_block = _patterns_from_affected_files(path)
+        allow.extend(file_allow)
+        block.extend(file_block)
+
+    return tuple(_dedupe_patterns(allow)), tuple(_dedupe_patterns(block))
+
+
+def _patterns_from_changeset(path: Path) -> tuple[ScopePattern, ...]:
+    if not path.is_file():
+        return ()
+    text = path.read_text(encoding="utf-8")
+    change_set = parse_changeset_markdown(text, path=_relative_path(path))
+    patterns: list[ScopePattern] = []
+    for document in change_set.changed_documents:
+        normalized = _normalize_path_token(str(document.path))
+        if normalized:
+            patterns.append(ScopePattern(normalized, "ChangeSet changed documents"))
+    for item in change_set.included_scope:
+        patterns.extend(
+            ScopePattern(pattern, "ChangeSet included scope")
+            for pattern in _extract_path_patterns(item)
+        )
+    for item in change_set.forbidden_changes + change_set.excluded_scope:
+        patterns.extend(
+            ScopePattern(pattern, "ChangeSet excluded/forbidden scope", "block")
+            for pattern in _extract_path_patterns(item)
+        )
+    return tuple(patterns)
+
+
+def _patterns_from_affected_files(
+    path: Path,
+) -> tuple[tuple[ScopePattern, ...], tuple[ScopePattern, ...]]:
+    if not path.is_file():
+        return (), ()
+    text = path.read_text(encoding="utf-8")
+    sections = _markdown_sections(text)
+    allow_text = "\n".join(
+        content
+        for title, content in sections.items()
+        if not _block_section_title(title)
+    )
+    block_text = "\n".join(
+        content for title, content in sections.items() if _block_section_title(title)
+    )
+    allow = tuple(
+        ScopePattern(pattern, f"affected-files {path.relative_to(path.parents[3])}")
+        for pattern in _extract_path_patterns(allow_text)
+    )
+    block = tuple(
+        ScopePattern(
+            pattern,
+            f"affected-files forbidden {path.relative_to(path.parents[3])}",
+            "block",
+        )
+        for pattern in _extract_path_patterns(block_text)
+    )
+    return allow, block
+
+
+def _patterns_from_markdown(path: Path, source: str) -> tuple[ScopePattern, ...]:
+    if not path.is_file():
+        return ()
+    return tuple(
+        ScopePattern(pattern, source)
+        for pattern in _extract_path_patterns(path.read_text(encoding="utf-8"))
+    )
+
+
+def _affected_file_docs(
+    repo_root: Path,
+    work_item_id: str,
+    metadata: Mapping[str, Any],
+) -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    for item in metadata.get("affected_work_items", ()):
+        if not isinstance(item, Mapping) or item.get("id") != work_item_id:
+            continue
+        for raw in item.get("executor_inputs", ()):
+            path = Path(str(raw))
+            if path.name == "affected-files.md":
+                candidates.append(repo_root / path)
+    candidates.extend(
+        (
+            repo_root / f"docs/use-cases/{work_item_id}/affected-files.md",
+            repo_root / f"docs/maintenance/{work_item_id}/affected-files.md",
+        )
+    )
+    return tuple(dict.fromkeys(candidates))
+
+
+def _extract_path_patterns(text: str) -> tuple[str, ...]:
+    values: list[str] = []
+    values.extend(match.group(1) for match in PATH_CODE_RE.finditer(text))
+    values.extend(match.group(1) for match in PATH_TOKEN_RE.finditer(text))
+    return tuple(
+        dict.fromkeys(
+            normalized
+            for value in values
+            if (normalized := _normalize_path_token(value))
+        )
+    )
+
+
+def _normalize_path_token(value: str) -> str:
+    token = value.strip().strip("|,;:)")
+    token = token.removeprefix("./")
+    if not token or "://" in token:
+        return ""
+    if "<" in token or ">" in token or "..." in token:
+        return ""
+    if token.startswith("/"):
+        return ""
+    return token
+
+
+def _matching_sources(path: str, patterns: Iterable[ScopePattern]) -> list[str]:
+    return [
+        pattern.source
+        for pattern in patterns
+        if _matches_pattern(path, pattern.pattern)
+    ]
+
+
+def _matches_pattern(path: str, pattern: str) -> bool:
+    if pattern.endswith("/"):
+        return path.startswith(pattern)
+    if any(char in pattern for char in "*?[]"):
+        return fnmatch.fnmatch(path, pattern)
+    return path == pattern
+
+
+def _is_suspicious_path(path: str, sources: Sequence[str]) -> bool:
+    config_names = {
+        "build.gradle",
+        "build.gradle.kts",
+        "settings.gradle",
+        "settings.gradle.kts",
+        "pom.xml",
+        "pyproject.toml",
+        "package.json",
+        "package-lock.json",
+    }
+    return Path(path).name in config_names and not any(
+        source in {"ChangeSet changed documents", "ChangeSet included scope"}
+        or source.startswith("affected-files")
+        for source in sources
+    )
+
+
+def _markdown_sections(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"^##\s+(.+?)\s*$", text, flags=re.MULTILINE))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections[match.group(1).strip()] = text[start:end]
+    if not sections:
+        sections[""] = text
+    return sections
+
+
+def _block_section_title(title: str) -> bool:
+    lowered = title.lower()
+    return (
+        "forbidden" in lowered
+        or "금지" in title
+        or "excluded" in lowered
+        or "제외" in title
+    )
+
+
+def _metadata_path(metadata: Mapping[str, Any], key: str) -> Path | None:
+    value = metadata.get(key)
+    if isinstance(value, str) and value.strip():
+        return Path(value)
+    return None
+
+
+def _dedupe_patterns(patterns: Sequence[ScopePattern]) -> tuple[ScopePattern, ...]:
+    seen: set[tuple[str, str, str]] = set()
+    result: list[ScopePattern] = []
+    for pattern in patterns:
+        key = (pattern.pattern, pattern.source, pattern.kind)
+        if key not in seen:
+            seen.add(key)
+            result.append(pattern)
+    return tuple(result)
+
+
+def _relative_path(path: Path) -> Path:
+    return Path(path.name) if path.is_absolute() else path
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -79,6 +79,106 @@ def write_agent_config(repo_root: Path, agent_id: str = "implementation_planner"
     )
 
 
+def init_git_repo(repo_root: Path) -> None:
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+
+
+def write_executor_scope_fixture(repo_root: Path) -> None:
+    write_agent_config(repo_root, "implementation_executor")
+    plan = repo_root / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True, exist_ok=True)
+    plan.write_text(
+        "\n".join(
+            [
+                "# Implementation Plan",
+                "",
+                "- Change allowed file: `src/main/java/com/example/ticketing/reservation/ReservationService.java`",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    change_set = repo_root / "docs/changes/active/CHG-001.md"
+    change_set.parent.mkdir(parents=True, exist_ok=True)
+    change_set.write_text(
+        "\n".join(
+            [
+                "# ChangeSet CHG-001",
+                "",
+                "## 1. Metadata",
+                "|Item|Value|",
+                "|---|---|",
+                "|ChangeSet ID|`CHG-001`|",
+                "|Status|active|",
+                "",
+                "## 8. Scope Boundary",
+                "### Included",
+                "- `src/main/java/com/example/ticketing/reservation/**`",
+                "- `src/test/java/com/example/ticketing/reservation/**`",
+                "",
+                "### Excluded",
+                "- `src/main/java/com/example/ticketing/payment/**`",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def executor_context(repo_root: Path) -> RunContext:
+    return RunContext(
+        run_id="run-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=repo_root / ".harness/runs/run-001/UC-001",
+        active_plan_path=Path("docs/plans/active/UC-001/plan.md"),
+        metadata={
+            "change_set_id": "CHG-001",
+            "change_set_path": "docs/changes/active/CHG-001.md",
+            "active_work_item_id": "UC-001",
+            "active_work_item_type": "use_case",
+            "active_plan_path": "docs/plans/active/UC-001/plan.md",
+            "affected_work_items": [
+                {
+                    "id": "UC-001",
+                    "type": "use_case",
+                    "executor_inputs": [
+                        "docs/plans/active/UC-001/plan.md",
+                        "docs/use-cases/UC-001/affected-files.md",
+                    ],
+                }
+            ],
+        },
+    )
+
+
+def executor_step() -> Step:
+    return Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute plan",
+        agent_id="implementation_executor",
+        skill_id=None,
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+    )
+
+
+class FileEditingAgentAdapter:
+    def __init__(self, edits: dict[str, str]) -> None:
+        self.edits = edits
+
+    def run(self, request: AgentRunRequest) -> AgentRunResult:
+        for path, text in self.edits.items():
+            target = request.context.repo_root / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
+        return AgentRunResult(
+            status=StepStatus.SUCCEEDED,
+            exit_code=0,
+            metadata={"fake": True},
+        )
+
+
 def write_skill(repo_root: Path, skill_id: str = "harness-code-planner") -> None:
     skill_dir = repo_root / ".codex/skills" / skill_id
     skill_dir.mkdir(parents=True)
@@ -220,6 +320,74 @@ def test_basic_step_runner_invokes_agent_adapter_and_writes_result(
     assert result_json["agent_id"] == "implementation_planner"
     assert result_json["status"] == "succeeded"
     assert result_json["metadata"] == {"fake": True}
+
+
+def test_implementation_executor_scope_diff_allows_changeset_scope(
+    tmp_path: Path,
+) -> None:
+    init_git_repo(tmp_path)
+    write_executor_scope_fixture(tmp_path)
+    runner = BasicStepRunner(
+        agent_adapter=FileEditingAgentAdapter(
+            {
+                "docs/plans/active/UC-001/plan.md": "# updated plan\n",
+                "src/main/java/com/example/ticketing/reservation/ReservationService.java": "class ReservationService {}\n",
+            }
+        )
+    )
+
+    result = runner.run(executor_step(), executor_context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata["scope_diff_status"] == "passed"
+    report = json.loads(
+        (
+            tmp_path
+            / ".harness/runs/run-001/UC-001/steps/execute-work-item/scope-diff-report.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert report["blocked"] == []
+    assert any(
+        row["path"]
+        == "src/main/java/com/example/ticketing/reservation/ReservationService.java"
+        for row in report["allowed"]
+    )
+
+
+def test_implementation_executor_scope_diff_blocks_unexpected_file(
+    tmp_path: Path,
+) -> None:
+    init_git_repo(tmp_path)
+    write_executor_scope_fixture(tmp_path)
+    runner = BasicStepRunner(
+        agent_adapter=FileEditingAgentAdapter(
+            {
+                "docs/plans/active/UC-001/plan.md": "# updated plan\n",
+                "build.gradle": "plugins {}\n",
+                "src/main/java/com/example/ticketing/payment/PaymentService.java": "class PaymentService {}\n",
+            }
+        )
+    )
+
+    result = runner.run(executor_step(), executor_context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "build.gradle" in (result.error or "")
+    assert "PaymentService.java" in (result.error or "")
+    result_json = json.loads((tmp_path / result.output_path).read_text(encoding="utf-8"))
+    assert result_json["status"] == "blocked"
+    assert "build.gradle" in result_json["metadata"]["scope_diff_blocked_files"]
+    blocked_paths = {
+        row["path"]
+        for row in json.loads(
+            (
+                tmp_path
+                / ".harness/runs/run-001/UC-001/steps/execute-work-item/scope-diff-report.json"
+            ).read_text(encoding="utf-8")
+        )["blocked"]
+    }
+    assert "build.gradle" in blocked_paths
+    assert "src/main/java/com/example/ticketing/payment/PaymentService.java" in blocked_paths
 
 
 def test_basic_step_runner_appends_runtime_remediation_task(tmp_path: Path) -> None:


### PR DESCRIPTION
## 구현 의도

- Fixes #248.
- `implementation_executor` 실행 전후 git 변경 snapshot을 기록하고, 실행 결과가 ChangeSet/work-item 범위를 벗어나면 completion으로 진행하지 못하게 한다.

## 구현 접근

- `harness_codex.runtime.validate_scope_diff`를 추가해 before/after snapshot, 파일 hash 비교, scope pattern 추출, JSON report 생성을 담당하게 했다.
- `BasicStepRunner`가 `implementation_executor` agent step에서 `scope-diff-before.json`, `scope-diff-after.json`, `scope-diff-report.json`을 `.harness/runs/<RUN-ID>/...` 아래에 기록한다.
- 허용 범위는 active plan output, active plan에 명시된 경로, ChangeSet changed documents/included scope, work-item `affected-files.md`, runtime artifact 경로에서 계산한다.
- forbidden/excluded scope 또는 어느 허용 source에도 매칭되지 않는 변경 파일은 blocked로 분류하고, 성공한 executor 결과를 `blocked`로 바꾼다.
- report는 changed files를 `allowed`, `suspicious`, `blocked` 그룹으로 제공한다.

## 검증 방법

- `python3 -m py_compile harness_codex/runtime/runner.py harness_codex/runtime/validate_scope_diff.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/runtime/test_affected_use_case_resolver.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/runtime/test_affected_use_case_resolver.py tests/runtime/test_ui_server_restart.py::test_ui_server_restarts_existing_server_for_repo`
- 전체 `./venv/bin/python3 -m pytest -q -s` 실행 결과: 323 passed, 2 failed. `test_ui_server_restarts_existing_server_for_repo`는 단독 재실행 PASS. `test_resume_reports_next_target`는 기존 fixture가 `.codex/agents/implementation_planner.toml`을 만들지 않아 `WAIT_FOR_ENVIRONMENT`로 실패하며, 이번 변경 범위 밖이다.

## Risks and rollback

- plan/ChangeSet/affected-files 경로 추출이 지나치게 엄격하면 합법적인 executor 변경이 blocked될 수 있다.
- rollback은 이 commit revert로 가능하다. 필요하면 특정 work-item의 plan 또는 ChangeSet scope에 허용 경로를 명시해 unblock할 수 있다.
