### PR TITLE
[codex] harness init 코드베이스 분석 추가

### DIFF
--- a/docs/README-harvest-quickstart.md
+++ b/docs/README-harvest-quickstart.md
@@ -7,7 +7,7 @@ This document explains the `harvest` command options and the relationship betwee
 When a repository does not yet have current design documents, run harvest before creating a ChangeSet.
 
 ```bash
-./harness agent-context init --description "<repo description>"
+./harness init --description "<repo description>"
 ./harness harvest --idea "<feature idea>" --plan
 ./harness harvest --idea "<feature idea>" --interactive --session-id harvest-001
 ./harness harvest sessions

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/script
 설치 후 다음 명령으로 프로젝트 컨텍스트와 ChangeSet을 시작한다.
 
 ```bash
-./harness agent-context init \
+./harness init \
   --description "New project managed by harness-codex runtime"
 
 ./harness changes create-from-design \
@@ -47,7 +47,7 @@ New repositories that use this harness should bootstrap repo-local agent context
 harvest or ChangeSet execution.
 
 ```bash
-./harness agent-context init --description "<repo description>"
+./harness init --description "<repo description>"
 ```
 
 The bootstrap creates a short `AGENTS.md` and cold-path context files under

--- a/docs/agent/commands.md
+++ b/docs/agent/commands.md
@@ -8,7 +8,7 @@
 - Preview use-case workflow: `python3 -m harness_codex run-use-case <CHG-ID> <UC-ID> --preview`
 - Preview work item workflow: `python3 -m harness_codex run-work-item <CHG-ID> <WORK-ITEM-ID> --preview`
 - Show run report: `python3 -m harness_codex report <RUN-ID>`
-- Bootstrap target repo agent context: `python3 -m harness_codex agent-context init --description "<repo description>"`
+- Initialize target repo agent context: `python3 -m harness_codex init --description "<repo description>"`
 
 Use `python3` for Python commands. Use the repository-root `venv` for dependencies and test execution.
 

