### PR TITLE
[codex] 플래너 지침 중복 제거

### DIFF
--- a/.codex/agents/references/implementation_planner.md
+++ b/.codex/agents/references/implementation_planner.md
@@ -1,236 +1,37 @@
-# implementation_planner Detailed Instructions
+# implementation_planner Agent Reference
 
 - Agent config: `.codex/agents/implementation_planner.toml`
-- Required skill: `.codex/skills/harness-code-planner/SKILL.md`
+- Required skill entrypoint: `.codex/skills/harness-code-planner/SKILL.md`
+- Canonical planning contract: `.codex/skills/harness-code-planner/references/detailed-instructions.md`
 
-You are the harness implementation planning agent.
+This reference intentionally avoids duplicating planner gates, input lists, path
+conventions, checklist rules, completion rules, test standards, and output
+templates. Those shared standards live in the skill detailed reference so the
+skill, agent, runtime workflow, and preflight checks have one rule source.
 
-Your job:
-- Read the active ChangeSet, exactly one affected work-item slice, architecture, repository settings, canonical domain references when named, and approved technical decisions as planning input.
-- Create or update exactly one work-item scoped active implementation plan:
-  - docs/plans/active/<WORK-ITEM-ID>/plan.md
-- Move it to docs/plans/completed/<WORK-ITEM-ID>/plan.md only after every checkbox is checked and successful build/test/e2e-or-maintenance/runtime-server/static-analysis verification is recorded.
+## Agent Role
+
+- Create or update one executor-ready work-item implementation plan.
 - Do not implement code.
-- Do not update integrated design docs. Integrated docs are synced after implementation and verification by docs-sync/complete stages.
+- Do not update integrated design docs.
+- Load the required skill entrypoint and canonical planning contract before
+  making workflow decisions.
+- Follow the runtime payload for active ChangeSet, work-item ID, work-item type,
+  active plan path, and verification goal path.
+- Stop and report the blocker when required inputs, approvals, scope, or write
+  permissions are missing.
 
-Work-item types:
-- use_case work item: selected slice is docs/use-cases/<UC-ID>/
-- maintenance work item: selected slice is docs/maintenance/<MAINT-ID>/
-- <WORK-ITEM-ID> is the selected concrete UC ID or MAINT ID.
+## Ownership
 
-Required planning input:
-- docs/changes/active/<CHG-ID>.md
-- one selected work-item slice:
-  - use_case: docs/use-cases/<UC-ID>/use-case.md
-  - use_case: docs/use-cases/<UC-ID>/event-storming.md
-  - use_case: docs/use-cases/<UC-ID>/technical-decisions.md
-  - use_case: docs/use-cases/<UC-ID>/e2e-goal.md
-  - maintenance: docs/maintenance/<MAINT-ID>/change-intent.md
-  - maintenance: docs/maintenance/<MAINT-ID>/affected-files.md
-  - maintenance: docs/maintenance/<MAINT-ID>/verification-goal.md
-- optional work-item files when present:
-  - requirements-slice.md
-  - domain-impact.md
-  - aggregate-delta.md
-  - ddd-design.md
-  - source-map.md
-- canonical domain docs referenced by domain-impact.md, aggregate-delta.md, or the ChangeSet, such as docs/domain/<BC-ID>/aggregates/<AGG-ID>.md and docs/domain/<BC-ID>/ports/<PORT-ID>.md
-- ARCHITECTURE.md
-- .codex/repository-settings.md
-- approved technical decisions relevant to this work item
+- Preserve unrelated worktree changes.
+- Keep writes limited to the plan paths allowed by the canonical planning
+  contract.
+- Do not edit production code, test code, build files, CI files, configuration
+  files, skill files, agent files, or integrated design docs.
+- Report changed files, verification commands, and blockers clearly.
 
-Instruction source:
-- Execute from this reference plus the required skill entrypoint.
-- Do not read ticketon-ddd blog markdown files.
-- Do not read unrelated skill markdown files as planning standards.
-- The planning, testing, and verification standards are embedded below.
+## Conflict Rule
 
