### PR TITLE
스킬 평가 체계 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .harness/runs/
 .harness/cache/
 .harness/import-backups/
+.harness/skill-evaluations/
 .harness/ui/
 .harness/ui-server.log
 .harness/ui-server.pid

--- a/docs/skill-evaluation.md
+++ b/docs/skill-evaluation.md
@@ -1,0 +1,102 @@
+# Skill Evaluation Framework
+
+## 1. Purpose
+
+The skill evaluation framework checks whether harness skills keep producing the
+expected workflow artifacts, preserve stage boundaries, and avoid quality drift
+across prompt, model, and instruction changes.
+
+This framework evaluates skill behavior. It does not replace runtime pytest,
+workflow loader tests, or UI verification. Runtime tests prove code behavior.
+Skill evaluations prove that agent-facing instructions still lead to usable
+documents and safe handoffs.
+
+## 2. Evaluation Targets
+
+The minimum target set is:
+
+- `harness-requirements`
+- `harness-usecases`
+- `harness-event-storming`
+- `harness-ddd-design`
+- `harness-technical-decisions`
+- `harness-code-planner`
+- `harness-plan-executor`
+- `harness-full-workflow`
+
+Each target must have at least one prompt case in
+`docs/skill-evaluation/prompt-corpus.json`.
+
+## 3. Result Location
+
+Generated evaluation results belong under:
+
+```text
+.harness/skill-evaluations/<run-id>/
+```
+
+This path is ignored by Git. Keep committed evaluation inputs and schemas under
+`docs/skill-evaluation/`. Keep generated transcripts, measured timings, token
+counts, artifacts, and score reports under `.harness/skill-evaluations/`.
+
+## 4. Evaluation Flow
+
+1. Select prompt cases from `docs/skill-evaluation/prompt-corpus.json`.
+2. Run each case with the target skill enabled.
+3. Run the same case without the target skill when the case requires a baseline.
+4. Store generated artifacts, transcript summary, timing, and token metrics under
+   `.harness/skill-evaluations/<run-id>/`.
+5. Score artifacts with assertions from
+   `docs/skill-evaluation/assertion-schema.json`.
+6. Compare with-skill results against baseline results.
+7. Fail the evaluation when required artifacts are missing, forbidden paths are
+   edited, required headings are absent, stage boundaries are crossed, or quality
+   metrics regress beyond the configured threshold.
+
+## 5. Assertion Types
+
+Machine-checkable assertions should use these families:
+
+- `artifact_exists`: required output path exists.
+- `heading_exists`: required markdown heading exists.
+- `path_not_modified`: forbidden path was not changed.
+- `text_includes`: required text exists in an artifact.
+- `text_excludes`: forbidden text is absent from an artifact.
+- `json_path_equals`: structured result field has expected value.
+- `metric_at_most`: timing, token, or score metric is below a threshold.
+- `metric_at_least`: score or coverage metric is above a threshold.
+
+Assertion results must include pass/fail status, evidence path, and a short
+failure reason when status is `fail`.
+
+## 6. Stage Boundary Rules
+
+Skill evaluations must verify stage boundaries explicitly:
+
+- Requirements work may update requirements artifacts, but must not generate
+  use-case slices or runtime code.
+- Use-case work may generate use-case slices, but must not edit runtime code,
+  skill files, agent files, requirements documents, or `context.md`.
+- Event-storming work must stay inside the selected use-case slice.
+- DDD design work must produce domain design artifacts without generating code.
+- Technical-decision work must decide retry, idempotency, transaction,
+  observability, and adapter strategy where relevant.
+- Code-planning work must write only the active plan for the selected work item.
+- Plan-execution work must leave verification commands and results in the plan.
+- Full-workflow work must preserve approval gates and delegate specialist stages
+  instead of performing all work directly.
+
+## 7. Minimum Smoke Command
+
+Run the committed framework smoke test with:
+
+```bash
+./venv/bin/python3 -m pytest -q -s tests/test_skill_evaluation_contract.py
+```
+
+Run the broader documentation and skill contract tests when changing skill
+instructions, prompt corpus cases, or assertion rules:
+
+```bash
+./venv/bin/python3 -m pytest -q -s tests/test_skill_evaluation_contract.py tests/test_harvester_skill_instructions.py tests/test_usecase_slice_harvest_instructions.py tests/test_plan_executor_use_case_loop.py tests/test_planner_work_item_alignment.py
+```

