### PR TITLE
[codex] 울트라워크 명령 추가

### DIFF
--- a/completions/_harness
+++ b/completions/_harness
@@ -22,6 +22,7 @@ _harness() {
     'agent-context:Initialize agent context files'
     'changes:List and create ChangeSets'
     'run-change:Run every work item in a ChangeSet'
+    'ultrawork:Create a ChangeSet and run every affected workflow'
     'run-use-case:Run one use case from a ChangeSet'
     'run-work-item:Run one work item from a ChangeSet'
     'stages:Inspect stage artifacts'
@@ -37,6 +38,17 @@ _harness() {
     '--preview:show preview without side effects'
     '--apply:run and apply side effects'
   )
+  local -a ultrawork_options
+  ultrawork_options=(
+    '--title[change title]'
+    '--change-set-id[explicit ChangeSet id]'
+    '--related-issue[related issue reference]'
+    '--uc[limit to a canonical use case]'
+    '--force[overwrite generated ChangeSet artifacts]'
+    '--plan[show execution plan]'
+    '--preview[show preview]'
+    '--apply[run and apply side effects]'
+  )
 
   case $words[2] in
     run-change)
@@ -45,6 +57,9 @@ _harness() {
       elif (( CURRENT == 4 )); then
         _describe 'mode' modes
       fi
+      ;;
+    ultrawork)
+      _describe 'option' ultrawork_options
       ;;
     *)
       if (( CURRENT == 2 )); then