-Stop conditions:
-- If docs/changes/active/<CHG-ID>.md does not exist or the ChangeSet ID is unclear, stop and explain that the parent ChangeSet workflow must select the ChangeSet first.
-- If the affected work-item ID is unclear, stop and ask the parent workflow to pass a single work-item ID.
-- If both use_case and maintenance work-item slices appear applicable, stop and ask the parent workflow to pass exactly one work-item type.
-- For use_case work items, stop if docs/use-cases/<UC-ID>/use-case.md, event-storming.md, technical-decisions.md, or e2e-goal.md is missing.
-- For use_case work items, stop if docs/use-cases/<UC-ID>/e2e-goal.md is not explicitly approved by the user.
-- For use_case work items, stop if docs/use-cases/<UC-ID>/technical-decisions.md is not explicitly approved.
-- For maintenance work items, stop if docs/maintenance/<MAINT-ID>/change-intent.md, affected-files.md, or verification-goal.md is missing.
-- For maintenance work items, stop if verification-goal.md is not concrete enough to verify the change.
-- If ARCHITECTURE.md does not exist, stop and explain that the parent skill must invoke or complete spring-package-structure first.
-- If repository settings are missing, stop and list the missing repository settings file.
-- If referenced technical decisions contain unresolved implementation-blocking decisions or lack explicit user approval, stop and list what must be confirmed.
-- If the ChangeSet and work-item slice do not contain enough design input to derive implementation scope, stop and list missing files.
-- If another active ChangeSet modifies the same canonical domain element, stop or require explicit rebase/coordination before planning.
-- If static-analysis commands or linting setup are unknown, do not stop. Record a static-analysis setup/procedure task for the executor and mark concrete commands as 확인 필요 or setup-required.
-- If docs/plans/active/<WORK-ITEM-ID> cannot be created, explain the reason and stop.
-
-Ownership:
-- You are not alone in the codebase.
-- Do not revert edits made by others.
-- Do not edit production code.
-- Do not edit test code.
-- Do not edit build files.
-- Do not edit CI files.
-- Do not edit configuration files.
-- Do not edit skill files.
-- Do not edit agent files.
-- Do not edit integrated design docs.
-- Keep writes limited to:
-  - docs/plans/active/<WORK-ITEM-ID>/plan.md
-  - docs/plans/completed/<WORK-ITEM-ID>/plan.md only when moving a completed and verified plan
-
-Plan requirements:
-- State the implementation goal.
-- State what must not be implemented.
-- List the ChangeSet, work-item ID, work-item type, work-item slice documents, E2E or maintenance verification goal, architecture, repository settings, canonical domain references, and whether each was available.
-- Capture architecture constraints from ARCHITECTURE.md.
-- Capture approved technical decisions and turn them into implementation, test, and verification tasks.
-- Capture the ChangeSet Before/After delta and keep the implementation scope inside that boundary.
-- Include the use-case E2E goal or maintenance verification goal as the plan's success target.
-- Capture domain impact from domain-impact.md, aggregate-delta.md, and canonical domain docs when present.
-- List reused, modified, and newly proposed aggregate/entity/value-object/domain-service/port elements.
-- Include compatibility tests for existing use cases that share a modified domain element.
-- Define implementation scope and assumptions.
-- Write the plan as markdown checkboxes.
-- If the repository is empty, lacks Spring Boot baseline files, or requires a new module, add an initial implementation task instructing the executor to use `spring-initializer` before package-structure work.
-- Add an implementation task instructing the executor to use `spring-package-structure` to create or verify the Spring module/package skeleton and ARCHITECTURE.md before feature code.
-- Include implementation tasks and matching test tasks.
-- Include verification tasks for `./gradlew build`, `./gradlew test`, Playwright MCP browser verification from the end user's perspective when the use-case implementation includes a browser-accessible web UI, existing API/runtime verification when it does not, maintenance verification where applicable, `.codex/test-gate.yaml` required stages, runtime server execution, and static analysis.
-- When a browser-accessible web UI calls a backend on another origin during local verification, include a task to define and verify the development request path: same-origin proxy or backend CORS configuration for the frontend origin, methods, and request headers used by the flow.
-- Include a runtime server verification task after build/test tasks. The plan must tell the executor how to start the application locally, usually with `./gradlew bootRun` or the repository's existing run command, and how to verify the implemented behavior against the running server through HTTP/API/UI checks when the feature exposes a runtime surface.
-- If the repository has no runnable server or the implementation has no server-visible behavior, record that explicitly as a runtime verification non-applicability note instead of inventing a command.
-- Static analysis must be included as a procedure in the plan.
-- If the repository already has static-analysis commands, record them.
-- If static-analysis tooling is missing, add executor tasks to set up or run ArchUnit/Semgrep-based architecture linting before final verification.
-- Do not invoke another skill or require another skill to run from this agent.
-
-Checkbox rules:
-- Use `- [ ]` for pending tasks.
-- Each task should be small enough for an executor to complete and verify.
-- If Spring baseline initialization or module addition is needed, the first implementation checkbox must be the `spring-initializer` initialization/module task.
-- The next structural checkbox must be the `spring-package-structure` structure setup/verification task.
-- A task is checked only after it is complete.
-- Executor must update checkboxes from `- [ ]` to `- [x]` as work completes.
-- Keep the final verification tasks unchecked until commands have succeeded.
-
-Completion move rule:
-- Keep plan at docs/plans/active/<WORK-ITEM-ID>/plan.md while any checkbox is unchecked.
-- Keep plan at docs/plans/active/<WORK-ITEM-ID>/plan.md if build, tests, E2E or maintenance verification, runtime server verification, test gate, or static analysis failed or were not run, unless runtime server verification is explicitly marked not applicable with a reason.
-- Move plan to docs/plans/completed/<WORK-ITEM-ID>/plan.md only when:
-  - every checkbox is checked
-  - tests required by the plan exist
-  - build succeeded
-  - tests succeeded
-  - E2E or maintenance verification succeeded when applicable
-  - `.codex/test-gate.yaml` required stages passed
-  - runtime server verification succeeded or is explicitly not applicable with a reason
-  - static analysis succeeded
-  - verification results are recorded in the plan
-
-Embedded test planning standards:
-- Domain rules must be tested close to the model that owns the rule.
-- Aggregate tests verify state transitions, invariants, and rule violations through aggregate behavior methods.
-- VO tests verify constructor-time validation, invalid value rejection, and immutability expectations.
-- Domain service tests verify calculations or decisions requiring multiple domain concepts.
-- Application service tests verify orchestration flow: repositories/ports called, aggregates loaded/saved, domain methods invoked, external ports used through interfaces, and failure paths trigger compensating actions when required.
-- Application service tests must not duplicate internal aggregate rule tests.
-- Infrastructure tests verify adapters, persistence mappings, serialization, messaging, local storage, framework wiring, and external technology integration.
-- Communication tests verify outbox/inbox behavior, idempotency, message identity, aggregate key ordering, retry metadata, and state checks before consuming events when messaging exists.
-- Compatibility tests verify existing use cases that share a modified aggregate/entity/value-object/domain-service/port.
-- Prefer focused unit tests for domain rules over broad integration tests when no external technology is involved.
-- Use integration tests only where persistence, messaging, HTTP clients, framework wiring, or transaction behavior must be verified.
-- Test names should describe the business rule or flow outcome.
-- Tests should cover success path, important failure path, and boundary conditions.
-
-Output template for docs/plans/active/<WORK-ITEM-ID>/plan.md:
-
-# Implementation Plan
-
-## 1. 구현 목표
-- ...
-
-## 2. 구현하지 말아야 할 것
-- ...
-
-## 3. 입력 문서
-|문서|사용 목적|상태|
-|---|---|---|
-
-## 3.1 ChangeSet 및 Work Item
-- ChangeSet:
-- Work item ID:
-- Work item type:
-- Work item slice:
-- E2E/verification goal:
-
-## 4. 아키텍처 제약
-- ARCHITECTURE.md 기준:
-- 모듈/패키지 경계:
-- 의존성 방향:
-- 금지 참조:
-
-## 5. 구현 범위
-- 포함:
-- 제외:
-- 가정:
-
-## 5.1 승인된 기술 결정
-|영역|결정|구현 반영|테스트/검증 반영|
-|---|---|---|---|
-
-## 5.2 도메인 영향
-|type|id|mode|canonical path|plan impact|
-|---|---|---|---|---|
-
-## 5.3 호환성 확인
-- 기존 유스케이스 영향:
-- 같은 도메인 요소를 수정하는 active ChangeSet 충돌 여부:
-
-## 6. 구현 계획
-- [ ] 필요 시 `spring-initializer`를 사용해 Spring Boot 프로젝트 기준 설정 또는 신규 모듈을 초기화한다.
-- [ ] `spring-package-structure`를 사용해 Spring 모듈/패키지 빈 구조와 `ARCHITECTURE.md`가 현재 설계와 일치하는지 생성 또는 검증한다.
-- [ ] ...
-
-## 7. 테스트 계획
-- [ ] Domain/Aggregate/VO 테스트:
-- [ ] Application Service 흐름 테스트:
-- [ ] Infrastructure/Adapter 테스트:
-- [ ] Communication/Transaction 테스트:
-- [ ] Compatibility 테스트:
-
-## 8. 검증 방법
-- [ ] Build:
-  - 명령: `./gradlew build`
-  - 성공 기준:
-- [ ] Tests:
-  - 명령: `./gradlew test`
-  - 성공 기준:
-- [ ] E2E 또는 maintenance verification:
-  - 명령:
-  - 목표:
-  - 성공 기준:
-- [ ] Test gate:
-  - 기준: `.codex/test-gate.yaml` required stage PASS
-- [ ] Runtime server verification:
-  - 서버 실행 명령:
-  - 구현사항 확인 방법:
-  - 성공 기준:
-- [ ] Static analysis:
-  - 절차:
-  - 명령:
-  - 성공 기준:
-
-## 9. 완료 조건
-- 모든 체크박스가 `- [x]` 상태다.
-- 구현 범위의 테스트가 작성되어 통과했다.
-- Build, Tests, E2E 또는 maintenance verification, Test gate, Runtime server verification, Static analysis가 성공했다.
-- 성공 후 `docs/plans/completed/<WORK-ITEM-ID>/plan.md`로 이동한다.
-
-## 10. 검증 결과
-- Build:
-- Tests:
-- E2E 또는 maintenance verification:
-- Test gate:
-- Runtime server verification:
-- Static analysis:
-
-## 11. 검증 실패
-- 없음
+If this file appears to conflict with the skill detailed reference, the skill
+detailed reference is the source of truth. Update the skill reference or runtime
+validator first, then keep this file as a thin agent contract.

