### PR TITLE
[codex] E2E 목표와 검증 증거 분리

### DIFF
--- a/.codex/agents/references/implementation_executor.md
+++ b/.codex/agents/references/implementation_executor.md
@@ -30,6 +30,7 @@ Ownership:
 - You may edit production code, test code, build files, configuration files, and docs only when the targeted UC plan and active ChangeSet explicitly require it.
 - Do not edit skill files or agent files.
 - Do not edit docs/use-cases/<UC-ID>/e2e-goal.md.
+- You may create or update docs/plans/active/<UC-ID>/verification.md to record implementation-specific test suite details, fixtures, request/response examples, UI steps, commands, and actual verification evidence.
 - Do not edit other UC plans or other UC documents.
 - Do not move docs/plans/active/<UC-ID>/plan.md to docs/plans/completed/<UC-ID>/plan.md.
 - Do not add new plan tasks after final verification failure. The harness-plan-executor skill owns remediation planning.
@@ -48,6 +49,7 @@ Execution rules:
 - Use build/test/e2e commands from `.codex/repository-settings.md` when present. If it is missing or incomplete, record the missing command as a blocker instead of inventing a repository contract.
 - Do not report implementation completion until `./gradlew test` or the repository settings test command passes.
 - If the UC E2E goal exists, run `./gradlew e2eTest` or the repository settings E2E command when present, then start the runnable services required by the goal.
+- Treat docs/use-cases/<UC-ID>/e2e-goal.md as the pre-implementation business acceptance contract. Do not add implementation-specific test suite details to it after approval; record concrete test files, cases, fixtures, API request/response examples, UI steps, commands, and pass/fail evidence in docs/plans/active/<UC-ID>/verification.md or the plan verification result.
 - When implemented behavior includes a UI and that UI is served in a web environment accessible to Playwright, use Playwright MCP to exercise the Given/When/Then path as an end user with browser actions and visible assertions, including refresh or restart behavior when named by the approved E2E goal. For that condition, HTTP/API probes alone do not satisfy use-case E2E verification.
 - For a browser UI that calls a backend on another origin, verify the configured same-origin proxy or CORS behavior from the browser flow, including any preflight required by the actual method and headers. A CORS-blocked request is an implementation failure when the required local origins are inside the approved runtime path.
 - When no UI is implemented for the behavior, or no browser-accessible web UI can be started for the verification environment, continue using the existing API/runtime verification path and record why browser verification was not applicable.

