### PR TITLE
[codex] complete-change-set 완료 동작 정렬

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -817,11 +817,14 @@ def run_change_command(args: argparse.Namespace, repo_root: Path) -> str:
             return f"BLOCKED: {exc.reason}"
         return (
             f"APPLY completed: run_id={run_id} status={RunStatus.SUCCEEDED.value} "
-            f"completed_path={completed_path}"
+            f"active_changeset_moved=true completed_path={completed_path}"
         )
 
     state, result = _apply_workflow(repo_root, change_set, scopes)
-    return f"APPLY started: run_id={state.run_id} status={result.status.value}"
+    return (
+        f"APPLY started: run_id={state.run_id} status={result.status.value} "
+        "active_changeset_moved=false"
+    )
 
 
 def run_use_case_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -12,9 +12,12 @@ from pathlib import Path
 from typing import Any, Mapping, Protocol, Sequence
 
 from harness_codex.runtime.completion import (
+    ChangeSetCompletionBlocked,
     PlanCompletionBlocked,
+    complete_change_set_if_ready,
     validate_plan_completion,
 )
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
 from harness_codex.runtime.changes.models import AffectedWorkItem, WorkItemType
 from harness_codex.runtime.contract_validators import (
     validate_technical_decision_plan_coverage,
@@ -484,6 +487,8 @@ class BasicStepRunner:
         if step.command:
             return self._run_command(step, context, step_dir)
         if len(step.inputs) == 1 and len(step.outputs) == 1:
+            if _is_change_set_completion_move(step.inputs[0], step.outputs[0]):
+                return _complete_change_set_boundary(step, context)
             source = context.repo_root / step.inputs[0]
             target = context.repo_root / step.outputs[0]
             if not source.exists():
@@ -514,6 +519,44 @@ class BasicStepRunner:
             shutil.move(str(source), str(target))
             return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
         return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error="git step requires an explicit command or one input/output move")
