### PR TITLE
[codex] 자가 발전 제안 루프 추가

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -54,6 +54,12 @@ from harness_codex.runtime.contract_validators import (
     validate_contracts,
 )
 from harness_codex.runtime.dashboard import dashboard_state_json
+from harness_codex.runtime.evolution import (
+    EvolutionError,
+    accept_evolution,
+    propose_evolution,
+    reject_evolution,
+)
 from harness_codex.runtime.interactive_harvest import (
     list_harvest_sessions,
     run_interactive_harvest,
@@ -257,6 +263,20 @@ def build_parser() -> argparse.ArgumentParser:
     run_work_item.add_argument("work_item_id")
     _add_mode_options(run_work_item)
     run_work_item.set_defaults(func=run_work_item_command)
+
+    evolution = subparsers.add_parser("evolution")
+    evolution_subparsers = evolution.add_subparsers(required=True)
+    evolution_propose = evolution_subparsers.add_parser("propose")
+    evolution_propose.add_argument("--change-set", required=True)
+    evolution_propose.add_argument("--work-item", required=True)
+    evolution_propose.add_argument("--run-id", required=True)
+    evolution_propose.set_defaults(func=evolution_propose_command)
+    evolution_accept = evolution_subparsers.add_parser("accept")
+    evolution_accept.add_argument("proposal_id")
+    evolution_accept.set_defaults(func=evolution_accept_command)
+    evolution_reject = evolution_subparsers.add_parser("reject")
+    evolution_reject.add_argument("proposal_id")
+    evolution_reject.set_defaults(func=evolution_reject_command)
 
     stages = subparsers.add_parser("stages")
     stages_subparsers = stages.add_subparsers(required=True)
@@ -1128,6 +1148,47 @@ def run_work_item_command(args: argparse.Namespace, repo_root: Path) -> str:
 
     state, result = _apply_workflow(repo_root, change_set, selected)
     return f"APPLY started: run_id={state.run_id} work_item_id={args.work_item_id} status={result.status.value}"
+
+
+def evolution_propose_command(args: argparse.Namespace, repo_root: Path) -> str:
+    try:
+        proposal = propose_evolution(
+            repo_root,
+            change_set_id=args.change_set,
+            work_item_id=args.work_item,
+            run_id=args.run_id,
+        )
+    except EvolutionError as error:
+        return f"Evolution proposal blocked: {error}"
+    return "\n".join(
+        [
+            f"Evolution proposal created: {proposal.proposal_path}",
+            f"Classification: {proposal.classification.status}",
+            f"Target path: {proposal.target_path}",
+            f"Experience: {proposal.experience_dir}",
+        ]
+    )
+
+
+def evolution_accept_command(args: argparse.Namespace, repo_root: Path) -> str:
+    try:
+        accepted_path, target_path = accept_evolution(repo_root, args.proposal_id)
+    except EvolutionError as error:
+        return f"Evolution accept blocked: {error}"
+    return "\n".join(
+        [
+            f"Evolution proposal accepted: {accepted_path}",
+            f"Component updated: {target_path}",
+        ]
+    )
+
+
+def evolution_reject_command(args: argparse.Namespace, repo_root: Path) -> str:
+    try:
+        proposal_path = reject_evolution(repo_root, args.proposal_id)
+    except EvolutionError as error:
+        return f"Evolution reject blocked: {error}"
+    return f"Evolution proposal rejected: {proposal_path}"
 
 
 def stages_list_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/harness_codex/runtime/evolution.py
+++ b/harness_codex/runtime/evolution.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+
+ALLOWED_COMPONENTS = ("agent-context", "skills", "runner-policy", "verification")
+EVOLUTION_ROOT = Path(".harness/evolution")
+
+
+class EvolutionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class EvolutionClassification:
+    status: str
+    reason: str
+    component: str
+
+
+@dataclass(frozen=True)
+class EvolutionProposal:
+    proposal_id: str
+    proposal_path: Path
+    experience_dir: Path
+    classification: EvolutionClassification
+    target_path: Path
+
+
+def propose_evolution(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    run_id: str,
+) -> EvolutionProposal:
+    root = Path(repo_root)
+    run_dir = root / ".harness/runs" / run_id
+    if not run_dir.exists():
+        raise EvolutionError(f"missing run directory: {_display(run_dir, root)}")
+
+    evidence = _collect_evidence(root, run_dir, work_item_id)
+    evidence_text = "\n".join(item.summary for item in evidence)
+    classification = classify_failure_for_evolution(evidence_text)
+    proposal_id = _next_proposal_id(root)
+    experience_dir = (
+        EVOLUTION_ROOT
+        / "experiences"
+        / change_set_id
+        / work_item_id
+        / run_id
+    )
+    absolute_experience_dir = root / experience_dir
+    absolute_experience_dir.mkdir(parents=True, exist_ok=True)
+
+    target_path = (
+        EVOLUTION_ROOT
+        / "components"
+        / classification.component
+        / f"{proposal_id}.md"
+    )
+    _write_experience_files(
+        root,
+        absolute_experience_dir,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        run_id=run_id,
+        evidence=evidence,
+        classification=classification,
+    )
+
+    proposal_path = EVOLUTION_ROOT / "proposals" / f"{proposal_id}.md"
+    absolute_proposal_path = root / proposal_path
+    absolute_proposal_path.parent.mkdir(parents=True, exist_ok=True)
+    absolute_proposal_path.write_text(
+        _proposal_markdown(
+            proposal_id=proposal_id,
+            change_set_id=change_set_id,
+            work_item_id=work_item_id,
+            run_id=run_id,
+            evidence=evidence,
+            classification=classification,
+            target_path=target_path,
+        ),
+        encoding="utf-8",
+    )
+
+    return EvolutionProposal(
+        proposal_id=proposal_id,
+        proposal_path=proposal_path,
+        experience_dir=experience_dir,
+        classification=classification,
+        target_path=target_path,
+    )
+
+
+def classify_failure_for_evolution(text: str) -> EvolutionClassification:
+    normalized = text.lower()
+    eligible_rules = (
+        (
+            ("rediscover", "over-read", "over read", "same context", "context loading"),
+            "agent-context",
+            "Failure repeats repository context discovery or context loading work.",
+        ),
+        (
+            ("command pattern", "wrong command", "incorrect command", "missing command"),
+            "runner-policy",
+            "Failure repeats an executable command or runner policy mistake.",
+        ),
+        (
+            ("verification step", "missing verification", "test gate", "no command evidence"),
+            "verification",
+            "Failure repeats a missed or weak verification step.",
+        ),
+        (
+            ("artifact format", "review status", "contract", "format violation"),
+            "skills",
+            "Failure repeats an agent artifact or skill-output contract violation.",
+        ),
+    )
+    for keywords, component, reason in eligible_rules:
+        if any(keyword in normalized for keyword in keywords):
+            return EvolutionClassification("eligible", reason, component)
+
+    not_eligible_rules = (
+        "simple implementation bug",
+        "unclear business requirement",
+        "upstream design",
+        "environment blocker",
+        "scope conflict",
+    )
+    if any(keyword in normalized for keyword in not_eligible_rules):
+        return EvolutionClassification(
+            "not_eligible",
+            "Failure looks like implementation, requirement, environment, or upstream-design work.",
+            "verification",
+        )
+
+    return EvolutionClassification(
+        "needs_review",
+        "Failure evidence is insufficient for automatic evolution eligibility.",
+        "verification",
+    )
+
+
+def accept_evolution(repo_root: Path | str, proposal_id: str) -> tuple[Path, Path]:
+    root = Path(repo_root)
+    proposal_path = EVOLUTION_ROOT / "proposals" / f"{proposal_id}.md"
+    absolute_proposal_path = root / proposal_path
+    if not absolute_proposal_path.exists():
+        raise EvolutionError(f"missing proposal: {proposal_path}")
+
+    text = absolute_proposal_path.read_text(encoding="utf-8")
+    target_path = _target_path_from_proposal(text)
+    _validate_component_target(target_path)
+
+    accepted_path = EVOLUTION_ROOT / "accepted" / f"{proposal_id}.md"
+    absolute_accepted_path = root / accepted_path
+    absolute_target_path = root / target_path
+    absolute_accepted_path.parent.mkdir(parents=True, exist_ok=True)
+    absolute_target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    accepted_text = _set_reviewer_decision(text, "accepted")
+    absolute_accepted_path.write_text(accepted_text, encoding="utf-8")
+    absolute_proposal_path.write_text(accepted_text, encoding="utf-8")
+    absolute_target_path.write_text(accepted_text, encoding="utf-8")
+    return accepted_path, target_path
+
+
+def reject_evolution(repo_root: Path | str, proposal_id: str) -> Path:
+    root = Path(repo_root)
+    proposal_path = EVOLUTION_ROOT / "proposals" / f"{proposal_id}.md"
+    absolute_proposal_path = root / proposal_path
+    if not absolute_proposal_path.exists():
+        raise EvolutionError(f"missing proposal: {proposal_path}")
+    text = absolute_proposal_path.read_text(encoding="utf-8")
+    absolute_proposal_path.write_text(
+        _set_reviewer_decision(text, "rejected"),
+        encoding="utf-8",
+    )
+    return proposal_path
+
+
+@dataclass(frozen=True)
+class _EvidenceItem:
+    path: Path
+    summary: str
+
+
+def _collect_evidence(root: Path, run_dir: Path, work_item_id: str) -> tuple[_EvidenceItem, ...]:
+    candidates = (
+        run_dir / "report.md",
+        run_dir / "report.json",
+        run_dir / "state.json",
+        run_dir / "work-items" / work_item_id / "verification" / "report.json",
+        run_dir / "work-items" / work_item_id / "verification" / "verification.md",
+    )
+    items: list[_EvidenceItem] = []
+    for path in candidates:
+        if path.exists() and path.is_file():
+            items.append(_EvidenceItem(_display(path, root), _summarize_file(path)))
+    for path in sorted((run_dir / "steps").glob("*/result.json"))[:8]:
+        items.append(_EvidenceItem(_display(path, root), _summarize_file(path)))
+    if not items:
+        items.append(_EvidenceItem(_display(run_dir, root), "Run directory exists, but no known failure evidence files were found."))
+    return tuple(items)
+
+
+def _write_experience_files(
+    root: Path,
+    experience_dir: Path,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    run_id: str,
+    evidence: Iterable[_EvidenceItem],
+    classification: EvolutionClassification,
+) -> None:
+    evidence_items = tuple(evidence)
+    (experience_dir / "trajectory-summary.md").write_text(
+        "\n".join(
+            [
+                f"# Trajectory Summary: {run_id}",
+                "",
+                f"- ChangeSet: `{change_set_id}`",
+                f"- Work item: `{work_item_id}`",
+                f"- Run: `{run_id}`",
+                "- Status: failed or blocked run selected for evolution review",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (experience_dir / "evidence.md").write_text(
+        "# Evidence\n\n"
+        + "\n".join(f"- `{item.path}`: {item.summary}" for item in evidence_items)
+        + "\n",
+        encoding="utf-8",
+    )
+    (experience_dir / "failure-analysis.md").write_text(
+        "\n".join(
+            [
+                "# Failure Analysis",
+                "",
+                f"- Classification: `{classification.status}`",
+                f"- Component: `{classification.component}`",
+                f"- Reason: {classification.reason}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _proposal_markdown(
+    *,
+    proposal_id: str,
+    change_set_id: str,
+    work_item_id: str,
+    run_id: str,
+    evidence: Iterable[_EvidenceItem],
+    classification: EvolutionClassification,
+    target_path: Path,
+) -> str:
+    evidence_lines = "\n".join(
+        f"- `{item.path}`: {item.summary}" for item in evidence
+    )
+    return (
+        f"# Evolution Proposal: {proposal_id}\n\n"
+        "## Observed Failure Pattern\n\n"
+        f"{classification.reason}\n\n"
+        "## Affected Workflow Step\n\n"
+        f"- ChangeSet: `{change_set_id}`\n"
+        f"- Work item: `{work_item_id}`\n"
+        f"- Run: `{run_id}`\n\n"
+        "## Evidence\n\n"
+        f"{evidence_lines}\n\n"
+        "## Proposed Mutable Component Change\n\n"
+        f"- Classification: `{classification.status}`\n"
+        f"- Component: `{classification.component}`\n"
+        f"- Target path: `{target_path}`\n"
+        "- Change: Capture this failure pattern as reusable harness guidance.\n\n"
+        "## Expected Impact\n\n"
+        "- Similar future failures should reach correct context, command, verification, or skill guidance faster.\n\n"
+        "## Validation Method\n\n"
+        "- Re-run the failed work item and compare verification outcome plus repeated remediation count.\n\n"
+        "## Rollback Method\n\n"
+        f"- Remove `{target_path}` and the accepted copy for this proposal.\n\n"
+        "## Reviewer Decision\n\n"
+        "- Reviewer decision: `pending`\n"
+    )
+
+
+def _next_proposal_id(root: Path) -> str:
+    today = datetime.now().strftime("%Y%m%d")
+    proposal_dir = root / EVOLUTION_ROOT / "proposals"
+    existing = sorted(proposal_dir.glob(f"EVO-{today}-*.md"))
+    numbers = []
+    for path in existing:
+        match = re.match(rf"EVO-{today}-(\d{{3}})\.md$", path.name)
+        if match:
+            numbers.append(int(match.group(1)))
+    return f"EVO-{today}-{(max(numbers) if numbers else 0) + 1:03d}"
+
+
+def _summarize_file(path: Path) -> str:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if path.suffix == ".json":
+        try:
+            data = json.loads(text)
+            if isinstance(data, dict):
+                keys = ("status", "failure_kind", "failed_step_id", "blocker", "error")
+                parts = [f"{key}={data[key]}" for key in keys if key in data and data[key]]
+                if parts:
+                    return "; ".join(parts)
+        except json.JSONDecodeError:
+            pass
+    compact = " ".join(line.strip() for line in text.splitlines() if line.strip())
+    return compact[:240] if compact else "empty file"
+
+
+def _target_path_from_proposal(text: str) -> Path:
+    match = re.search(r"Target path:\s*`([^`]+)`", text)
+    if not match:
+        raise EvolutionError("proposal missing target path")
+    return Path(match.group(1))
+
+
+def _validate_component_target(path: Path) -> None:
+    parts = path.parts
+    expected_prefix = (".harness", "evolution", "components")
+    if len(parts) < 5 or parts[:3] != expected_prefix:
+        raise EvolutionError("target path must be under .harness/evolution/components/")
+    if parts[3] not in ALLOWED_COMPONENTS:
+        allowed = ", ".join(ALLOWED_COMPONENTS)
+        raise EvolutionError(f"target component must be one of: {allowed}")
+    if any(part in ("..", "") for part in parts):
+        raise EvolutionError("target path must not contain parent traversal")
+
+
+def _set_reviewer_decision(text: str, decision: str) -> str:
+    replacement = f"- Reviewer decision: `{decision}`"
+    updated, count = re.subn(
+        r"- Reviewer decision:\s*`[^`]+`",
+        replacement,
+        text,
+        count=1,
+    )
+    if count:
+        return updated
+    return text.rstrip() + f"\n\n## Reviewer Decision\n\n{replacement}\n"
+
+
+def _display(path: Path, root: Path) -> Path:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path

--- a/tests/runtime/test_evolution.py
+++ b/tests/runtime/test_evolution.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+
+from harness_codex.cli import main
+from harness_codex.runtime.evolution import (
+    EvolutionError,
+    accept_evolution,
+    classify_failure_for_evolution,
+    propose_evolution,
+)
+
+
+def test_failure_classification_marks_missing_verification_as_eligible() -> None:
+    result = classify_failure_for_evolution(
+        "Plan completed with no command evidence and missing verification step."
+    )
+
+    assert result.status == "eligible"
+    assert result.component == "verification"
+
+
+def test_propose_evolution_writes_experience_and_reviewable_proposal(tmp_path: Path) -> None:
+    _write_failed_run(
+        tmp_path,
+        run_id="run-001",
+        work_item_id="UC-001",
+        report='{"status": "FAIL", "blocker": "missing verification step"}',
+    )
+
+    proposal = propose_evolution(
+        tmp_path,
+        change_set_id="CHG-001",
+        work_item_id="UC-001",
+        run_id="run-001",
+    )
+
+    proposal_text = (tmp_path / proposal.proposal_path).read_text(encoding="utf-8")
+    assert proposal.proposal_id.startswith("EVO-")
+    assert proposal.classification.status == "eligible"
+    assert (tmp_path / proposal.experience_dir / "trajectory-summary.md").exists()
+    assert "Reviewer decision: `pending`" in proposal_text
+    assert "Target path: `.harness/evolution/components/verification/" in proposal_text
+
+
+def test_accept_evolution_materializes_only_allowed_component_path(tmp_path: Path) -> None:
+    _write_failed_run(
+        tmp_path,
+        run_id="run-001",
+        work_item_id="UC-001",
+        report='{"status": "FAIL", "blocker": "missing verification step"}',
+    )
+    proposal = propose_evolution(
+        tmp_path,
+        change_set_id="CHG-001",
+        work_item_id="UC-001",
+        run_id="run-001",
+    )
+
+    accepted_path, target_path = accept_evolution(tmp_path, proposal.proposal_id)
+
+    assert (tmp_path / accepted_path).exists()
+    assert (tmp_path / target_path).exists()
+    assert target_path.parts[:4] == (
+        ".harness",
+        "evolution",
+        "components",
+        "verification",
+    )
+    assert "Reviewer decision: `accepted`" in (tmp_path / target_path).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_accept_evolution_rejects_protected_path(tmp_path: Path) -> None:
+    proposal_dir = tmp_path / ".harness/evolution/proposals"
+    proposal_dir.mkdir(parents=True)
+    (proposal_dir / "EVO-20260603-001.md").write_text(
+        "\n".join(
+            [
+                "# Evolution Proposal",
+                "",
+                "## Proposed Mutable Component Change",
+                "",
+                "- Target path: `harness_codex/runtime/runner.py`",
+                "",
+                "## Reviewer Decision",
+                "",
+                "- Reviewer decision: `pending`",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        accept_evolution(tmp_path, "EVO-20260603-001")
+    except EvolutionError as error:
+        assert ".harness/evolution/components/" in str(error)
+    else:
+        raise AssertionError("protected path should be rejected")
+
+
+def test_evolution_cli_propose_accept_reject(tmp_path: Path, capsys) -> None:
+    _write_failed_run(
+        tmp_path,
+        run_id="run-001",
+        work_item_id="UC-001",
+        report='{"status": "FAIL", "blocker": "missing verification step"}',
+    )
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "evolution",
+            "propose",
+            "--change-set",
+            "CHG-001",
+            "--work-item",
+            "UC-001",
+            "--run-id",
+            "run-001",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Evolution proposal created:" in output
+    proposal_id = next(
+        path.stem
+        for path in (tmp_path / ".harness/evolution/proposals").glob("EVO-*.md")
+    )
+
+    exit_code = main(
+        ["--repo-root", str(tmp_path), "evolution", "accept", proposal_id]
+    )
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Component updated:" in output
+
+    exit_code = main(
+        ["--repo-root", str(tmp_path), "evolution", "reject", proposal_id]
+    )
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Evolution proposal rejected:" in output
+
+
+def _write_failed_run(
+    root: Path,
+    *,
+    run_id: str,
+    work_item_id: str,
+    report: str,
+) -> None:
+    verification_dir = (
+        root / ".harness/runs" / run_id / "work-items" / work_item_id / "verification"
+    )
+    verification_dir.mkdir(parents=True)
+    (verification_dir / "report.json").write_text(report, encoding="utf-8")
+    run_dir = root / ".harness/runs" / run_id
+    (run_dir / "report.md").write_text(
+        "# Run Report\n\n- Status: failed\n",
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Implementation intent

반복되는 워크아이템 실패를 안전하게 분석하고, 런타임을 직접 수정하지 않는 검토 가능한 자가 발전 제안 루프를 추가합니다. 실패 실행 기록을 `.harness/evolution/` 아래 경험/분석/제안 아티팩트로 남기고, 승인된 제안만 허용된 컴포넌트 영역에 반영합니다.

## Implementation approach

`harness_codex.runtime.evolution` 모듈을 추가해 실패 실행 증거를 수집하고, 실패 유형을 `eligible`, `not_eligible`, `needs_review`로 분류한 뒤 `EVO-*.md` 제안서를 생성합니다. CLI에는 `harness evolution propose|accept|reject` 명령을 추가했습니다. `accept`는 `.harness/evolution/components/{agent-context,skills,runner-policy,verification}/` 하위 대상만 허용해 런타임/대시보드/핵심 워크플로우 코드가 자가 발전 경로로 수정되지 않도록 막습니다.

## Verification method

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_evolution.py` → `5 passed`
- `python3 -m py_compile harness_codex/runtime/evolution.py harness_codex/cli.py` → 통과
- `./venv/bin/python3 -m pytest -q -s` → `389 passed in 90.42s`

## Risks and rollback

자가 발전 제안이 과도하게 생성되면 노이즈가 늘 수 있습니다. 문제가 있으면 생성된 `EVO-*.md`, `.harness/evolution/accepted/` 사본, `.harness/evolution/components/` 반영본을 제거하면 됩니다. 런타임 보호 경로는 accept 단계에서 차단됩니다.

Closes #278
