### PR TITLE
[codex] 문서 계약 레지스트리 추가

### DIFF
--- a/.harness/contracts/document-contracts.yaml
+++ b/.harness/contracts/document-contracts.yaml
@@ -1,0 +1,475 @@
+version: 1
+
+contracts:
+  - doc_type: context
+    path_pattern: context.md
+    owner_stage: harvest-ubiquitous-language
+    producer:
+      skill: harness-ubiquitous-language
+      agent: ubiquitous_language_reviewer
+    consumes:
+      - requirements.functional
+      - requirements.business_policy
+    produces:
+      - context.ubiquitous_language.terms
+      - context.ubiquitous_language.forbidden_terms
+    gates:
+      - canonical_terms_are_unique
+      - forbidden_terms_are_declared
+    stales_downstream:
+      - requirements
+      - use_case_index
+      - use_case_slice
+      - e2e_goal
+      - event_storming
+      - ddd_design
+      - technical_decisions
+      - active_plan
+    dashboard_fields: &default_dashboard_fields
+      - status
+      - blocker
+      - approval_status
+      - checksum
+      - stale
+
+  - doc_type: requirements
+    path_pattern: docs/design/요구사항.md
+    owner_stage: harvest-requirements
+    producer:
+      skill: harness-requirements
+      agent: requirements_interviewer
+    consumes:
+      - product_intent
+      - context.ubiquitous_language.terms
+    produces:
+      - requirements.functional
+      - requirements.business_policy
+      - requirements.readiness
+    gates:
+      - functional_requirements_are_confirmed
+      - business_policy_readiness_is_declared
+    stales_downstream:
+      - use_case_index
+      - use_case_slice
+      - e2e_goal
+      - event_storming
+      - ddd_design
+      - technical_decisions
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: use_case_index
+    path_pattern: docs/design/유스케이스.md
+    owner_stage: harvest-use-cases
+    producer:
+      skill: harness-usecases
+      agent: harness_usecases
+    consumes:
+      - context.ubiquitous_language.terms
+      - requirements.functional
+    produces:
+      - use_case.index
+      - use_case.actors
+      - use_case.goals
+    gates:
+      - external_actor_use_cases_only
+      - uses_only_canonical_terms
+    stales_downstream:
+      - use_case_slice
+      - e2e_goal
+      - event_storming
+      - ddd_design
+      - technical_decisions
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: change_set
+    path_pattern: docs/changes/active/<CHG-ID>.md
+    owner_stage: change_set
+    producer:
+      runtime: changes.create-from-design
+    consumes:
+      - use_case.index
+      - use_case.slice_status
+      - maintenance.intent
+    produces:
+      - change_set.scope
+      - change_set.changed_documents
+      - change_set.work_items
+    gates:
+      - affected_work_items_are_declared
+      - planner_scope_is_declared
+      - completion_conditions_are_declared
+    stales_downstream:
+      - use_case_slice
+      - e2e_goal
+      - technical_decisions
+      - active_plan
+      - run_state
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: completed_change_set
+    path_pattern: docs/changes/completed/<CHG-ID>.md
+    owner_stage: complete-change-set
+    producer:
+      runtime: complete_change_set_if_ready
+    consumes:
+      - change_set.scope
+      - completed_plan.status
+      - run_state.status
+    produces:
+      - change_set.completion_record
+      - change_set.rollback_context
+    gates:
+      - all_affected_work_item_plans_completed
+      - completion_report_written
+    stales_downstream: []
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: use_case_slice
+    path_pattern: docs/use-cases/<UC-ID>/use-case.md
+    owner_stage: use-case-definition
+    producer:
+      skill: harness-usecases
+      agent: harness_usecases
+    consumes:
+      - context.ubiquitous_language.terms
+      - requirements.functional
+      - use_case.index
+    produces:
+      - use_case.actor
+      - use_case.goal
+      - use_case.preconditions
+      - use_case.main_flow
+      - use_case.failure_flow
+      - use_case.result
+    gates:
+      - exactly_one_external_actor_goal
+      - uses_only_canonical_terms
+      - scope_boundary_is_declared
+    stales_downstream:
+      - e2e_goal
+      - event_storming
+      - ddd_design
+      - technical_decisions
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: use_case_index_slice
+    path_pattern: docs/use-cases/<UC-ID>/index.md
+    owner_stage: use-case-definition
+    producer:
+      skill: harness-usecases
+      agent: harness_usecases
+    consumes:
+      - use_case.actor
+      - use_case.goal
+      - change_set.scope
+    produces:
+      - use_case.slice_status
+      - use_case.document_inventory
+      - use_case.canonical_tracking
+    gates:
+      - related_changeset_is_declared
+      - required_slice_documents_are_listed
+    stales_downstream:
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: e2e_goal
+    path_pattern: docs/use-cases/<UC-ID>/e2e-goal.md
+    owner_stage: e2e-goal
+    producer:
+      skill: harness-usecases
+      agent: harness_usecases
+    consumes:
+      - use_case.actor
+      - use_case.goal
+      - use_case.main_flow
+    produces:
+      - e2e.given
+      - e2e.when
+      - e2e.then
+      - e2e.verification_commands
+      - e2e.approval_status
+    gates:
+      - approval_status_is_approved_before_planning
+      - observable_user_result_is_declared
+      - repository_test_gate_is_declared
+    stales_downstream:
+      - active_plan
+      - run_state
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: event_storming
+    path_pattern: docs/use-cases/<UC-ID>/event-storming.md
+    owner_stage: event-storming
+    producer:
+      skill: harness-event-storming
+      agent: oracle
+    consumes:
+      - use_case.actor
+      - use_case.goal
+      - use_case.main_flow
+      - use_case.failure_flow
+    produces:
+      - event_storming.commands
+      - event_storming.events
+      - event_storming.policies
+      - event_storming.invariants
+    gates:
+      - commands_map_to_use_case_flow
+      - invariants_are_declared
+      - external_systems_are_identified
+    stales_downstream:
+      - ddd_design
+      - technical_decisions
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: ddd_design
+    path_pattern: docs/use-cases/<UC-ID>/ddd-design.md
+    owner_stage: ddd-design
+    producer:
+      skill: harness-ddd-design
+      agent: ddd_architect
+    consumes:
+      - event_storming.commands
+      - event_storming.events
+      - event_storming.policies
+      - event_storming.invariants
+    produces:
+      - ddd.domain_model
+      - ddd.aggregates
+      - ddd.application_services
+      - ddd.domain_services
+      - ddd.ports
+      - ddd.bounded_contexts
+    gates:
+      - aggregate_names_are_present
+      - entities_and_value_objects_are_typed
+      - application_service_methods_are_declared
+    stales_downstream:
+      - technical_decisions
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: technical_decisions
+    path_pattern: docs/use-cases/<UC-ID>/technical-decisions.md
+    owner_stage: technical-decisions
+    producer:
+      skill: harness-technical-decisions
+      agent: technical_decision_maker
+    consumes:
+      - ddd.domain_model
+      - ddd.aggregates
+      - ddd.ports
+      - e2e.verification_commands
+      - change_set.scope
+    produces:
+      - technical_decision.persistence
+      - technical_decision.transaction
+      - technical_decision.external_collaboration
+      - technical_decision.retry_policy
+      - technical_decision.observability
+      - technical_decision.approval_status
+    gates:
+      - implementation_affecting_decisions_are_approved
+      - repository_commands_are_declared
+      - unresolved_decisions_are_declared
+    stales_downstream:
+      - active_plan
+      - run_state
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: use_case_affected_files
+    path_pattern: docs/use-cases/<UC-ID>/affected-files.md
+    owner_stage: use-case-definition
+    producer:
+      skill: harness-usecases
+      agent: harness_usecases
+    consumes:
+      - change_set.scope
+      - use_case.goal
+    produces:
+      - scope.expected_files
+      - scope.forbidden_files
+      - scope.test_targets
+    gates:
+      - expected_files_are_declared
+      - forbidden_paths_are_declared
+    stales_downstream:
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: maintenance_index
+    path_pattern: docs/maintenance/<MAINT-ID>/index.md
+    owner_stage: maintenance-definition
+    producer:
+      runtime: changes.create-from-design
+    consumes:
+      - maintenance.intent
+      - change_set.scope
+    produces:
+      - maintenance.document_inventory
+      - maintenance.status
+    gates:
+      - related_changeset_is_declared
+      - required_maintenance_documents_are_listed
+    stales_downstream:
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: maintenance_change_intent
+    path_pattern: docs/maintenance/<MAINT-ID>/change-intent.md
+    owner_stage: maintenance-definition
+    producer:
+      runtime: changes.create-from-design
+    consumes:
+      - change_set.scope
+      - maintenance.intent
+    produces:
+      - maintenance.before_state
+      - maintenance.after_state
+      - maintenance.scope_boundary
+    gates:
+      - before_after_are_declared
+      - scope_boundary_is_declared
+    stales_downstream:
+      - maintenance_technical_decisions
+      - maintenance_verification_goal
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: maintenance_affected_files
+    path_pattern: docs/maintenance/<MAINT-ID>/affected-files.md
+    owner_stage: maintenance-definition
+    producer:
+      runtime: changes.create-from-design
+    consumes:
+      - maintenance.before_state
+      - maintenance.after_state
+    produces:
+      - scope.expected_files
+      - scope.forbidden_files
+      - scope.test_targets
+    gates:
+      - expected_files_are_declared
+      - forbidden_paths_are_declared
+    stales_downstream:
+      - active_plan
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: maintenance_technical_decisions
+    path_pattern: docs/maintenance/<MAINT-ID>/technical-decisions.md
+    owner_stage: maintenance-technical-decisions
+    producer:
+      skill: harness-technical-decisions
+      agent: technical_decision_maker
+    consumes:
+      - maintenance.before_state
+      - maintenance.after_state
+      - scope.expected_files
+    produces:
+      - technical_decision.maintenance_strategy
+      - technical_decision.approval_status
+    gates:
+      - implementation_affecting_decisions_are_approved
+      - unresolved_decisions_are_declared
+    stales_downstream:
+      - active_plan
+      - run_state
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: maintenance_verification_goal
+    path_pattern: docs/maintenance/<MAINT-ID>/verification-goal.md
+    owner_stage: maintenance-verification-goal
+    producer:
+      runtime: changes.create-from-design
+    consumes:
+      - maintenance.before_state
+      - maintenance.after_state
+      - scope.test_targets
+    produces:
+      - verification.given
+      - verification.when
+      - verification.then
+      - verification.commands
+    gates:
+      - observable_result_is_declared
+      - repository_test_gate_is_declared
+    stales_downstream:
+      - active_plan
+      - run_state
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: active_plan
+    path_pattern: docs/plans/active/<WORK-ITEM-ID>/plan.md
+    owner_stage: plan-work-item
+    producer:
+      skill: harness-code-planner
+      agent: implementation_planner
+    consumes:
+      - change_set.scope
+      - use_case.actor
+      - use_case.goal
+      - e2e.verification_commands
+      - technical_decision.approval_status
+      - verification.commands
+    produces:
+      - plan.tasks
+      - plan.verification_obligations
+      - plan.completion_checklist
+    gates:
+      - all_upstream_artifacts_are_current
+      - verification_obligations_are_declared
+      - unchecked_tasks_are_actionable
+    stales_downstream:
+      - completed_plan
+      - run_state
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: completed_plan
+    path_pattern: docs/plans/completed/<WORK-ITEM-ID>/plan.md
+    owner_stage: complete-work-item-plan
+    producer:
+      skill: harness-plan-executor
+      agent: implementation_executor
+    consumes:
+      - plan.tasks
+      - plan.verification_obligations
+      - run_state.verification_result
+    produces:
+      - completed_plan.tasks
+      - completed_plan.verification_evidence
+      - completed_plan.completion_status
+    gates:
+      - all_plan_tasks_are_checked
+      - verification_evidence_is_recorded
+      - required_test_gate_passed
+    stales_downstream:
+      - completed_change_set
+    dashboard_fields: *default_dashboard_fields
+
+  - doc_type: run_state
+    path_pattern: .harness/runs/<RUN-ID>/state.json
+    owner_stage: runtime
+    producer:
+      runtime: RunStateStore
+    consumes:
+      - change_set.scope
+      - plan.tasks
+      - verification.commands
+    produces:
+      - run_state.status
+      - run_state.current_stage
+      - run_state.blocker
+      - run_state.verification_result
+    gates:
+      - state_json_is_loadable
+      - current_stage_is_known
+      - blocker_is_recorded_when_blocked
+    stales_downstream:
+      - completed_plan
+      - completed_change_set
+    dashboard_fields: *default_dashboard_fields

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -11,6 +11,14 @@ from harness_codex.runtime.completion import (
     complete_change_set_if_ready,
     validate_plan_completion,
 )
