### PR TITLE
[P1] 생성 문서 메타데이터 계약 추가

### DIFF
--- a/harness_codex/runtime/changes/design_bridge.py
+++ b/harness_codex/runtime/changes/design_bridge.py
@@ -7,6 +7,13 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from harness_codex.runtime.document_metadata import (
+    apply_front_matter,
+    infer_document_metadata,
+    parse_front_matter,
+    write_contract_sidecar,
+)
+
 
 USE_CASE_RE = re.compile(
     r"^(?:##\s+|-\s+)?(?P<id>UC[- ]?\d+)\.?\s*(?P<name>.+?)\s*$",
@@ -75,14 +82,20 @@ def create_changeset_from_design(
     change_set_path = Path("docs/changes/active") / f"{change_set_id}.md"
     documents: dict[Path, str] = {}
     overwrite_allowed: set[Path] = set()
-    documents[change_set_path] = _render_change_set(
+    documents[change_set_path] = _with_metadata(
+        change_set_path,
+        _render_change_set(
+            change_set_id=change_set_id,
+            title=title,
+            related_issue=related_issue,
+            requirements_path=requirements_path,
+            use_cases_path=use_cases_path,
+            requirements=requirements,
+            use_cases=use_cases,
+        ),
         change_set_id=change_set_id,
-        title=title,
-        related_issue=related_issue,
-        requirements_path=requirements_path,
-        use_cases_path=use_cases_path,
-        requirements=requirements,
-        use_cases=use_cases,
+        source_docs=(requirements_path, use_cases_path),
+        status="active",
     )
     created_paths = [change_set_path]
 
@@ -98,6 +111,15 @@ def create_changeset_from_design(
             if path.name == "e2e-goal.md":
                 current = (repo / path).read_text(encoding="utf-8")
                 approved = _ensure_e2e_goal_approved(current)
+                approved = _with_metadata(
+                    path,
+                    approved,
+                    change_set_id=change_set_id,
+                    work_item_id=use_case.uc_id,
+                    source_docs=(change_set_path, use_case.slice_path / "use-case.md"),
+                    approval_status="approved",
+                    status="approved",
+                )
                 if approved != current:
                     documents[path] = approved
                     overwrite_allowed.add(path)
@@ -108,12 +130,21 @@ def create_changeset_from_design(
                     "|`e2e-goal.md`|Given/When/Then verification target|pending approval|",
                     "|`e2e-goal.md`|Given/When/Then verification target|approved|",
                 )
+                approved = _with_metadata(
+                    path,
+                    approved,
+                    change_set_id=change_set_id,
+                    work_item_id=use_case.uc_id,
+                    source_docs=(change_set_path,),
+                    status="draft",
+                )
                 if approved != current:
                     documents[path] = approved
                     overwrite_allowed.add(path)
                     created_paths.append(path)
 
     _write_documents(repo, documents, force=force, overwrite_allowed=overwrite_allowed)
+    _write_contracts(repo, documents)
     return DesignBridgeResult(
         change_set_id=change_set_id,
         change_set_path=change_set_path,
@@ -385,17 +416,55 @@ def _render_use_case_slice(
     use_case: DesignUseCase,
 ) -> dict[Path, str]:
     change_set_path = Path("docs/changes/active") / f"{change_set_id}.md"
+    use_case_path = use_case.slice_path / "use-case.md"
+    e2e_path = use_case.slice_path / "e2e-goal.md"
     return {
-        use_case.slice_path / "index.md": _render_index(change_set_path, use_case),
-        use_case.slice_path / "use-case.md": _render_use_case(change_set_path, use_case),
-        use_case.slice_path / "event-storming.md": _render_event_storming(
-            change_set_path,
-            use_case,
+        use_case.slice_path / "index.md": _with_metadata(
+            use_case.slice_path / "index.md",
+            _render_index(change_set_path, use_case),
+            change_set_id=change_set_id,
+            work_item_id=use_case.uc_id,
+            source_docs=(change_set_path,),
+            status="draft",
         ),
-        use_case.slice_path / "e2e-goal.md": _render_e2e_goal(change_set_path, use_case),
-        use_case.slice_path / "affected-files.md": _render_affected_files(
-            change_set_path,
-            use_case,
+        use_case_path: _with_metadata(
+            use_case_path,
+            _render_use_case(change_set_path, use_case),
+            change_set_id=change_set_id,
+            work_item_id=use_case.uc_id,
+            source_docs=(change_set_path, Path("docs/design/유스케이스.md")),
+            status="draft",
+        ),
+        use_case.slice_path / "event-storming.md": _with_metadata(
+            use_case.slice_path / "event-storming.md",
+            _render_event_storming(
+                change_set_path,
+                use_case,
+            ),
+            change_set_id=change_set_id,
+            work_item_id=use_case.uc_id,
+            source_docs=(change_set_path, use_case_path, e2e_path),
+            status="pending",
+        ),
+        e2e_path: _with_metadata(
+            e2e_path,
+            _render_e2e_goal(change_set_path, use_case),
+            change_set_id=change_set_id,
+            work_item_id=use_case.uc_id,
+            source_docs=(change_set_path, use_case_path),
+            approval_status="approved",
+            status="approved",
+        ),
+        use_case.slice_path / "affected-files.md": _with_metadata(
+            use_case.slice_path / "affected-files.md",
+            _render_affected_files(
+                change_set_path,
+                use_case,
+            ),
+            change_set_id=change_set_id,
+            work_item_id=use_case.uc_id,
+            source_docs=(change_set_path, use_case_path),
+            status="draft",
         ),
     }
 
@@ -668,6 +737,42 @@ def _write_documents(
         path = repo / relative_path
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(text, encoding="utf-8")
+
+
+def _with_metadata(
+    relative_path: Path,
+    text: str,
+    *,
+    change_set_id: str,
+    work_item_id: str = "",
+    source_docs: tuple[Path, ...] = (),
+    approval_status: str = "",
+    status: str = "",
+) -> str:
+    metadata = infer_document_metadata(
+        relative_path,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        source_docs=source_docs,
+        approval_status=approval_status,
+        status=status,
+    )
+    return apply_front_matter(text, {**metadata, **parse_front_matter(text)})
+
+
+def _write_contracts(repo: Path, documents: dict[Path, str]) -> None:
+    for relative_path, text in documents.items():
+        metadata = parse_front_matter(text)
+        if not metadata:
+            continue
+        source_docs = tuple(Path(path) for path in metadata.get("source_docs", ()))
+        write_contract_sidecar(
+            repo,
+            relative_path,
+            text,
+            metadata,
+            upstream_docs=source_docs,
+        )
 
 
 def _first_non_empty_line(text: str) -> str:

--- a/harness_codex/runtime/changes/resolver.py
+++ b/harness_codex/runtime/changes/resolver.py
@@ -12,6 +12,10 @@ from harness_codex.runtime.changes.models import (
     WorkItemType,
 )
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.document_metadata import (
+    approval_status_from_markdown,
+    approval_status_from_metadata_or_markdown,
+)
 
 
 APPROVED_STATUS = "approved"
@@ -354,7 +358,7 @@ def _use_case_approval_status(repo_root: Path, e2e_goal_path: Path) -> tuple[boo
     if not absolute_path.exists():
         return False, ""
 
-    return _approval_status_from_markdown(absolute_path.read_text(encoding="utf-8"))
+    return approval_status_from_metadata_or_markdown(absolute_path.read_text(encoding="utf-8"))
 
 
 def _technical_decision_blocker(
@@ -364,7 +368,7 @@ def _technical_decision_blocker(
 ) -> str | None:
     absolute_path = repo_root / technical_path
     text = absolute_path.read_text(encoding="utf-8")
-    approval_found, approval_status = _approval_status_from_markdown(text)
+    approval_found, approval_status = approval_status_from_metadata_or_markdown(text)
     normalized_status = approval_status.lower()
     if not approval_found or normalized_status != APPROVED_STATUS:
         status = approval_status or ("<missing>" if not approval_found else "<blank>")
@@ -387,14 +391,7 @@ def _technical_decision_blocker(
 
 
 def _approval_status_from_markdown(text: str) -> tuple[bool, str]:
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped.startswith("|") or "---" in stripped:
-            continue
-        cells = [cell.strip().strip("`") for cell in stripped.strip("|").split("|")]
-        if len(cells) >= 2 and cells[0] in {"Approval Status", "승인 상태"}:
-            return True, cells[1]
-    return False, ""
+    return approval_status_from_markdown(text)
 
 
 def _pending_decision_items_from_markdown(text: str) -> tuple[str, ...]:

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -10,6 +10,10 @@ from typing import Any
 
 from harness_codex.runtime.changes.models import WorkItemType
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.document_metadata import (
+    ensure_generated_document_metadata,
+    parse_front_matter,
+)
 from harness_codex.runtime.dashboard import DashboardRun, load_dashboard_runs
 from harness_codex.runtime.procedure_stages import procedure_stage, update_changeset_stage_status
 
@@ -136,6 +140,16 @@ def save_dashboard_document(
         )
 
     path.write_text(normalized, encoding="utf-8")
+    relative_path = path.relative_to(root)
+    parts = document_id.split(":")
+    ensure_generated_document_metadata(
+        root,
+        relative_path,
+        change_set_id=parts[1] if len(parts) > 1 else "",
+        work_item_id=parts[2] if len(parts) > 2 else "",
+        status="ready",
+    )
+    normalized = path.read_text(encoding="utf-8")
     change_path.write_text(change_text, encoding="utf-8")
     if document["kind"] == "generated-use-case":
         _invalidate_scoped_event_storming(root, document_id.split(":")[1], document_id.split(":")[2])
@@ -196,40 +210,52 @@ def _document_summaries(
     lifecycle: str,
     change_path: Path,
     workflow_state: dict[str, Any] | None = None,
-) -> list[dict[str, str | bool]]:
+) -> list[dict[str, Any]]:
     if lifecycle != "active":
         return [
-            {
-                "id": f"change-set:{change_set.change_set_id}",
-                "kind": "change-set",
-                "label": "ChangeSet (Read only)",
-                "path": _relative_path(root, change_path),
-                "editable": False,
-            }
+            _with_document_metadata(
+                root,
+                change_path,
+                {
+                    "id": f"change-set:{change_set.change_set_id}",
+                    "kind": "change-set",
+                    "label": "ChangeSet (Read only)",
+                    "path": _relative_path(root, change_path),
+                    "editable": False,
+                },
+            )
         ]
-    summaries: list[dict[str, str | bool]] = []
+    summaries: list[dict[str, Any]] = []
     requirements = root / "docs/design/요구사항.md"
     if requirements.exists():
         summaries.append(
-            {
-                "id": f"requirements:{change_set.change_set_id}",
-                "kind": "requirements",
-                "label": "Requirements",
-                "path": _relative_path(root, requirements),
-                "editable": True,
-            }
+            _with_document_metadata(
+                root,
+                requirements,
+                {
+                    "id": f"requirements:{change_set.change_set_id}",
+                    "kind": "requirements",
+                    "label": "Requirements",
+                    "path": _relative_path(root, requirements),
+                    "editable": True,
+                },
+            )
         )
     scoped_root = root / SCOPED_UI_STATE_ROOT / change_set.change_set_id
     use_cases = scoped_root / "docs/design/유스케이스.md"
     if workflow_state and workflow_state.get("use_cases_ready") and use_cases.exists():
         summaries.append(
-            {
-                "id": f"generated-use-cases:{change_set.change_set_id}",
-                "kind": "generated-use-cases",
-                "label": "Use Cases (Read only)",
-                "path": _relative_path(root, use_cases),
-                "editable": False,
-            }
+            _with_document_metadata(
+                root,
+                use_cases,
+                {
+                    "id": f"generated-use-cases:{change_set.change_set_id}",
+                    "kind": "generated-use-cases",
+                    "label": "Use Cases (Read only)",
+                    "path": _relative_path(root, use_cases),
+                    "editable": False,
+                },
+            )
         )
     declared_use_case_ids = {
         item.work_item_id
@@ -241,13 +267,17 @@ def _document_summaries(
             uc_id = path.parent.name
             if uc_id not in declared_use_case_ids:
                 summaries.append(
-                    {
-                        "id": f"generated-use-case:{change_set.change_set_id}:{uc_id}",
-                        "kind": "generated-use-case",
-                        "label": f"{uc_id} Use Case",
-                        "path": _relative_path(root, path),
-                        "editable": True,
-                    }
+                    _with_document_metadata(
+                        root,
+                        path,
+                        {
+                            "id": f"generated-use-case:{change_set.change_set_id}:{uc_id}",
+                            "kind": "generated-use-case",
+                            "label": f"{uc_id} Use Case",
+                            "path": _relative_path(root, path),
+                            "editable": True,
+                        },
+                    )
                 )
     event_state = (workflow_state or {}).get("event_storming") or {}
     for uc_id in event_state.get("uc_ids", []):
@@ -255,13 +285,17 @@ def _document_summaries(
         path = scoped_root / "docs/use-cases" / uc_id / "event-storming.md"
         if item.get("status") == "complete" and path.exists():
             summaries.append(
-                {
-                    "id": f"event-storming:{change_set.change_set_id}:{uc_id}",
-                    "kind": "event-storming",
-                    "label": f"{uc_id} Event Storming",
-                    "path": _relative_path(root, path),
-                    "editable": True,
-                }
+                _with_document_metadata(
+                    root,
+                    path,
+                    {
+                        "id": f"event-storming:{change_set.change_set_id}:{uc_id}",
+                        "kind": "event-storming",
+                        "label": f"{uc_id} Event Storming",
+                        "path": _relative_path(root, path),
+                        "editable": True,
+                    },
+                )
             )
     ddd_state = (workflow_state or {}).get("ddd_architecture") or {}
     for uc_id in ddd_state.get("uc_ids", []):
@@ -269,28 +303,50 @@ def _document_summaries(
         path = scoped_root / "docs/use-cases" / uc_id / "ddd-design.md"
         if any(step.get("status") == "complete" for step in item.get("steps", {}).values()) and path.exists():
             summaries.append(
-                {
-                    "id": f"ddd-design:{change_set.change_set_id}:{uc_id}",
-                    "kind": "ddd-design",
-                    "label": f"{uc_id} DDD Design",
-                    "path": _relative_path(root, path),
-                    "editable": True,
-                }
+                _with_document_metadata(
+                    root,
+                    path,
+                    {
+                        "id": f"ddd-design:{change_set.change_set_id}:{uc_id}",
+                        "kind": "ddd-design",
+                        "label": f"{uc_id} DDD Design",
+                        "path": _relative_path(root, path),
+                        "editable": True,
+                    },
+                )
             )
     for item in change_set.ordered_work_items():
         if item.work_item_type is WorkItemType.USE_CASE:
             path = root / "docs/use-cases" / item.work_item_id / "use-case.md"
             if path.exists():
                 summaries.append(
-                    {
-                        "id": f"use-case:{change_set.change_set_id}:{item.work_item_id}",
-                        "kind": "use-case",
-                        "label": f"{item.work_item_id} Use Case",
-                        "path": _relative_path(root, path),
-                        "editable": True,
-                    }
+                    _with_document_metadata(
+                        root,
+                        path,
+                        {
+                            "id": f"use-case:{change_set.change_set_id}:{item.work_item_id}",
+                            "kind": "use-case",
+                            "label": f"{item.work_item_id} Use Case",
+                            "path": _relative_path(root, path),
+                            "editable": True,
+                        },
+                    )
                 )
     return summaries
+
+
+def _with_document_metadata(root: Path, path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        metadata = parse_front_matter(path.read_text(encoding="utf-8"))
+    except OSError:
+        metadata = {}
+    if metadata:
+        payload["metadata"] = metadata
+        payload["doc_type"] = metadata.get("doc_type", "")
+        payload["approval_status"] = metadata.get("approval_status", "")
+        payload["contract_version"] = metadata.get("contract_version", "")
+    payload.setdefault("path", _relative_path(root, path))
+    return payload
 
 
 def _resolve_readable_document(root: Path, document_id: str) -> dict[str, Any]:
@@ -485,6 +541,7 @@ def _document_payload(root: Path, document: dict[str, Any], content: str) -> dic
         "label": document["label"],
         "path": _relative_path(root, document["path"]),
         "content": content,
+        "metadata": parse_front_matter(content),
         "revision": _revision(content),
         "editable": document["editable"],
     }

--- a/harness_codex/runtime/document_metadata.py
+++ b/harness_codex/runtime/document_metadata.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+CONTRACT_VERSION = 1
+
+FRONT_MATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n?", re.DOTALL)
+
+DOC_TYPES_BY_NAME = {
+    "use-case.md": "use_case",
+    "event-storming.md": "event_storming",
+    "ddd-design.md": "ddd_design",
+    "technical-decisions.md": "technical_decisions",
+    "e2e-goal.md": "e2e_goal",
+    "affected-files.md": "affected_files",
+    "index.md": "use_case_index",
+}
+
+
+def parse_front_matter(text: str) -> dict[str, Any]:
+    match = FRONT_MATTER_RE.match(text)
+    if match is None:
+        return {}
+
+    metadata: dict[str, Any] = {}
+    current_key = ""
+    for raw_line in match.group("body").splitlines():
+        if not raw_line.strip():
+            continue
+        if raw_line.startswith("  - ") and current_key:
+            values = metadata.setdefault(current_key, [])
+            if isinstance(values, list):
+                values.append(_parse_scalar(raw_line[4:].strip()))
+            continue
+        if ":" not in raw_line:
+            continue
+        key, value = raw_line.split(":", maxsplit=1)
+        current_key = key.strip()
+        value = value.strip()
+        metadata[current_key] = [] if value == "" else _parse_scalar(value)
+    return metadata
+
+
+def strip_front_matter(text: str) -> str:
+    match = FRONT_MATTER_RE.match(text)
+    if match is None:
+        return text
+    return text[match.end() :]
+
+
+def apply_front_matter(text: str, metadata: dict[str, Any]) -> str:
+    clean = strip_front_matter(text).lstrip("\n")
+    return _render_front_matter(metadata) + clean
+
+
+def approval_status_from_metadata_or_markdown(text: str) -> tuple[bool, str]:
+    metadata = parse_front_matter(text)
+    approval = metadata.get("approval_status")
+    if isinstance(approval, str):
+        return True, approval
+    return approval_status_from_markdown(text)
+
+
+def approval_status_from_markdown(text: str) -> tuple[bool, str]:
+    for line in strip_front_matter(text).splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|") or "---" in stripped:
+            continue
+        cells = [cell.strip().strip("`") for cell in stripped.strip("|").split("|")]
+        if len(cells) >= 2 and cells[0] in {"Approval Status", "승인 상태"}:
+            return True, cells[1]
+    return False, ""
+
+
+def infer_document_metadata(
+    relative_path: Path,
+    *,
+    change_set_id: str = "",
+    work_item_id: str = "",
+    source_docs: tuple[Path, ...] = (),
+    approval_status: str = "",
+    status: str = "",
+) -> dict[str, Any]:
+    doc_type = _doc_type_for_path(relative_path)
+    inferred_work_item_id = work_item_id or _work_item_id_for_path(relative_path)
+    inferred_change_set_id = change_set_id or _change_set_id_for_path(relative_path)
+    doc_id = _doc_id(doc_type, inferred_change_set_id, inferred_work_item_id)
+
+    metadata: dict[str, Any] = {
+        "doc_type": doc_type,
+        "doc_id": doc_id,
+        "contract_version": CONTRACT_VERSION,
+    }
+    if inferred_change_set_id:
+        metadata["change_set_id"] = inferred_change_set_id
+    if inferred_work_item_id:
+        metadata["work_item_id"] = inferred_work_item_id
+    if source_docs:
+        metadata["source_docs"] = [str(path) for path in source_docs]
+    if approval_status:
+        metadata["approval_status"] = approval_status
+    if status:
+        metadata["status"] = status
+    return metadata
+
+
+def ensure_generated_document_metadata(
+    repo_root: Path,
+    relative_path: Path,
+    *,
+    change_set_id: str = "",
+    work_item_id: str = "",
+    source_docs: tuple[Path, ...] = (),
+    approval_status: str = "",
+    status: str = "",
+    blockers: tuple[str, ...] = (),
+    downstream_docs: tuple[Path, ...] = (),
+) -> Path | None:
+    if relative_path.suffix != ".md":
+        return None
+    if not generated_doc_type(relative_path):
+        return None
+
+    absolute_path = repo_root / relative_path
+    if not absolute_path.exists():
+        return None
+
+    text = absolute_path.read_text(encoding="utf-8")
+    metadata = infer_document_metadata(
+        relative_path,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        source_docs=source_docs,
+        approval_status=approval_status,
+        status=status,
+    )
+    merged = {**metadata, **parse_front_matter(text)}
+    updated = apply_front_matter(text, merged)
+    if updated != text:
+        absolute_path.write_text(updated, encoding="utf-8")
+        text = updated
+
+    return write_contract_sidecar(
+        repo_root,
+        relative_path,
+        text,
+        merged,
+        blockers=blockers,
+        upstream_docs=source_docs,
+        downstream_docs=downstream_docs,
+    )
+
+
+def generated_doc_type(relative_path: Path) -> str:
+    return _doc_type_for_path(relative_path)
+
+
+def write_contract_sidecar(
+    repo_root: Path,
+    relative_path: Path,
+    text: str,
+    metadata: dict[str, Any],
+    *,
+    blockers: tuple[str, ...] = (),
+    upstream_docs: tuple[Path, ...] = (),
+    downstream_docs: tuple[Path, ...] = (),
+) -> Path:
+    payload = {
+        "doc_type": metadata.get("doc_type", _doc_type_for_path(relative_path)),
+        "doc_id": metadata.get("doc_id", ""),
+        "path": str(relative_path),
+        "checksum": _checksum(text),
+        "contract_version": metadata.get("contract_version", CONTRACT_VERSION),
+        "status": metadata.get("status", "ready" if not blockers else "blocked"),
+        "approval_status": metadata.get("approval_status", ""),
+        "change_set_id": metadata.get("change_set_id", ""),
+        "work_item_id": metadata.get("work_item_id", ""),
+        "blockers": list(blockers),
+        "upstream_docs": [str(path) for path in upstream_docs],
+        "downstream_docs": [str(path) for path in downstream_docs],
+    }
+    sidecar = contract_sidecar_path(relative_path, metadata)
+    absolute_sidecar = repo_root / sidecar
+    absolute_sidecar.parent.mkdir(parents=True, exist_ok=True)
+    absolute_sidecar.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return sidecar
+
+
+def contract_sidecar_path(relative_path: Path, metadata: dict[str, Any]) -> Path:
+    doc_type = str(metadata.get("doc_type") or _doc_type_for_path(relative_path))
+    change_set_id = str(
+        metadata.get("change_set_id") or _change_set_id_for_path(relative_path)
+    )
+    work_item_id = str(
+        metadata.get("work_item_id") or _work_item_id_for_path(relative_path)
+    )
+    if change_set_id and work_item_id:
+        return (
+            Path(".harness/contracts")
+            / change_set_id
+            / work_item_id
+            / f"{doc_type}.contract.json"
+        )
+    if change_set_id:
+        return Path(".harness/contracts") / change_set_id / f"{doc_type}.contract.json"
+    return Path(".harness/contracts/repository") / f"{doc_type}.contract.json"
+
+
+def _render_front_matter(metadata: dict[str, Any]) -> str:
+    lines = ["---"]
+    for key in sorted(metadata):
+        value = metadata[key]
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {_format_scalar(item)}")
+        else:
+            lines.append(f"{key}: {_format_scalar(value)}")
+    lines.append("---")
+    return "\n".join(lines) + "\n"
+
+
+def _parse_scalar(value: str) -> Any:
+    if value in {"true", "false"}:
+        return value == "true"
+    if value.isdigit():
+        return int(value)
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def _format_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    text = str(value)
+    if (
+        not text
+        or text.strip() != text
+        or any(ch in text for ch in ":#[]{}&,*?!|>'\"%@`")
+    ):
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def _doc_type_for_path(relative_path: Path) -> str:
+    parts = relative_path.parts
+    if len(parts) >= 3 and parts[0] == "docs" and parts[1] == "changes":
+        return "change_set"
+    if (
+        len(parts) >= 3
+        and parts[0] == "docs"
+        and parts[1] == "plans"
+        and relative_path.name == "plan.md"
+    ):
+        return "plan"
+    if len(parts) >= 2 and parts[0] == "docs" and parts[1] == "design":
+        if relative_path.name == "요구사항.md":
+            return "requirements"
+        if relative_path.name == "유스케이스.md":
+            return "canonical_use_cases"
+    if relative_path.name == "context.md":
+        return "context"
+    return DOC_TYPES_BY_NAME.get(relative_path.name, "")
+
+
+def _work_item_id_for_path(relative_path: Path) -> str:
+    parts = relative_path.parts
+    if (
+        len(parts) >= 3
+        and parts[0] == "docs"
+        and parts[1] in {"use-cases", "maintenance"}
+    ):
+        return parts[2]
+    if len(parts) >= 4 and parts[0] == "docs" and parts[1] == "plans":
+        return parts[3]
+    return ""
+
+
+def _change_set_id_for_path(relative_path: Path) -> str:
+    parts = relative_path.parts
+    if len(parts) >= 4 and parts[0] == "docs" and parts[1] == "changes":
+        return relative_path.stem
+    return ""
+
+
+def _doc_id(doc_type: str, change_set_id: str, work_item_id: str) -> str:
+    if work_item_id:
+        return f"{work_item_id}:{doc_type}"
+    if change_set_id:
+        return f"{change_set_id}:{doc_type}"
+    return doc_type
+
+
+def _checksum(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -23,6 +23,7 @@ from harness_codex.runtime.models import (
     StepResult,
     StepStatus,
 )
+from harness_codex.runtime.document_metadata import ensure_generated_document_metadata
 from harness_codex.runtime.prompt import build_agent_prompt
 from harness_codex.runtime.validate_scope_diff import (
     ScopePattern,
@@ -376,6 +377,8 @@ class BasicStepRunner:
                     error=validation_error,
                     metadata=result.metadata,
                 )
+            else:
+                _update_generated_output_contracts(step, context)
         result_path.write_text(
             json.dumps(
                 {
@@ -875,6 +878,29 @@ def _validate_agent_outputs(step: Step, context: RunContext) -> str | None:
     if missing_slice_files:
         return "missing required use-case slice outputs: " + ", ".join(missing_slice_files)
     return None
+
+
+def _update_generated_output_contracts(step: Step, context: RunContext) -> None:
+    change_set_id = _context_string(context, "change_set_id") or ""
+    work_item_id = _context_string(context, "active_work_item_id") or ""
+    source_docs = tuple(step.inputs)
+    for output in step.outputs:
+        ensure_generated_document_metadata(
+            context.repo_root,
+            output,
+            change_set_id=change_set_id,
+            work_item_id=work_item_id,
+            source_docs=source_docs,
+            status=_metadata_status_for_output(output),
+        )
+
+
+def _metadata_status_for_output(output: Path) -> str:
+    if output.name == "plan.md":
+        return "active"
+    if output.name in {"event-storming.md", "ddd-design.md", "technical-decisions.md"}:
+        return "ready"
+    return ""
 
 
 def _resolve_provider_command(request: AgentRunRequest, final_message_path: Path, *, default_codex_binary: str) -> tuple[list[str], dict[str, Any]] | AgentRunResult:

--- a/tests/runtime/test_affected_use_case_resolver.py
+++ b/tests/runtime/test_affected_use_case_resolver.py
@@ -270,6 +270,29 @@ def test_resolver_blocks_pending_e2e_approval_before_planning(tmp_path: Path) ->
     assert "docs/use-cases/UC-001/e2e-goal.md" in result.reason
 
 
+def test_resolver_prefers_e2e_front_matter_approval_over_body_table(
+    tmp_path: Path,
+) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(tmp_path, approval_status="approved")
+    e2e_goal = tmp_path / "docs/use-cases/UC-001/e2e-goal.md"
+    e2e_goal.write_text(
+        "---\n"
+        "approval_status: pending\n"
+        "contract_version: 1\n"
+        "doc_type: e2e_goal\n"
+        "---\n"
+        + e2e_goal.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "status=pending" in result.reason
+
+
 def test_resolver_blocks_pending_changeset_approval_before_planning(tmp_path: Path) -> None:
     path = write_changeset(tmp_path, CHANGESET_WITH_PENDING_APPROVAL)
     write_use_case_slice(tmp_path, approval_status="approved")

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -313,6 +313,9 @@ def test_dashboard_exposes_editable_scoped_generated_use_case_slice(tmp_path: Pa
     )
 
     assert "Save edited note." in saved["content"]
+    assert saved["metadata"]["doc_type"] == "use_case"
+    assert saved["metadata"]["change_set_id"] == "CHG-001"
+    assert saved["metadata"]["work_item_id"] == "UC-001"
     assert "|event-storming|Event Storming|stale|" in change_path.read_text(encoding="utf-8")
 
 

--- a/tests/runtime/test_document_metadata.py
+++ b/tests/runtime/test_document_metadata.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from harness_codex.runtime.document_metadata import (
+    approval_status_from_metadata_or_markdown,
+    ensure_generated_document_metadata,
+    parse_front_matter,
+)
+
+
+def test_parse_front_matter_metadata_and_strip_legacy_body_tables() -> None:
+    text = """---
+approval_status: pending
+contract_version: 1
+doc_type: e2e_goal
+source_docs:
+  - docs/use-cases/UC-001/use-case.md
+---
+# E2E
+
+|Item|Value|
+|---|---|
+|Approval Status|approved|
+"""
+
+    metadata = parse_front_matter(text)
+    found, status = approval_status_from_metadata_or_markdown(text)
+
+    assert metadata["doc_type"] == "e2e_goal"
+    assert metadata["source_docs"] == ["docs/use-cases/UC-001/use-case.md"]
+    assert found is True
+    assert status == "pending"
+
+
+def test_missing_front_matter_falls_back_to_markdown_approval_table() -> None:
+    text = """# Technical Decisions
+
+|Item|Value|
+|---|---|
+|Approval Status|approved|
+"""
+
+    found, status = approval_status_from_metadata_or_markdown(text)
+
+    assert found is True
+    assert status == "approved"
+
+
+def test_contract_sidecar_checksum_updates_when_document_changes(tmp_path: Path) -> None:
+    relative_path = Path("docs/plans/active/UC-001/plan.md")
+    absolute_path = tmp_path / relative_path
+    absolute_path.parent.mkdir(parents=True)
+    absolute_path.write_text("# Plan\n", encoding="utf-8")
+
+    sidecar = ensure_generated_document_metadata(
+        tmp_path,
+        relative_path,
+        change_set_id="CHG-001",
+        work_item_id="UC-001",
+        source_docs=(Path("docs/use-cases/UC-001/e2e-goal.md"),),
+        status="active",
+    )
+    first_payload = json.loads((tmp_path / sidecar).read_text(encoding="utf-8"))
+    first_text = absolute_path.read_text(encoding="utf-8")
+
+    absolute_path.write_text(
+        first_text + "\n- [ ] Add implementation task\n",
+        encoding="utf-8",
+    )
+    ensure_generated_document_metadata(
+        tmp_path,
+        relative_path,
+        change_set_id="CHG-001",
+        work_item_id="UC-001",
+        source_docs=(Path("docs/use-cases/UC-001/e2e-goal.md"),),
+        status="active",
+    )
+    second_text = absolute_path.read_text(encoding="utf-8")
+    second_payload = json.loads((tmp_path / sidecar).read_text(encoding="utf-8"))
+
+    assert first_payload["checksum"] != second_payload["checksum"]
+    assert second_payload["checksum"] == hashlib.sha256(
+        second_text.encode("utf-8")
+    ).hexdigest()
+    assert second_payload["doc_type"] == "plan"
+    assert second_payload["upstream_docs"] == ["docs/use-cases/UC-001/e2e-goal.md"]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from harness_codex.cli import main
@@ -368,6 +369,19 @@ def test_changes_create_from_design_blocks_planning_before_decision_gates(
     assert (tmp_path / "docs/use-cases/UC-001/event-storming.md").is_file()
     assert (tmp_path / "docs/use-cases/UC-001/e2e-goal.md").is_file()
     assert (tmp_path / "docs/use-cases/UC-001/affected-files.md").is_file()
+    e2e_text = (tmp_path / "docs/use-cases/UC-001/e2e-goal.md").read_text(
+        encoding="utf-8"
+    )
+    assert e2e_text.startswith("---\n")
+    assert "doc_type: e2e_goal\n" in e2e_text
+    assert "approval_status: approved\n" in e2e_text
+    sidecar = (
+        tmp_path
+        / ".harness/contracts/CHG-20260507-001/UC-001/e2e_goal.contract.json"
+    )
+    contract = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert contract["path"] == "docs/use-cases/UC-001/e2e-goal.md"
+    assert contract["approval_status"] == "approved"
     assert (tmp_path / "AGENTS.md").is_file()
     assert (tmp_path / "docs/agent/context.md").is_file()
 


### PR DESCRIPTION
Closes #251

## 구현 의도
생성된 harness Markdown 문서가 본문 표 스크래핑 없이 기본 식별자, 상태, 승인 상태, 계약 버전을 읽을 수 있도록 공통 메타데이터 계층을 추가합니다.

## 구현 접근
- `document_metadata` 모듈을 추가해 front matter 파싱/생성, 승인 상태 fallback, 문서 타입 추론, sidecar contract JSON 생성을 공통화했습니다.
- `create-from-design` 생성 문서에 front matter를 붙이고 `.harness/contracts/<CHG>/<WORK-ITEM>/*.contract.json` sidecar를 기록하도록 연결했습니다.
- agent runner와 dashboard 저장 경로가 event-storming, ddd-design, technical-decisions, e2e-goal, plan 등 생성 Markdown 출력에 메타데이터와 checksum contract를 갱신하도록 했습니다.
- resolver는 front matter 승인 상태를 우선 사용하고, front matter가 없는 기존 문서는 기존 Markdown 표 파싱으로 fallback합니다.
- dashboard document payload와 document summary에 metadata/doc_type/approval_status/contract_version을 노출했습니다.

## 검증 방법
- `python3 -m py_compile harness_codex/runtime/document_metadata.py harness_codex/runtime/changes/design_bridge.py harness_codex/runtime/changes/resolver.py harness_codex/runtime/document_dashboard.py harness_codex/runtime/runner.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_document_metadata.py tests/runtime/test_affected_use_case_resolver.py::test_resolver_prefers_e2e_front_matter_approval_over_body_table tests/test_cli_commands.py::test_changes_create_from_design_blocks_planning_before_decision_gates tests/runtime/test_document_dashboard.py::test_dashboard_exposes_editable_scoped_generated_use_case_slice` → 6 passed
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/runtime/test_document_dashboard.py tests/runtime/test_affected_use_case_resolver.py tests/test_cli_commands.py tests/runtime/test_document_metadata.py` → 95 passed
- `./venv/bin/python3 -m pytest -q -s` → 345 passed

## 위험 및 롤백
- 생성 문서 저장 시 front matter가 추가되어 문서 맨 앞 형식이 바뀝니다. Markdown 본문은 유지하고 resolver fallback을 보존해 기존 문서 호환성을 유지했습니다.
- 문제 발생 시 이 PR을 revert하면 front matter/sidecar 자동 생성 경로가 제거되고 기존 본문 표 기반 파싱으로 돌아갑니다.