--- a/docs/runtime-interactive-harvest.md
+++ b/docs/runtime-interactive-harvest.md
@@ -13,7 +13,7 @@
 ## Recommended flow
 
 ```bash
-./harness agent-context init --description "<repo description>"
+./harness init --description "<repo description>"
 ./harness harvest --idea "<feature idea>" --interactive
 ./harness changes create-from-design --title "<change title>" --change-set-id CHG-YYYYMMDD-001
 ./harness run-change CHG-YYYYMMDD-001 --plan

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -104,6 +104,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo-root", default=".")
     subparsers = parser.add_subparsers(required=True)
 
+    init = subparsers.add_parser("init")
+    init.add_argument("--description", default="")
+    init.add_argument("--force", action="store_true")
+    init.add_argument("--no-llm", action="store_true")
+    init.set_defaults(func=init_command)
+
     harvest = subparsers.add_parser(
         "harvest",
         description="Harvest a product idea into canonical design documents.",
@@ -154,6 +160,8 @@ def build_parser() -> argparse.ArgumentParser:
     agent_context_init = agent_context_subparsers.add_parser("init")
     agent_context_init.add_argument("--description", default="")
     agent_context_init.add_argument("--force", action="store_true")
+    agent_context_init.add_argument("--llm", action="store_true")
+    agent_context_init.add_argument("--no-llm", action="store_true")
     agent_context_init.set_defaults(func=agent_context_init_command)
 
     changes = subparsers.add_parser("changes")
@@ -328,11 +336,22 @@ def update_command(args: argparse.Namespace, repo_root: Path) -> str:
     return "\n".join(lines)
 
 
+def init_command(args: argparse.Namespace, repo_root: Path) -> str:
+    result = bootstrap_agent_context(
+        repo_root,
+        _repo_description(args.description),
+        force=args.force,
+        use_llm=not args.no_llm,
+    )
+    return _format_agent_context_result(result)
+
+
 def agent_context_init_command(args: argparse.Namespace, repo_root: Path) -> str:
     result = bootstrap_agent_context(
         repo_root,
         _repo_description(args.description),
         force=args.force,
+        use_llm=bool(args.llm and not args.no_llm),
     )
     return _format_agent_context_result(result)
 
@@ -1121,7 +1140,11 @@ def _format_agent_context_result(result: AgentContextBootstrapResult) -> str:
         "Agent context:",
         f"- baseline AGENTS.md words: {result.baseline_agent_words}",
         f"- final AGENTS.md words: {result.final_agent_words}",
+        f"- analyzer mode: {result.analyzer_mode}",
+        f"- LLM summary: {result.llm_status}",
     ]
+    if result.llm_error:
+        lines.append(f"- LLM error: {result.llm_error}")
     lines.extend(f"- {item.path}: {item.action}" for item in result.files)
     return "\n".join(lines)
 

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -69,6 +69,13 @@ from harness_codex.runtime.agent_context import (
     AgentContextFileResult,
     bootstrap_agent_context,
 )
+from harness_codex.runtime.repo_analyzer import (
+    LlmRepoSummary,
+    RepoAnalysis,
+    RepoCommand,
+    analyze_repository,
+    summarize_repository_with_llm,
+)
 from harness_codex.runtime.state import (
     ArtifactDirtyState,
     MaintenanceStep,
@@ -125,6 +132,7 @@ __all__ = [
     "FailureKind",
     "HARNESS_FULL_WORKFLOW",
     "HARNESS_AGENT_CONTEXT_MARKER",
+    "LlmRepoSummary",
     "MaintenanceStep",
     "ArtifactManifest",
     "ReportWriter",
@@ -141,6 +149,8 @@ __all__ = [
     "RunState",
     "RunStateStore",
     "RunnerEngine",
+    "RepoAnalysis",
+    "RepoCommand",
     "ResumeDisposition",
     "ResumeTarget",
     "Step",
@@ -164,6 +174,7 @@ __all__ = [
     "VerificationTier",
     "Workflow",
     "WorkflowValidationError",
+    "analyze_repository",
     "bootstrap_agent_context",
     "complete_change_set_if_ready",
     "decide_resume_target",
@@ -173,5 +184,6 @@ __all__ = [
     "stage_artifact_notes",
     "stage_artifact_status",
     "load_document_contract_registry",
+    "summarize_repository_with_llm",
     "validate_plan_completion",
 ]

--- a/harness_codex/runtime/agent_context.py
+++ b/harness_codex/runtime/agent_context.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from harness_codex.runtime.repo_analyzer import (
+    LlmRepoSummary,
+    RepoAnalysis,
+    analyze_repository,
+    analysis_to_markdown,
+    summarize_repository_with_llm,
+)
+
 
 HARNESS_AGENT_CONTEXT_MARKER = "<!-- harness-agent-context:v1 -->"
 AGENT_CONTEXT_FILES = (
@@ -28,6 +36,9 @@ class AgentContextBootstrapResult:
     baseline_agent_words: int
     final_agent_words: int
     preserved_existing_agents: bool
+    analyzer_mode: str = "static"
+    llm_status: str = "skipped"
+    llm_error: str = ""
 
     @property
     def changed_paths(self) -> tuple[Path, ...]:
@@ -41,11 +52,19 @@ def bootstrap_agent_context(
     repo_description: str,
     *,
     force: bool = False,
+    use_llm: bool = False,
 ) -> AgentContextBootstrapResult:
     """Create or update compact agent context files for a target repo."""
 
     repo = Path(repo_root)
-    description = repo_description.strip() or "Repository managed by the harness workflow."
+    analysis = analyze_repository(repo, repo_description)
+    llm_summary = summarize_repository_with_llm(repo, analysis, enabled=use_llm)
+    description = (
+        llm_summary.purpose.strip()
+        or analysis.description
+        or repo_description.strip()
+        or "Repository managed by the harness workflow."
+    )
     baseline_agent_words = _word_count(repo / "AGENTS.md")
     existing_agents_text = _read_text(repo / "AGENTS.md")
     preserve_agents = bool(
@@ -56,6 +75,8 @@ def bootstrap_agent_context(
         description=description,
         baseline_agent_words=baseline_agent_words,
         preserve_agents=preserve_agents,
+        analysis=analysis,
+        llm_summary=llm_summary,
     )
     results: list[AgentContextFileResult] = []
 
@@ -78,6 +99,8 @@ def bootstrap_agent_context(
             if path != Path("AGENTS.md")
         },
         preserve_agents=preserve_agents,
+        analysis=analysis,
+        llm_summary=llm_summary,
     )
     report_path = repo / "docs/agent/token-reduction-report.md"
     report_action = _write_if_changed(report_path, rendered_report)
@@ -93,6 +116,9 @@ def bootstrap_agent_context(
         baseline_agent_words=baseline_agent_words,
         final_agent_words=final_agent_words,
         preserved_existing_agents=preserve_agents,
+        analyzer_mode="static+llm" if use_llm else "static",
+        llm_status=llm_summary.status,
+        llm_error=llm_summary.error,
     )
 
 
@@ -101,30 +127,42 @@ def _render_docs(
     description: str,
     baseline_agent_words: int,
     preserve_agents: bool,
+    analysis: RepoAnalysis,
+    llm_summary: LlmRepoSummary,
 ) -> dict[Path, str]:
     return {
-        Path("AGENTS.md"): _render_agents(description),
-        Path("docs/agent/context.md"): _render_context(description),
-        Path("docs/agent/commands.md"): _render_commands(),
+        Path("AGENTS.md"): _render_agents(description, analysis),
+        Path("docs/agent/context.md"): _render_context(
+            description, analysis, llm_summary
+        ),
+        Path("docs/agent/commands.md"): _render_commands(analysis, llm_summary),
         Path("docs/agent/session-state.md"): _render_session_state(
-            preserve_agents=preserve_agents
+            preserve_agents=preserve_agents,
+            analysis=analysis,
+            llm_summary=llm_summary,
         ),
         Path("docs/agent/token-reduction-report.md"): _render_token_reduction_report(
             baseline_agent_words=baseline_agent_words,
             final_agent_words=0,
             doc_counts={},
             preserve_agents=preserve_agents,
+            analysis=analysis,
+            llm_summary=llm_summary,
         ),
     }
 
 
-def _render_agents(description: str) -> str:
+def _render_agents(description: str, analysis: RepoAnalysis) -> str:
+    source_roots = _markdown_list(analysis.source_roots, default="source roots not detected")
+    test_roots = _markdown_list(analysis.test_roots, default="test roots not detected")
     return f"""# Agent Context
 {HARNESS_AGENT_CONTEXT_MARKER}
 
 Write all agent input/output and user-facing output in English.
 
 This repo is: {description}
+
+Detected stack: {_comma(analysis.technologies)}.
 
 ## Fast Context
 - Repo map: `docs/agent/context.md`
@@ -134,6 +172,10 @@ This repo is: {description}
 - Module-specific guidance: nearest nested `AGENTS.md`
 
 Read only the smallest relevant context file. Prefer `rg`, targeted file reads, Serena, and Graphify over broad dumps. Use concise output for routine work.
+
+## Detected Roots
+- Source: {source_roots}
+- Tests: {test_roots}
 
 ## Hard Rules
 - Preserve project-specific rules from existing local docs and config.
@@ -158,12 +200,24 @@ Each PR must include:
 """
 
 
-def _render_context(description: str) -> str:
+def _render_context(
+    description: str,
+    analysis: RepoAnalysis,
+    llm_summary: LlmRepoSummary,
+) -> str:
+    llm_module_map = _optional_section("LLM Module Map", llm_summary.module_map)
+    llm_guidance = _optional_section(
+        "LLM Context Guidance", llm_summary.context_guidance
+    )
     return f"""# Agent Context Map
 
 ## Repository Purpose
 
 {description}
+
+## Static Analysis
+
+{analysis_to_markdown(analysis)}
 
 ## Main Paths
 
@@ -183,18 +237,21 @@ Start with the nearest `AGENTS.md`, then read only the smallest relevant file fr
 ## Harness Workflow Guidance
 
 When ChangeSet docs exist, use the active ChangeSet and selected work-item slice as the primary scope. Read canonical design docs only when the slice points there or shared design context is required.
+{llm_module_map}{llm_guidance}
 """
 
 
-def _render_commands() -> str:
-    return """# Agent Commands
+def _render_commands(analysis: RepoAnalysis, llm_summary: LlmRepoSummary) -> str:
+    detected_commands = "\n".join(
+        f"- {item.label}: `{item.command}`" for item in analysis.commands
+    )
+    detected_commands = detected_commands or "- none detected"
+    llm_notes = _optional_section("LLM Command Notes", llm_summary.command_notes)
+    return f"""# Agent Commands
 
 ## Discovery
 
-- List files: `rg --files`
-- Search text: `rg -n "<pattern>"`
-- Git status: `git status --porcelain=v1 -uno`
-- Diff stat: `git diff --stat`
+{detected_commands}
 
 ## Harness Commands
 
@@ -202,14 +259,16 @@ def _render_commands() -> str:
 - Create ChangeSet from design: `python3 -m harness_codex changes create-from-design --title "<title>"`
 - List active ChangeSets: `python3 -m harness_codex changes list`
 - Preview use-case workflow: `python3 -m harness_codex run-use-case <CHG-ID> <UC-ID> --preview`
+- Initialize repo context: `python3 -m harness_codex init --description "<repo description>"`
 - Bootstrap agent context: `python3 -m harness_codex agent-context init --description "<repo description>"`
+{llm_notes}
 
 ## Agent Context Verification
 
 ```bash
 find . -name AGENTS.md -print | sort | xargs -r wc -w
 wc -w docs/agent/*.md
-rg -n -P "\\p{Hangul}" AGENTS.md docs/agent || true
+rg -n -P "\\p{{Hangul}}" AGENTS.md docs/agent || true
 git diff --stat
 git status --porcelain=v1 -uno
 ```
@@ -220,7 +279,12 @@ Use concise status commands first. Use diff stats before targeted diffs. Summari
 """
 
 
-def _render_session_state(*, preserve_agents: bool) -> str:
+def _render_session_state(
+    *,
+    preserve_agents: bool,
+    analysis: RepoAnalysis,
+    llm_summary: LlmRepoSummary,
+) -> str:
     agents_state = (
         "Existing unmarked root `AGENTS.md` was preserved."
         if preserve_agents
@@ -232,6 +296,9 @@ def _render_session_state(*, preserve_agents: bool) -> str:
 
 - {agents_state}
 - `docs/agent/` contains cold-path context generated by harness bootstrap.
+- Analyzer mode: static repository scan.
+- LLM summary status: {llm_summary.status}{_status_error(llm_summary)}.
+- Detected technologies: {_comma(analysis.technologies)}.
 - Check `git status --porcelain=v1 -uno` before modifying files.
 
 ## Handoff Rules
@@ -249,6 +316,8 @@ def _render_token_reduction_report(
     final_agent_words: int,
     doc_counts: dict[Path, int],
     preserve_agents: bool,
+    analysis: RepoAnalysis,
+    llm_summary: LlmRepoSummary,
 ) -> str:
     doc_rows = "\n".join(
         f"- `{path}`: {count} words" for path, count in sorted(doc_counts.items())
@@ -270,6 +339,9 @@ def _render_token_reduction_report(
 - `AGENTS.md` word count after bootstrap: {final_agent_words} words.
 - {root_note}
 - Detailed repo context now lives under `docs/agent/`.
+- Analyzer mode: static repository scan.
+- LLM summary status: {llm_summary.status}{_status_error(llm_summary)}.
+- Detected technologies: {_comma(analysis.technologies)}.
 
 ## Agent Doc Counts
 
@@ -306,3 +378,25 @@ def _word_count(path: Path) -> int:
     if not path.exists():
         return 0
     return len(path.read_text(encoding="utf-8").split())
+
+
+def _markdown_list(paths: tuple[Path, ...], *, default: str) -> str:
+    if not paths:
+        return default
+    return ", ".join(f"`{path.as_posix()}`" for path in paths)
+
+
+def _comma(values: tuple[str, ...]) -> str:
+    return ", ".join(values) if values else "none detected"
+
+
+def _optional_section(title: str, body: str) -> str:
+    if not body.strip():
+        return ""
+    return f"\n## {title}\n\n{body.strip()}\n"
+
+
+def _status_error(summary: LlmRepoSummary) -> str:
+    if not summary.error:
+        return ""
+    return f" ({summary.error})"

--- a/harness_codex/runtime/repo_analyzer.py
+++ b/harness_codex/runtime/repo_analyzer.py
@@ -1,0 +1,399 @@
+"""Static repository analysis for harness agent-context bootstrap."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+SKIP_DIRS = {
+    ".git",
+    ".harness/runs",
+    ".pytest_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "target",
+    "venv",
+}
+
+
+MANIFEST_TECHNOLOGIES = {
+    "pyproject.toml": "Python",
+    "requirements.txt": "Python",
+    "setup.py": "Python",
+    "setup.cfg": "Python",
+    "package.json": "Node.js",
+    "pnpm-lock.yaml": "Node.js",
+    "yarn.lock": "Node.js",
+    "package-lock.json": "Node.js",
+    "build.gradle": "Java/Gradle",
+    "build.gradle.kts": "Java/Gradle",
+    "settings.gradle": "Java/Gradle",
+    "settings.gradle.kts": "Java/Gradle",
+    "pom.xml": "Java/Maven",
+    "go.mod": "Go",
+    "Cargo.toml": "Rust",
+}
+
+
+@dataclass(frozen=True)
+class RepoCommand:
+    label: str
+    command: str
+
+
+@dataclass(frozen=True)
+class RepoAnalysis:
+    description: str
+    readme_title: str
+    technologies: tuple[str, ...]
+    manifests: tuple[Path, ...]
+    source_roots: tuple[Path, ...]
+    test_roots: tuple[Path, ...]
+    docs_roots: tuple[Path, ...]
+    config_files: tuple[Path, ...]
+    workflow_docs: tuple[Path, ...]
+    commands: tuple[RepoCommand, ...]
+
+
+@dataclass(frozen=True)
+class LlmRepoSummary:
+    status: str
+    purpose: str = ""
+    module_map: str = ""
+    command_notes: str = ""
+    context_guidance: str = ""
+    error: str = ""
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def analyze_repository(repo_root: Path | str, description: str = "") -> RepoAnalysis:
+    """Return deterministic, compact repo facts for generated agent docs."""
+
+    repo = Path(repo_root)
+    manifests = _existing_paths(repo, MANIFEST_TECHNOLOGIES)
+    technologies = _technologies_for(manifests)
+    source_roots = _detect_source_roots(repo)
+    test_roots = _detect_test_roots(repo)
+    docs_roots = _detect_docs_roots(repo)
+    config_files = _detect_config_files(repo)
+    workflow_docs = _detect_workflow_docs(repo)
+    commands = _infer_commands(repo, manifests)
+    readme_title = _readme_title(repo)
+    purpose = description.strip() or readme_title or _static_description(technologies)
+
+    return RepoAnalysis(
+        description=purpose,
+        readme_title=readme_title,
+        technologies=technologies,
+        manifests=manifests,
+        source_roots=source_roots,
+        test_roots=test_roots,
+        docs_roots=docs_roots,
+        config_files=config_files,
+        workflow_docs=workflow_docs,
+        commands=commands,
+    )
+
+
+def summarize_repository_with_llm(
+    repo_root: Path | str,
+    analysis: RepoAnalysis,
+    *,
+    enabled: bool,
+    codex_binary: str = "codex",
+    timeout_sec: int = 60,
+    runner: Runner | None = None,
+) -> LlmRepoSummary:
+    """Ask Codex for a concise repo summary, with safe static fallback status."""
+
+    if not enabled:
+        return LlmRepoSummary(status="skipped", error="disabled")
+    if shutil.which(codex_binary) is None:
+        return LlmRepoSummary(
+            status="blocked",
+            error=f"agent provider binary not found: {codex_binary}",
+        )
+
+    repo = Path(repo_root)
+    run = runner or subprocess.run
+    prompt = _llm_prompt(analysis)
+    try:
+        with tempfile.TemporaryDirectory(prefix="harness-init-") as tmp:
+            output_path = Path(tmp) / "summary.md"
+            completed = run(
+                [
+                    codex_binary,
+                    "exec",
+                    "--skip-git-repo-check",
+                    "--cd",
+                    str(repo),
+                    "-c",
+                    'approval_policy="never"',
+                    "--output-last-message",
+                    str(output_path),
+                    "-",
+                ],
+                input=prompt,
+                text=True,
+                capture_output=True,
+                timeout=timeout_sec,
+                check=False,
+            )
+            if completed.returncode != 0:
+                return LlmRepoSummary(
+                    status="blocked",
+                    error=_first_line(completed.stderr or completed.stdout),
+                )
+            message = output_path.read_text(encoding="utf-8") if output_path.exists() else completed.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return LlmRepoSummary(status="blocked", error=str(exc))
+
+    return _parse_llm_summary(message)
+
+
+def analysis_to_markdown(analysis: RepoAnalysis) -> str:
+    lines = [
+        f"- Description: {analysis.description}",
+        f"- Technologies: {_join(analysis.technologies)}",
+        f"- Manifests: {_join_paths(analysis.manifests)}",
+        f"- Source roots: {_join_paths(analysis.source_roots)}",
+        f"- Test roots: {_join_paths(analysis.test_roots)}",
+        f"- Docs roots: {_join_paths(analysis.docs_roots)}",
+        f"- Config files: {_join_paths(analysis.config_files)}",
+        f"- Workflow docs: {_join_paths(analysis.workflow_docs)}",
+    ]
+    if analysis.commands:
+        lines.append("- Commands:")
+        lines.extend(f"  - {item.label}: `{item.command}`" for item in analysis.commands)
+    return "\n".join(lines)
+
+
+def _existing_paths(repo: Path, names: dict[str, str]) -> tuple[Path, ...]:
+    return tuple(Path(name) for name in names if (repo / name).exists())
+
+
+def _technologies_for(manifests: Sequence[Path]) -> tuple[str, ...]:
+    values = []
+    for path in manifests:
+        tech = MANIFEST_TECHNOLOGIES.get(path.as_posix())
+        if tech and tech not in values:
+            values.append(tech)
+    return tuple(values)
+
+
+def _detect_source_roots(repo: Path) -> tuple[Path, ...]:
+    candidates = ["src", "app", "lib", "harness_codex"]
+    roots = [Path(name) for name in candidates if _has_code(repo / name)]
+    if not roots:
+        roots.extend(path for path in _top_level_code_dirs(repo) if path not in roots)
+    return tuple(roots)
+
+
+def _detect_test_roots(repo: Path) -> tuple[Path, ...]:
+    return tuple(Path(name) for name in ("tests", "test", "spec") if (repo / name).is_dir())
+
+
+def _detect_docs_roots(repo: Path) -> tuple[Path, ...]:
+    roots = [Path(name) for name in ("docs", "doc") if (repo / name).is_dir()]
+    roots.extend(Path(name) for name in ("README.md", "AGENTS.md") if (repo / name).is_file())
+    return tuple(roots)
+
+
+def _detect_config_files(repo: Path) -> tuple[Path, ...]:
+    candidates = [
+        ".codex/config.toml",
+        ".codex/openai.yaml",
+        ".github",
+        ".gitignore",
+        ".harness/workflows",
+        "AGENTS.md",
+    ]
+    return tuple(Path(name) for name in candidates if (repo / name).exists())
+
+
+def _detect_workflow_docs(repo: Path) -> tuple[Path, ...]:
+    candidates = [
+        "docs/design",
+        "docs/changes",
+        "docs/use-cases",
+        "docs/maintenance",
+        "docs/plans",
+        ".harness/workflows",
+    ]
+    return tuple(Path(name) for name in candidates if (repo / name).exists())
+
+
+def _infer_commands(repo: Path, manifests: Sequence[Path]) -> tuple[RepoCommand, ...]:
+    commands: list[RepoCommand] = [
+        RepoCommand("List files", "rg --files"),
+        RepoCommand("Search text", 'rg -n "<pattern>"'),
+        RepoCommand("Git status", "git status --porcelain=v1 -uno"),
+        RepoCommand("Diff stat", "git diff --stat"),
+    ]
+    manifest_names = {path.as_posix() for path in manifests}
+    if manifest_names & {"pyproject.toml", "requirements.txt", "setup.py", "setup.cfg"} or _has_code(repo / "harness_codex"):
+        commands.append(RepoCommand("Python tests", f"{_python_command(repo)} -m pytest -q -s"))
+    if (repo / "harness_codex").is_dir():
+        commands.append(RepoCommand("Harness CLI help", "python3 -m harness_codex --help"))
+    if "package.json" in manifest_names:
+        commands.extend(_node_commands(repo / "package.json"))
+    if manifest_names & {"build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"}:
+        commands.append(RepoCommand("Gradle tests", "./gradlew test" if (repo / "gradlew").exists() else "gradle test"))
+    if "pom.xml" in manifest_names:
+        commands.append(RepoCommand("Maven tests", "./mvnw test" if (repo / "mvnw").exists() else "mvn test"))
+    if "go.mod" in manifest_names:
+        commands.append(RepoCommand("Go tests", "go test ./..."))
+    if "Cargo.toml" in manifest_names:
+        commands.append(RepoCommand("Rust tests", "cargo test"))
+    return tuple(_dedupe_commands(commands))
+
+
+def _node_commands(package_json: Path) -> tuple[RepoCommand, ...]:
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return (RepoCommand("Node package scripts", "npm run"),)
+    scripts = data.get("scripts")
+    if not isinstance(scripts, dict) or not scripts:
+        return (RepoCommand("Node package scripts", "npm run"),)
+    preferred = ["test", "build", "lint", "dev", "start"]
+    commands = [
+        RepoCommand(f"npm {name}", f"npm run {name}")
+        for name in preferred
+        if isinstance(scripts.get(name), str)
+    ]
+    return tuple(commands or [RepoCommand("Node package scripts", "npm run")])
+
+
+def _python_command(repo: Path) -> str:
+    if (repo / "venv/bin/python3").exists():
+        return "./venv/bin/python3"
+    return "python3"
+
+
+def _top_level_code_dirs(repo: Path) -> tuple[Path, ...]:
+    roots = []
+    for path in sorted(repo.iterdir()):
+        if not path.is_dir() or _skip(path.relative_to(repo)):
+            continue
+        if _has_code(path):
+            roots.append(path.relative_to(repo))
+    return tuple(roots[:8])
+
+
+def _has_code(path: Path) -> bool:
+    if not path.exists():
+        return False
+    if path.is_file():
+        return path.suffix in {".py", ".js", ".ts", ".java", ".go", ".rs", ".kt"}
+    for child in path.rglob("*"):
+        if _skip_relative(child, path):
+            continue
+        if child.is_file() and child.suffix in {".py", ".js", ".ts", ".java", ".go", ".rs", ".kt"}:
+            return True
+    return False
+
+
+def _skip_relative(path: Path, root: Path) -> bool:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    return _skip(relative)
+
+
+def _skip(path: Path) -> bool:
+    text = path.as_posix()
+    parts = set(path.parts)
+    return text in SKIP_DIRS or bool(parts & SKIP_DIRS)
+
+
+def _readme_title(repo: Path) -> str:
+    readme = repo / "README.md"
+    if not readme.exists():
+        return ""
+    try:
+        for line in readme.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# "):
+                return stripped[2:].strip()
+    except OSError:
+        return ""
+    return ""
+
+
+def _static_description(technologies: Sequence[str]) -> str:
+    if technologies:
+        return f"Repository using {_join(technologies)}."
+    return "Repository managed by the harness workflow."
+
+
+def _llm_prompt(analysis: RepoAnalysis) -> str:
+    return f"""You are summarizing a repository for Codex agent handoff docs.
+
+Use only these static facts. Do not invent missing files or commands.
+Write concise English. Return JSON only with keys:
+purpose, module_map, command_notes, context_guidance.
+
+Static facts:
+{analysis_to_markdown(analysis)}
+"""
+
+
+def _parse_llm_summary(message: str) -> LlmRepoSummary:
+    try:
+        start = message.index("{")
+        end = message.rindex("}") + 1
+        data = json.loads(message[start:end])
+    except (ValueError, json.JSONDecodeError) as exc:
+        return LlmRepoSummary(status="blocked", error=f"invalid LLM summary JSON: {exc}")
+    return LlmRepoSummary(
+        status="completed",
+        purpose=_string(data.get("purpose")),
+        module_map=_string(data.get("module_map")),
+        command_notes=_string(data.get("command_notes")),
+        context_guidance=_string(data.get("context_guidance")),
+    )
+
+
+def _dedupe_commands(commands: Sequence[RepoCommand]) -> tuple[RepoCommand, ...]:
+    seen = set()
+    unique = []
+    for command in commands:
+        if command.command in seen:
+            continue
+        seen.add(command.command)
+        unique.append(command)
+    return tuple(unique)
+
+
+def _join(values: Sequence[str]) -> str:
+    return ", ".join(values) if values else "none detected"
+
+
+def _join_paths(values: Sequence[Path]) -> str:
+    return ", ".join(f"`{path.as_posix()}`" for path in values) if values else "none detected"
+
+
+def _string(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _first_line(value: str) -> str:
+    for line in value.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return "agent summary unavailable"

--- a/tests/runtime/test_agent_context.py
+++ b/tests/runtime/test_agent_context.py
@@ -6,9 +6,12 @@ from harness_codex.runtime.agent_context import (
     HARNESS_AGENT_CONTEXT_MARKER,
     bootstrap_agent_context,
 )
+from harness_codex.runtime.repo_analyzer import LlmRepoSummary
 
 
 def test_bootstrap_agent_context_creates_expected_files(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='sample'\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
     result = bootstrap_agent_context(tmp_path, "Sample project")
 
     assert result.baseline_agent_words == 0
@@ -18,6 +21,9 @@ def test_bootstrap_agent_context_creates_expected_files(tmp_path: Path) -> None:
     assert HARNESS_AGENT_CONTEXT_MARKER in (tmp_path / "AGENTS.md").read_text(
         encoding="utf-8"
     )
+    commands = (tmp_path / "docs/agent/commands.md").read_text(encoding="utf-8")
+    assert "Python tests" in commands
+    assert "python3 -m pytest -q -s" in commands
 
 
 def test_bootstrap_agent_context_preserves_unmarked_agents(
@@ -81,3 +87,23 @@ def test_bootstrap_agent_context_report_records_counts(tmp_path: Path) -> None:
     assert "`AGENTS.md` word count before bootstrap: 0 words" in report
     assert "`AGENTS.md` word count after bootstrap:" in report
     assert "`docs/agent/context.md`:" in report
+    assert "Analyzer mode: static repository scan." in report
+
+
+def test_bootstrap_agent_context_falls_back_when_llm_blocks(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "harness_codex.runtime.agent_context.summarize_repository_with_llm",
+        lambda *_args, **_kwargs: LlmRepoSummary(status="blocked", error="quota"),
+    )
+
+    result = bootstrap_agent_context(tmp_path, "Sample project", use_llm=True)
+
+    assert result.llm_status == "blocked"
+    assert result.llm_error == "quota"
+    session_state = (tmp_path / "docs/agent/session-state.md").read_text(
+        encoding="utf-8"
+    )
+    assert "LLM summary status: blocked (quota)." in session_state

--- a/tests/runtime/test_repo_analyzer.py
+++ b/tests/runtime/test_repo_analyzer.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.repo_analyzer import analyze_repository
+
+
+def test_analyze_repository_detects_python_project(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='sample'\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/sample.py").write_text("print('sample')\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests/test_sample.py").write_text("def test_sample(): pass\n", encoding="utf-8")
+    (tmp_path / "venv/bin").mkdir(parents=True)
+    (tmp_path / "venv/bin/python3").write_text("", encoding="utf-8")
+
+    analysis = analyze_repository(tmp_path, "sample project")
+
+    assert "Python" in analysis.technologies
+    assert Path("pyproject.toml") in analysis.manifests
+    assert Path("src") in analysis.source_roots
+    assert Path("tests") in analysis.test_roots
+    assert any(command.command == "./venv/bin/python3 -m pytest -q -s" for command in analysis.commands)
+
+
+def test_analyze_repository_detects_node_scripts(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"scripts": {"test": "vitest", "build": "vite build"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/app.ts").write_text("export {}\n", encoding="utf-8")
+
+    analysis = analyze_repository(tmp_path)
+
+    assert "Node.js" in analysis.technologies
+    assert Path("package.json") in analysis.manifests
+    assert any(command.command == "npm run test" for command in analysis.commands)
+    assert any(command.command == "npm run build" for command in analysis.commands)
+
+
+def test_analyze_repository_deduplicates_mixed_commands(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='sample'\n", encoding="utf-8")
+    (tmp_path / "requirements.txt").write_text("pytest\n", encoding="utf-8")
+    (tmp_path / "package.json").write_text(
+        json.dumps({"scripts": {"test": "vitest"}}),
+        encoding="utf-8",
+    )
+
+    analysis = analyze_repository(tmp_path)
+
+    command_values = [command.command for command in analysis.commands]
+    assert len(command_values) == len(set(command_values))
+    assert "Python" in analysis.technologies
+    assert "Node.js" in analysis.technologies

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -286,6 +286,64 @@ def test_agent_context_init_creates_expected_files(
     assert (tmp_path / "docs/agent/token-reduction-report.md").is_file()
 
 
+def test_init_creates_expected_files_without_llm(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    (tmp_path / "package.json").write_text(
+        '{"scripts":{"test":"vitest","build":"vite build"}}\n',
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "init",
+            "--description",
+            "sample app",
+            "--no-llm",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Agent context:" in output
+    assert "LLM summary: skipped" in output
+    commands = (tmp_path / "docs/agent/commands.md").read_text(encoding="utf-8")
+    assert "npm run test" in commands
+    assert "npm run build" in commands
+
+
+def test_init_falls_back_when_llm_blocks(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    from harness_codex.runtime.repo_analyzer import LlmRepoSummary
+
+    monkeypatch.setattr(
+        "harness_codex.runtime.agent_context.summarize_repository_with_llm",
+        lambda *_args, **_kwargs: LlmRepoSummary(status="blocked", error="quota"),
+    )
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "init",
+            "--description",
+            "sample app",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "LLM summary: blocked" in output
+    assert "LLM error: quota" in output
+    assert (tmp_path / "docs/agent/context.md").is_file()
+
+
 def test_harvest_apply_warns_and_uses_interactive_runtime(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## Implementation intent

`harness init` 명령이 현재 코드베이스를 분석해 agent context 문서를 생성하도록 한다. 기존 `harness agent-context init`은 호환성을 유지하면서 같은 분석 기반 bootstrap 경로를 사용한다.

## Implementation approach

정적 분석 모듈을 추가해 manifest, 기술 스택, source/test/docs root, config, workflow 문서, 실행 명령 후보를 수집한다. `harness init`은 기본적으로 LLM 요약을 시도하고, 실패하거나 차단되면 정적 분석 결과만으로 문서를 생성한다. 렌더러는 분석 결과와 LLM 상태를 `AGENTS.md`, `docs/agent/context.md`, `docs/agent/commands.md`, `docs/agent/session-state.md`, `docs/agent/token-reduction-report.md`에 반영한다.

## Verification method

- `python3 -m py_compile harness_codex/runtime/repo_analyzer.py harness_codex/runtime/agent_context.py harness_codex/runtime/__init__.py harness_codex/cli.py`
- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_repo_analyzer.py tests/runtime/test_agent_context.py tests/test_cli_commands.py`
- `git diff --check`
- `python3 -m harness_codex --help`
- `python3 -m harness_codex init --help`

## Risks and rollback

LLM 요약 호출이 환경별로 차단될 수 있지만, 정적 분석 fallback으로 문서 생성은 계속된다. 문제가 있으면 이 커밋을 revert하면 기존 `agent-context init` 중심 동작으로 돌아간다.