### PR TITLE
[codex] 이슈 247 에이전트 파이프라인 검토 게이트 추가

### DIFF
--- a/.codex/agents/artifact_reviewer.toml
+++ b/.codex/agents/artifact_reviewer.toml
@@ -1,0 +1,19 @@
+name = "artifact_reviewer"
+description = "Review critical workflow artifacts before downstream execution"
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the artifact_reviewer agent.
+
+Hot-path contract:
+- Role: Independently review a produced workflow artifact before a downstream agent may execute it.
+- Load `.codex/agents/references/artifact_reviewer.md` before making workflow decisions.
+- Use `.codex/skills/harness-artifact-reviewer/SKILL.md` as the required skill entrypoint.
+- Read only files declared by the runtime payload unless the review cannot be completed without a named referenced file.
+- Keep writes limited to the runtime-declared review output artifact.
+- Preserve unrelated worktree changes.
+- Stop and report the blocker when required inputs, review scope, or output path are missing.
+- Report review status, blocking findings, changed files, and blockers clearly.
+"""

--- a/.codex/agents/references/artifact_reviewer.md
+++ b/.codex/agents/references/artifact_reviewer.md
@@ -1,0 +1,41 @@
+# artifact_reviewer Detailed Instructions
+
+- Agent config: `.codex/agents/artifact_reviewer.toml`
+- Required skill: `.codex/skills/harness-artifact-reviewer/SKILL.md`
+
+You are the harness artifact review agent.
+
+Your job:
+- Review exactly one runtime-declared artifact before a downstream agent consumes it.
+- Treat this as a producer-reviewer gate, not direct agent messaging.
+- Write exactly one review report to the runtime-declared output path.
+- Do not edit the artifact under review.
+- Do not edit product code, tests, build files, workflow files, agent configs, or skills.
+
+Supported artifact types:
+- `plan`: implementation plan review before `implementation_executor`
+- `technical_decisions`: technical-decision review before planning when a workflow opts into that gate
+
+Review output contract:
+- The first non-heading status line must be `Review Status: approved` or `Review Status: rejected`.
+- Use `approved` only when the artifact can safely move to the next workflow step.
+- Use `rejected` when a blocking issue exists.
+- Include `Blocking Findings`, `Nonblocking Findings`, and `Reviewed Inputs` sections.
+- Keep findings concrete and cite the relevant file path.
+
+Plan review checklist:
+- Plan stays inside the active ChangeSet and one work-item scope.
+- Required inputs are present: ChangeSet, work-item slice, E2E or maintenance verification goal, architecture, repository settings when required, and approved technical decisions for use-case work.
+- Plan has small unchecked implementation and test tasks.
+- Verification tasks cover build, focused tests, E2E or maintenance goal, runtime server verification or explicit non-applicability, static analysis, and `.codex/test-gate.yaml` stages when configured.
+- Plan does not ask the executor to resolve upstream design, approval, or scope conflicts silently.
+
+Technical-decision review checklist:
+- Decisions trace to the selected use-case or maintenance slice.
+- Approval status is explicit.
+- Implementation-blocking items are resolved or clearly marked as blockers.
+- Retry, idempotency, transaction, adapter, cache, and observability decisions are present when relevant to the slice.
+
+Blocking rule:
+- If any checklist item blocks safe downstream execution, write `Review Status: rejected`.
+- Do not create a passing report by adding assumptions that are not present in input artifacts.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -37,3 +37,7 @@ config_file = "agents/implementation_planner.toml"
 [agents.implementation_executor]
 description = "Implement active plan tasks without replanning"
 config_file = "agents/implementation_executor.toml"
+
+[agents.artifact_reviewer]
+description = "Review critical workflow artifacts before downstream execution"
+config_file = "agents/artifact_reviewer.toml"

--- a/.codex/skills/harness-artifact-reviewer/SKILL.md
+++ b/.codex/skills/harness-artifact-reviewer/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harness-artifact-reviewer
+description: Review a single critical harness workflow artifact, such as plan.md or technical-decisions.md, before a downstream agent consumes it. Writes one review report and uses an explicit Review Status gate.
+---
+
+# Harness Artifact Reviewer
+
+## Hot Path
+
+- Use this skill only for the workflow described in the frontmatter.
+- Read `.codex/agents/references/artifact_reviewer.md` before making workflow decisions or producing required artifacts.
+- Read additional files only when named by the runtime payload or required to verify a cited input.
+- Keep writes inside the single review output declared by the runtime payload.
+- Preserve unrelated worktree changes.
+- Write `Review Status: approved` only when downstream execution can proceed.
+- Write `Review Status: rejected` when any blocking finding remains.

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -36,10 +36,33 @@ steps:
       stage: plan
       scope: work_item
 
+  - id: review-work-item-plan
+    kind: agent
+    name: Review the work item implementation plan before execution
+    needs: [plan-work-item]
+    agent_id: artifact_reviewer
+    skill_id: harness-artifact-reviewer
+    inputs:
+      - docs/changes/active/<CHG-ID>.md
+      - docs/plans/active/<WORK-ITEM-ID>/plan.md
+      - docs/use-cases/<UC-ID>
+      - docs/maintenance/<MAINT-ID>
+      - .codex/test-gate.yaml
+    outputs:
+      - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/reviews/plan-review.md
+    metadata:
+      stage: review
+      scope: work_item
+      artifact_type: plan
+      review_gate:
+        output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/reviews/plan-review.md
+        status_label: Review Status
+        approved_status: approved
+
   - id: execute-work-item
     kind: agent
     name: Execute unchecked work item plan tasks
-    needs: [plan-work-item]
+    needs: [review-work-item-plan]
     agent_id: implementation_executor
     skill_id: harness-plan-executor
     inputs:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Runtime workflow tools for ChangeSet-based Codex implementation. The CLI turns an early change idea into verified stage artifacts, plans, implementation runs, and resumable project state.
 
+Harness uses an agent-backed sequential pipeline, not an agent team runtime. Specialist agents hand off through workflow artifacts and `needs` dependencies. Explicit producer-reviewer gates, such as plan review before execution, are modeled as normal workflow steps. See `docs/runtime-agent-pipeline.md`.
+
 ## Installation
 
 Install into a target repository:

--- a/docs/agent/context.md
+++ b/docs/agent/context.md
@@ -35,6 +35,12 @@ Active implementation plans live in `docs/plans/active/<WORK-ITEM-ID>/plan.md`. 
 
 Runtime state is written under `.harness/runs/<run-id>/`.
 
+## Agent Execution Model
+
+Harness is an agent-backed sequential pipeline, not an agent team architecture. Specialist agents do not communicate directly. They hand off through declared artifacts and workflow dependencies.
+
+Producer-reviewer behavior must be modeled as an explicit workflow step. See `docs/runtime-agent-pipeline.md`.
+
 ## Context Loading Guidance
 
 Start with the nearest `AGENTS.md`, then read only the smallest relevant file from `docs/agent/`. Prefer `rg`, targeted reads, and symbol tools. Avoid full `docs/design/**` or broad file dumps unless needed for the current decision.

--- a/docs/runtime-agent-pipeline.md
+++ b/docs/runtime-agent-pipeline.md
@@ -1,0 +1,42 @@
+# Runtime Agent Pipeline Model
+
+Harness uses an agent-backed sequential pipeline.
+
+Each workflow step is a runtime action with declared inputs, outputs, and `needs` dependencies. For an agent step, the runtime builds a prompt and invokes the configured specialist agent through `codex exec`. The runtime then validates declared outputs and moves to dependent steps only when the current step succeeds.
+
+Harness is not an agent team architecture. There is no runtime protocol for direct inter-agent messaging, shared team rooms, peer chat, fan-out/fan-in discussion, or autonomous agent-to-agent handoff. Agent coordination happens through artifacts on disk and workflow dependencies.
+
+## Producer-Reviewer Gates
+
+Team-like review is modeled explicitly as another workflow step.
+
+For example, the ChangeSet work-item workflow now uses this order:
+
+```text
+plan-work-item
+-> review-work-item-plan
+-> execute-work-item
+-> verify-work-item
+```
+
+The reviewer reads the produced artifact and writes a review report. The report must contain `Review Status: approved` for downstream execution to continue. Any other status blocks the workflow before the executor runs.
+
+This pattern can also be used for other critical artifacts, including `technical-decisions.md`, by adding a reviewer step with:
+
+- an artifact-specific input list
+- a review output under `.harness/runs/<RUN-ID>/...`
+- `metadata.review_gate.output`
+- `metadata.review_gate.status_label`
+- `metadata.review_gate.approved_status`
+
+## Correct Terminology
+
+Use these terms:
+
+- agent-backed sequential workflow
+- pipeline orchestrator
+- specialist agent per step
+- explicit producer-reviewer gate
+- artifact-mediated handoff
+
+Avoid terms that imply agents can communicate directly unless the runtime has a concrete protocol for that behavior.

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -388,10 +388,43 @@ HARNESS_FULL_WORKFLOW = Workflow(
             },
         ),
         Step(
+            id="review-use-case-plan",
+            kind=StepKind.AGENT,
+            name="Review one use-case implementation plan before execution",
+            needs=("planner-create-use-case-plan",),
+            agent_id="artifact_reviewer",
+            skill_id="harness-artifact-reviewer",
+            inputs=(
+                Path("docs/changes/active/<CHG-ID>.md"),
+                Path("docs/plans/active/<UC-ID>/plan.md"),
+                Path("docs/use-cases/<UC-ID>"),
+                Path(".codex/test-gate.yaml"),
+            ),
+            outputs=(
+                Path(
+                    ".harness/runs/<RUN-ID>/work-items/<UC-ID>/reviews/plan-review.md"
+                ),
+            ),
+            metadata={
+                "stage": "review",
+                "scope": "use_case",
+                "artifact_type": "plan",
+                "review_gate": {
+                    "output": ".harness/runs/<RUN-ID>/work-items/<UC-ID>/reviews/plan-review.md",
+                    "status_label": "Review Status",
+                    "approved_status": "approved",
+                },
+                "purpose": (
+                    "Block implementation until an independent reviewer approves "
+                    "the UC plan artifact."
+                ),
+            },
+        ),
+        Step(
             id="executor-implement-use-case-plan",
             kind=StepKind.AGENT,
             name="Implement unchecked tasks in one use-case scoped plan",
-            needs=("planner-create-use-case-plan",),
+            needs=("review-use-case-plan",),
             agent_id="implementation_executor",
             inputs=(
                 Path("docs/plans/active/<UC-ID>/plan.md"),

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -378,7 +378,20 @@ class BasicStepRunner:
                     metadata=result.metadata,
                 )
             else:
-                _update_generated_output_contracts(step, context)
+                review_gate_error = _validate_review_gate(step, context)
+                if review_gate_error:
+                    result = AgentRunResult(
+                        status=StepStatus.BLOCKED,
+                        exit_code=result.exit_code,
+                        error=review_gate_error,
+                        metadata={
+                            **dict(result.metadata),
+                            "review_gate_status": "blocked",
+                            "review_gate_error": review_gate_error,
+                        },
+                    )
+                else:
+                    _update_generated_output_contracts(step, context)
         result_path.write_text(
             json.dumps(
                 {
@@ -877,6 +890,46 @@ def _validate_agent_outputs(step: Step, context: RunContext) -> str | None:
                 missing_slice_files.append(str(target.relative_to(context.repo_root)))
     if missing_slice_files:
         return "missing required use-case slice outputs: " + ", ".join(missing_slice_files)
+    return None
+
+
+def _validate_review_gate(step: Step, context: RunContext) -> str | None:
+    gate = step.metadata.get("review_gate")
+    if not isinstance(gate, Mapping):
+        return None
+
+    output_value = gate.get("output")
+    output_path = Path(output_value) if isinstance(output_value, str) and output_value else None
+    if output_path is None:
+        output_path = step.outputs[0] if step.outputs else None
+    if output_path is None:
+        return "review gate requires an output artifact"
+
+    review_path = context.repo_root / output_path
+    if not review_path.exists():
+        return f"missing review gate output: {output_path}"
+
+    status_label = gate.get("status_label")
+    label = status_label if isinstance(status_label, str) and status_label else "Review Status"
+    approved_value = gate.get("approved_status")
+    approved = (
+        approved_value if isinstance(approved_value, str) and approved_value else "approved"
+    ).strip().lower()
+    status = _review_status_from_text(review_path.read_text(encoding="utf-8"), label)
+
+    if status is None:
+        return f"review gate output missing `{label}: {approved}`"
+    if status.strip().lower() != approved:
+        return f"review gate status is `{status}`, expected `{approved}`"
+    return None
+
+
+def _review_status_from_text(text: str, label: str) -> str | None:
+    prefix = f"{label}:"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            return stripped[len(prefix) :].strip()
     return None
 
 

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -47,6 +47,20 @@ class FakeAgentAdapter:
         return self.result
 
 
+class ReviewAgentAdapter(FakeAgentAdapter):
+    def __init__(self, review_text: str) -> None:
+        super().__init__()
+        self.review_text = review_text
+
+    def run(self, request: AgentRunRequest) -> AgentRunResult:
+        self.requests.append(request)
+        for output in request.step.outputs:
+            target = request.context.repo_root / output
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(self.review_text, encoding="utf-8")
+        return self.result
+
+
 def context(repo_root: Path) -> RunContext:
     return RunContext(
         run_id="run-001",
@@ -600,6 +614,37 @@ def test_basic_step_runner_fails_when_agent_output_is_missing(tmp_path: Path) ->
 
     assert result.status == StepStatus.FAILED
     assert result.error == "missing agent outputs: docs/plans/active/UC-001/plan.md"
+
+
+def test_basic_step_runner_blocks_rejected_review_gate(tmp_path: Path) -> None:
+    write_agent_config(tmp_path, "artifact_reviewer")
+    write_skill(tmp_path, "harness-artifact-reviewer")
+    runner = BasicStepRunner(
+        agent_adapter=ReviewAgentAdapter("Review Status: rejected\n\nBlocking Findings\n")
+    )
+    step = Step(
+        id="review-work-item-plan",
+        kind=StepKind.AGENT,
+        name="Review plan",
+        agent_id="artifact_reviewer",
+        skill_id="harness-artifact-reviewer",
+        outputs=(
+            Path(".harness/runs/run-001/work-items/UC-001/reviews/plan-review.md"),
+        ),
+        metadata={
+            "review_gate": {
+                "output": ".harness/runs/run-001/work-items/UC-001/reviews/plan-review.md",
+                "status_label": "Review Status",
+                "approved_status": "approved",
+            }
+        },
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.error == "review gate status is `rejected`, expected `approved`"
+    assert result.metadata["review_gate_status"] == "blocked"
 
 
 def test_basic_step_runner_fails_when_required_use_case_slices_are_missing(tmp_path: Path) -> None:

--- a/tests/runtime/test_engine.py
+++ b/tests/runtime/test_engine.py
@@ -182,6 +182,46 @@ def test_engine_stops_when_step_is_blocked() -> None:
     assert fake_runner.executed_step_ids == ["analyze"]
 
 
+def test_engine_blocks_executor_when_reviewer_rejects_artifact() -> None:
+    workflow = Workflow(
+        name="review-gated",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="plan", kind=StepKind.AGENT, name="Plan"),
+            Step(
+                id="review-plan",
+                kind=StepKind.AGENT,
+                name="Review plan",
+                needs=("plan",),
+                metadata={"review_gate": {"approved_status": "approved"}},
+            ),
+            Step(
+                id="execute",
+                kind=StepKind.AGENT,
+                name="Execute plan",
+                needs=("review-plan",),
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner(
+        results_by_step_id={
+            "review-plan": StepResult(
+                step_id="review-plan",
+                status=StepStatus.BLOCKED,
+                error="review gate status is `rejected`, expected `approved`",
+            )
+        }
+    )
+    engine = RunnerEngine(fake_runner)
+
+    result = engine.run(workflow, context())
+
+    assert result.status == RunStatus.BLOCKED
+    assert result.failed_step_id == "review-plan"
+    assert result.blocker == "review gate status is `rejected`, expected `approved`"
+    assert fake_runner.executed_step_ids == ["plan", "review-plan"]
+
+
 def test_engine_loops_implementation_failure_through_remediation() -> None:
     workflow = Workflow(
         name="example",

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -120,6 +120,7 @@ def test_harness_full_workflow_models_top_level_harness_lifecycle() -> None:
         "storm-affected-use-case",
         "design-affected-use-case",
         "planner-create-use-case-plan",
+        "review-use-case-plan",
         "executor-implement-use-case-plan",
         "verifier-run-use-case-e2e",
         "classify-use-case-verification-result",
@@ -178,6 +179,7 @@ def test_harness_full_workflow_orchestrates_use_case_scoped_loop() -> (
     storming = HARNESS_FULL_WORKFLOW.step_by_id("storm-affected-use-case")
     design = HARNESS_FULL_WORKFLOW.step_by_id("design-affected-use-case")
     planner = HARNESS_FULL_WORKFLOW.step_by_id("planner-create-use-case-plan")
+    reviewer = HARNESS_FULL_WORKFLOW.step_by_id("review-use-case-plan")
     executor = HARNESS_FULL_WORKFLOW.step_by_id("executor-implement-use-case-plan")
     verification = HARNESS_FULL_WORKFLOW.step_by_id("verifier-run-use-case-e2e")
 
@@ -196,9 +198,15 @@ def test_harness_full_workflow_orchestrates_use_case_scoped_loop() -> (
     assert planner.needs == ("design-affected-use-case",)
     assert Path("docs/plans/active/<UC-ID>/plan.md") in planner.outputs
 
+    assert reviewer.kind == StepKind.AGENT
+    assert reviewer.agent_id == "artifact_reviewer"
+    assert reviewer.skill_id == "harness-artifact-reviewer"
+    assert reviewer.needs == ("planner-create-use-case-plan",)
+    assert reviewer.metadata["review_gate"]["approved_status"] == "approved"
+
     assert executor.kind == StepKind.AGENT
     assert executor.agent_id == "implementation_executor"
-    assert executor.needs == ("planner-create-use-case-plan",)
+    assert executor.needs == ("review-use-case-plan",)
     assert Path("docs/plans/active/<UC-ID>/plan.md") in executor.inputs
 
     assert verification.kind == StepKind.VALIDATOR

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -121,9 +121,15 @@ def test_default_changeset_work_item_workflow_loads() -> None:
     assert workflow.name == "changeset-use-case-workflow"
     assert workflow.step_by_id("plan-work-item").agent_id == "implementation_planner"
     assert workflow.step_by_id("plan-work-item").skill_id == "harness-code-planner"
+    review = workflow.step_by_id("review-work-item-plan")
+    assert review.agent_id == "artifact_reviewer"
+    assert review.skill_id == "harness-artifact-reviewer"
+    assert review.needs == ("plan-work-item",)
+    assert review.metadata["review_gate"]["approved_status"] == "approved"
     assert workflow.step_by_id("execute-work-item").skill_id == (
         "harness-plan-executor"
     )
+    assert workflow.step_by_id("execute-work-item").needs == ("review-work-item-plan",)
     assert workflow.step_by_id("verify-work-item").command == (
         "python3 -m harness_codex.runtime.verify_work_item "
         "--change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>"


### PR DESCRIPTION
## 구현 의도

- #247 해결을 위해 하네스 런타임이 에이전트 팀 구조가 아니라 에이전트 기반 순차 파이프라인임을 명확히 문서화한다.
- 실행 전 산출물을 독립 검토하는 producer-reviewer 게이트를 명시적 워크플로우 단계로 제공한다.

## 구현 방식

- `artifact_reviewer` 에이전트와 `harness-artifact-reviewer` 스킬을 추가해 `plan.md` 및 `technical-decisions.md` 같은 중요 산출물 검토 계약을 정의했다.
- ChangeSet work-item 워크플로우와 `HARNESS_FULL_WORKFLOW`에 계획 검토 단계를 추가해 `plan -> review -> execute -> verify` 흐름으로 변경했다.
- `metadata.review_gate` 검증을 런타임에 추가해 검토 보고서가 `Review Status: approved`를 포함하지 않으면 downstream executor 실행이 차단되도록 했다.
- `docs/runtime-agent-pipeline.md`, README, agent context에 현재 런타임 모델과 올바른 용어를 문서화했다.

## 검증 방법

- `python3 -m py_compile harness_codex/runtime/runner.py harness_codex/runtime/models.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_models.py tests/runtime/test_workflow_loader.py tests/runtime/test_agent_runner.py tests/runtime/test_engine.py` -> 72 passed
- `./venv/bin/python3 -m pytest -q -s` -> 357 passed

## 위험 및 롤백

- 위험: 기본 work-item workflow에 새 검토 단계가 추가되어 기존 실행 경로보다 한 에이전트 호출이 늘어난다.
- 롤백: `review-work-item-plan` / `review-use-case-plan` 단계를 제거하고 executor의 `needs`를 planner 단계로 되돌리면 기존 순차 실행으로 복구된다.

Closes #247