--- a/completions/harness.bash
+++ b/completions/harness.bash
@@ -16,7 +16,7 @@ _harness_completion() {
   local current_word="${COMP_WORDS[COMP_CWORD]}"
 
   if [[ $COMP_CWORD -eq 1 ]]; then
-    COMPREPLY=( $(compgen -W "harvest agent-context changes run-change run-use-case run-work-item stages artifacts run-stage resume report dashboard ui-server" -- "$current_word") )
+    COMPREPLY=( $(compgen -W "harvest agent-context changes run-change ultrawork run-use-case run-work-item stages artifacts run-stage resume report dashboard ui-server" -- "$current_word") )
     return 0
   fi
 
@@ -27,6 +27,11 @@ _harness_completion() {
 
   if [[ "$command" == "run-change" && $COMP_CWORD -eq 3 ]]; then
     COMPREPLY=( $(compgen -W "--plan --preview --apply" -- "$current_word") )
+    return 0
+  fi
+
+  if [[ "$command" == "ultrawork" && "$current_word" == --* ]]; then
+    COMPREPLY=( $(compgen -W "--title --change-set-id --related-issue --uc --force --plan --preview --apply" -- "$current_word") )
     return 0
   fi
 

--- a/docs/agent/commands.md
+++ b/docs/agent/commands.md
@@ -3,6 +3,7 @@
 ## Python Runtime
 
 - Full Python test gate: `./venv/bin/python3 -m pytest -q -s`
+- Create a ChangeSet and run all affected workflows: `python3 -m harness_codex ultrawork --title "<title>"`
 - List active ChangeSets: `python3 -m harness_codex changes list`
 - Show ChangeSet: `python3 -m harness_codex changes show <CHG-ID>`
 - Preview use-case workflow: `python3 -m harness_codex run-use-case <CHG-ID> <UC-ID> --preview`

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -214,6 +214,26 @@ def build_parser() -> argparse.ArgumentParser:
     _add_mode_options(run_change)
     run_change.set_defaults(func=run_change_command)
 
+    ultrawork = subparsers.add_parser(
+        "ultrawork",
+        description=(
+            "Create a ChangeSet from canonical design documents and immediately "
+            "run every affected workflow."
+        ),
+    )
+    ultrawork.add_argument("--title", default="")
+    ultrawork.add_argument("--change-set-id")
+    ultrawork.add_argument("--related-issue", default="")
+    ultrawork.add_argument(
+        "--uc",
+        action="append",
+        default=[],
+        help="Limit generated slices to one canonical use case. May be passed more than once.",
+    )
+    ultrawork.add_argument("--force", action="store_true")
+    _add_optional_mode_options(ultrawork)
+    ultrawork.set_defaults(func=ultrawork_command)
+
     run_use_case = subparsers.add_parser("run-use-case")
     run_use_case.add_argument("change_set_id")
     run_use_case.add_argument("uc_id")
@@ -546,16 +566,7 @@ def _change_set_file_path(change_set: ChangeSet) -> Path:
 
 
 def changes_create_from_design_command(args: argparse.Namespace, repo_root: Path) -> str:
-    title, change_set_id = _resolve_changes_create_from_design_inputs(repo_root, args)
-    result = create_changeset_from_design(
-        repo_root,
-        title=title,
-        change_set_id=change_set_id,
-        related_issue=args.related_issue,
-        selected_use_cases=tuple(args.uc),
-        force=args.force,
-    )
-    agent_context = bootstrap_agent_context(repo_root, _repo_description(title))
+    result, agent_context = _create_changeset_from_design(repo_root, args)
     lines = [
         f"CREATED: {result.change_set_id}",
         f"ChangeSet: {result.change_set_path}",
@@ -566,6 +577,97 @@ def changes_create_from_design_command(args: argparse.Namespace, repo_root: Path
         _format_agent_context_result(agent_context),
     ]
     return "\n".join(lines)
+
+
+def ultrawork_command(args: argparse.Namespace, repo_root: Path) -> str:
+    result, agent_context = _create_changeset_from_design(repo_root, args)
+    mode = _selected_mode(args)
+    prep_outputs = _run_post_changeset_prep_workflows(
+        repo_root,
+        result.change_set_id,
+        tuple(use_case.uc_id for use_case in result.use_cases),
+        args,
+    )
+    blocked_prep = any(not _procedure_stage_output_allows_next(output) for output in prep_outputs)
+    run_args = argparse.Namespace(
+        change_set_id=result.change_set_id,
+        plan=mode == RunMode.PLAN,
+        preview=mode == RunMode.PREVIEW,
+        apply=mode == RunMode.APPLY,
+    )
+    run_output = (
+        "SKIPPED: post-ChangeSet prep workflow blocked"
+        if blocked_prep
+        else run_change_command(run_args, repo_root)
+    )
+    return "\n".join(
+        [
+            f"CREATED: {result.change_set_id}",
+            f"ChangeSet: {result.change_set_path}",
+            "Affected use cases:",
+            *[f"- {use_case.uc_id}: {use_case.name}" for use_case in result.use_cases],
+            _format_agent_context_result(agent_context),
+            "Post-ChangeSet prep workflows:",
+            *prep_outputs,
+            "Workflow run:",
+            run_output,
+        ]
+    )
+
+
+def _create_changeset_from_design(
+    repo_root: Path,
+    args: argparse.Namespace,
+):
+    title, change_set_id = _resolve_changes_create_from_design_inputs(repo_root, args)
+    result = create_changeset_from_design(
+        repo_root,
+        title=title,
+        change_set_id=change_set_id,
+        related_issue=args.related_issue,
+        selected_use_cases=tuple(args.uc),
+        force=args.force,
+    )
+    agent_context = bootstrap_agent_context(repo_root, _repo_description(title))
+    return result, agent_context
+
+
+def _run_post_changeset_prep_workflows(
+    repo_root: Path,
+    change_set_id: str,
+    use_case_ids: tuple[str, ...],
+    args: argparse.Namespace,
+) -> list[str]:
+    outputs: list[str] = []
+    for uc_id in use_case_ids:
+        for stage_id in (
+            "event-storming",
+            "ddd-architecture-definition",
+            "technical-decisions",
+        ):
+            stage_args = argparse.Namespace(
+                procedure_stage_id=stage_id,
+                change_set_id=change_set_id,
+                uc=uc_id,
+                title=args.title,
+                idea=args.title,
+                plan=args.plan,
+                preview=args.preview,
+                apply=not args.plan and not args.preview,
+            )
+            output = procedure_stage_command(stage_args, repo_root)
+            outputs.append(output)
+            if not _procedure_stage_output_allows_next(output):
+                return outputs
+    return outputs
+
+
+def _procedure_stage_output_allows_next(output: str) -> bool:
+    return (
+        "ChangeSet status: blocked" not in output
+        and "Verification: failed" not in output
+        and not output.startswith("BLOCKED:")
+    )
 
 
 def _resolve_changes_create_from_design_inputs(
@@ -1008,6 +1110,17 @@ def _add_mode_options(parser: argparse.ArgumentParser) -> None:
     mode.add_argument("--plan", action="store_true")
     mode.add_argument("--preview", action="store_true")
     mode.add_argument("--apply", action="store_true")
+
+
+def _add_optional_mode_options(parser: argparse.ArgumentParser) -> None:
+    mode = parser.add_mutually_exclusive_group(required=False)
+    mode.add_argument("--plan", action="store_true")
+    mode.add_argument("--preview", action="store_true")
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Run workflows after creating the ChangeSet. Default for this command.",
+    )
 
 
 def _add_harvest_mode_options(parser: argparse.ArgumentParser) -> None:

--- a/scripts/harness-completion.bash
+++ b/scripts/harness-completion.bash
@@ -185,6 +185,9 @@ _harness_options_for_command() {
     changes)
       [[ "$sub" == "create-from-design" ]] && printf '%s\n' "--title --change-set-id --related-issue --uc --force" || true
       ;;
+    ultrawork)
+      printf '%s\n' "--title --change-set-id --related-issue --uc --force --plan --preview --apply"
+      ;;
     run-change|run-use-case|run-work-item|run-stage)
       printf '%s\n' "--plan --preview --apply"
       ;;
@@ -198,7 +201,7 @@ _harness() {
   local cur prev commands global_options
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  commands="harvest agent-context changes run-change run-use-case run-work-item stages artifacts run-stage resume report dashboard ui-server"
+  commands="harvest agent-context changes run-change ultrawork run-use-case run-work-item stages artifacts run-stage resume report dashboard ui-server"
   global_options="--repo-root"
 
   case "$prev" in

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import harness_codex.cli as cli_module
 from harness_codex.cli import main
 
 
@@ -476,6 +477,110 @@ def test_changes_create_from_design_reports_missing_design_doc(
     assert "Required design document not found" in captured.err
     assert not (tmp_path / "AGENTS.md").exists()
     assert not (tmp_path / "docs/agent").exists()
+
+
+def test_ultrawork_creates_changeset_and_runs_all_workflows(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_design_docs(tmp_path)
+    stage_calls = []
+
+    def fake_procedure_stage_command(args, repo_root):
+        stage_calls.append((args.procedure_stage_id, args.change_set_id, args.uc, args.apply))
+        return "\n".join(
+            [
+                f"Stage: {args.procedure_stage_id}",
+                "Agent status: succeeded",
+                "Verification: passed",
+                "ChangeSet status: verified",
+            ]
+        )
+
+    def fake_run_change_command(args, repo_root):
+        assert args.change_set_id == "CHG-20260507-001"
+        assert args.apply is True
+        return "APPLY started: run_id=run-test status=succeeded active_changeset_moved=false"
+
+    monkeypatch.setattr(
+        cli_module,
+        "procedure_stage_command",
+        fake_procedure_stage_command,
+    )
+    monkeypatch.setattr(cli_module, "run_change_command", fake_run_change_command)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "ultrawork",
+            "--title",
+            "simple calculator app",
+            "--change-set-id",
+            "CHG-20260507-001",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "CREATED: CHG-20260507-001" in output
+    assert "Workflow run:" in output
+    assert "APPLY started:" in output
+    assert (tmp_path / "docs/changes/active/CHG-20260507-001.md").is_file()
+    assert (tmp_path / "docs/use-cases/UC-001/use-case.md").is_file()
+    assert stage_calls == [
+        ("event-storming", "CHG-20260507-001", "UC-001", True),
+        ("ddd-architecture-definition", "CHG-20260507-001", "UC-001", True),
+        ("technical-decisions", "CHG-20260507-001", "UC-001", True),
+    ]
+
+
+def test_ultrawork_preview_creates_changeset_without_starting_run(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_design_docs(tmp_path)
+
+    def fake_procedure_stage_command(args, repo_root):
+        return "\n".join(
+            [
+                f"Stage: {args.procedure_stage_id}",
+                "Verification: passed",
+            ]
+        )
+
+    def fake_run_change_command(args, repo_root):
+        assert args.preview is True
+        return "Mode: preview\nChangeSet: CHG-20260507-001\nSide effects: false"
+
+    monkeypatch.setattr(
+        cli_module,
+        "procedure_stage_command",
+        fake_procedure_stage_command,
+    )
+    monkeypatch.setattr(cli_module, "run_change_command", fake_run_change_command)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "ultrawork",
+            "--title",
+            "simple calculator app",
+            "--change-set-id",
+            "CHG-20260507-001",
+            "--preview",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "CREATED: CHG-20260507-001" in output
+    assert "Workflow run:" in output
+    assert "Mode: preview" in output
+    assert not (tmp_path / ".harness/runs").exists()
 
 
 def test_changes_document_delta_preview_has_no_side_effects(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## 구현 의도

초기 ChangeSet 생성 이후 분리되어 있던 후속 워크플로우를 한 번에 실행할 수 있는 `harness ultrawork` 명령을 추가합니다.

## 구현 접근

`ultrawork`는 기존 `changes create-from-design` 생성 경로를 재사용해 ChangeSet과 유스케이스 slice를 만든 뒤, 영향 유스케이스별로 `event-storming`, `ddd-architecture-definition`, `technical-decisions` 절차 단계를 순서대로 실행합니다. 준비 단계가 차단되지 않으면 같은 ChangeSet에 대해 `run-change`를 호출해 모든 영향 워크플로우 실행으로 이어집니다.

명령은 기본적으로 apply 동작을 수행하며, `--plan`과 `--preview`도 지원합니다. bash/zsh completion과 agent command 문서에도 새 명령을 추가했습니다.

## 검증 방법

- `./venv/bin/python3 -m py_compile harness_codex/cli.py tests/test_cli_commands.py`
- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py tests/runtime/test_shell_completion.py`

## 위험 및 롤백

위험은 새 wrapper 명령과 completion 변경에 한정됩니다. 문제가 생기면 `ultrawork` 명령 추가 커밋을 되돌리면 기존 `changes create-from-design`, 절차 단계 명령, `run-change` 흐름은 그대로 유지됩니다.
