### PR TITLE
[codex] 런타임 의미 계약 검증 게이트 추가

### DIFF
--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -15,7 +15,14 @@ from harness_codex.runtime.completion import (
     PlanCompletionBlocked,
     validate_plan_completion,
 )
+from harness_codex.runtime.changes.models import AffectedWorkItem, WorkItemType
+from harness_codex.runtime.contract_validators import (
+    validate_technical_decision_plan_coverage,
+    validate_use_case_e2e_alignment,
+)
 from harness_codex.runtime.models import (
+    ContractValidationResult,
+    ContractValidationStatus,
     FailureKind,
     RunContext,
     Step,
@@ -292,6 +299,10 @@ class BasicStepRunner:
         if preflight_error is not None:
             return _blocked_agent_result(step, context, step_dir, preflight_error)
 
+        contract_error = _semantic_contract_preflight(step, context)
+        if contract_error is not None:
+            return _blocked_agent_result(step, context, step_dir, contract_error)
+
         skill_id = _step_skill_id(step)
         skill_path: Path | None = None
         if skill_id is not None:
@@ -465,6 +476,13 @@ class BasicStepRunner:
             if not source.exists():
                 return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error=f"missing source: {step.inputs[0]}")
             if _is_plan_completion_move(step.inputs[0], step.outputs[0]):
+                contract_error = _plan_completion_contract_error(context, step.inputs[0])
+                if contract_error is not None:
+                    return StepResult(
+                        step_id=step.id,
+                        status=StepStatus.BLOCKED,
+                        error=f"plan completion blocked: {contract_error}",
+                    )
                 try:
                     validate_plan_completion(
                         context.repo_root,
@@ -713,6 +731,67 @@ def _runtime_scope_allow_patterns(
             "runtime run artifacts",
         ),
     )
