### PR TITLE
결정 단계 런타임 분류 구현

### DIFF
--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -77,12 +77,22 @@ steps:
     metadata:
       stage: verification
       scope: work_item
+      classifier: verification_result
       failure_kinds:
-        - implementation failure
-        - scope conflict
-        - environment blocker
-        - verification goal unclear
+        - IMPLEMENTATION_FAILURE
+        - UNCLEAR_E2E_GOAL
+        - DOCUMENT_DELTA_CONFLICT
+        - UPSTREAM_DESIGN_CONFLICT
+        - ENVIRONMENT_BLOCKER
+        - SCOPE_CONFLICT
+        - VERIFICATION_GOAL_UNCLEAR
       on_implementation_failure: remediate-work-item
+      on_unclear_e2e_goal: e2e-goal-approval
+      on_document_delta_conflict: change-set-revision
+      on_upstream_design_failure: upstream-design-stage
+      on_environment_blocker: environment
+      on_scope_conflict: change-set-revision
+      on_verification_goal_unclear: verification-goal-approval
 
   - id: remediate-work-item
     kind: record

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Mapping
 from uuid import uuid4
 
 from harness_codex.runtime import (
@@ -1315,6 +1316,7 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
         current_work_item_id=current_scope.display_id,
         status=final_result.status,
         failure_kind=_run_failure_kind(final_result.failure_kind),
+        decision_results=_workflow_decision_results(result_by_work_item),
         work_item_states=tuple(
             WorkItemLoopState(
                 work_item_id=scope.display_id,
@@ -1385,9 +1387,26 @@ def _run_failure_kind(failure_kind: FailureKind | None) -> RunFailureKind | None
         return RunFailureKind.UPSTREAM_DESIGN_CONFLICT
     if failure_kind == FailureKind.ENVIRONMENT_BLOCKER:
         return RunFailureKind.ENVIRONMENT_BLOCKER
+    if failure_kind == FailureKind.UNCLEAR_E2E_GOAL:
+        return RunFailureKind.UNCLEAR_E2E_GOAL
+    if failure_kind == FailureKind.DOCUMENT_DELTA_CONFLICT:
+        return RunFailureKind.DOCUMENT_DELTA_CONFLICT
+    if failure_kind == FailureKind.SCOPE_CONFLICT:
+        return RunFailureKind.SCOPE_CONFLICT
+    if failure_kind == FailureKind.VERIFICATION_GOAL_UNCLEAR:
+        return RunFailureKind.VERIFICATION_GOAL_UNCLEAR
     if failure_kind == FailureKind.UNKNOWN:
         return RunFailureKind.UNCLEAR_E2E_GOAL
     return None
+
+
+def _workflow_decision_results(result_by_work_item: Mapping[str, RunResult]) -> dict[str, object]:
+    decisions: dict[str, object] = {}
+    for work_item_id, result in result_by_work_item.items():
+        item_decisions = tuple(result.metadata.get("decisions", ()))
+        if item_decisions:
+            decisions[work_item_id] = item_decisions
+    return decisions
 
 
 def _latest_run_id_for_change_set(repo_root: Path, change_set_id: str) -> str | None:

--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -355,6 +355,14 @@ class RunnerEngine:
             for result in step_results
             if "policy_decision" in result.metadata
         )
+        decisions = tuple(
+            {
+                "step_id": result.step_id,
+                **dict(result.metadata["decision"]),
+            }
+            for result in step_results
+            if "decision" in result.metadata
+        )
 
         metadata: dict[str, object] = {
             "mode": context.mode.value,
@@ -362,6 +370,7 @@ class RunnerEngine:
             "planned_steps": execution_plan.step_ids(),
             "side_effects": context.mode == RunMode.APPLY,
             "policy_decisions": policy_decisions,
+            "decisions": decisions,
         }
         if extra:
             metadata.update(extra)

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -73,6 +73,10 @@ class FailureKind(str, Enum):
     IMPLEMENTATION = "implementation"
     UPSTREAM_DESIGN = "upstream_design"
     ENVIRONMENT_BLOCKER = "environment_blocker"
+    UNCLEAR_E2E_GOAL = "unclear_e2e_goal"
+    DOCUMENT_DELTA_CONFLICT = "document_delta_conflict"
+    SCOPE_CONFLICT = "scope_conflict"
+    VERIFICATION_GOAL_UNCLEAR = "verification_goal_unclear"
     UNKNOWN = "unknown"
 
 
@@ -413,10 +417,15 @@ HARNESS_FULL_WORKFLOW = Workflow(
             metadata={
                 "stage": "verifier",
                 "scope": "use_case",
+                "classifier": "verification_result",
                 "on_success": "complete-use-case-plan",
                 "on_implementation_failure": "revise-use-case-plan-and-repeat",
+                "on_unclear_e2e_goal": "e2e-goal-approval",
+                "on_document_delta_conflict": "change-set-revision",
                 "on_upstream_design_failure": "record-use-case-blocker",
                 "on_environment_blocker": "record-use-case-blocker",
+                "on_scope_conflict": "change-set-revision",
+                "on_verification_goal_unclear": "verification-goal-approval",
                 "purpose": (
                     "Classify verification result before repeating only the "
                     "affected UC plan loop or stopping with blocker evidence."

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -222,8 +222,56 @@ class BasicStepRunner:
             return self._run_git_boundary(step, context, step_dir)
         if step.kind == StepKind.AGENT:
             return self._run_agent(step, context, step_dir)
+        if step.kind == StepKind.DECISION:
+            return self._run_decision(step, context, step_dir)
 
-        return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.BLOCKED,
+            error=f"unsupported step kind: {step.kind.value}",
+        )
+
+    def _run_decision(self, step: Step, context: RunContext, step_dir: Path) -> StepResult:
+        classifier = str(step.metadata.get("classifier") or "")
+        if not classifier and step.id in {
+            "classify-verification-result",
+            "classify-use-case-verification-result",
+        }:
+            classifier = "verification_result"
+
+        if classifier != "verification_result":
+            evidence = _write_decision_evidence(
+                step,
+                context,
+                step_dir,
+                {
+                    "classifier": classifier,
+                    "decision": "UNSUPPORTED_DECISION_STEP",
+                    "blocked": True,
+                    "reason": "decision classifier is required",
+                },
+            )
+            return StepResult(
+                step_id=step.id,
+                status=StepStatus.BLOCKED,
+                output_path=_relative_to_repo(evidence, context),
+                error="decision classifier is required",
+                metadata={"decision": _decision_result_from_file(evidence)},
+            )
+
+        decision = _classify_verification_result(step, context)
+        evidence = _write_decision_evidence(step, context, step_dir, decision)
+        status = StepStatus.BLOCKED if decision["blocked"] else StepStatus.SUCCEEDED
+        failure_kind = _decision_failure_kind(str(decision["decision"]))
+        error = str(decision["reason"]) if decision["blocked"] else None
+        return StepResult(
+            step_id=step.id,
+            status=status,
+            output_path=_relative_to_repo(evidence, context),
+            error=error,
+            failure_kind=failure_kind if decision["blocked"] else None,
+            metadata={"decision": decision},
+        )
 
     def _run_agent(self, step: Step, context: RunContext, step_dir: Path) -> StepResult:
         if not step.agent_id:
@@ -432,6 +480,183 @@ class BasicStepRunner:
             shutil.move(str(source), str(target))
             return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
         return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error="git step requires an explicit command or one input/output move")
+
+
+def _classify_verification_result(
+    step: Step,
+    context: RunContext,
+) -> dict[str, Any]:
+    failed_step_id = _context_string(context, "runtime_failed_step_id")
+    raw_failure_kind = _context_string(context, "runtime_failure_kind")
+    raw_error = _context_string(context, "runtime_failure_error") or ""
+
+    if not failed_step_id and not raw_failure_kind and not raw_error:
+        route = _metadata_string(step, "on_success") or "complete"
+        return {
+            "classifier": "verification_result",
+            "decision": "VERIFICATION_PASSED",
+            "failed_step_id": None,
+            "source_failure_kind": None,
+            "route": route,
+            "blocked": False,
+            "owner_stage": "completion",
+            "reason": "verification passed",
+        }
+
+    decision = _decision_code(raw_failure_kind or "", raw_error)
+    route = _decision_route(step, decision)
+    blocked = decision != "IMPLEMENTATION_FAILURE"
+    return {
+        "classifier": "verification_result",
+        "decision": decision,
+        "failed_step_id": failed_step_id,
+        "source_failure_kind": raw_failure_kind,
+        "route": route,
+        "blocked": blocked,
+        "owner_stage": _decision_owner_stage(decision),
+        "reason": _decision_reason(decision, raw_error),
+    }
+
+
+def _decision_code(raw_failure_kind: str, raw_error: str) -> str:
+    normalized = raw_failure_kind.strip().lower().replace("-", "_").replace(" ", "_")
+    direct = {
+        "implementation": "IMPLEMENTATION_FAILURE",
+        "implementation_failure": "IMPLEMENTATION_FAILURE",
+        "unclear_e2e_goal": "UNCLEAR_E2E_GOAL",
+        "document_delta_conflict": "DOCUMENT_DELTA_CONFLICT",
+        "upstream_design": "UPSTREAM_DESIGN_CONFLICT",
+        "upstream_design_conflict": "UPSTREAM_DESIGN_CONFLICT",
+        "environment_blocker": "ENVIRONMENT_BLOCKER",
+        "scope_conflict": "SCOPE_CONFLICT",
+        "verification_goal_unclear": "VERIFICATION_GOAL_UNCLEAR",
+    }
+    if normalized in direct:
+        return direct[normalized]
+
+    lowered_error = raw_error.lower()
+    if "document delta" in lowered_error or "stale document" in lowered_error:
+        return "DOCUMENT_DELTA_CONFLICT"
+    if "scope conflict" in lowered_error or "out of scope" in lowered_error:
+        return "SCOPE_CONFLICT"
+    if "verification goal unclear" in lowered_error:
+        return "VERIFICATION_GOAL_UNCLEAR"
+    if "e2e" in lowered_error and (
+        "unclear" in lowered_error or "ambiguous" in lowered_error
+    ):
+        return "UNCLEAR_E2E_GOAL"
+    if any(
+        marker in lowered_error
+        for marker in (
+            "requirements",
+            "upstream",
+            "architecture",
+            "technical decision",
+            "ddd design",
+            "event storming",
+        )
+    ):
+        return "UPSTREAM_DESIGN_CONFLICT"
+    if any(
+        marker in lowered_error
+        for marker in ("environment", "unavailable", "timed out", "binary not found")
+    ):
+        return "ENVIRONMENT_BLOCKER"
+    return "UNCLEAR_E2E_GOAL"
+
+
+def _decision_route(step: Step, decision: str) -> str:
+    metadata_key_by_decision = {
+        "IMPLEMENTATION_FAILURE": "on_implementation_failure",
+        "UNCLEAR_E2E_GOAL": "on_unclear_e2e_goal",
+        "DOCUMENT_DELTA_CONFLICT": "on_document_delta_conflict",
+        "UPSTREAM_DESIGN_CONFLICT": "on_upstream_design_failure",
+        "ENVIRONMENT_BLOCKER": "on_environment_blocker",
+        "SCOPE_CONFLICT": "on_scope_conflict",
+        "VERIFICATION_GOAL_UNCLEAR": "on_verification_goal_unclear",
+    }
+    defaults = {
+        "IMPLEMENTATION_FAILURE": "remediation",
+        "UNCLEAR_E2E_GOAL": "e2e-goal-approval",
+        "DOCUMENT_DELTA_CONFLICT": "change-set-revision",
+        "UPSTREAM_DESIGN_CONFLICT": "upstream-design-stage",
+        "ENVIRONMENT_BLOCKER": "environment",
+        "SCOPE_CONFLICT": "change-set-revision",
+        "VERIFICATION_GOAL_UNCLEAR": "verification-goal-approval",
+    }
+    key = metadata_key_by_decision.get(decision, "")
+    return _metadata_string(step, key) or defaults.get(decision, "blocked")
+
+
+def _decision_owner_stage(decision: str) -> str:
+    return {
+        "IMPLEMENTATION_FAILURE": "executor",
+        "UNCLEAR_E2E_GOAL": "e2e-goal-approval",
+        "DOCUMENT_DELTA_CONFLICT": "change-set",
+        "UPSTREAM_DESIGN_CONFLICT": "upstream-design",
+        "ENVIRONMENT_BLOCKER": "environment",
+        "SCOPE_CONFLICT": "change-set",
+        "VERIFICATION_GOAL_UNCLEAR": "verification-goal",
+    }.get(decision, "orchestrator")
+
+
+def _decision_reason(decision: str, raw_error: str) -> str:
+    prefix = {
+        "IMPLEMENTATION_FAILURE": "implementation failure can return to remediation",
+        "UNCLEAR_E2E_GOAL": "return to E2E goal approval gate",
+        "DOCUMENT_DELTA_CONFLICT": "return to ChangeSet revision",
+        "UPSTREAM_DESIGN_CONFLICT": "return to upstream design stage",
+        "ENVIRONMENT_BLOCKER": "wait for environment recovery",
+        "SCOPE_CONFLICT": "return to ChangeSet scope revision",
+        "VERIFICATION_GOAL_UNCLEAR": "return to verification goal approval",
+    }.get(decision, "decision blocked")
+    detail = _first_line(raw_error)
+    return f"{prefix}: {detail}" if detail else prefix
+
+
+def _decision_failure_kind(decision: str) -> FailureKind | None:
+    return {
+        "IMPLEMENTATION_FAILURE": FailureKind.IMPLEMENTATION,
+        "UNCLEAR_E2E_GOAL": FailureKind.UNCLEAR_E2E_GOAL,
+        "DOCUMENT_DELTA_CONFLICT": FailureKind.DOCUMENT_DELTA_CONFLICT,
+        "UPSTREAM_DESIGN_CONFLICT": FailureKind.UPSTREAM_DESIGN,
+        "ENVIRONMENT_BLOCKER": FailureKind.ENVIRONMENT_BLOCKER,
+        "SCOPE_CONFLICT": FailureKind.SCOPE_CONFLICT,
+        "VERIFICATION_GOAL_UNCLEAR": FailureKind.VERIFICATION_GOAL_UNCLEAR,
+    }.get(decision)
+
+
+def _metadata_string(step: Step, key: str) -> str | None:
+    value = step.metadata.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _write_decision_evidence(
+    step: Step,
+    context: RunContext,
+    step_dir: Path,
+    decision: Mapping[str, Any],
+) -> Path:
+    evidence = step_dir / "decision.json"
+    evidence.write_text(
+        json.dumps(
+            {
+                "step_id": step.id,
+                "work_item_id": context.metadata.get("active_work_item_id"),
+                "change_set_id": context.metadata.get("change_set_id"),
+                **dict(decision),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return evidence
+
+
+def _decision_result_from_file(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _relative_to_repo(path: Path | None, context: RunContext) -> Path:

--- a/harness_codex/runtime/state.py
+++ b/harness_codex/runtime/state.py
@@ -137,6 +137,7 @@ class RunState:
     failed_step_id: str | None = None
     failure_kind: RunFailureKind | None = None
     status: RunStatus = RunStatus.PENDING
+    decision_results: Mapping[str, Any] = field(default_factory=dict)
     use_case_states: tuple[UseCaseLoopState, ...] = ()
     work_item_states: tuple[WorkItemLoopState, ...] = ()
     artifact_states: tuple[StageArtifactState, ...] = ()
@@ -433,6 +434,7 @@ def _run_state_from_json(data: Mapping[str, Any]) -> RunState:
             else None
         ),
         status=RunStatus(data["status"]),
+        decision_results=data.get("decision_results", {}),
         use_case_states=use_case_states,
         work_item_states=work_item_states,
         artifact_states=artifact_states,

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 
 from harness_codex.runtime.models import (
+    FailureKind,
     RunContext,
     RunMode,
     Step,
@@ -425,6 +426,93 @@ def test_basic_step_runner_appends_runtime_remediation_task(tmp_path: Path) -> N
     assert "- [ ] Retry 1: fix `verify-work-item` (implementation)" in plan_text
     assert "missing branch" in plan_text
     assert "extra details" not in plan_text
+
+
+def test_basic_step_runner_classifies_implementation_failure(tmp_path: Path) -> None:
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    run_context = RunContext(
+        run_id="run-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-001",
+        metadata={
+            "change_set_id": "CHG-001",
+            "active_work_item_id": "UC-001",
+            "runtime_failed_step_id": "verify-work-item",
+            "runtime_failure_kind": "implementation",
+            "runtime_failure_error": "assertion failed",
+        },
+    )
+    step = Step(
+        id="classify-verification-result",
+        kind=StepKind.DECISION,
+        name="Classify",
+        metadata={
+            "classifier": "verification_result",
+            "on_implementation_failure": "remediate-work-item",
+        },
+    )
+
+    result = runner.run(step, run_context)
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.failure_kind is None
+    assert result.metadata["decision"]["decision"] == "IMPLEMENTATION_FAILURE"
+    assert result.metadata["decision"]["route"] == "remediate-work-item"
+    assert result.metadata["decision"]["blocked"] is False
+    evidence = tmp_path / result.output_path
+    assert json.loads(evidence.read_text(encoding="utf-8"))["work_item_id"] == "UC-001"
+
+
+def test_basic_step_runner_blocks_unclear_e2e_goal_decision(tmp_path: Path) -> None:
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    run_context = RunContext(
+        run_id="run-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-001",
+        metadata={
+            "runtime_failed_step_id": "verify-work-item",
+            "runtime_failure_kind": "unknown",
+            "runtime_failure_error": "ambiguous E2E goal",
+        },
+    )
+    step = Step(
+        id="classify-verification-result",
+        kind=StepKind.DECISION,
+        name="Classify",
+        metadata={
+            "classifier": "verification_result",
+            "on_unclear_e2e_goal": "e2e-goal-approval",
+        },
+    )
+
+    result = runner.run(step, run_context)
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.failure_kind == FailureKind.UNCLEAR_E2E_GOAL
+    assert result.metadata["decision"]["decision"] == "UNCLEAR_E2E_GOAL"
+    assert result.metadata["decision"]["owner_stage"] == "e2e-goal-approval"
+    assert "return to E2E goal approval gate" in result.error
+
+
+def test_basic_step_runner_blocks_unsupported_decision_step(tmp_path: Path) -> None:
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="pick-next-thing",
+        kind=StepKind.DECISION,
+        name="Unsupported decision",
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.error == "decision classifier is required"
+    assert result.metadata["decision"]["decision"] == "UNSUPPORTED_DECISION_STEP"
 
 
 def test_basic_step_runner_records_skill_invocation_manifest(tmp_path: Path) -> None:

--- a/tests/runtime/test_engine.py
+++ b/tests/runtime/test_engine.py
@@ -315,6 +315,51 @@ def test_engine_blocks_non_implementation_failure_without_remediation() -> None:
     ]
 
 
+def test_engine_records_decision_metadata() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="verify", kind=StepKind.VALIDATOR, name="Verify"),
+            Step(
+                id="classify",
+                kind=StepKind.DECISION,
+                name="Classify",
+                needs=("verify",),
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner(
+        results_by_step_id={
+            "classify": StepResult(
+                step_id="classify",
+                status=StepStatus.SUCCEEDED,
+                metadata={
+                    "decision": {
+                        "classifier": "verification_result",
+                        "decision": "VERIFICATION_PASSED",
+                        "route": "complete",
+                        "blocked": False,
+                    }
+                },
+            ),
+        }
+    )
+
+    result = RunnerEngine(fake_runner).run(workflow, context())
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.metadata["decisions"] == (
+        {
+            "step_id": "classify",
+            "classifier": "verification_result",
+            "decision": "VERIFICATION_PASSED",
+            "route": "complete",
+            "blocked": False,
+        },
+    )
+
+
 def test_plan_rejects_duplicate_step_ids() -> None:
     workflow = Workflow(
         name="example",

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -220,6 +220,8 @@ def test_harness_full_workflow_records_use_case_repeat_loop_intent() -> None:
         decision.metadata["on_implementation_failure"]
         == "revise-use-case-plan-and-repeat"
     )
+    assert decision.metadata["classifier"] == "verification_result"
+    assert decision.metadata["on_unclear_e2e_goal"] == "e2e-goal-approval"
     assert decision.metadata["on_success"] == "complete-use-case-plan"
 
     assert remediation.kind == StepKind.RECORD

--- a/tests/runtime/test_run_state_resume.py
+++ b/tests/runtime/test_run_state_resume.py
@@ -26,6 +26,15 @@ def test_run_state_store_round_trips_json(tmp_path: Path) -> None:
         current_use_case_id="UC-001",
         current_step_id=UseCaseStep.VERIFY,
         status=RunStatus.RUNNING,
+        decision_results={
+            "UC-001": [
+                {
+                    "step_id": "classify-verification-result",
+                    "decision": "IMPLEMENTATION_FAILURE",
+                    "route": "remediate-work-item",
+                },
+            ]
+        },
         use_case_states=(
             UseCaseLoopState(
                 uc_id="UC-001",

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -128,6 +128,10 @@ def test_default_changeset_work_item_workflow_loads() -> None:
         "python3 -m harness_codex.runtime.verify_work_item "
         "--change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>"
     )
+    decision = workflow.step_by_id("classify-verification-result")
+    assert decision.kind == StepKind.DECISION
+    assert decision.metadata["classifier"] == "verification_result"
+    assert "UNCLEAR_E2E_GOAL" in decision.metadata["failure_kinds"]
     remediation = workflow.step_by_id("remediate-work-item")
     assert remediation.needs == ("classify-verification-result",)
     assert remediation.metadata["loop_target"] == "execute-work-item"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -605,7 +605,7 @@ def test_run_change_apply_completes_when_work_item_plan_already_completed(
     assert (run_dir / "changeset-completion-report.md").is_file()
 
 
-def test_resume_reports_next_target(tmp_path: Path, capsys) -> None:
+def test_resume_reports_environment_blocker(tmp_path: Path, capsys) -> None:
     write_changeset(tmp_path)
     main(["--repo-root", str(tmp_path), "run-change", "CHG-001", "--apply"])
     capsys.readouterr()
@@ -615,7 +615,7 @@ def test_resume_reports_next_target(tmp_path: Path, capsys) -> None:
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Resume: NEXT_USE_CASE" in output
+    assert "Resume: WAIT_FOR_ENVIRONMENT" in output
     assert "UC: UC-001" in output
 
 


### PR DESCRIPTION
## 구현 의도
- #240의 `decision` 단계가 더 이상 무의미하게 성공하지 않도록 런타임 분류기를 구현한다.
- `classify-verification-result`가 검증 결과를 구조화된 결정으로 남기고, 구현 실패만 보정 루프로 보낸다.

## 구현 방식
- `BasicStepRunner`에 `StepKind.DECISION` 처리를 추가하고 `verification_result` 분류기를 통해 성공, 구현 실패, E2E 목표 불명확, 문서 델타 충돌, 상위 설계 충돌, 환경 차단, 범위 충돌, 검증 목표 불명확을 분류한다.
- 미지원 결정 단계는 `decision classifier is required`로 차단한다.
- 결정 결과는 step evidence `decision.json`, `RunResult.metadata["decisions"]`, `RunState.decision_results`에 저장한다.
- 기본 ChangeSet 워크플로와 내장 HARNESS_FULL_WORKFLOW에 명시적 classifier와 차단 라우팅 메타데이터를 추가한다.

## 검증 방법
- `./venv/bin/python3 -m py_compile harness_codex/runtime/runner.py harness_codex/runtime/engine.py harness_codex/runtime/models.py harness_codex/runtime/state.py harness_codex/cli.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/runtime/test_engine.py tests/runtime/test_run_state_resume.py tests/runtime/test_workflow_loader.py tests/runtime/test_models.py`
- `./venv/bin/python3 -m pytest -q -s`
- `git diff --check`

## 위험 및 롤백
- 결정 단계가 fail-closed로 바뀌므로 classifier가 없는 새 decision 워크플로는 차단된다. 필요한 경우 해당 워크플로에 classifier 메타데이터를 추가한다.
- 문제가 생기면 이 커밋을 되돌리면 기존 no-op decision 동작으로 돌아간다.

Closes #240