--- a/.codex/skills/harness-code-planner/agents/openai.yaml
+++ b/.codex/skills/harness-code-planner/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Harness Code Planner"
   short_description: "Create executor-ready implementation plan."
-  default_prompt: "docs/design과 ARCHITECTURE.md를 바탕으로 spring-initializer, spring-package-structure, 테스트 계획, 빌드/테스트/정적 분석 절차가 포함된 docs/plans/active/plan.md를 작성합니다."
+  default_prompt: "Create one ChangeSet work-item implementation plan at docs/plans/active/<WORK-ITEM-ID>/plan.md using the active slice, ARCHITECTURE.md, repository settings, approved technical decisions, tests, runtime verification, and static-analysis procedures."

--- a/.codex/skills/harness-code-planner/references/detailed-instructions.md
+++ b/.codex/skills/harness-code-planner/references/detailed-instructions.md
@@ -46,6 +46,7 @@ Required:
 
 - `docs/use-cases/<UC-ID>/use-case.md`
 - `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/ddd-design.md`
 - `docs/use-cases/<UC-ID>/technical-decisions.md`
 - `docs/use-cases/<UC-ID>/e2e-goal.md`
 
@@ -54,7 +55,6 @@ Optional but should be read when present:
 - `docs/use-cases/<UC-ID>/requirements-slice.md`
 - `docs/use-cases/<UC-ID>/domain-impact.md`
 - `docs/use-cases/<UC-ID>/aggregate-delta.md`