+
+
+def _semantic_contract_preflight(step: Step, context: RunContext) -> str | None:
+    if not _is_use_case_planner_step(step):
+        return None
+    work_item = _use_case_work_item_for_step(step, context)
+    if work_item is None:
+        return None
+    return _contract_error(validate_use_case_e2e_alignment(context.repo_root, work_item))
+
+
+def _plan_completion_contract_error(context: RunContext, plan_path: Path) -> str | None:
+    work_item_id = _work_item_id_from_plan_path(plan_path)
+    if not work_item_id:
+        return None
+    work_item = _use_case_work_item(work_item_id)
+    return _contract_error(
+        validate_technical_decision_plan_coverage(context.repo_root, work_item)
+    )
+
+
+def _contract_error(result: ContractValidationResult) -> str | None:
+    if result.status != ContractValidationStatus.FAIL:
+        return None
+    return (
+        f"{result.contract_id} failed between {result.from_path} and {result.to_path}: "
+        f"{result.blocker}"
+    )
+
+
+def _is_use_case_planner_step(step: Step) -> bool:
+    if step.id == "planner-create-use-case-plan":
+        return True
+    return step.metadata.get("stage") == "planner" and step.metadata.get("scope") == "use_case"
+
+
+def _use_case_work_item_for_step(step: Step, context: RunContext) -> AffectedWorkItem | None:
+    work_item_id = _context_string(context, "active_work_item_id")
+    if not work_item_id:
+        for path in (*step.outputs, *step.inputs):
+            work_item_id = _work_item_id_from_plan_path(path) or _work_item_id_from_slice_path(path)
+            if work_item_id:
+                break
+    return _use_case_work_item(work_item_id) if work_item_id else None
+
+
+def _use_case_work_item(work_item_id: str) -> AffectedWorkItem:
+    return AffectedWorkItem(
+        work_item_id=work_item_id,
+        work_item_type=WorkItemType.USE_CASE,
+        name=work_item_id,
+        impact_type="modify",
+        slice_path=Path("docs/use-cases") / work_item_id,
+    )
+
+
+def _work_item_id_from_slice_path(path: Path) -> str | None:
+    parts = path.parts
+    if len(parts) >= 3 and parts[:2] == ("docs", "use-cases") and parts[2].startswith("UC-"):
+        return parts[2]
+    return None
 
 
 def _append_runtime_remediation_task(

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -237,6 +237,12 @@ def write_completed_plan(
     if empty_result is not None:
         results[empty_result] = ""
 
+    decisions_path = repo_root / "docs/use-cases/UC-001/technical-decisions.md"
+    decisions_path.parent.mkdir(parents=True, exist_ok=True)
+    decisions_path.write_text(
+        "# Technical Decisions\n\nApproved decision: Test gate.\n",
+        encoding="utf-8",
+    )
     plan_path.write_text(
         "\n".join(
             [
@@ -273,6 +279,18 @@ def write_completed_plan(
         encoding="utf-8",
     )
     return plan_path
+
+
+def write_use_case_e2e_contract(
+    repo_root: Path,
+    *,
+    use_case: str = "Goal: Buyer reserves a seat.\nResult: Seat is held for payment.\n",
+    e2e: str = "When the buyer reserves a seat\nThen the seat is held for payment.\n",
+) -> None:
+    use_case_dir = repo_root / "docs/use-cases/UC-001"
+    use_case_dir.mkdir(parents=True, exist_ok=True)
+    (use_case_dir / "use-case.md").write_text(f"# Use Case\n\n{use_case}", encoding="utf-8")
+    (use_case_dir / "e2e-goal.md").write_text(f"# E2E\n\n{e2e}", encoding="utf-8")
 
 
 def agent_request(tmp_path: Path, agent_config: dict) -> AgentRunRequest:
@@ -626,6 +644,35 @@ def test_basic_step_runner_fails_when_required_use_case_slices_are_missing(tmp_p
     assert result.error == "missing required use-case slices under docs/use-cases"
 
 
+def test_basic_step_runner_blocks_planner_when_use_case_e2e_contract_fails(
+    tmp_path: Path,
+) -> None:
+    write_agent_config(tmp_path)
+    write_use_case_e2e_contract(
+        tmp_path,
+        use_case="Goal: Buyer reserves a seat.\nResult: Seat is held for payment.\n",
+        e2e="When the buyer purchases a ticket\nThen the ticket is issued immediately.\n",
+    )
+    fake_adapter = FakeAgentAdapter()
+    runner = BasicStepRunner(agent_adapter=fake_adapter)
+    step = Step(
+        id="planner-create-use-case-plan",
+        kind=StepKind.AGENT,
+        name="Create plan",
+        agent_id="implementation_planner",
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        metadata={"stage": "planner", "scope": "use_case"},
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert fake_adapter.requests == []
+    assert "use_case_e2e_alignment failed between" in (result.error or "")
+    assert "docs/use-cases/UC-001/use-case.md" in (result.error or "")
+    assert "docs/use-cases/UC-001/e2e-goal.md" in (result.error or "")
+
+
 def test_basic_step_runner_blocks_plan_completion_with_unchecked_checkbox(
     tmp_path: Path,
 ) -> None:
@@ -684,6 +731,34 @@ def test_basic_step_runner_blocks_plan_completion_with_missing_evidence(
     assert ".harness/runs/run-001/steps/final-verification/static-analysis.txt" in (
         result.error or ""
     )
+    assert (tmp_path / "docs/plans/active/UC-001/plan.md").exists()
+
+
+def test_basic_step_runner_blocks_plan_completion_when_decision_lacks_plan_coverage(
+    tmp_path: Path,
+) -> None:
+    write_completed_plan(tmp_path)
+    decisions_path = tmp_path / "docs/use-cases/UC-001/technical-decisions.md"
+    decisions_path.write_text(
+        "# Technical Decisions\n\n"
+        "Approved decision: Duplicate payment requests must use idempotency keys.\n",
+        encoding="utf-8",
+    )
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="complete-use-case-plan",
+        kind=StepKind.GIT,
+        name="Complete plan",
+        inputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        outputs=(Path("docs/plans/completed/UC-001/plan.md"),),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "technical_decision_plan_coverage failed between" in (result.error or "")
+    assert "docs/use-cases/UC-001/technical-decisions.md" in (result.error or "")
+    assert "docs/plans/active/UC-001/plan.md" in (result.error or "")
     assert (tmp_path / "docs/plans/active/UC-001/plan.md").exists()
 
 


### PR DESCRIPTION
## 구현 의도

- 런타임이 파일 존재 여부만 확인하고 의미적으로 충돌하는 산출물을 다음 단계로 넘기는 문제를 막습니다.
- `use-case.md`와 `e2e-goal.md`가 어긋난 상태에서 계획 수립을 시작하지 않게 합니다.
- 승인된 `technical-decisions.md`가 `plan.md`에 반영되지 않은 상태에서 완료 처리하지 않게 합니다.

## 구현 접근

- `BasicStepRunner`의 use-case planner 실행 전 `validate_use_case_e2e_alignment()`를 호출하는 의미 계약 프리플라이트를 추가했습니다.
- `docs/plans/active/<UC-ID>/plan.md`를 completed로 이동하기 직전에 `validate_technical_decision_plan_coverage()`를 호출합니다.
- 실패 메시지는 계약 ID, 양쪽 파일 경로, blocker 내용을 포함해 수정 대상 파일을 바로 알 수 있게 했습니다.
- 기존 파일 존재 검증과 plan completion 검증은 유지하고, 그 앞단에 의미 계약 게이트를 추가했습니다.

## 검증 방법

- `./venv/bin/python3 -m py_compile harness_codex/runtime/runner.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/runtime/test_contract_validators.py` → 39 passed
- `./venv/bin/python3 -m pytest -q -s` → 356 passed, 1 failed (`tests/runtime/test_ui_server_restart.py::test_ui_server_restarts_existing_server_for_repo`, UI 서버 재시작 readiness 타이밍 실패)
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_ui_server_restart.py::test_ui_server_restarts_existing_server_for_repo` → 1 passed
- `git diff --check`

## 위험 및 롤백

- 의미 계약 휴리스틱이 너무 엄격하면 planning/completion이 기존보다 빨리 blocked 될 수 있습니다.
- 문제 발생 시 `BasicStepRunner`에 추가된 의미 계약 프리플라이트와 completion 직전 계약 검증 호출만 되돌리면 기존 파일/완료 검증 동작으로 복구됩니다.

Closes #244