+
+
+def _complete_change_set_boundary(step: Step, context: RunContext) -> StepResult:
+    change_set_path = context.repo_root / step.inputs[0]
+    if not change_set_path.exists():
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.BLOCKED,
+            error=f"missing source: {step.inputs[0]}",
+        )
+
+    change_set = parse_changeset_markdown(
+        change_set_path.read_text(encoding="utf-8"),
+        path=step.inputs[0],
+    )
+    try:
+        completion = complete_change_set_if_ready(
+            context.repo_root,
+            change_set,
+            run_id=context.run_id,
+        )
+    except ChangeSetCompletionBlocked as exc:
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.BLOCKED,
+            error=f"ChangeSet completion blocked: {exc.reason}",
+        )
+
+    return StepResult(
+        step_id=step.id,
+        status=StepStatus.SUCCEEDED,
+        output_path=completion.report_path,
+        metadata={
+            "completed_path": str(completion.completed_path),
+            "completed_work_items": list(completion.completed_work_items),
+            "already_completed": completion.already_completed,
+        },
+    )
 
 
 def _classify_verification_result(
@@ -711,6 +754,17 @@ def _is_plan_completion_move(source: Path, target: Path) -> bool:
         and source.parts[3] == target.parts[3]
         and source.name == "plan.md"
         and target.name == "plan.md"
+    )
+
+
+def _is_change_set_completion_move(source: Path, target: Path) -> bool:
+    return (
+        len(source.parts) == 4
+        and len(target.parts) == 4
+        and source.parts[:3] == ("docs", "changes", "active")
+        and target.parts[:3] == ("docs", "changes", "completed")
+        and source.name == target.name
+        and source.suffix == ".md"
     )
 
 

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -295,6 +295,66 @@ def write_completed_plan(
     return plan_path
 
 
+def write_changeset_ready_for_completion(repo_root: Path, *, active_plan: bool = False) -> None:
+    active_changeset = repo_root / "docs/changes/active/CHG-001.md"
+    active_changeset.parent.mkdir(parents=True, exist_ok=True)
+    active_changeset.write_text(
+        "\n".join(
+            [
+                "# ChangeSet CHG-001",
+                "",
+                "## 1. 메타데이터",
+                "|항목|값|",
+                "|---|---|",
+                "|ChangeSet ID|`CHG-001`|",
+                "|상태|active|",
+                "",
+                "## 5. 영향 유스케이스",
+                "|UC ID|유스케이스 이름|영향 유형|Slice 경로|상태|",
+                "|---|---|---|---|---|",
+                "|`UC-001`|결제 승인|update|`docs/use-cases/UC-001/`|planned|",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    completed_plan = repo_root / "docs/plans/completed/UC-001/plan.md"
+    completed_plan.parent.mkdir(parents=True, exist_ok=True)
+    completed_plan.write_text("# Completed Plan\n", encoding="utf-8")
+    if active_plan:
+        active = repo_root / "docs/plans/active/UC-001/plan.md"
+        active.parent.mkdir(parents=True, exist_ok=True)
+        active.write_text("# Active Plan\n", encoding="utf-8")
+
+    run_dir = repo_root / ".harness/runs/run-001"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "report.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-001",
+                "change_set_id": "CHG-001",
+                "workflow_name": "changeset-use-case-workflow",
+                "mode": "apply",
+                "status": "succeeded",
+                "affected_use_cases": ["UC-001"],
+                "failed_use_cases": [],
+                "blocked_use_cases": [],
+                "work_item_reports": [
+                    {
+                        "work_item_id": "UC-001",
+                        "work_item_type": "use_case",
+                        "active_plan_path": "docs/plans/active/UC-001/plan.md",
+                        "completed_plan_path": "docs/plans/completed/UC-001/plan.md",
+                        "status": "succeeded",
+                        "verification_goal_path": "docs/use-cases/UC-001/e2e-goal.md",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def write_use_case_e2e_contract(
     repo_root: Path,
     *,
@@ -825,6 +885,52 @@ def test_basic_step_runner_moves_completed_plan_after_completion_validation(
     assert result.status == StepStatus.SUCCEEDED
     assert not (tmp_path / "docs/plans/active/UC-001/plan.md").exists()
     assert (tmp_path / "docs/plans/completed/UC-001/plan.md").exists()
+
+
+def test_basic_step_runner_completes_changeset_with_completion_report(
+    tmp_path: Path,
+) -> None:
+    write_changeset_ready_for_completion(tmp_path)
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="complete-change-set",
+        kind=StepKind.GIT,
+        name="Complete ChangeSet",
+        inputs=(Path("docs/changes/active/CHG-001.md"),),
+        outputs=(Path("docs/changes/completed/CHG-001.md"),),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.output_path == Path(
+        ".harness/runs/run-001/changeset-completion-report.md"
+    )
+    assert result.metadata["completed_path"] == "docs/changes/completed/CHG-001.md"
+    assert not (tmp_path / "docs/changes/active/CHG-001.md").exists()
+    assert (tmp_path / "docs/changes/completed/CHG-001.md").exists()
+    assert (tmp_path / result.output_path).is_file()
+
+
+def test_basic_step_runner_blocks_changeset_completion_with_active_plan(
+    tmp_path: Path,
+) -> None:
+    write_changeset_ready_for_completion(tmp_path, active_plan=True)
+    runner = BasicStepRunner(agent_adapter=FakeAgentAdapter())
+    step = Step(
+        id="complete-change-set",
+        kind=StepKind.GIT,
+        name="Complete ChangeSet",
+        inputs=(Path("docs/changes/active/CHG-001.md"),),
+        outputs=(Path("docs/changes/completed/CHG-001.md"),),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "active work item plans still exist" in (result.error or "")
+    assert (tmp_path / "docs/changes/active/CHG-001.md").exists()
+    assert not (tmp_path / "docs/changes/completed/CHG-001.md").exists()
 
 
 def test_basic_step_runner_blocks_implementation_executor_on_gradle_workspace_sandbox(


### PR DESCRIPTION
Closes #243

## 구현 의도 (Implementation intent)
`complete-change-set` 워크플로 단계가 완료 산출물을 선언하면서 단순 파일 이동이나 무동작으로 성공하지 않도록, 실제 ChangeSet 완료 게이트와 동일한 동작을 실행하게 합니다.

## 구현 접근 (Implementation approach)
`BasicStepRunner`의 `GIT` 경계에서 `docs/changes/active/<CHG-ID>.md` -> `docs/changes/completed/<CHG-ID>.md` 이동 패턴을 감지하면 기존 `complete_change_set_if_ready()` 서비스를 호출합니다. 이 서비스가 완료된 work item 계획, 남은 active 계획, 성공 run report를 검증하고 ChangeSet 이동 및 `changeset-completion-report.md` 생성을 담당합니다. `run-change --apply` 출력에는 active ChangeSet 이동 여부를 명시했습니다.

## 검증 방법 (Verification method)
- `./venv/bin/python3 -m py_compile harness_codex/runtime/runner.py harness_codex/cli.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py::test_basic_step_runner_completes_changeset_with_completion_report tests/runtime/test_agent_runner.py::test_basic_step_runner_blocks_changeset_completion_with_active_plan tests/test_cli_commands.py::test_run_change_apply_creates_resume_state tests/test_cli_commands.py::test_run_change_apply_completes_when_work_item_plan_already_completed`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py tests/runtime/test_changeset_completion.py tests/test_cli_commands.py`
- `./venv/bin/python3 -m pytest -q -s`

## 위험 및 롤백 (Risks and rollback)
완료 단계가 이제 fail-closed로 동작하므로 완료된 계획, active 계획 제거, 성공 run report가 없으면 기존보다 더 엄격하게 차단됩니다. 문제가 있으면 이 커밋을 되돌려 기존 generic git move 경계로 복구할 수 있습니다.