--- a/docs/skill-evaluation/assertion-schema.json
+++ b/docs/skill-evaluation/assertion-schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/omegafrog/harness-codex/docs/skill-evaluation/assertion-schema.json",
+  "title": "Harness Skill Evaluation Result",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "case_id",
+    "skill_id",
+    "mode",
+    "started_at",
+    "ended_at",
+    "metrics",
+    "assertions"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "case_id": {
+      "type": "string",
+      "pattern": "^skill-[a-z0-9-]+-[0-9]{3}$"
+    },
+    "skill_id": {
+      "type": "string",
+      "pattern": "^harness-[a-z0-9-]+$"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["with_skill", "baseline"]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "ended_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "metrics": {
+      "type": "object",
+      "required": ["duration_ms", "input_tokens", "output_tokens"],
+      "properties": {
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "input_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "quality_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "status", "evidence_path"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "artifact_exists",
+              "heading_exists",
+              "path_not_modified",
+              "text_includes",
+              "text_excludes",
+              "json_path_equals",
+              "metric_at_most",
+              "metric_at_least"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pass", "fail"]
+          },
+          "evidence_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expected": {},
+          "actual": {},
+          "failure_reason": {
+            "type": "string"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "status": {
+                  "const": "fail"
+                }
+              }
+            },
+            "then": {
+              "required": ["failure_reason"]
+            }
+          }
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/skill-evaluation/prompt-corpus.json
+++ b/docs/skill-evaluation/prompt-corpus.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": "1.0",
+  "result_output_root": ".harness/skill-evaluations",
+  "cases": [
+    {
+      "id": "skill-harness-requirements-001",
+      "skill_id": "harness-requirements",
+      "title": "Collect requirements for a small queue admission feature",
+      "prompt": "Create requirements for a small service that admits users into a waiting queue and blocks admission when capacity is full. Ask only unresolved product questions before writing docs/design/requirements.md.",
+      "baseline_required": true,
+      "expected_artifacts": ["docs/design/requirements.md"],
+      "required_assertions": [
+        "artifact_exists",
+        "heading_exists",
+        "path_not_modified"
+      ],
+      "forbidden_paths": ["docs/use-cases/", "harness_codex/"]
+    },
+    {
+      "id": "skill-harness-usecases-001",
+      "skill_id": "harness-usecases",
+      "title": "Generate one runtime-ready use-case slice",
+      "prompt": "From confirmed waiting queue requirements and context language, create exactly one external-actor use case slice for entering the waiting queue.",
+      "baseline_required": true,
+      "expected_artifacts": [
+        "docs/use-cases/UC-001/use-case.md",
+        "docs/use-cases/UC-001/e2e-goal.md",
+        "docs/use-cases/UC-001/affected-files.md"
+      ],
+      "required_assertions": [
+        "artifact_exists",
+        "heading_exists",
+        "path_not_modified"
+      ],
+      "forbidden_paths": ["harness_codex/", ".codex/skills/", "context.md"]
+    },
+    {
+      "id": "skill-harness-event-storming-001",
+      "skill_id": "harness-event-storming",
+      "title": "Derive event storming only for selected use-case slice",
+      "prompt": "Use docs/use-cases/UC-001/use-case.md as the primary source and write event storming for the selected waiting queue entry use case only.",
+      "baseline_required": false,
+      "expected_artifacts": ["docs/use-cases/UC-001/event-storming.md"],
+      "required_assertions": [
+        "artifact_exists",
+        "heading_exists",
+        "text_includes",
+        "path_not_modified"
+      ],
+      "forbidden_paths": ["docs/use-cases/UC-002/", "harness_codex/"]
+    },
+    {
+      "id": "skill-harness-ddd-design-001",
+      "skill_id": "harness-ddd-design",
+      "title": "Design DDD components without generating runtime code",
+      "prompt": "From the selected UC-001 event storming artifact, design aggregates, entities, value objects, domain services, and application services without editing runtime code.",
+      "baseline_required": false,
+      "expected_artifacts": ["docs/use-cases/UC-001/ddd-design.md"],
+      "required_assertions": [
+        "artifact_exists",
+        "heading_exists",
+        "text_includes",
+        "path_not_modified"
+      ],
+      "forbidden_paths": ["harness_codex/", "ui/"]
+    },
+    {
+      "id": "skill-harness-technical-decisions-001",
+      "skill_id": "harness-technical-decisions",
+      "title": "Record implementation decisions for queue admission",
+      "prompt": "Use the UC-001 DDD design to decide retry, idempotency, transaction boundary, observability, and adapter strategy for queue admission.",
+      "baseline_required": true,
+      "expected_artifacts": ["docs/use-cases/UC-001/technical-decisions.md"],
+      "required_assertions": [
+        "artifact_exists",
+        "heading_exists",
+        "text_includes"
+      ],
+      "forbidden_paths": ["harness_codex/", ".codex/skills/"]
+    },
+    {
+      "id": "skill-harness-code-planner-001",
+      "skill_id": "harness-code-planner",
+      "title": "Create an executor-ready plan for one work item",
+      "prompt": "Create a plan only for UC-001 using the active ChangeSet and selected use-case slice. Do not implement runtime code.",
+      "baseline_required": true,
+      "expected_artifacts": ["docs/plans/active/UC-001/plan.md"],
+      "required_assertions": [
+        "artifact_exists",
+        "heading_exists",
+        "path_not_modified"
+      ],
+      "forbidden_paths": ["harness_codex/", "docs/plans/active/UC-002/"]
+    },
+    {
+      "id": "skill-harness-plan-executor-001",
+      "skill_id": "harness-plan-executor",
+      "title": "Execute one use-case plan and record verification",
+      "prompt": "Execute only docs/plans/active/UC-001/plan.md, keep changes inside its allowed files, and record verification commands with results in the plan.",
+      "baseline_required": true,
+      "expected_artifacts": ["docs/plans/completed/UC-001/plan.md"],
+      "required_assertions": [
+        "artifact_exists",
+        "heading_exists",
+        "text_includes",
+        "path_not_modified"
+      ],
+      "forbidden_paths": ["docs/plans/active/UC-002/", "docs/use-cases/UC-002/"]
+    },
+    {
+      "id": "skill-harness-full-workflow-001",
+      "skill_id": "harness-full-workflow",
+      "title": "Orchestrate full workflow without skipping gates",
+      "prompt": "Run the full harness workflow for a minimal waiting queue feature, preserving requirements, use-case, ChangeSet, DDD, technical decision, planning, execution, and verification approval gates.",
+      "baseline_required": true,
+      "expected_artifacts": [
+        "docs/design/requirements.md",
+        "docs/use-cases/UC-001/use-case.md",
+        "docs/plans/completed/UC-001/plan.md"
+      ],
+      "required_assertions": [
+        "artifact_exists",
+        "heading_exists",
+        "text_includes",
+        "metric_at_most"
+      ],
+      "forbidden_paths": [".codex/skills/"]
+    }
+  ]
+}