-- `docs/use-cases/<UC-ID>/ddd-design.md`
 - `docs/use-cases/<UC-ID>/source-map.md`
 
 ### Maintenance work-item slice
@@ -100,8 +100,9 @@ Integrated documents under the design documentation area are source-of-truth ref
 
 For a use-case work item:
 
-- If `use-case.md`, `event-storming.md`, or `e2e-goal.md` is missing, stop and list the missing files.
+- If `use-case.md`, `event-storming.md`, `ddd-design.md`, `technical-decisions.md`, or `e2e-goal.md` is missing, stop and list the missing files.
 - If `e2e-goal.md` is not explicitly approved by the user, stop and list what must be approved.
+- If `technical-decisions.md` is not explicitly approved, stop and list what must be approved.
 
 ### Maintenance gate
 
@@ -179,12 +180,14 @@ The work-item plan must include:
   - existing domain element to modify
   - canonical domain reference files read
   - compatibility tests for existing use cases that share the domain element
+- Whether another active ChangeSet modifies the same canonical domain element.
 - Scope assumptions and unresolved risks.
 - Spring project/module initialization task using `spring-initializer` when the repository needs a new Spring Boot baseline or a new module.
 - A structural task to use `spring-package-structure` to create or verify the Spring module/package skeleton against `ARCHITECTURE.md` before feature code.
 - Implementation checklist using markdown checkboxes.
 - Matching test tasks.
 - Verification tasks for build, tests, E2E or maintenance verification, test gate, runtime server verification, and static analysis.
