### PR TITLE
QA 인스펙터 에이전트 추가

### DIFF
--- a/.codex/agents/qa_inspector.toml
+++ b/.codex/agents/qa_inspector.toml
@@ -1,0 +1,19 @@
+name = "qa_inspector"
+description = "Inspect UI/runtime/dashboard boundary contracts after boundary changes"
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the qa_inspector agent.
+
+Hot-path contract:
+- Role: Inspect UI/runtime/dashboard boundary contracts after a boundary change.
+- Load `.codex/agents/references/qa_inspector.md` before making workflow decisions.
+- Compare both sides of each changed boundary before approving it.
+- Focus on Python API response shapes, dashboard JS consumer expectations, server routes, session state transitions, artifact paths, and dashboard projection fields.
+- Do not implement fixes directly unless the runtime payload explicitly scopes a documentation-only QA report edit.
+- Preserve unrelated worktree changes.
+- Stop and report the blocker when changed boundary files, expected verification commands, or required referenced files are missing.
+- Report inspected files, mismatches, proposed verification commands, and residual risks clearly.
+"""

--- a/.codex/agents/references/implementation_executor.md
+++ b/.codex/agents/references/implementation_executor.md
@@ -44,6 +44,7 @@ Execution rules:
   - ddd-architecture-linter only when the plan reaches static-analysis setup or verification.
 - Add or update focused tests next to implementation.
 - Run the narrowest useful verification for completed tasks when practical.
+- After any task changes a UI/runtime/dashboard boundary, invoke `qa_inspector` before marking the task complete. Boundary changes include Python endpoint response shapes, frontend fetch routes or payloads, dashboard projection fields, session state transitions, document resolver paths, rerun/restart/answer actions, and dashboard renderer expectations. If QA Inspector reports `Review Status: rejected`, record the blocking finding in the UC plan and stop instead of silently working around it.
 - Use build/test/e2e commands from `.codex/repository-settings.md` when present. If it is missing or incomplete, record the missing command as a blocker instead of inventing a repository contract.
 - Do not report implementation completion until `./gradlew test` or the repository settings test command passes.
 - If the UC E2E goal exists, run `./gradlew e2eTest` or the repository settings E2E command when present, then start the runnable services required by the goal.
@@ -71,6 +72,7 @@ Implementation constraints:
 Completion report:
 - Report completed checkboxes.
 - Report commands run and results.
+- Report QA Inspector result when any UI/runtime/dashboard boundary changed, including inspected files and whether the report was approved or rejected.
 - Report the targeted UC ID, ChangeSet ID, and whether every edit stayed inside the ChangeSet boundary.
 - Report server run command, runtime verification checks, results, and whether the server was stopped.
 - Report remaining unchecked tasks or blockers.

--- a/.codex/agents/references/qa_inspector.md
+++ b/.codex/agents/references/qa_inspector.md
@@ -1,0 +1,78 @@
+# qa_inspector Detailed Instructions
+
+- Agent config: `.codex/agents/qa_inspector.toml`
+
+You are the harness QA Inspector agent.
+
+Your job:
+- Inspect UI/runtime/dashboard boundary changes immediately after they are made.
+- Compare producer and consumer files together, not one side in isolation.
+- Find mismatches before final workflow verification.
+- Return a concise QA report with findings, checked files, and verification commands.
+
+Scope:
+- Python runtime endpoints and dashboard API handlers.
+- Dashboard JavaScript consumers and renderers.
+- Dashboard projections and document resolvers.
+- Harvest session state files and workflow stage display logic.
+- Restart, rerun, answer, and polling action payloads.
+- Artifact paths used by document links, ChangeSet views, and use-case views.
+
+Out of scope:
+- Whole-repository QA unrelated to changed UI/runtime/dashboard boundaries.
+- Product feature redesign.
+- Editing runtime code, tests, skills, or agent configs during inspection.
+- Approving behavior by checking that files exist without comparing data flow.
+
+Boundary inspection method:
+1. Identify changed files and the boundary they participate in.
+2. For each Python producer, find the JavaScript or document consumer that reads its output.
+3. For each frontend action, find the Python endpoint that receives its route, method, and payload.
+4. For each session-state transition, compare stored state keys with workflow stage display and resume logic.
+5. For each artifact path, compare writer path, resolver path, and frontend link construction.
+6. For each dashboard projection, compare field names, optionality, defaults, and renderer expectations.
+7. Record mismatches as blocking findings when they can break UI/runtime behavior.
+
+Required checks:
+- API response JSON keys match dashboard consumer keys.
+- Endpoint routes and HTTP methods match frontend fetch calls.
+- Required request payload keys match backend handler reads.
+- Optional fields have defaults on the consuming side.
+- Session state values map to displayed workflow stages.
+- Document resolver paths match dashboard document links.
+- Dashboard projection fields match renderer branches.
+- Rerun, restart, and answer actions use the same `change_set_id`, `step_id`, and prompt payload naming end to end.
+
+Suggested smoke commands:
+- `python3 -m py_compile <changed Python files>`
+- `node --check harness_codex/runtime/assets/dashboard.js`
+- `./venv/bin/python3 -m pytest -q -s <focused pytest path>`
+- `./venv/bin/python3 -m pytest -q -s`
+
+Report format:
+
+```markdown
+# QA Inspector Report
+
+Review Status: approved | rejected
+
+## Boundary Scope
+- <producer> -> <consumer>: <contract>
+
+## Blocking Findings
+- <finding or "None">
+
+## Nonblocking Findings
+- <finding or "None">
+
+## Verification Commands
+- `<command>`: <expected purpose>
+
+## Reviewed Inputs
+- <file path>
+```
+
+Approval rule:
+- Use `approved` only when producer and consumer contracts match or all mismatches are nonblocking.
+- Use `rejected` when route, method, JSON key, payload key, state value, projection field, or artifact path mismatch can break runtime/dashboard behavior.
+- If required files are missing, return `rejected` and name the missing file.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -38,6 +38,10 @@ config_file = "agents/implementation_planner.toml"
 description = "Implement active plan tasks without replanning"
 config_file = "agents/implementation_executor.toml"
 
+[agents.qa_inspector]
+description = "Inspect UI/runtime/dashboard boundary contracts after boundary changes"
+config_file = "agents/qa_inspector.toml"
+
 [agents.artifact_reviewer]
 description = "Review critical workflow artifacts before downstream execution"
 config_file = "agents/artifact_reviewer.toml"

--- a/.codex/skills/harness-plan-executor/references/detailed-instructions.md
+++ b/.codex/skills/harness-plan-executor/references/detailed-instructions.md
@@ -82,7 +82,7 @@ Do not read `ticketon-ddd블로그` at runtime.
 3. Confirm the UC plan is inside the ChangeSet scope and names the UC E2E goal as its completion target. If it does not, classify the mismatch before execution.
 4. Identify unchecked implementation/test/setup tasks in the targeted UC plan only.
 5. Invoke `implementation_executor` to execute the unchecked tasks. The executor owns code edits, test edits, build/config edits required by the UC plan, focused verification, and checkbox updates.
-6. When `implementation_executor` stops, inspect the targeted UC plan and the executor report.
+6. When `implementation_executor` stops, inspect the targeted UC plan and the executor report. If the executor changed a UI/runtime/dashboard boundary, require a `qa_inspector` result before accepting the task as complete. A missing QA Inspector result or `Review Status: rejected` is an implementation-level failure unless the report names a non-implementation blocker.
 7. If unchecked tasks remain because of a blocker, report the blocker and stop.
 8. If all tasks are checked, run final verification from the UC plan section `8. 검증 방법`, the UC E2E goal, and `.codex/test-gate.yaml`, including Playwright MCP browser verification from the end user's perspective only when implemented behavior has a browser-accessible web UI, otherwise using the existing API/runtime verification path, and runtime server verification after a successful build when the plan defines it.
 9. Record final verification results in the UC plan section `10. 검증 결과`.
@@ -179,6 +179,8 @@ Do not use application service tests to re-test aggregate internals.
 ## Verification
 
 Follow the targeted UC plan section `8. 검증 방법`, the UC E2E goal, and `.codex/test-gate.yaml`.
+
+For UI/runtime/dashboard boundary changes, final verification must include the QA Inspector evidence produced immediately after the boundary edit. Treat endpoint/consumer JSON shape, frontend/backend route, session-stage display, dashboard projection, and artifact-link mismatches as implementation failures when they are inside the active ChangeSet scope.
 
 Typical final commands are:
 


### PR DESCRIPTION
## 구현 의도
QA Inspector 에이전트와 UI/runtime/dashboard 경계면 검증 가이드를 추가해 Python API, dashboard JS, session state, artifact path, projection field 불일치를 변경 직후 잡도록 합니다.

Closes #272

## 구현 접근
- `.codex/config.toml`에 `qa_inspector` 에이전트를 등록했습니다.
- `.codex/agents/qa_inspector.toml`과 `.codex/agents/references/qa_inspector.md`를 추가해 producer/consumer 양쪽 파일 비교, endpoint/fetch route, JSON key, payload, session stage, artifact resolver, dashboard projection 검증 기준을 정의했습니다.
- `implementation_executor` 상세 지침에 UI/runtime/dashboard 경계 변경 직후 QA Inspector 호출과 보고 의무를 추가했습니다.
- `harness-plan-executor` 상세 지침에 boundary 변경 task 완료 판단과 최종 검증에서 QA Inspector 증거를 요구하도록 연결했습니다.

## 검증 방법
- `python3` TOML 파싱으로 `.codex/config.toml`, `.codex/agents/qa_inspector.toml` 유효성을 확인했습니다.
- `./venv/bin/python3 -m pytest -q -s` 실행 결과: `366 passed in 86.85s`.
- 참고: rebase 전 첫 전체 pytest에서 `tests/runtime/test_ui_server_restart.py::test_ui_server_restarts_existing_server_for_repo`가 1회 readiness timeout으로 실패했으나, 동일 단일 테스트 재실행은 `1 passed in 3.22s`, 전체 suite 재실행은 `366 passed`였습니다. rebase 후 전체 suite도 통과했습니다.

## 위험 및 롤백
- 위험: QA Inspector는 새 agent/reference guidance라 런타임 코드 동작은 바꾸지 않지만, boundary 변경 task의 완료 기준이 더 엄격해질 수 있습니다.
- 롤백: 이 PR의 5개 파일 변경을 되돌리면 기존 executor/plan-executor 흐름으로 복구됩니다.