+from harness_codex.runtime.contracts import (
+    DEFAULT_CONTRACT_REGISTRY_PATH,
+    DocumentContract,
+    DocumentContractRegistry,
+    DocumentContractRegistryError,
+    DocumentProducer,
+    load_document_contract_registry,
+)
 from harness_codex.runtime.engine import (
     ExecutionPlan,
     RunnerEngine,
@@ -97,6 +105,11 @@ __all__ = [
     "BasicStepRunner",
     "CodexCliAgentAdapter",
     "ConfigurableCliAgentAdapter",
+    "DEFAULT_CONTRACT_REGISTRY_PATH",
+    "DocumentContract",
+    "DocumentContractRegistry",
+    "DocumentContractRegistryError",
+    "DocumentProducer",
     "ExecutionPlan",
     "FailureKind",
     "HARNESS_FULL_WORKFLOW",
@@ -143,5 +156,6 @@ __all__ = [
     "complete_change_set_if_ready",
     "decide_resume_target",
     "file_checksum",
+    "load_document_contract_registry",
     "validate_plan_completion",
 ]

--- a/harness_codex/runtime/contracts/__init__.py
+++ b/harness_codex/runtime/contracts/__init__.py
@@ -1,0 +1,31 @@
+"""Document contract registry API."""
+
+from harness_codex.runtime.contracts.dashboard_projection import (
+    DocumentContractDashboardRow,
+    document_contract_dashboard_rows,
+)
+from harness_codex.runtime.contracts.models import (
+    DEFAULT_DASHBOARD_FIELDS,
+    DocumentContract,
+    DocumentProducer,
+)
+from harness_codex.runtime.contracts.registry import (
+    DEFAULT_CONTRACT_REGISTRY_PATH,
+    DocumentContractRegistry,
+    load_document_contract_registry,
+    load_document_contract_registry_text,
+)
+from harness_codex.runtime.contracts.validators import DocumentContractRegistryError
+
+__all__ = [
+    "DEFAULT_CONTRACT_REGISTRY_PATH",
+    "DEFAULT_DASHBOARD_FIELDS",
+    "DocumentContract",
+    "DocumentContractDashboardRow",
+    "DocumentContractRegistry",
+    "DocumentContractRegistryError",
+    "DocumentProducer",
+    "document_contract_dashboard_rows",
+    "load_document_contract_registry",
+    "load_document_contract_registry_text",
+]

--- a/harness_codex/runtime/contracts/dashboard_projection.py
+++ b/harness_codex/runtime/contracts/dashboard_projection.py
@@ -1,0 +1,35 @@
+"""Dashboard projection for document contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from harness_codex.runtime.contracts.registry import DocumentContractRegistry
+
+
+@dataclass(frozen=True)
+class DocumentContractDashboardRow:
+    """Small dashboard-safe row for one document contract."""
+
+    doc_type: str
+    path_pattern: str
+    owner_stage: str
+    dashboard_fields: tuple[str, ...]
+    stales_downstream: tuple[str, ...]
+
+
+def document_contract_dashboard_rows(
+    registry: DocumentContractRegistry,
+) -> tuple[DocumentContractDashboardRow, ...]:
+    """Project contracts into deterministic dashboard rows."""
+
+    return tuple(
+        DocumentContractDashboardRow(
+            doc_type=contract.doc_type,
+            path_pattern=contract.path_pattern,
+            owner_stage=contract.owner_stage,
+            dashboard_fields=contract.dashboard_fields,
+            stales_downstream=contract.stales_downstream,
+        )
+        for contract in registry.contracts
+    )

--- a/harness_codex/runtime/contracts/models.py
+++ b/harness_codex/runtime/contracts/models.py
@@ -1,0 +1,32 @@
+"""Models for document contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+DEFAULT_DASHBOARD_FIELDS = ("status", "blocker", "approval_status", "checksum", "stale")
+
+
+@dataclass(frozen=True)
+class DocumentProducer:
+    """Runtime producer identity for one artifact contract."""
+
+    skill: str = ""
+    agent: str = ""
+    runtime: str = ""
+
+
+@dataclass(frozen=True)
+class DocumentContract:
+    """Contract for one harness artifact type."""
+
+    doc_type: str
+    path_pattern: str
+    owner_stage: str
+    producer: DocumentProducer
+    consumes: tuple[str, ...] = ()
+    produces: tuple[str, ...] = ()
+    gates: tuple[str, ...] = ()
+    stales_downstream: tuple[str, ...] = ()
+    dashboard_fields: tuple[str, ...] = DEFAULT_DASHBOARD_FIELDS

--- a/harness_codex/runtime/contracts/registry.py
+++ b/harness_codex/runtime/contracts/registry.py
@@ -1,0 +1,122 @@
+"""Load document contract registries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from harness_codex.runtime.contracts.models import DocumentContract, DocumentProducer
+from harness_codex.runtime.contracts.validators import (
+    DocumentContractRegistryError,
+    validate_contracts,
+)
+from harness_codex.runtime.workflows.schema import (
+    require_mapping,
+    require_optional_string,
+    require_sequence,
+    require_string,
+)
+
+DEFAULT_CONTRACT_REGISTRY_PATH = Path(".harness/contracts/document-contracts.yaml")
+
+
+@dataclass(frozen=True)
+class DocumentContractRegistry:
+    """Deterministic lookup table for harness document contracts."""
+
+    contracts: tuple[DocumentContract, ...]
+
+    def __post_init__(self) -> None:
+        validate_contracts(self.contracts)
+
+    def by_doc_type(self, doc_type: str) -> DocumentContract:
+        for contract in self.contracts:
+            if contract.doc_type == doc_type:
+                return contract
+        raise KeyError(doc_type)
+
+    def downstream_of(self, doc_type: str) -> tuple[DocumentContract, ...]:
+        contract = self.by_doc_type(doc_type)
+        return tuple(self.by_doc_type(target) for target in contract.stales_downstream)
+
+    def path_patterns(self) -> tuple[str, ...]:
+        return tuple(contract.path_pattern for contract in self.contracts)
+
+
+def load_document_contract_registry(
+    repo_root: Path | str = Path("."),
+    registry_path: Path | str = DEFAULT_CONTRACT_REGISTRY_PATH,
+) -> DocumentContractRegistry:
+    """Load the default document contract registry from a repo root."""
+
+    path = Path(registry_path)
+    if not path.is_absolute():
+        path = Path(repo_root) / path
+    return load_document_contract_registry_text(path.read_text(encoding="utf-8"))
+
+
+def load_document_contract_registry_text(text: str) -> DocumentContractRegistry:
+    """Load registry YAML text into a validated registry."""
+
+    try:
+        document = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise DocumentContractRegistryError(f"Invalid contract registry YAML: {exc}") from exc
+
+    root = require_mapping(document, "contract registry")
+    raw_contracts = require_sequence(root.get("contracts"), "contracts")
+    contracts = tuple(
+        _to_contract(require_mapping(raw_contract, f"contracts[{index}]"))
+        for index, raw_contract in enumerate(raw_contracts)
+    )
+    return DocumentContractRegistry(contracts=contracts)
+
+
+def _to_contract(raw_contract: Mapping[str, Any]) -> DocumentContract:
+    producer = _to_producer(raw_contract.get("producer"))
+    doc_type = require_string(raw_contract.get("doc_type"), "contracts[].doc_type")
+    return DocumentContract(
+        doc_type=doc_type,
+        path_pattern=require_string(
+            raw_contract.get("path_pattern"), f"contracts[{doc_type}].path_pattern"
+        ),
+        owner_stage=require_string(
+            raw_contract.get("owner_stage"), f"contracts[{doc_type}].owner_stage"
+        ),
+        producer=producer,
+        consumes=_string_tuple(
+            raw_contract.get("consumes"), f"contracts[{doc_type}].consumes"
+        ),
+        produces=_string_tuple(
+            raw_contract.get("produces"), f"contracts[{doc_type}].produces"
+        ),
+        gates=_string_tuple(raw_contract.get("gates"), f"contracts[{doc_type}].gates"),
+        stales_downstream=_string_tuple(
+            raw_contract.get("stales_downstream"),
+            f"contracts[{doc_type}].stales_downstream",
+        ),
+        dashboard_fields=_string_tuple(
+            raw_contract.get("dashboard_fields"),
+            f"contracts[{doc_type}].dashboard_fields",
+        )
+        or DocumentContract.dashboard_fields,
+    )
+
+
+def _to_producer(value: Any) -> DocumentProducer:
+    producer = require_mapping(value, "contracts[].producer")
+    return DocumentProducer(
+        skill=require_optional_string(producer.get("skill"), "producer.skill") or "",
+        agent=require_optional_string(producer.get("agent"), "producer.agent") or "",
+        runtime=require_optional_string(producer.get("runtime"), "producer.runtime") or "",
+    )
+
+
+def _string_tuple(value: Any, path: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    sequence = require_sequence(value, path)
+    return tuple(require_string(item, f"{path}[]") for item in sequence)

--- a/harness_codex/runtime/contracts/validators.py
+++ b/harness_codex/runtime/contracts/validators.py
@@ -1,0 +1,67 @@
+"""Validation helpers for document contract registries."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from harness_codex.runtime.contracts.models import DocumentContract
+
+
+class DocumentContractRegistryError(ValueError):
+    """Raised when a document contract registry is invalid."""
+
+
+def validate_contracts(contracts: tuple[DocumentContract, ...]) -> None:
+    """Validate registry invariants that downstream tools rely on."""
+
+    if not contracts:
+        raise DocumentContractRegistryError("contracts must not be empty")
+
+    _reject_duplicates("doc_type", (contract.doc_type for contract in contracts))
+    _reject_duplicates(
+        "path_pattern", (contract.path_pattern for contract in contracts)
+    )
+
+    doc_types = {contract.doc_type for contract in contracts}
+    for contract in contracts:
+        if not contract.consumes:
+            raise DocumentContractRegistryError(
+                f"{contract.doc_type} must declare consumed fields"
+            )
+        if not contract.produces:
+            raise DocumentContractRegistryError(
+                f"{contract.doc_type} must declare produced fields"
+            )
+        if not contract.gates:
+            raise DocumentContractRegistryError(f"{contract.doc_type} must declare gates")
+        if not contract.dashboard_fields:
+            raise DocumentContractRegistryError(
+                f"{contract.doc_type} must declare dashboard fields"
+            )
+        if not (
+            contract.producer.skill
+            or contract.producer.agent
+            or contract.producer.runtime
+        ):
+            raise DocumentContractRegistryError(
+                f"{contract.doc_type} must declare at least one producer identity"
+            )
+
+        unknown_edges = [
+            target
+            for target in contract.stales_downstream
+            if target not in doc_types
+        ]
+        if unknown_edges:
+            joined = ", ".join(sorted(unknown_edges))
+            raise DocumentContractRegistryError(
+                f"{contract.doc_type} has unknown downstream contract(s): {joined}"
+            )
+
+
+def _reject_duplicates(label: str, values) -> None:
+    counts = Counter(values)
+    duplicates = sorted(value for value, count in counts.items() if count > 1)
+    if duplicates:
+        joined = ", ".join(duplicates)
+        raise DocumentContractRegistryError(f"duplicate {label}: {joined}")

--- a/tests/runtime/test_document_contract_registry.py
+++ b/tests/runtime/test_document_contract_registry.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+import pytest
+
+from harness_codex.runtime.contracts import (
+    DocumentContractRegistryError,
+    document_contract_dashboard_rows,
+    load_document_contract_registry,
+    load_document_contract_registry_text,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_default_document_contract_registry_loads_deterministically() -> None:
+    registry = load_document_contract_registry(REPO_ROOT)
+
+    assert registry.by_doc_type("context").path_pattern == "context.md"
+    assert registry.by_doc_type("use_case_slice").owner_stage == "use-case-definition"
+    assert registry.by_doc_type("run_state").path_pattern == (
+        ".harness/runs/<RUN-ID>/state.json"
+    )
+
+    assert registry.path_patterns() == tuple(
+        contract.path_pattern for contract in registry.contracts
+    )
+
+
+def test_registry_covers_known_harness_artifact_path_patterns() -> None:
+    registry = load_document_contract_registry(REPO_ROOT)
+
+    expected_patterns = {
+        "context.md",
+        "docs/design/요구사항.md",
+        "docs/design/유스케이스.md",
+        "docs/changes/active/<CHG-ID>.md",
+        "docs/changes/completed/<CHG-ID>.md",
+        "docs/use-cases/<UC-ID>/index.md",
+        "docs/use-cases/<UC-ID>/use-case.md",
+        "docs/use-cases/<UC-ID>/e2e-goal.md",
+        "docs/use-cases/<UC-ID>/event-storming.md",
+        "docs/use-cases/<UC-ID>/ddd-design.md",
+        "docs/use-cases/<UC-ID>/technical-decisions.md",
+        "docs/use-cases/<UC-ID>/affected-files.md",
+        "docs/maintenance/<MAINT-ID>/index.md",
+        "docs/maintenance/<MAINT-ID>/change-intent.md",
+        "docs/maintenance/<MAINT-ID>/technical-decisions.md",
+        "docs/maintenance/<MAINT-ID>/affected-files.md",
+        "docs/maintenance/<MAINT-ID>/verification-goal.md",
+        "docs/plans/active/<WORK-ITEM-ID>/plan.md",
+        "docs/plans/completed/<WORK-ITEM-ID>/plan.md",
+        ".harness/runs/<RUN-ID>/state.json",
+    }
+
+    assert expected_patterns <= set(registry.path_patterns())
+
+
+def test_registry_validates_downstream_stale_edges() -> None:
+    registry = load_document_contract_registry(REPO_ROOT)
+
+    assert tuple(contract.doc_type for contract in registry.downstream_of("context")) == (
+        "requirements",
+        "use_case_index",
+        "use_case_slice",
+        "e2e_goal",
+        "event_storming",
+        "ddd_design",
+        "technical_decisions",
+        "active_plan",
+    )
+    assert tuple(
+        contract.doc_type for contract in registry.downstream_of("use_case_slice")
+    ) == (
+        "e2e_goal",
+        "event_storming",
+        "ddd_design",
+        "technical_decisions",
+        "active_plan",
+    )
+    assert tuple(
+        contract.doc_type for contract in registry.downstream_of("technical_decisions")
+    ) == ("active_plan", "run_state")
+
+
+def test_registry_rejects_unknown_downstream_edges() -> None:
+    text = """
+contracts:
+  - doc_type: source
+    path_pattern: source.md
+    owner_stage: stage
+    producer:
+      runtime: test
+    consumes: [input.field]
+    produces: [output.field]
+    gates: [gate]
+    stales_downstream: [missing]
+    dashboard_fields: [status]
+"""
+
+    with pytest.raises(
+        DocumentContractRegistryError,
+        match="source has unknown downstream contract",
+    ):
+        load_document_contract_registry_text(text)
+
+
+def test_dashboard_projection_exposes_contract_rows() -> None:
+    registry = load_document_contract_registry(REPO_ROOT)
+    rows = document_contract_dashboard_rows(registry)
+
+    context_row = rows[0]
+    assert context_row.doc_type == "context"
+    assert context_row.path_pattern == "context.md"
+    assert context_row.dashboard_fields == (
+        "status",
+        "blocker",
+        "approval_status",
+        "checksum",
+        "stale",
+    )


### PR DESCRIPTION
Closes #250

## 구현 의도

Harness 산출물별 암묵 계약을 런타임에서 조회 가능한 문서 계약 레지스트리로 정의합니다. 각 산출물의 소유 단계, 생산자, 입력/출력 필드, 게이트, downstream stale edge, dashboard 노출 필드를 한 곳에서 관리하도록 합니다.

## 구현 접근

- `harness_codex/runtime/contracts` 패키지를 추가해 `DocumentContract`, `DocumentProducer`, `DocumentContractRegistry` 모델과 YAML 로더, 검증기, dashboard projection을 분리했습니다.
- `.harness/contracts/document-contracts.yaml`에 context, requirements, use-case index/slice, e2e goal, ChangeSet, event-storming, DDD design, technical decisions, active/completed plan, run state 및 maintenance 산출물 계약을 등록했습니다.
- 로더는 YAML을 결정적으로 dataclass tuple로 변환하고, 중복 doc type/path pattern 및 알 수 없는 downstream edge를 fail-fast로 검증합니다.
- `harness_codex.runtime`에서 새 계약 API를 export해 런타임/대시보드가 같은 registry를 재사용할 수 있게 했습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_contract_registry.py` -> 5 passed
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_contract_registry.py tests/runtime/test_workflow_loader.py` -> 19 passed
- `./venv/bin/python3 -m py_compile harness_codex/runtime/contracts/*.py harness_codex/runtime/__init__.py` -> passed
- `./venv/bin/python3 -m pytest -q -s` -> 332 passed, 2 failed. 실패는 이 변경과 무관하게 격리 재실행에서도 재현되는 기존 환경/플레이키 실패입니다: `test_ui_server_restarts_existing_server_for_repo`, `test_resume_reports_next_target`.

## 위험 및 롤백

새 registry API는 기존 workflow 실행 경로를 변경하지 않는 additive 변경입니다. 문제가 생기면 `.harness/contracts/document-contracts.yaml`, `harness_codex/runtime/contracts/`, `tests/runtime/test_document_contract_registry.py`, runtime export 변경을 되돌리면 됩니다.