+- When browser-accessible web UI work calls a backend on another origin during local verification, include a task to define and verify the development request path: same-origin proxy or backend CORS configuration for the frontend origin, methods, and request headers.
 - Runtime server verification after build/test tasks. The plan must specify the local run command, usually `./gradlew bootRun` or the repository's existing command, and concrete behavior checks through HTTP/API/UI when the feature has a runtime surface.
 - If there is no runnable server or no server-visible behavior, state runtime server verification is not applicable and explain why.
 - Completion policy explaining when to move the active plan to the completed path.

--- a/tests/test_planner_browser_origin_scope.py
+++ b/tests/test_planner_browser_origin_scope.py
@@ -5,9 +5,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_planner_requires_browser_origin_request_path_for_cross_origin_ui() -> None:
-    path = REPO_ROOT / ".codex/agents/implementation_planner.toml"
+    path = REPO_ROOT / ".codex/skills/harness-code-planner/SKILL.md"
     planner = path.read_text(encoding="utf-8") + "\n" + (
-        path.parent / "references/implementation_planner.md"
+        path.parent / "references/detailed-instructions.md"
     ).read_text(encoding="utf-8")
 
     assert "same-origin proxy or backend CORS configuration" in planner

--- a/tests/test_planner_use_case_scope.py
+++ b/tests/test_planner_use_case_scope.py
@@ -5,9 +5,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def read_planner() -> str:
-    path = REPO_ROOT / ".codex/agents/implementation_planner.toml"
-    return path.read_text(encoding="utf-8") + "\n" + (
-        path.parent / "references/implementation_planner.md"
+    skill = REPO_ROOT / ".codex/skills/harness-code-planner/SKILL.md"
+    return skill.read_text(encoding="utf-8") + "\n" + (
+        skill.parent / "references/detailed-instructions.md"
     ).read_text(encoding="utf-8")
 
 
@@ -29,6 +29,7 @@ def test_planner_uses_changeset_and_work_item_slice_as_inputs() -> None:
         "docs/changes/active/<CHG-ID>.md",
         "docs/use-cases/<UC-ID>/use-case.md",
         "docs/use-cases/<UC-ID>/event-storming.md",
+        "docs/use-cases/<UC-ID>/ddd-design.md",
         "docs/use-cases/<UC-ID>/e2e-goal.md",
         "docs/maintenance/<MAINT-ID>/change-intent.md",
         "docs/maintenance/<MAINT-ID>/affected-files.md",
@@ -52,6 +53,7 @@ def test_planner_requires_e2e_or_maintenance_and_repository_gate_verification() 
     assert ".codex/test-gate.yaml" in planner
     assert "E2E or maintenance verification" in planner
     assert "E2E/verification goal" in planner
+    assert "technical-decisions.md` is not explicitly approved" in planner
 
 
 def test_planner_tracks_domain_impact_and_compatibility() -> None:

--- a/tests/test_planner_work_item_alignment.py
+++ b/tests/test_planner_work_item_alignment.py
@@ -1,4 +1,10 @@
+import re
 from pathlib import Path
+
+from harness_codex.runtime.changes.resolver import (
+    _missing_maintenance_documents,
+    _missing_use_case_documents,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -18,8 +24,27 @@ def read(path: str) -> str:
     return text
 
 
+def read_skill_contract() -> str:
+    return read(".codex/skills/harness-code-planner/SKILL.md")
+
+
+def read_agent_contract() -> str:
+    path = ".codex/agents/implementation_planner.toml"
+    return read(path)
+
+
+def required_skill_paths(skill: str, section: str) -> tuple[str, ...]:
+    match = re.search(
+        rf"### {re.escape(section)}\n\nRequired:\n\n(?P<body>.*?)\n\nOptional",
+        skill,
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    return tuple(re.findall(r"`([^`]+)`", match.group("body")))
+
+
 def test_harness_code_planner_uses_only_work_item_plan_paths() -> None:
-    skill = read(".codex/skills/harness-code-planner/SKILL.md")
+    skill = read_skill_contract()
 
     assert "docs/plans/active/<WORK-ITEM-ID>/plan.md" in skill
     assert "docs/plans/completed/<WORK-ITEM-ID>/plan.md" in skill
@@ -30,7 +55,7 @@ def test_harness_code_planner_uses_only_work_item_plan_paths() -> None:
 
 
 def test_harness_code_planner_does_not_require_integrated_design_docs_as_primary_inputs() -> None:
-    skill = read(".codex/skills/harness-code-planner/SKILL.md")
+    skill = read_skill_contract()
 
     assert "docs/changes/active/<CHG-ID>.md" in skill
     assert "docs/use-cases/<UC-ID>/" in skill
@@ -48,32 +73,63 @@ def test_harness_code_planner_does_not_require_integrated_design_docs_as_primary
 
 
 def test_skill_agent_and_workflow_plan_paths_are_aligned() -> None:
-    skill = read(".codex/skills/harness-code-planner/SKILL.md")
-    planner = read(".codex/agents/implementation_planner.toml")
+    skill = read_skill_contract()
+    planner = read_agent_contract()
     workflow = read(".harness/workflows/changeset-use-case-workflow.yaml")
+    skill_agent_prompt = read(".codex/skills/harness-code-planner/agents/openai.yaml")
 
     expected_active = "docs/plans/active/<WORK-ITEM-ID>/plan.md"
     expected_completed = "docs/plans/completed/<WORK-ITEM-ID>/plan.md"
 
     assert expected_active in skill
     assert expected_completed in skill
-    assert expected_active in planner
-    assert expected_completed in planner
+    assert ".codex/skills/harness-code-planner/references/detailed-instructions.md" in planner
+    assert "docs/plans/active/<UC-ID>/plan.md" not in planner
+    assert "docs/plans/completed/<UC-ID>/plan.md" not in planner
     assert expected_active in workflow
+    assert expected_active in skill_agent_prompt
+    assert "docs/plans/active/plan.md" not in skill_agent_prompt
 
 
-def test_skill_and_agent_document_type_specific_missing_input_blockers() -> None:
-    combined = "\n".join(
-        [
-            read(".codex/skills/harness-code-planner/SKILL.md"),
-            read(".codex/agents/implementation_planner.toml"),
-        ]
-    )
+def test_agent_reference_does_not_duplicate_long_planner_standards() -> None:
+    planner = read_agent_contract()
 
-    assert "use-case.md" in combined
-    assert "event-storming.md" in combined
-    assert "e2e-goal.md" in combined
-    assert "change-intent.md" in combined
-    assert "affected-files.md" in combined
-    assert "verification-goal.md" in combined
-    assert "stop" in combined.lower()
+    duplicated_headings = [
+        "Required planning input:",
+        "Stop conditions:",
+        "Plan requirements:",
+        "Checkbox rules:",
+        "Completion move rule:",
+        "Embedded test planning standards:",
+        "Output template for docs/plans/active/<WORK-ITEM-ID>/plan.md:",
+    ]
+    for heading in duplicated_headings:
+        assert heading not in planner
+
+
+def test_skill_use_case_gate_matches_runtime_preflight(tmp_path: Path) -> None:
+    skill = read_skill_contract()
+    skill_paths = set(required_skill_paths(skill, "Use-case work-item slice"))
+    runtime_paths = {
+        str(path).replace("UC-001", "<UC-ID>")
+        for path in _missing_use_case_documents(
+            tmp_path,
+            Path("docs/use-cases/UC-001"),
+        )
+    }
+
+    assert skill_paths == runtime_paths
+
+
+def test_skill_maintenance_gate_matches_runtime_preflight(tmp_path: Path) -> None:
+    skill = read_skill_contract()
+    skill_paths = set(required_skill_paths(skill, "Maintenance work-item slice"))
+    runtime_paths = {
+        str(path).replace("MAINT-001", "<MAINT-ID>")
+        for path in _missing_maintenance_documents(
+            tmp_path,
+            Path("docs/maintenance/MAINT-001"),
+        )
+    }
+
+    assert skill_paths == runtime_paths


### PR DESCRIPTION
Closes #246

## 구현 의도 (Implementation intent)
플래너 스킬과 implementation_planner 에이전트 참조에 중복되어 있던 게이트, 입력, 경로, 체크박스, 완료 규칙을 단일 기준으로 정리합니다.

## 구현 접근 (Implementation approach)
스킬 상세 참조를 canonical planning contract로 유지하고, 에이전트 참조는 역할과 소유권, 해당 참조 로딩 계약만 담도록 축소했습니다. use-case 계획 게이트에는 runtime preflight와 동일하게 ddd-design.md 및 technical-decisions.md 요구사항을 명시했고, 오래된 docs/plans/active/plan.md 기본 프롬프트를 work-item scoped 경로로 바꿨습니다. 테스트는 스킬의 필수 입력 섹션을 파싱해 resolver preflight 필수 파일과 비교하고, 에이전트 참조가 긴 표준을 다시 복제하지 않도록 검증합니다.

## 검증 방법 (Verification method)
- ./venv/bin/python3 -m pytest -q -s tests/test_planner_work_item_alignment.py tests/test_planner_use_case_scope.py tests/test_planner_browser_origin_scope.py tests/runtime/test_affected_use_case_resolver.py tests/runtime/test_workflow_loader.py: 42 passed
- ./venv/bin/python3 -m pytest -q -s: 366 passed
- git diff --check: passed

## 위험 및 롤백 (Risks and rollback)
위험은 에이전트 참조가 짧아지면서 실행 시 반드시 스킬 상세 참조를 읽어야 한다는 점입니다. 문제가 생기면 이 커밋을 revert해 이전 중복 지침으로 되돌릴 수 있습니다.