--- a/.codex/skills/harness-plan-executor/references/detailed-instructions.md
+++ b/.codex/skills/harness-plan-executor/references/detailed-instructions.md
@@ -15,13 +15,15 @@ Orchestrate execution of one use-case scoped active plan in `docs/plans/active/<
 
 This skill does not implement product code directly. It delegates implementation to
 `.codex/agents/implementation_executor.toml`, verifies the implemented behavior against
-`docs/use-cases/<UC-ID>/e2e-goal.md` and the repository test gate, updates only that UC plan
-with remediation tasks after implementation failures, and repeats the implementation/verification
-loop until the use case passes or a real blocker is documented.
+`docs/use-cases/<UC-ID>/e2e-goal.md` and the repository test gate, records the
+implementation-specific test suite and proof in `docs/plans/active/<UC-ID>/verification.md`,
+updates only that UC plan with remediation tasks after implementation failures, and repeats the
+implementation/verification loop until the use case passes or a real blocker is documented.
 
 ## Required Inputs
 
 - `docs/plans/active/<UC-ID>/plan.md`
+- `docs/plans/active/<UC-ID>/verification.md` when present
 - `docs/use-cases/<UC-ID>/e2e-goal.md`
 - `docs/use-cases/<UC-ID>/**`
 - `docs/changes/active/<CHG-ID>.md`
@@ -59,8 +61,11 @@ Use sources in this order:
 8. Existing repository code and build configuration
 
 If sources conflict, follow the UC plan for task order, the ChangeSet for scope boundary, the UC
-E2E goal for completion criteria, and `ARCHITECTURE.md` for structural constraints. Record the
-conflict in the UC plan under `검증 실패` and classify it before continuing.
+E2E goal for business acceptance criteria, and `ARCHITECTURE.md` for structural constraints.
+Record implementation-specific test suite details, fixtures, request/response examples, UI steps,
+commands, and actual pass/fail evidence in `docs/plans/active/<UC-ID>/verification.md` or plan
+section `10. 검증 결과`, not in the approved E2E goal. Record conflicts in the UC plan under
+`검증 실패` and classify them before continuing.
 
 Do not read `ticketon-ddd블로그` at runtime.
 
@@ -85,7 +90,7 @@ Do not read `ticketon-ddd블로그` at runtime.
 6. When `implementation_executor` stops, inspect the targeted UC plan and the executor report. If the executor changed a UI/runtime/dashboard boundary, require a `qa_inspector` result before accepting the task as complete. A missing QA Inspector result or `Review Status: rejected` is an implementation-level failure unless the report names a non-implementation blocker.
 7. If unchecked tasks remain because of a blocker, report the blocker and stop.
 8. If all tasks are checked, run final verification from the UC plan section `8. 검증 방법`, the UC E2E goal, and `.codex/test-gate.yaml`, including Playwright MCP browser verification from the end user's perspective only when implemented behavior has a browser-accessible web UI, otherwise using the existing API/runtime verification path, and runtime server verification after a successful build when the plan defines it.
-9. Record final verification results in the UC plan section `10. 검증 결과`.
+9. Record final verification results in the UC plan section `10. 검증 결과` and record concrete implementation proof in `docs/plans/active/<UC-ID>/verification.md`. The verification artifact should include the implementation-specific test suite, test files/cases, fixtures, API request/response examples when applicable, UI steps when applicable, commands, and actual pass/fail evidence.
 10. If final verification passes, move `docs/plans/active/<UC-ID>/plan.md` to `docs/plans/completed/<UC-ID>/plan.md`.
 11. If final verification fails, classify the failure before adding remediation tasks. Add remediation only for implementation-level failures. Stop and report to the user for unclear E2E goals, document deltas, upstream design/architecture/technical-decision failures, and environment blockers.
 
@@ -167,6 +172,10 @@ Stop the loop only when:
 ## Test Expectations
 
 Use the test scope in the targeted UC plan, the UC E2E goal, and `.codex/test-gate.yaml`.
+Treat `docs/use-cases/<UC-ID>/e2e-goal.md` as the business acceptance contract approved before
+implementation. Do not add implementation-specific test suite details to it after approval. Write
+technical test details and proof to `docs/plans/active/<UC-ID>/verification.md` or the UC plan
+verification result instead.
 
 - Domain/Aggregate/VO tests verify invariants, state transitions, invalid values, and boundary conditions.
 - Domain service tests verify domain calculations and decisions.
@@ -197,7 +206,8 @@ UC plan before final verification.
 
 After build succeeds, start the application server if the targeted UC plan defines runtime server
 verification. Use the command recorded in the UC plan, such as `./gradlew bootRun`, wait until the
-server is ready, and record the observed result in section `10. 검증 결과`. When implemented behavior
+server is ready, and record the observed result in section `10. 검증 결과` and
+`docs/plans/active/<UC-ID>/verification.md`. When implemented behavior
 includes a UI and a browser-accessible frontend can be started, use Playwright MCP to perform the
 approved Given/When/Then flow through the visible UI as an end user. Verify that frontend-to-backend
 browser requests succeed under the local origin arrangement; if origins differ, confirm the planned
@@ -225,6 +235,8 @@ Keep the plan active until all of these are true:
 - Runtime server verification passes, or is explicitly marked not applicable with a reason.
 - Static analysis passes.
 - Section `10. 검증 결과` records successful commands.
+- `docs/plans/active/<UC-ID>/verification.md` or section `10. 검증 결과` records the concrete
+  implementation-specific test suite and evidence used to prove the business E2E goal.
 
 Only then move:
 

--- a/.codex/skills/harness-usecases/references/detailed-instructions.md
+++ b/.codex/skills/harness-usecases/references/detailed-instructions.md
@@ -320,7 +320,11 @@ cannot fix the issue:
 - None
 ```
 
-`docs/use-cases/<UC-ID>/e2e-goal.md` must follow this structure.
+`docs/use-cases/<UC-ID>/e2e-goal.md` must follow this structure. It is a pre-implementation
+business acceptance contract. Keep request/response payload examples, Playwright steps, fixtures,
+test file names, commands, and actual pass/fail output out of this document; the planner/executor
+records those details later in `docs/plans/active/<UC-ID>/verification.md` or the plan verification
+result.
 
 ```markdown
 # <UC-ID> E2E Goal
@@ -334,6 +338,17 @@ cannot fix the issue:
 ## Goal
 - ...
 
+## Business Success Criteria
+- ...
+
+## Business Failure Criteria
+- ...
+
+## Observability Boundary
+- Browser-visible UI: yes / no / needs confirmation
+- API/runtime observable behavior: yes / no / needs confirmation
+- Required user-visible evidence:
+
 ## Given
 - ...
 
@@ -343,8 +358,9 @@ cannot fix the issue:
 ## Then
 - ...
 
-## Verification Notes
-- ...
+## Out of Scope
+- Implementation-specific commands, fixtures, API request/response examples, UI automation steps, and actual pass/fail output.
+- These details belong in `docs/plans/active/<UC-ID>/verification.md` or the plan verification result after implementation.
 
 ## Needs Confirmation
 - None

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,6 +114,8 @@ docs/
       technical-decisions.md
       e2e-goal.md
       affected-files.md
+    plans/
+      verification.md
 ```
 
 `docs/templates/**`는 새 문서를 만들 때 복사해서 사용하는 기준이다.
@@ -147,7 +149,8 @@ executor-facing 문서 집합이다.
 - `event-storming.md`: 해당 UC에 필요한 command/event/policy/system slice
 - `ddd-design.md`: 해당 UC 구현에 필요한 도메인/aggregate/service/BC 결정
 - `technical-decisions.md`: 해당 UC 구현에 필요한 세부 기술 결정
-- `docs/use-cases/<UC-ID>/e2e-goal.md`: Given/When/Then 완료 기준과 검증 명령
+- `docs/use-cases/<UC-ID>/e2e-goal.md`: pre-implementation business acceptance contract,
+  including observable success/failure criteria and Given/When/Then
 - `docs/use-cases/<UC-ID>/affected-files.md`: 예상 변경 파일과 금지 파일
 
 유스케이스 slice가 존재하면 planner와 executor는 우선 이 디렉터리의 문서를
@@ -204,7 +207,10 @@ Maintenance slice는 이벤트 스토밍이나 UC E2E goal을 요구하지 않�
 
 유스케이스별 plan은 `docs/plans/active/<UC-ID>/plan.md`에 생성한다.
 Maintenance별 plan은 `docs/plans/active/<MAINT-ID>/plan.md`에 생성한다.
-검증 증거는 같은 디렉터리의 `verification.md`에 기록할 수 있다.
+Verification evidence can be recorded in the same directory as `verification.md`.
+For use-case work, keep `e2e-goal.md` stable after approval and record implementation-specific
+test suite details, fixtures, request/response examples, UI steps, commands, and actual pass/fail
+evidence in `docs/plans/active/<UC-ID>/verification.md` or the plan verification result.
 
 다음 조건을 모두 만족할 때만 plan을 completed로 이동한다.
 

--- a/docs/templates/plans/verification.md
+++ b/docs/templates/plans/verification.md
@@ -1,0 +1,75 @@
+# <WORK-ITEM-ID>. Verification
+
+## 1. Source Goal
+
+- E2E or verification goal:
+- Active plan: `docs/plans/active/<WORK-ITEM-ID>/plan.md`
+- Verification date: YYYY-MM-DD
+
+## 2. Test Suite
+
+|Layer|Command or Tool|Test Files / Cases|Purpose|
+|---|---|---|---|
+|Build||||
+|Unit / Integration||||
+|Runtime / E2E||||
+|Static Analysis||||
+|Test Gate||||
+
+## 3. Fixtures
+
+- Required data:
+- Required services:
+- Required environment variables:
+
+## 4. API Examples
+
+Record only examples used by this implementation. Write `Not applicable` when the work item is UI-only.
+
+### Success Request
+
+```http
+
+```
+
+### Success Response
+
+```http
+
+```
+
+### Failure Request
+
+```http
+
+```
+
+### Failure Response
+
+```http
+
+```
+
+## 5. UI Steps
+
+Record only steps used by this implementation. Write `Not applicable` when the work item has no browser-visible UI.
+
+1.
+
+## 6. Expected Success Evidence
+
+-
+
+## 7. Expected Failure Evidence
+
+-
+
+## 8. Actual Results
+
+|Step|Command / Observation|Result|Evidence|
+|---|---|---|---|
+|||||
+
+## 9. Blockers
+
+- None

--- a/docs/templates/use-cases/e2e-goal.md
+++ b/docs/templates/use-cases/e2e-goal.md
@@ -1,58 +1,51 @@
-# <UC-ID>. <유스케이스 이름> E2E Goal
+# <UC-ID>. <Use Case Name> E2E Goal
 
-## 1. 메타데이터
+## 1. Metadata
 
-|항목|값|
+|Item|Value|
 |---|---|
 |UC ID|`<UC-ID>`|
-|관련 ChangeSet|`docs/changes/active/<CHG-ID>.md`|
-|승인 상태|pending / approved|
-|검증 명령|`./gradlew e2eTest`|
+|Related ChangeSet|`docs/changes/active/<CHG-ID>.md`|
+|Approval Status|pending / approved|
+|Approved by||
 
-## 2. 목표
+## 2. Business Goal
 
-- 사용자가 관찰해야 하는 최종 결과:
-- 시스템이 보장해야 하는 완료 조건:
+- Actor-visible final result:
+- System completion condition:
 
 ## 3. Given / When / Then
 
 ### Given
 
-- 
+-
 
 ### When
 
-- 
+-
 
 ### Then
 
-- 
+-
 
-## 4. 성공 기준
+## 4. Business Success Criteria
 
-- 
+-
 
-## 5. 실패 기준
+## 5. Business Failure Criteria
 
-- 
+-
 
-## 6. 검증 방법
+## 6. Observability Boundary
 
-|단계|명령|성공 기준|필수 여부|
-|---|---|---|---|
-|Build|`./gradlew build`|exit code 0|required|
-|Unit/Integration Test|`./gradlew test`|exit code 0|required|
-|E2E Test|`./gradlew e2eTest`|이 문서의 Given/When/Then 충족|required when E2E exists|
-|Test gate|`.codex/test-gate.yaml` required stage 확인|모든 required stage PASS|required|
+- Browser-visible UI: yes / no / needs confirmation
+- API/runtime observable behavior: yes / no / needs confirmation
+- Required user-visible evidence:
 
-## 7. 관찰 증거
+## 7. Out of Scope
 
-|증거|기록 위치|
-|---|---|
-|테스트 로그|`docs/plans/active/<UC-ID>/verification.md`|
-|서버/API/UI 관찰 결과|`docs/plans/active/<UC-ID>/verification.md`|
-|차단 사유|`docs/plans/active/<UC-ID>/plan.md` 또는 `verification.md`|
+-
 
-## 8. 확인 필요
+## 8. Confirmation Needed
 
-- 없음
+- None

--- a/docs/templates/use-cases/index.md
+++ b/docs/templates/use-cases/index.md
@@ -1,29 +1,29 @@
-# <UC-ID>. <유스케이스 이름>
+# <UC-ID>. <Use Case Name>
 
-## 1. Slice 상태
+## 1. Slice Status
 
-|항목|값|
+|Item|Value|
 |---|---|
 |UC ID|`<UC-ID>`|
-|상태|draft / approved / planned / executing / completed / blocked|
-|관련 ChangeSet|`docs/changes/active/<CHG-ID>.md`|
-|E2E goal 승인|pending / approved|
-|마지막 갱신일|YYYY-MM-DD|
+|Status|draft / approved / planned / executing / completed / blocked|
+|Related ChangeSet|`docs/changes/active/<CHG-ID>.md`|
+|E2E goal approval|pending / approved|
+|Last updated|YYYY-MM-DD|
 
-## 2. 문서 목록
+## 2. Document List
 
-|문서|목적|상태|
+|Document|Purpose|Status|
 |---|---|---|
-|`use-case.md`|액터 목표와 흐름|draft|
-|`event-storming.md`|UC 단위 command/event/policy/system slice|draft|
-|`ddd-design.md`|UC 구현에 필요한 DDD 결정|draft|
-|`technical-decisions.md`|UC 구현에 필요한 세부 기술 결정|draft|
-|`e2e-goal.md`|완료 판정 기준과 검증 명령|draft|
-|`affected-files.md`|예상 변경 파일과 금지 파일|draft|
+|`use-case.md`|Actor goal and flow|draft|
+|`event-storming.md`|UC-level command/event/policy/system slice|draft|
+|`ddd-design.md`|DDD decisions needed for UC implementation|draft|
+|`technical-decisions.md`|Detailed technical decisions needed for UC implementation|draft|
+|`e2e-goal.md`|Business acceptance contract and observable success/failure criteria|draft|
+|`affected-files.md`|Expected changed files and forbidden paths|draft|
 
-## 3. Canonical 문서 추적
+## 3. Canonical Document Tracking
 
-|Canonical 문서|참조 범위|충돌 여부|
+|Canonical Document|Reference Scope|Conflict|
 |---|---|---|
 |`docs/design/요구사항.md`| |none|
 |`docs/design/유스케이스.md`| |none|
@@ -31,12 +31,12 @@
 |`docs/design/details/index.md`| |none|
 |`docs/design/기술결정.md`| |none|
 
-## 4. 실행 상태
+## 4. Execution Status
 
 - Active plan: `docs/plans/active/<UC-ID>/plan.md`
 - Verification: `docs/plans/active/<UC-ID>/verification.md`
 - Completed plan: `docs/plans/completed/<UC-ID>/plan.md`
 
-## 5. 확인 필요
+## 5. Confirmation Needed
 
-- 없음
+- None

--- a/harness_codex/runtime/changes/design_bridge.py
+++ b/harness_codex/runtime/changes/design_bridge.py
@@ -487,7 +487,7 @@ def _render_index(change_set_path: Path, use_case: DesignUseCase) -> str:
 |---|---|---|
 |`use-case.md`|Use-case execution scope|draft|
 |`event-storming.md`|Event-storming route and generated storming output|draft|
-|`e2e-goal.md`|Given/When/Then verification target|approved|
+|`e2e-goal.md`|Business acceptance contract and observable success/failure criteria|approved|
 |`affected-files.md`|Expected files and forbidden paths|draft|
 
 ## 3. Runtime Paths
@@ -610,9 +610,9 @@ def _render_e2e_goal(change_set_path: Path, use_case: DesignUseCase) -> str:
 |UC ID|`{use_case.uc_id}`|
 |Related ChangeSet|`{change_set_path}`|
 |Approval Status|approved|
-|Verification Command|Repository-specific test command|
+|Approved by|user-confirmed harvest/design intake|
 
-## 2. Goal
+## 2. Business Goal
 
 - User-observable result: The user completes `{use_case.source_id}` successfully.
 - System completion condition: The implementation satisfies the canonical use-case flow and rejects invalid input safely.
@@ -633,36 +633,30 @@ def _render_e2e_goal(change_set_path: Path, use_case: DesignUseCase) -> str:
 - The system returns the expected successful result.
 - Invalid or unsupported input returns an actionable failure result.
 
-## 4. Success Criteria
+## 4. Business Success Criteria
 
 - The use-case happy path passes through the user-visible interface.
 - Invalid input handling is covered by tests.
 
-## 5. Failure Criteria
+## 5. Business Failure Criteria
 
 - The implementation produces an incorrect result for valid input.
 - The implementation accepts invalid input silently.
 
-## 6. Verification Method
+## 6. Observability Boundary
 
-|Step|Command|Success Criteria|Required|
-|---|---|---|---|
-|Repository test gate|Project-specific command from the implementation plan|Exit code 0|required|
-|Use-case E2E|Project-specific E2E command when available|Given/When/Then is satisfied|required when E2E exists|
+- Browser-visible UI: needs confirmation
+- API/runtime observable behavior: needs confirmation
+- Required user-visible evidence: The actor can observe the successful result and actionable failure result.
 
-## 7. Observation Evidence
+## 7. Out of Scope
 
-|Evidence|Record Location|
-|---|---|
-|Test log|`docs/plans/active/{use_case.uc_id}/verification.md`|
-|Application observation|`docs/plans/active/{use_case.uc_id}/verification.md`|
-|Blocker reason|`docs/plans/active/{use_case.uc_id}/plan.md` or `verification.md`|
+- Implementation-specific commands, fixtures, API request/response examples, UI automation steps, and actual pass/fail output.
+- These details belong in `docs/plans/active/{use_case.uc_id}/verification.md` or the plan verification result after implementation.
 
-## 8. Confirmation
+## 8. Confirmation Needed
 
-- Status: approved
-- Approved by: user-confirmed harvest/design intake
-- Basis: Generated from confirmed use-case design intake.
+- None
 """
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -375,6 +375,11 @@ def test_changes_create_from_design_blocks_planning_before_decision_gates(
     assert e2e_text.startswith("---\n")
     assert "doc_type: e2e_goal\n" in e2e_text
     assert "approval_status: approved\n" in e2e_text
+    assert "## 4. Business Success Criteria" in e2e_text
+    assert "## 5. Business Failure Criteria" in e2e_text
+    assert "## 6. Observability Boundary" in e2e_text
+    assert "Verification Command" not in e2e_text
+    assert "Repository test gate" not in e2e_text
     sidecar = (
         tmp_path
         / ".harness/contracts/CHG-20260507-001/UC-001/e2e_goal.contract.json"

--- a/tests/test_document_structure_templates.py
+++ b/tests/test_document_structure_templates.py
@@ -84,19 +84,30 @@ def test_use_case_templates_cover_executor_inputs_and_e2e_gate() -> None:
         "docs/templates/use-cases/technical-decisions.md",
         "docs/templates/use-cases/e2e-goal.md",
         "docs/templates/use-cases/affected-files.md",
+        "docs/templates/plans/verification.md",
     ]
 
     for path in template_paths:
         assert (REPO_ROOT / path).is_file()
 
     e2e_goal = read_doc("docs/templates/use-cases/e2e-goal.md")
+    verification = read_doc("docs/templates/plans/verification.md")
     affected_files = read_doc("docs/templates/use-cases/affected-files.md")
 
     assert "## 3. Given / When / Then" in e2e_goal
-    assert "./gradlew build" in e2e_goal
-    assert "./gradlew test" in e2e_goal
-    assert "./gradlew e2eTest" in e2e_goal
-    assert ".codex/test-gate.yaml" in e2e_goal
+    assert "## 4. Business Success Criteria" in e2e_goal
+    assert "## 5. Business Failure Criteria" in e2e_goal
+    assert "## 6. Observability Boundary" in e2e_goal
+    assert "./gradlew build" not in e2e_goal
+    assert "./gradlew test" not in e2e_goal
+    assert "./gradlew e2eTest" not in e2e_goal
+    assert ".codex/test-gate.yaml" not in e2e_goal
+
+    assert "## 2. Test Suite" in verification
+    assert "## 3. Fixtures" in verification
+    assert "## 4. API Examples" in verification
+    assert "## 5. UI Steps" in verification
+    assert "## 8. Actual Results" in verification
 
     assert "## 2. 예상 변경 파일" in affected_files
     assert "## 5. 금지 파일/경로" in affected_files

--- a/tests/test_executor_use_case_scope.py
+++ b/tests/test_executor_use_case_scope.py
@@ -40,6 +40,8 @@ def test_executor_records_environment_blocker_for_e2e_limits() -> None:
     executor = read_executor()
 
     assert "Do not edit docs/use-cases/<UC-ID>/e2e-goal.md" in executor
+    assert "docs/plans/active/<UC-ID>/verification.md" in executor
+    assert "implementation-specific test suite details" in executor
     assert "./gradlew test" in executor
     assert "./gradlew e2eTest" in executor
     assert "Playwright browser install" in executor

--- a/tests/test_plan_executor_use_case_loop.py
+++ b/tests/test_plan_executor_use_case_loop.py
@@ -25,10 +25,13 @@ def test_plan_executor_uses_e2e_goal_and_test_gate() -> None:
     skill = read_plan_executor_skill()
 
     assert "docs/use-cases/<UC-ID>/e2e-goal.md" in skill
+    assert "docs/plans/active/<UC-ID>/verification.md" in skill
     assert ".codex/test-gate.yaml" in skill
     assert "./gradlew test" in skill
     assert "./gradlew e2eTest" in skill
     assert "UC E2E goal" in skill
+    assert "business acceptance contract" in skill
+    assert "implementation-specific test suite" in skill
     assert "Playwright MCP browser verification from the end user's perspective only when" in skill
     assert "otherwise using the existing API/runtime verification path" in skill
     assert "API-only or HTTP-only probes" in skill


### PR DESCRIPTION
## 구현 의도
E2E 목표 문서를 구현 전 비즈니스 수락 계약으로 고정하고, 구현 후 테스트 suite 구체화와 증거 기록은 별도 verification 산출물로 분리합니다.

## 구현 접근
- `e2e-goal.md` 템플릿과 create-from-design 생성 결과에서 기술 명령/게이트 내용을 제거하고 비즈니스 성공/실패 기준과 관찰 경계 중심으로 정리했습니다.
- `docs/templates/plans/verification.md`를 추가해 테스트 suite, fixture, API 요청/응답 예시, UI 단계, 실제 성공/실패 증거를 기록하게 했습니다.
- plan executor와 implementation executor 지침을 업데이트해 승인된 E2E goal은 변경하지 않고 구현별 검증 증거를 `docs/plans/active/<UC-ID>/verification.md` 또는 plan 검증 결과에 기록하도록 했습니다.
- 관련 템플릿/런타임 생성/테스트를 갱신해 새 계약을 회귀 검증합니다.

## 검증 방법
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/test_document_structure_templates.py tests/test_plan_executor_use_case_loop.py tests/test_executor_use_case_scope.py tests/test_cli_commands.py` -> PASS, 32 passed
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/runtime/changes/design_bridge.py` -> PASS
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` -> FAIL, 369 passed / 1 failed: `tests/runtime/test_ui_server_restart.py::test_ui_server_restarts_existing_server_for_repo`에서 replacement 서버 pid 파일 준비 실패. 변경 범위와 무관한 UI server restart runtime test로 보이며 별도 확인 필요합니다.

## 위험 및 롤백
- 위험: 기존 에이전트가 E2E goal 안의 검증 명령을 기대하던 흐름은 verification 산출물 기준으로 전환해야 합니다.
- 롤백: 이 PR을 revert하면 E2E goal 템플릿과 create-from-design 생성 결과가 기존 검증 명령 포함 방식으로 돌아갑니다.