### PR TITLE
[codex] 임시 ChangeSet 확정 및 자동완성 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Use-case-scoped commands also require a UC ID:
 
 ## Recommended Workflow
 
-Start from the first runtime stage. This creates the ChangeSet early, records stage state in the ChangeSet, and lets later commands resume from durable files.
+Start from the first runtime stage. This creates a temporary ChangeSet early, records stage state in the ChangeSet, and lets later commands resume from durable files. After use-case design is verified, the runtime finalizes the temporary ChangeSet into a normal `CHG-YYYYMMDD-NNN` ChangeSet generated from the design.
 
 ```bash
-./harness requirements-definition CHG-YYYYMMDD-001 \
+./harness requirements-definition \
   --title "change title" \
   --idea "short product or engineering goal" \
   --apply

--- a/completions/_harness
+++ b/completions/_harness
@@ -7,11 +7,12 @@
 #   fpath=(~/.zfunc $fpath)
 #   autoload -Uz compinit && compinit
 
-_harness_run_change_ids() {
+_harness_changeset_ids() {
+  local scope="${1:-all}"
   local -a candidates
-  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion run-change --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion change-set --repo-root . --prefix "$PREFIX" --scope "$scope" --format zsh 2>/dev/null)}")
   if (( ${#candidates[@]} )); then
-    _describe 'active ChangeSet' candidates
+    _describe 'ChangeSet' candidates
   fi
 }
 
@@ -21,6 +22,14 @@ _harness() {
     'harvest:Harvest a product idea into design documents'
     'agent-context:Initialize agent context files'
     'changes:List and create ChangeSets'
+    'requirements-definition:Define requirements and create temp ChangeSet when needed'
+    'ubiquitous-language-definition:Define project ubiquitous language'
+    'use-case-definition:Define use cases and finalize temp ChangeSet'
+    'event-storming:Create event storming for one use case'
+    'ddd-architecture-definition:Create DDD architecture for one use case'
+    'technical-decisions:Record technical decisions for one use case'
+    'plan-writing:Write implementation plan for one use case'
+    'implementation:Run implementation for one use case'
     'run-change:Run every work item in a ChangeSet'
     'run-use-case:Run one use case from a ChangeSet'
     'run-work-item:Run one work item from a ChangeSet'
@@ -39,10 +48,60 @@ _harness() {
   )
 
   case $words[2] in
+    changes)
+      local -a changes_commands
+      changes_commands=(
+        'list:List ChangeSets'
+        'active:Show active ChangeSet summary'
+        'show:Show one ChangeSet'
+        'contents:Show ChangeSet contents'
+        'create-from-design:Create ChangeSet from design docs'
+        'document-delta:Apply document delta to ChangeSet work item'
+      )
+      if (( CURRENT == 3 )); then
+        _describe 'changes command' changes_commands
+      elif (( CURRENT == 4 )) && [[ "$words[3]" == (show|contents) ]]; then
+        _harness_changeset_ids all
+      elif (( CURRENT == 4 )) && [[ "$words[3]" == document-delta ]]; then
+        _harness_changeset_ids active
+      fi
+      ;;
+    contracts)
+      if (( CURRENT == 4 )) && [[ "$words[3]" == validate ]]; then
+        _harness_changeset_ids all
+      fi
+      ;;
     run-change)
       if (( CURRENT == 3 )); then
-        _harness_run_change_ids
+        _harness_changeset_ids active
       elif (( CURRENT == 4 )); then
+        _describe 'mode' modes
+      fi
+      ;;
+    run-use-case|run-work-item|run-stage)
+      if (( CURRENT == 3 )); then
+        _harness_changeset_ids active
+      fi
+      ;;
+    stages)
+      if (( CURRENT == 4 )) && [[ "$words[3]" == list ]]; then
+        _harness_changeset_ids all
+      fi
+      ;;
+    artifacts)
+      if (( CURRENT == 4 )) && [[ "$words[3]" == (show|accept) ]]; then
+        _harness_changeset_ids all
+      fi
+      ;;
+    ubiquitous-language-definition|use-case-definition|event-storming|ddd-architecture-definition|technical-decisions|plan-writing|implementation)
+      if (( CURRENT == 3 )); then
+        _harness_changeset_ids active
+      elif (( CURRENT == 4 )); then
+        _describe 'mode' modes
+      fi
+      ;;
+    requirements-definition)
+      if (( CURRENT == 3 )); then
         _describe 'mode' modes
       fi
       ;;

--- a/completions/harness.bash
+++ b/completions/harness.bash
@@ -3,12 +3,13 @@
 #   source completions/harness.bash
 # or add that line to ~/.bashrc.
 
-_harness_complete_run_change_ids() {
+_harness_complete_changeset_ids() {
+  local scope="${1:-all}"
   local current_word="${COMP_WORDS[COMP_CWORD]}"
   COMPREPLY=()
   while IFS= read -r candidate; do
     COMPREPLY+=("$candidate")
-  done < <(python3 -m harness_codex.runtime.shell_completion run-change --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+  done < <(python3 -m harness_codex.runtime.shell_completion change-set --repo-root . --prefix "$current_word" --scope "$scope" --format bash 2>/dev/null)
 }
 
 _harness_completion() {
@@ -16,12 +17,49 @@ _harness_completion() {
   local current_word="${COMP_WORDS[COMP_CWORD]}"
 
   if [[ $COMP_CWORD -eq 1 ]]; then
-    COMPREPLY=( $(compgen -W "harvest agent-context changes run-change run-use-case run-work-item stages artifacts run-stage resume report dashboard ui-server" -- "$current_word") )
+    COMPREPLY=( $(compgen -W "harvest agent-context changes requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation run-change run-use-case run-work-item stages artifacts run-stage resume report dashboard ui-server" -- "$current_word") )
     return 0
   fi
 
   if [[ "$command" == "run-change" && $COMP_CWORD -eq 2 ]]; then
-    _harness_complete_run_change_ids
+    _harness_complete_changeset_ids active
+    return 0
+  fi
+
+  if [[ "$command" == "run-use-case" || "$command" == "run-work-item" || "$command" == "run-stage" ]]; then
+    if [[ $COMP_CWORD -eq 2 ]]; then
+      _harness_complete_changeset_ids active
+      return 0
+    fi
+  fi
+
+  if [[ "$command" =~ ^(ubiquitous-language-definition|use-case-definition|event-storming|ddd-architecture-definition|technical-decisions|plan-writing|implementation)$ && $COMP_CWORD -eq 2 ]]; then
+    _harness_complete_changeset_ids active
+    return 0
+  fi
+
+  if [[ "$command" == "changes" && ("${COMP_WORDS[2]:-}" == "show" || "${COMP_WORDS[2]:-}" == "contents") && $COMP_CWORD -eq 3 ]]; then
+    _harness_complete_changeset_ids all
+    return 0
+  fi
+
+  if [[ "$command" == "changes" && "${COMP_WORDS[2]:-}" == "document-delta" && $COMP_CWORD -eq 3 ]]; then
+    _harness_complete_changeset_ids active
+    return 0
+  fi
+
+  if [[ "$command" == "contracts" && "${COMP_WORDS[2]:-}" == "validate" && $COMP_CWORD -eq 3 ]]; then
+    _harness_complete_changeset_ids all
+    return 0
+  fi
+
+  if [[ "$command" == "stages" && "${COMP_WORDS[2]:-}" == "list" && $COMP_CWORD -eq 3 ]]; then
+    _harness_complete_changeset_ids all
+    return 0
+  fi
+
+  if [[ "$command" == "artifacts" && ("${COMP_WORDS[2]:-}" == "show" || "${COMP_WORDS[2]:-}" == "accept") && $COMP_CWORD -eq 3 ]]; then
+    _harness_complete_changeset_ids all
     return 0
   fi
 

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import replace as dataclass_replace
 from datetime import datetime
 from pathlib import Path
 from typing import Mapping
@@ -278,7 +279,10 @@ def _add_procedure_stage_parser(
     stage: ProcedureStage,
 ) -> None:
     command = subparsers.add_parser(stage.stage_id)
-    command.add_argument("change_set_id")
+    if stage.stage_id == "requirements-definition":
+        command.add_argument("change_set_id", nargs="?")
+    else:
+        command.add_argument("change_set_id")
     command.add_argument("--uc", default="")
     command.add_argument("--title", default="")
     command.add_argument("--idea", default="")
@@ -631,6 +635,7 @@ def procedure_stage_command(args: argparse.Namespace, repo_root: Path) -> str:
     if stage.requires_uc and not uc_id:
         raise ValueError(f"{stage.stage_id} requires --uc")
 
+    args.change_set_id = _resolve_procedure_change_set_id(repo_root, args, mode)
     change_set_path = Path("docs/changes/active") / f"{args.change_set_id}.md"
     if mode == RunMode.PLAN:
         return _format_procedure_stage_plan(stage, args.change_set_id, uc_id)
@@ -701,16 +706,133 @@ def procedure_stage_command(args: argparse.Namespace, repo_root: Path) -> str:
     status = "verified" if result.successful and passed else "blocked"
     notes = "; ".join(problems) or result.error or "-"
     _record_procedure_stage_status(repo_root, change_set_path, stage, status, notes)
-    return "\n".join(
-        [
-            f"Stage: {stage.stage_id}",
-            f"Run: {run_id}",
-            f"Agent status: {result.status.value}",
-            f"Verification: {'passed' if passed else 'failed'}",
-            f"ChangeSet status: {status}",
-            f"Notes: {notes}",
-        ]
+    lines = [
+        f"Stage: {stage.stage_id}",
+        f"Run: {run_id}",
+        f"Agent status: {result.status.value}",
+        f"Verification: {'passed' if passed else 'failed'}",
+        f"ChangeSet status: {status}",
+        f"Notes: {notes}",
+    ]
+    if stage.stage_id == "use-case-definition" and status == "verified":
+        finalized = _finalize_temporary_changeset(
+            repo_root,
+            change_set_id=args.change_set_id,
+            run_id=run_id,
+        )
+        if finalized:
+            final_id, final_path = finalized
+            lines.append(f"Finalized ChangeSet: {args.change_set_id} -> {final_id}")
+            lines.append(f"Finalized path: {final_path}")
+    return "\n".join(lines)
+
+
+def _resolve_procedure_change_set_id(
+    repo_root: Path,
+    args: argparse.Namespace,
+    mode: RunMode,
+) -> str:
+    provided = (args.change_set_id or "").strip()
+    if provided:
+        return provided
+    if args.procedure_stage_id != "requirements-definition":
+        raise ValueError(f"{args.procedure_stage_id} requires change_set_id")
+    if mode == RunMode.PLAN:
+        return "CHG-TEMP-<auto>"
+    return _suggest_temporary_change_set_id(repo_root)
+
+
+def _suggest_temporary_change_set_id(repo_root: Path) -> str:
+    repo = Path(repo_root)
+    date = datetime.now().strftime("%Y%m%d")
+    directories = (
+        repo / "docs/changes/active",
+        repo / "docs/changes/completed",
     )
+    sequence = 1
+    for directory in directories:
+        if not directory.exists():
+            continue
+        for path in directory.glob(f"CHG-TEMP-{date}-*.md"):
+            try:
+                sequence = max(sequence, int(path.stem.rsplit("-", maxsplit=1)[1]) + 1)
+            except (IndexError, ValueError):
+                continue
+    return f"CHG-TEMP-{date}-{sequence:03d}"
+
+
+def _finalize_temporary_changeset(
+    repo_root: Path,
+    *,
+    change_set_id: str,
+    run_id: str,
+) -> tuple[str, Path] | None:
+    if not change_set_id.startswith("CHG-TEMP-"):
+        return None
+
+    old_path = Path("docs/changes/active") / f"{change_set_id}.md"
+    old_absolute = repo_root / old_path
+    if not old_absolute.exists() or not _harvest_design_docs_exist(repo_root):
+        return None
+
+    old_text = old_absolute.read_text(encoding="utf-8")
+    final_title = _title_from_design(repo_root) or change_set_id
+    final_id = _suggest_next_change_set_id(repo_root)
+    result = create_changeset_from_design(
+        repo_root,
+        title=final_title,
+        change_set_id=final_id,
+        force=False,
+    )
+    final_absolute = repo_root / result.change_set_path
+    final_text = final_absolute.read_text(encoding="utf-8")
+    final_absolute.write_text(
+        _append_runtime_procedure_state(final_text, old_text),
+        encoding="utf-8",
+    )
+    old_absolute.unlink()
+    _retarget_run_state(repo_root, run_id=run_id, change_set_id=final_id)
+    return final_id, result.change_set_path
+
+
+def _title_from_design(repo_root: Path) -> str:
+    for relative_path in (Path("docs/design/요구사항.md"), Path("docs/design/유스케이스.md")):
+        path = repo_root / relative_path
+        if not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith(("-", "*")):
+                stripped = stripped.lstrip("-* ").strip()
+            if ":" in stripped:
+                stripped = stripped.split(":", maxsplit=1)[1].strip()
+            return stripped.rstrip(".")
+    return ""
+
+
+def _append_runtime_procedure_state(final_text: str, old_text: str) -> str:
+    heading = "## 3. Runtime Procedure State"
+    start = old_text.find(heading)
+    if start < 0:
+        return final_text
+    end = old_text.find("\n## ", start + len(heading))
+    procedure_section = old_text[start : end if end >= 0 else len(old_text)].strip()
+    if not procedure_section:
+        return final_text
+    if heading in final_text:
+        return final_text
+    return final_text.rstrip() + "\n\n" + procedure_section + "\n"
+
+
+def _retarget_run_state(repo_root: Path, *, run_id: str, change_set_id: str) -> None:
+    store = RunStateStore(repo_root)
+    try:
+        state = store.load(run_id)
+    except (FileNotFoundError, KeyError, ValueError):
+        return
+    store.save(dataclass_replace(state, change_set_id=change_set_id))
 
 
 def _create_initial_procedure_changeset(

--- a/harness_codex/runtime/shell_completion.py
+++ b/harness_codex/runtime/shell_completion.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from harness_codex.runtime.changes import ChangeSetResolver, NoActiveChangeSetsError
+from harness_codex.runtime.changes import ChangeSet, ChangeSetResolver, NoActiveChangeSetsError
 
 
 @dataclass(frozen=True)
@@ -34,17 +34,44 @@ class CompletionInstallResult:
 def run_change_candidates(repo_root: Path | str, prefix: str = "") -> tuple[CompletionCandidate, ...]:
     """Return active ChangeSet IDs for `run-change` completion."""
 
+    return change_set_candidates(repo_root, prefix, scope="active")
+
+
+def change_set_candidates(
+    repo_root: Path | str,
+    prefix: str = "",
+    *,
+    scope: str = "all",
+) -> tuple[CompletionCandidate, ...]:
+    """Return ChangeSet IDs with status/title descriptions."""
+
     normalized_prefix = prefix.strip()
-    try:
-        change_sets = ChangeSetResolver(Path(repo_root)).list_active()
-    except NoActiveChangeSetsError:
-        return ()
+    resolver = ChangeSetResolver(Path(repo_root))
+    change_sets: list[ChangeSet] = []
+    if scope in ("active", "all"):
+        try:
+            change_sets.extend(resolver.list_active())
+        except NoActiveChangeSetsError:
+            pass
+    if scope in ("completed", "all"):
+        completed_dir = Path(repo_root) / "docs/changes/completed"
+        for path in sorted(completed_dir.glob("*.md")):
+            change_sets.append(resolver.load(path))
 
     return tuple(
-        CompletionCandidate(change_set.change_set_id, change_set.title)
+        CompletionCandidate(
+            change_set.change_set_id,
+            _change_set_description(change_set),
+        )
         for change_set in change_sets
         if not normalized_prefix or change_set.change_set_id.startswith(normalized_prefix)
     )
+
+
+def _change_set_description(change_set: ChangeSet) -> str:
+    status = change_set.status or "-"
+    title = change_set.title or change_set.intent_summary or "-"
+    return f"{status} - {title}"
 
 
 def format_candidates(
@@ -105,6 +132,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_change.set_defaults(func=run_change_completion_command)
 
+    change_set = subparsers.add_parser("change-set")
+    change_set.add_argument("--repo-root", default=".")
+    change_set.add_argument("--prefix", default="")
+    change_set.add_argument("--scope", choices=("active", "completed", "all"), default="all")
+    change_set.add_argument(
+        "--format",
+        choices=("bash", "zsh", "tsv"),
+        default="tsv",
+    )
+    change_set.set_defaults(func=change_set_completion_command)
+
     install = subparsers.add_parser("install")
     install.add_argument("--repo-root", default=".")
     install.add_argument("--shell", choices=("auto", "zsh", "bash", "all"), default="auto")
@@ -115,6 +153,13 @@ def build_parser() -> argparse.ArgumentParser:
 def run_change_completion_command(args: argparse.Namespace) -> str:
     return format_candidates(
         run_change_candidates(args.repo_root, args.prefix),
+        shell_format=args.format,
+    )
+
+
+def change_set_completion_command(args: argparse.Namespace) -> str:
+    return format_candidates(
+        change_set_candidates(args.repo_root, args.prefix, scope=args.scope),
         shell_format=args.format,
     )
 

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from harness_codex.runtime.shell_completion import (
+    change_set_candidates,
     format_candidates,
     install_completion,
     run_change_candidates,
@@ -57,8 +58,8 @@ def test_run_change_candidates_returns_active_changeset_ids_and_titles(tmp_path:
     candidates = run_change_candidates(tmp_path)
 
     assert [(item.value, item.description) for item in candidates] == [
-        ("CHG-20260522-001", "Add note analysis"),
-        ("CHG-20260522-002", "Improve runtime completion"),
+        ("CHG-20260522-001", "active - Add note analysis"),
+        ("CHG-20260522-002", "active - Improve runtime completion"),
     ]
 
 
@@ -71,7 +72,7 @@ def test_run_change_candidates_filters_by_prefix(tmp_path: Path):
     candidates = run_change_candidates(tmp_path, "CHG-20260522-002")
 
     assert [(item.value, item.description) for item in candidates] == [
-        ("CHG-20260522-002", "Improve runtime completion"),
+        ("CHG-20260522-002", "active - Improve runtime completion"),
     ]
 
 
@@ -86,8 +87,33 @@ def test_format_candidates_supports_bash_zsh_and_tsv(tmp_path: Path):
     candidates = run_change_candidates(tmp_path)
 
     assert format_candidates(candidates, shell_format="bash") == "CHG-20260522-001"
-    assert format_candidates(candidates, shell_format="zsh") == "CHG-20260522-001:Add note analysis"
-    assert format_candidates(candidates, shell_format="tsv") == "CHG-20260522-001\tAdd note analysis"
+    assert (
+        format_candidates(candidates, shell_format="zsh")
+        == "CHG-20260522-001:active - Add note analysis"
+    )
+    assert (
+        format_candidates(candidates, shell_format="tsv")
+        == "CHG-20260522-001\tactive - Add note analysis"
+    )
+
+
+def test_change_set_candidates_include_completed_status_and_title(tmp_path: Path):
+    active_dir = tmp_path / "docs/changes/active"
+    completed_dir = tmp_path / "docs/changes/completed"
+    active_dir.mkdir(parents=True)
+    completed_dir.mkdir(parents=True)
+    (active_dir / "CHG-20260522-001.md").write_text(CHANGESET_A, encoding="utf-8")
+    (completed_dir / "CHG-20260522-002.md").write_text(
+        CHANGESET_B.replace("| Status | active |", "| Status | completed |"),
+        encoding="utf-8",
+    )
+
+    candidates = change_set_candidates(tmp_path, scope="all")
+
+    assert [(item.value, item.description) for item in candidates] == [
+        ("CHG-20260522-001", "active - Add note analysis"),
+        ("CHG-20260522-002", "completed - Improve runtime completion"),
+    ]
 
 
 def test_install_completion_copies_zsh_completion(tmp_path: Path):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 
 from harness_codex.cli import main
+from harness_codex.runtime.models import StepResult, StepStatus
+from harness_codex.runtime.procedure_stages import render_initial_changeset
 
 
 CHANGESET = """# ChangeSet CHG-001
@@ -547,6 +549,83 @@ class FakeDateTime:
                 return "20260507"
 
         return _Now()
+
+
+class FakeSuccessfulRunner:
+    def run(self, step, context):
+        return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
+
+
+def test_requirements_definition_creates_temporary_changeset_without_id(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("harness_codex.cli.BasicStepRunner", FakeSuccessfulRunner)
+    monkeypatch.setattr("harness_codex.cli.verify_procedure_stage", lambda *_, **__: (True, ()))
+    monkeypatch.setattr("harness_codex.cli.datetime", FakeDateTime)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "requirements-definition",
+            "--idea",
+            "Build note capture",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Stage: requirements-definition" in output
+    temp_path = tmp_path / "docs/changes/active/CHG-TEMP-20260507-001.md"
+    assert temp_path.is_file()
+    assert "|ChangeSet ID|`CHG-TEMP-20260507-001`|" in temp_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_use_case_definition_finalizes_temporary_changeset_from_design(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_design_docs(tmp_path)
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    temp_path = active_dir / "CHG-TEMP-20260507-001.md"
+    temp_path.write_text(
+        render_initial_changeset(
+            change_set_id="CHG-TEMP-20260507-001",
+            title="temporary",
+            request_summary="Build note capture",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("harness_codex.cli.BasicStepRunner", FakeSuccessfulRunner)
+    monkeypatch.setattr("harness_codex.cli.verify_procedure_stage", lambda *_, **__: (True, ()))
+    monkeypatch.setattr("harness_codex.cli.datetime", FakeDateTime)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "use-case-definition",
+            "CHG-TEMP-20260507-001",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    final_path = tmp_path / "docs/changes/active/CHG-20260507-001.md"
+    assert exit_code == 0
+    assert "Finalized ChangeSet: CHG-TEMP-20260507-001 -> CHG-20260507-001" in output
+    assert not temp_path.exists()
+    assert final_path.is_file()
+    final_text = final_path.read_text(encoding="utf-8")
+    assert "|ChangeSet ID|`CHG-20260507-001`|" in final_text
+    assert "|use-case-definition|Use Case Definition|verified|" in final_text
 
 
 def test_run_change_plan_has_no_side_effects(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## 구현 의도 (Implementation intent)

requirements-definition 단계에서 ChangeSet 이름을 먼저 요구하지 않고 임시 ChangeSet을 생성하도록 변경합니다. 설계가 끝난 뒤 use-case-definition 검증 결과를 바탕으로 정식 ChangeSet ID와 문서로 확정합니다.

## 구현 접근 (Implementation approach)

requirements-definition의 change_set_id 인자를 선택값으로 바꾸고, 값이 없으면 CHG-TEMP-YYYYMMDD-NNN 형식 임시 ChangeSet을 생성합니다. use-case-definition 검증 성공 시 설계 문서를 읽어 create_changeset_from_design으로 정식 ChangeSet을 만들고, 기존 Runtime Procedure State를 새 문서에 이관한 뒤 임시 문서를 제거합니다. shell_completion에는 ChangeSet 후보 조회 명령을 추가하고 zsh/bash completion에서 ChangeSet 인자 위치마다 후보를 제공하도록 연결했습니다. zsh 후보 설명에는 상태와 제목이 함께 표시됩니다.

## 검증 방법 (Verification method)

- ./venv/bin/python3 -m pytest -q -s tests/runtime/test_shell_completion.py tests/test_cli_commands.py
- ./venv/bin/python3 -m py_compile harness_codex/cli.py harness_codex/runtime/shell_completion.py
- bash -n completions/harness.bash && zsh -n completions/_harness

## 위험 및 롤백 (Risks and rollback)

임시 ChangeSet 확정 시 기존 설계 문서가 없거나 검증이 실패하면 확정을 건너뛰므로 기존 단계 진행이 유지됩니다. 문제 발생 시 이 커밋을 되돌리면 기존 명시적 ChangeSet ID 입력 방식과 run-change 중심 completion 동작으로 복구됩니다.