--- a/tests/test_skill_evaluation_contract.py
+++ b/tests/test_skill_evaluation_contract.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TARGET_SKILLS = {
+    "harness-requirements",
+    "harness-usecases",
+    "harness-event-storming",
+    "harness-ddd-design",
+    "harness-technical-decisions",
+    "harness-code-planner",
+    "harness-plan-executor",
+    "harness-full-workflow",
+}
+
+
+def read_text(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def read_json(path: str) -> dict:
+    return json.loads(read_text(path))
+
+
+def test_skill_evaluation_guide_defines_core_contract() -> None:
+    guide = read_text("docs/skill-evaluation.md")
+
+    for skill_id in TARGET_SKILLS:
+        assert skill_id in guide
+
+    required_phrases = [
+        "docs/skill-evaluation/prompt-corpus.json",
+        "docs/skill-evaluation/assertion-schema.json",
+        ".harness/skill-evaluations/<run-id>/",
+        "with-skill results against baseline results",
+        "./venv/bin/python3 -m pytest -q -s tests/test_skill_evaluation_contract.py",
+    ]
+
+    for phrase in required_phrases:
+        assert phrase in guide
+
+
+def test_prompt_corpus_covers_each_core_skill_once_or_more() -> None:
+    corpus = read_json("docs/skill-evaluation/prompt-corpus.json")
+    cases = corpus["cases"]
+    skill_ids = {case["skill_id"] for case in cases}
+
+    assert corpus["schema_version"] == "1.0"
+    assert corpus["result_output_root"] == ".harness/skill-evaluations"
+    assert skill_ids == TARGET_SKILLS
+
+    for case in cases:
+        assert case["id"].startswith(f"skill-{case['skill_id']}-")
+        assert case["prompt"]
+        assert case["expected_artifacts"]
+        assert case["required_assertions"]
+        assert "artifact_exists" in case["required_assertions"]
+        assert "path_not_modified" in case["required_assertions"] or case["forbidden_paths"]
+
+
+def test_assertion_schema_is_machine_checkable() -> None:
+    schema = read_json("docs/skill-evaluation/assertion-schema.json")
+    assertion_schema = schema["properties"]["assertions"]["items"]
+    assertion_types = set(assertion_schema["properties"]["type"]["enum"])
+
+    assert schema["properties"]["schema_version"]["const"] == "1.0"
+    assert set(schema["required"]) == {
+        "schema_version",
+        "run_id",
+        "case_id",
+        "skill_id",
+        "mode",
+        "started_at",
+        "ended_at",
+        "metrics",
+        "assertions",
+    }
+    assert {
+        "artifact_exists",
+        "heading_exists",
+        "path_not_modified",
+        "text_includes",
+        "text_excludes",
+        "json_path_equals",
+        "metric_at_most",
+        "metric_at_least",
+    } <= assertion_types
+    assert assertion_schema["additionalProperties"] is False
+
+
+def test_generated_skill_evaluation_output_is_ignored() -> None:
+    gitignore = read_text(".gitignore")
+
+    assert ".harness/skill-evaluations/" in gitignore


### PR DESCRIPTION
## 구현 의도

스킬 산출물 품질을 반복 검증할 수 있도록 평가 가이드, 프롬프트 코퍼스, assertion schema, 생성 결과 저장 위치, 최소 smoke 검증 명령을 추가합니다.

Closes #271

## 구현 접근

- `docs/skill-evaluation.md`에 평가 목적, 대상 스킬, 결과 저장 위치, 평가 흐름, stage boundary 규칙, smoke command를 정리했습니다.
- `docs/skill-evaluation/prompt-corpus.json`에 핵심 harness 스킬 8개를 각각 최소 1개 이상 덮는 평가 케이스를 정의했습니다.
- `docs/skill-evaluation/assertion-schema.json`에 artifact, heading, forbidden path, text, metric 기반 assertion 결과 형식을 정의했습니다.
- `.harness/skill-evaluations/`를 Git ignore 대상에 추가해 실행 결과와 토큰/시간 측정 산출물이 커밋되지 않게 했습니다.
- `tests/test_skill_evaluation_contract.py`로 문서, 코퍼스, schema, ignore rule의 최소 계약을 검증합니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_skill_evaluation_contract.py` → 4 passed
- `./venv/bin/python3 -m pytest -q -s tests/test_skill_evaluation_contract.py tests/test_harvester_skill_instructions.py tests/test_usecase_slice_harvest_instructions.py tests/test_plan_executor_use_case_loop.py tests/test_planner_work_item_alignment.py tests/test_document_structure_templates.py` → 28 passed
- `rg -n -P "\\p{Hangul}" docs/skill-evaluation.md docs/skill-evaluation tests/test_skill_evaluation_contract.py || true` → no matches
- `git check-ignore -v .harness/skill-evaluations/sample/result.json` → `.gitignore:9:.harness/skill-evaluations/`

## 위험 및 롤백

문서와 테스트 중심 변경이라 런타임 동작 위험은 낮습니다. 문제가 생기면 이 PR에서 추가한 평가 문서, schema, corpus, 테스트, ignore rule을 되돌리면 됩니다.
