### PR TITLE
문서: 대시보드 소스 설명 수정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Write all agent input/output and user-facing output in English.
 
-This repo is a Python Codex harness for ChangeSet/use-case workflows with a React/Vite dashboard.
+This repo is a Python Codex harness for ChangeSet/use-case workflows with a bundled runtime dashboard.
 
 ## Fast Context
 - Repo map: `docs/agent/context.md`

--- a/docs/agent/commands.md
+++ b/docs/agent/commands.md
@@ -12,11 +12,11 @@
 
 Use `python3` for Python commands. Use the repository-root `venv` for dependencies and test execution.
 
-## UI
+## Dashboard
 
-- Lint UI: `cd ui && npm run lint`
-- Build UI: `cd ui && npm run build`
-- Run UI dev server: `cd ui && npm run dev`
+- Check dashboard JavaScript syntax: `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
+- Check runtime dashboard Python modules: `python3 -m py_compile harness_codex/runtime/ui_server.py harness_codex/runtime/document_dashboard.py`
+- Run dashboard server: `python3 -m harness_codex ui-server`
 
 ## Agent Context Measurement
 

--- a/docs/agent/context.md
+++ b/docs/agent/context.md
@@ -2,14 +2,14 @@
 
 ## Repository Purpose
 
-This repository contains a Python runtime and CLI for Codex-oriented ChangeSet and use-case workflows. It also includes a React/Vite dashboard under `ui` for viewing workflow state.
+This repository contains a Python runtime and CLI for Codex-oriented ChangeSet and use-case workflows. It also includes a bundled runtime dashboard for viewing workflow state.
 
 The runtime can bootstrap compact repo-local agent context in any target repository through `python3 -m harness_codex agent-context init --description "<repo description>"`.
 
 ## Main Paths
 
 - `harness_codex/cli.py`: CLI entrypoint for harvest, ChangeSet, work-item, stage, artifact, resume, report, and dashboard commands.
-- `harness_codex/runtime/`: workflow engine, models, policy, reports, runner, state, verifier, and dashboard JSON.
+- `harness_codex/runtime/`: workflow engine, models, policy, reports, runner, state, verifier, UI server, and dashboard JSON.
 - `.harness/workflows/`: YAML workflow definitions for harvest and ChangeSet/use-case execution.
 - `docs/design/`: canonical product and domain design documents.
 - `docs/changes/`: active and completed ChangeSet documents.
@@ -17,7 +17,9 @@ The runtime can bootstrap compact repo-local agent context in any target reposit
 - `docs/maintenance/`: executor-facing maintenance slices.
 - `docs/plans/`: active and completed implementation plans.
 - `docs/templates/`: templates for ChangeSet, use-case, and maintenance documents.
-- `ui/`: React, TypeScript, Tailwind, and Vite dashboard app.
+- `harness_codex/runtime/dashboard_assets/`: bundled dashboard JavaScript and CSS served by the runtime UI server.
+- `harness_codex/runtime/ui_server.py`: local dashboard HTTP server and asset routing.
+- `harness_codex/runtime/document_dashboard.py`: dashboard document projection and view data assembly.
 - `tests/`: Python tests for CLI, runtime, workflow parsing, document structure, and planning/execution behavior.
 - `docs/agent/`: hot/cold-path agent context bootstrap output used by this repo and generated for new target repos.
 


### PR DESCRIPTION
Closes #273

## 구현 의도

미래 agent가 존재하지 않는 `ui/` 프론트엔드 경로와 React/Vite toolchain을 기준으로 대시보드 작업을 시작하지 않도록 agent context 문서를 현재 repository 구조에 맞게 수정합니다.

## 구현 접근

- `AGENTS.md`와 `docs/agent/context.md`의 대시보드 설명을 bundled runtime dashboard 기준으로 변경했습니다.
- `docs/agent/context.md`의 주요 경로에 `harness_codex/runtime/dashboard_assets/`, `ui_server.py`, `document_dashboard.py`를 source of truth로 추가했습니다.
- `docs/agent/commands.md`의 UI 검증 명령을 없는 `ui/` npm 명령 대신 실제 runtime asset/module 검증 명령으로 교체했습니다.

## 검증 방법

- `rg -n "ui/|Vite|React" docs README.md AGENTS.md || true`
- `python3` 기반 bounded scanner로 stale frontend toolchain hit 0건 확인
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `python3 -m py_compile harness_codex/runtime/ui_server.py harness_codex/runtime/document_dashboard.py`
- `git diff --check`

## 위험 및 롤백

문서 전용 변경이라 runtime 동작 위험은 낮습니다. 문제가 있으면 이 PR의 문서 변경 3개 파일만 되돌리면 됩니다.