### PR TITLE
[codex] changes 삭제 명령 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Inspect ChangeSets:
 ./harness changes active
 ./harness changes show CHG-YYYYMMDD-001
 ./harness changes contents CHG-YYYYMMDD-001
+./harness changes delete CHG-YYYYMMDD-001
 ```
 
 Run legacy executor flow:

--- a/docs/agent/commands.md
+++ b/docs/agent/commands.md
@@ -6,6 +6,7 @@
 - Create a ChangeSet and run all affected workflows: `python3 -m harness_codex ultrawork --title "<title>"`
 - List active ChangeSets: `python3 -m harness_codex changes list`
 - Show ChangeSet: `python3 -m harness_codex changes show <CHG-ID>`
+- Delete active ChangeSet: `python3 -m harness_codex changes delete <CHG-ID>`
 - Preview use-case workflow: `python3 -m harness_codex run-use-case <CHG-ID> <UC-ID> --preview`
 - Preview work item workflow: `python3 -m harness_codex run-work-item <CHG-ID> <WORK-ITEM-ID> --preview`
 - Show run report: `python3 -m harness_codex report <RUN-ID>`

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -173,6 +173,9 @@ def build_parser() -> argparse.ArgumentParser:
     changes_show = changes_subparsers.add_parser("show")
     changes_show.add_argument("change_set_id")
     changes_show.set_defaults(func=changes_show_command)
+    changes_delete = changes_subparsers.add_parser("delete")
+    changes_delete.add_argument("change_set_id")
+    changes_delete.set_defaults(func=changes_delete_command)
     changes_contents = changes_subparsers.add_parser("contents")
     changes_contents.add_argument("change_set_id")
     changes_contents.add_argument(
@@ -411,6 +414,16 @@ def changes_show_command(args: argparse.Namespace, repo_root: Path) -> str:
             f"Work items: {work_items}",
         ]
     )
+
+
+def changes_delete_command(args: argparse.Namespace, repo_root: Path) -> str:
+    path = Path("docs/changes/active") / f"{args.change_set_id}.md"
+    absolute_path = repo_root / path
+    if not absolute_path.exists():
+        raise ValueError(f"Active ChangeSet file not found: {path}")
+
+    absolute_path.unlink()
+    return f"DELETED: {path}"
 
 
 def changes_contents_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -176,6 +176,28 @@ def test_changes_show_outputs_affected_use_cases(tmp_path: Path, capsys) -> None
     assert "Before: old" in output
 
 
+def test_changes_delete_removes_active_changeset(tmp_path: Path, capsys) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(["--repo-root", str(tmp_path), "changes", "delete", "CHG-001"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "DELETED: docs/changes/active/CHG-001.md" in output
+    assert not (tmp_path / "docs/changes/active/CHG-001.md").exists()
+
+
+def test_changes_delete_reports_missing_active_changeset(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    exit_code = main(["--repo-root", str(tmp_path), "changes", "delete", "CHG-999"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Active ChangeSet file not found: docs/changes/active/CHG-999.md" in captured.err
+
+
 def test_harvest_plan_outputs_runtime_harvester_stage(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## 구현 의도

활성 ChangeSet을 CLI에서 삭제할 수 있는 `changes delete <CHG-ID>` 명령을 추가합니다.

## 구현 접근

`changes` 하위 명령에 `delete`를 등록하고, `docs/changes/active/<CHG-ID>.md` 경로만 삭제합니다. 파일이 없으면 기존 CLI 오류 흐름에 맞춰 명확한 메시지를 반환합니다. README와 agent commands 문서에도 사용법을 추가했습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py -k "changes_delete or changes_list or changes_show"`
- `./venv/bin/python3 -m pytest -q -s tests/test_document_structure_templates.py`
- `./venv/bin/python3 -m harness_codex changes --help`

## 위험 및 롤백

삭제 대상은 active ChangeSet markdown 파일 하나로 제한됩니다. 문제가 있으면 이번 커밋을 되돌리면 기존 CLI 명령 목록으로 복구됩니다.