### PR TITLE
[codex] 런타임 CLI 도움말과 자동완성 개선

### DIFF
--- a/completions/_harness
+++ b/completions/_harness
@@ -16,14 +16,59 @@ _harness_changeset_ids() {
   fi
 }
 
+_harness_use_case_ids() {
+  local change_set_id="$1"
+  local -a candidates
+  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion use-case "$change_set_id" --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  if (( ${#candidates[@]} )); then
+    _describe 'use case' candidates
+  fi
+}
+
+_harness_use_case_dirs() {
+  local -a candidates
+  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion use-case-directory --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  if (( ${#candidates[@]} )); then
+    _describe 'use case' candidates
+  fi
+}
+
+_harness_work_item_ids() {
+  local change_set_id="$1"
+  local -a candidates
+  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion work-item "$change_set_id" --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  if (( ${#candidates[@]} )); then
+    _describe 'work item' candidates
+  fi
+}
+
+_harness_run_ids() {
+  local -a candidates
+  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion run --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  if (( ${#candidates[@]} )); then
+    _describe 'run' candidates
+  fi
+}
+
+_harness_stage_ids() {
+  local change_set_id="$1"
+  local -a candidates
+  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion stage "$change_set_id" --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  if (( ${#candidates[@]} )); then
+    _describe 'stage' candidates
+  fi
+}
+
 _harness() {
-  local -a commands modes changes_commands
+  local -a commands changes_commands modes ultrawork_options reset_scopes reset_options
   commands=(
-    'init:Initialize repository agent context'
-    'update:Update local harness assets'
+    'help:Show runtime help'
+    'init:Initialize agent context files'
+    'update:Update installed runtime files'
+    'reset:Reset local runtime artifacts'
     'agent-context:Initialize agent context files'
-    'changes:List and inspect ChangeSets'
-    'contracts:Validate runtime contracts'
+    'changes:List and create ChangeSets'
+    'contracts:Validate document handoff contracts'
     'requirements-definition:Define requirements and create temp ChangeSet when needed'
     'ubiquitous-language-definition:Define project ubiquitous language'
     'use-case-definition:Define use cases and finalize temp ChangeSet'
@@ -46,13 +91,31 @@ _harness() {
     'active:Show active ChangeSet summary'
     'show:Show one ChangeSet'
     'contents:Show ChangeSet contents'
-    'delete:Delete active ChangeSet'
+    'delete:Delete one active ChangeSet'
     'document-delta:Apply document delta to ChangeSet work item'
   )
   modes=(
     '--plan:show execution plan without side effects'
     '--preview:show preview without side effects'
     '--apply:run and apply side effects'
+  )
+  ultrawork_options=(
+    '--title[change title]'
+    '--change-set-id[explicit ChangeSet id]'
+    '--related-issue[related issue reference]'
+    '--uc[limit to a canonical use case]'
+    '--force[overwrite generated ChangeSet artifacts]'
+    '--plan[show execution plan]'
+    '--preview[show preview]'
+    '--apply[run and apply side effects]'
+  )
+  reset_scopes=(
+    '--runs:target run state only'
+    '--workflow-artifacts:target workflow artifacts'
+    '--all:target both scopes'
+  )
+  reset_options=(
+    '--apply:apply reset'
   )
 
   case $words[2] in
@@ -89,23 +152,15 @@ _harness() {
         _describe 'mode' modes
       fi
       ;;
-    ultrawork)
-      _arguments \
-        '--title[change title]' \
-        '--change-set-id[explicit ChangeSet id]' \
-        '--related-issue[related issue reference]' \
-        '--uc[limit to a canonical use case]' \
-        '--force[overwrite generated ChangeSet artifacts]' \
-        '--plan[show execution plan]' \
-        '--preview[show preview]' \
-        '--apply[run and apply side effects]'
-      ;;
     ubiquitous-language-definition|use-case-definition|event-storming|ddd-architecture-definition|technical-decisions|plan-writing|implementation)
       if (( CURRENT == 3 )); then
         _harness_changeset_ids active
       elif (( CURRENT == 4 )); then
         _describe 'mode' modes
       fi
+      ;;
+    ultrawork)
+      _arguments "${ultrawork_options[@]}"
       ;;
     stages)
       if (( CURRENT == 3 )); then
@@ -119,6 +174,25 @@ _harness() {
         _describe 'artifacts command' ('show:Show stage artifact' 'accept:Accept stage artifact')
       elif (( CURRENT == 4 )) && [[ "$words[3]" == (show|accept) ]]; then
         _harness_changeset_ids all
+      elif (( CURRENT == 5 )) && [[ "$words[3]" == (show|accept) ]]; then
+        _harness_stage_ids "$words[4]"
+      fi
+      ;;
+    help)
+      if (( CURRENT == 3 )); then
+        _describe 'help topic' commands
+      fi
+      ;;
+    reset)
+      if (( CURRENT == 3 )); then
+        _describe 'reset scope' reset_scopes
+      elif (( CURRENT == 4 )); then
+        _describe 'reset option' reset_options
+      fi
+      ;;
+    resume|report)
+      if (( CURRENT == 3 )); then
+        _harness_run_ids
       fi
       ;;
     *)

--- a/completions/harness.bash
+++ b/completions/harness.bash
@@ -12,13 +12,61 @@ _harness_complete_changeset_ids() {
   done < <(python3 -m harness_codex.runtime.shell_completion change-set --repo-root . --prefix "$current_word" --scope "$scope" --format bash 2>/dev/null)
 }
 
+_harness_complete_use_case_ids() {
+  local change_set_id="$1"
+  local current_word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+  while IFS= read -r candidate; do
+    COMPREPLY+=("$candidate")
+  done < <(python3 -m harness_codex.runtime.shell_completion use-case "$change_set_id" --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+}
+
+_harness_complete_use_case_dirs() {
+  local current_word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+  while IFS= read -r candidate; do
+    COMPREPLY+=("$candidate")
+  done < <(python3 -m harness_codex.runtime.shell_completion use-case-directory --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+}
+
+_harness_complete_work_item_ids() {
+  local change_set_id="$1"
+  local current_word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+  while IFS= read -r candidate; do
+    COMPREPLY+=("$candidate")
+  done < <(python3 -m harness_codex.runtime.shell_completion work-item "$change_set_id" --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+}
+
+_harness_complete_run_ids() {
+  local current_word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+  while IFS= read -r candidate; do
+    COMPREPLY+=("$candidate")
+  done < <(python3 -m harness_codex.runtime.shell_completion run --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+}
+
+_harness_complete_stage_ids() {
+  local change_set_id="$1"
+  local current_word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+  while IFS= read -r candidate; do
+    COMPREPLY+=("$candidate")
+  done < <(python3 -m harness_codex.runtime.shell_completion stage "$change_set_id" --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+}
+
 _harness_completion() {
   local command="${COMP_WORDS[1]:-}"
   local subcommand="${COMP_WORDS[2]:-}"
   local current_word="${COMP_WORDS[COMP_CWORD]}"
 
   if [[ $COMP_CWORD -eq 1 ]]; then
-    COMPREPLY=( $(compgen -W "init update agent-context changes contracts requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation ultrawork evolution stages artifacts resume report dashboard ui-server" -- "$current_word") )
+    COMPREPLY=( $(compgen -W "help init update reset agent-context changes contracts requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation ultrawork evolution stages artifacts resume report dashboard ui-server" -- "$current_word") )
+    return 0
+  fi
+
+  if [[ "$command" == "help" && $COMP_CWORD -eq 2 ]]; then
+    COMPREPLY=( $(compgen -W "help init agent-context changes contracts requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation ultrawork evolution stages artifacts resume report dashboard ui-server update reset" -- "$current_word") )
     return 0
   fi
 
@@ -57,11 +105,6 @@ _harness_completion() {
     return 0
   fi
 
-  if [[ "$command" == "ultrawork" && "$current_word" == --* ]]; then
-    COMPREPLY=( $(compgen -W "--title --change-set-id --related-issue --uc --force --plan --preview --apply" -- "$current_word") )
-    return 0
-  fi
-
   if [[ "$command" =~ ^(requirements-definition|ubiquitous-language-definition|use-case-definition|event-storming|ddd-architecture-definition|technical-decisions|plan-writing|implementation)$ && $COMP_CWORD -eq 2 ]]; then
     _harness_complete_changeset_ids active
     return 0
@@ -89,6 +132,31 @@ _harness_completion() {
 
   if [[ "$command" == "artifacts" && ("$subcommand" == "show" || "$subcommand" == "accept") && $COMP_CWORD -eq 3 ]]; then
     _harness_complete_changeset_ids all
+    return 0
+  fi
+
+  if [[ "$command" == "artifacts" && ("$subcommand" == "show" || "$subcommand" == "accept") && $COMP_CWORD -eq 4 ]]; then
+    _harness_complete_stage_ids "${COMP_WORDS[3]}"
+    return 0
+  fi
+
+  if [[ "$command" == "ultrawork" && "$current_word" == --* ]]; then
+    COMPREPLY=( $(compgen -W "--title --change-set-id --related-issue --uc --force --plan --preview --apply" -- "$current_word") )
+    return 0
+  fi
+
+  if [[ ("$command" == "resume" || "$command" == "report") && $COMP_CWORD -eq 2 ]]; then
+    _harness_complete_run_ids
+    return 0
+  fi
+
+  if [[ "$command" == "update" && "$current_word" == --* ]]; then
+    COMPREPLY=( $(compgen -W "--repo --ref --skip-venv --dry-run" -- "$current_word") )
+    return 0
+  fi
+
+  if [[ "$command" == "reset" && "$current_word" == --* ]]; then
+    COMPREPLY=( $(compgen -W "--runs --workflow-artifacts --all --apply" -- "$current_word") )
     return 0
   fi
 

--- a/docs/runtime-shell-completion.md
+++ b/docs/runtime-shell-completion.md
@@ -1,39 +1,45 @@
 # Runtime Shell Completion
 
-`harness` provides Bash and Zsh completion scripts for current staged workflow commands.
+The `harness` runtime ships Bash and Zsh completion scripts.
 
-Completion reads the local repository filesystem, so users can discover ChangeSet IDs, UC IDs, run IDs, and stage IDs with `Tab`.
+Completion reads the current repository filesystem, so IDs such as `change_set_id`, `uc_id`, `work_item_id`, `run_id`, and `stage` can be selected with `Tab`.
 
 ## Bash
 
-Run from the repository root:
+From repository root:
 
 ```bash
 source completions/harness.bash
 ```
 
-To keep completion enabled, add the same command to `~/.bashrc`.
+To keep it enabled, add this to `~/.bashrc`:
+
+```bash
+source /path/to/harness-codex/completions/harness.bash
+```
 
 ## Zsh
 
-Install completion from the repository root:
+From repository root:
 
 ```zsh
 mkdir -p ~/.zfunc
 cp completions/_harness ~/.zfunc/_harness
-```
-
-Then ensure `~/.zshrc` loads the completion directory:
-
-```zsh
 fpath=(~/.zfunc $fpath)
 autoload -Uz compinit && compinit
 ```
 
 ## Completion Targets
 
-| Command | Candidate source |
+| Command | Completion candidates |
 | --- | --- |
+| `harness help <TAB>` | Supported runtime command names |
+| `harness changes <TAB>` | Supported `changes` subcommands |
+| `harness changes show <TAB>` | ChangeSet IDs from `docs/changes/active/*.md` and `docs/changes/completed/*.md` |
+| `harness changes contents <TAB>` | ChangeSet IDs from `docs/changes/active/*.md` and `docs/changes/completed/*.md` |
+| `harness changes delete <TAB>` | Active ChangeSet IDs |
+| `harness changes document-delta <TAB>` | Active ChangeSet IDs |
+| `harness contracts validate <TAB>` | ChangeSet IDs from active and completed ChangeSets |
 | `harness requirements-definition <TAB>` | Active ChangeSet IDs |
 | `harness ubiquitous-language-definition <TAB>` | Active ChangeSet IDs |
 | `harness use-case-definition <TAB>` | Active ChangeSet IDs |
@@ -42,6 +48,26 @@ autoload -Uz compinit && compinit
 | `harness technical-decisions <TAB>` | Active ChangeSet IDs |
 | `harness plan-writing <TAB>` | Active ChangeSet IDs |
 | `harness implementation <TAB>` | Active ChangeSet IDs |
+| `harness stages list <TAB>` | ChangeSet IDs from active and completed ChangeSets |
+| `harness artifacts show <CHG-ID> <TAB>` | Runtime stage IDs |
+| `harness artifacts accept <CHG-ID> <TAB>` | Runtime stage IDs |
+| `harness resume <TAB>` | Run IDs from `.harness/runs/*` |
+| `harness report <TAB>` | Run IDs from `.harness/runs/*` |
+| `harness update --<TAB>` | Supported runtime update options |
+| `harness reset --<TAB>` | Supported reset scope/options |
+
+## Lookup Root
+
+Completion reads from the current working directory. Start completion from the repository root so candidates match the target project.
+
+## Candidate Rules
+
+- ChangeSet ID: file stem from `docs/changes/active/*.md` and `docs/changes/completed/*.md`
+- UC ID: directory name from `docs/use-cases/*` or affected use-case rows in the selected ChangeSet document
+- Maintenance ID: affected maintenance/work-item rows in the selected ChangeSet document
+- Work item ID: ordered work item IDs from the selected ChangeSet document
+- Run ID: directory name from `.harness/runs/*`
+- Stage ID: built-in runtime stage names and file stems from `.harness/stages/<CHG-ID>/*.md`
 
 ## Examples
 
@@ -49,4 +75,5 @@ autoload -Uz compinit && compinit
 harness requirements-definition CHG-20260507-001 --preview
 harness event-storming CHG-20260507-001 --uc UC-001 --preview
 harness implementation CHG-20260507-001 --uc UC-001 --apply
+harness artifacts show CHG-20260507-001 technical-decisions
 ```

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -71,7 +71,9 @@ from harness_codex.runtime.procedure_stages import (
     update_changeset_stage_status,
     verify_procedure_stage,
 )
-from harness_codex.runtime.shell_completion import install_completion
+from harness_codex.runtime.reset import format_result as format_reset_result
+from harness_codex.runtime.reset import run_reset
+from harness_codex.runtime.self_update import DEFAULT_REF, DEFAULT_REPO, run_self_update
 from harness_codex.runtime.ui_server import run_ui_server
 from harness_codex.runtime.workflows import (
     WorkflowMaterializationError,
@@ -89,6 +91,67 @@ INTERACTIVE_GRILL_ME_STAGE_IDS = frozenset(
         "event-storming",
     }
 )
+
+
+COMMAND_HELP: tuple[tuple[str, str], ...] = (
+    ("help", "Show runtime help."),
+    ("init", "Initialize repo-local agent context files."),
+    ("agent-context", "Initialize repo-local agent context files."),
+    ("changes", "List, inspect, create, or delete ChangeSets."),
+    ("contracts", "Validate document handoff contracts."),
+    ("requirements-definition", "Define requirements and create temp ChangeSet when needed."),
+    ("ubiquitous-language-definition", "Define project ubiquitous language."),
+    ("use-case-definition", "Define use cases and finalize temp ChangeSet."),
+    ("event-storming", "Create event storming for one use case."),
+    ("ddd-architecture-definition", "Create DDD architecture for one use case."),
+    ("technical-decisions", "Record technical decisions for one use case."),
+    ("plan-writing", "Write implementation plan for one use case."),
+    ("implementation", "Run implementation for one use case."),
+    ("ultrawork", "Create a ChangeSet and run affected workflows."),
+    ("evolution", "Manage evolution proposals."),
+    ("stages", "Inspect runtime procedure stage artifacts."),
+    ("artifacts", "Show or accept generated stage artifacts."),
+    ("resume", "Inspect next resume target for one run."),
+    ("report", "Print one run report."),
+    ("dashboard", "Print dashboard state JSON."),
+    ("ui-server", "Run local dashboard server."),
+    ("update", "Update installed harness-codex runtime files."),
+    ("reset", "Reset local harness runtime artifacts."),
+)
+
+
+TOPIC_HELP: Mapping[str, str] = {
+    "help": "Usage: harness help [command]\n\nShow runtime help. Without command, prints command overview.",
+    "init": "Usage: harness init [--description TEXT] [--force] [--no-llm]",
+    "agent-context": "Usage: harness agent-context init [--description TEXT] [--force] [--llm|--no-llm]",
+    "changes": (
+        "Usage: harness changes list|active\n"
+        "       harness changes show|delete|contents <CHG-ID>\n"
+        "       harness changes document-delta <CHG-ID> --uc UC-ID --summary TEXT --plan|--preview|--apply"
+    ),
+    "contracts": "Usage: harness contracts validate <CHG-ID> [--work-item ID] [--json]",
+    "requirements-definition": "Usage: harness requirements-definition [CHG-ID] --plan|--preview|--apply",
+    "ubiquitous-language-definition": "Usage: harness ubiquitous-language-definition <CHG-ID> --plan|--preview|--apply",
+    "use-case-definition": "Usage: harness use-case-definition <CHG-ID> --plan|--preview|--apply",
+    "event-storming": "Usage: harness event-storming <CHG-ID> --uc UC-ID --plan|--preview|--apply",
+    "ddd-architecture-definition": "Usage: harness ddd-architecture-definition <CHG-ID> --uc UC-ID --plan|--preview|--apply",
+    "technical-decisions": "Usage: harness technical-decisions <CHG-ID> --uc UC-ID --plan|--preview|--apply",
+    "plan-writing": "Usage: harness plan-writing <CHG-ID> --uc UC-ID --plan|--preview|--apply",
+    "implementation": "Usage: harness implementation <CHG-ID> --uc UC-ID --plan|--preview|--apply",
+    "ultrawork": (
+        "Usage: harness ultrawork [--title TEXT] [--change-set-id ID] "
+        "[--uc UC-ID] [--force] [--plan|--preview|--apply]"
+    ),
+    "evolution": "Usage: harness evolution propose|accept|reject ...",
+    "stages": "Usage: harness stages list <CHG-ID>",
+    "artifacts": "Usage: harness artifacts show|accept <CHG-ID> <stage>",
+    "resume": "Usage: harness resume <RUN-ID>",
+    "report": "Usage: harness report <RUN-ID>",
+    "dashboard": "Usage: harness dashboard [contracts --change-set CHG-ID --format json]",
+    "ui-server": "Usage: harness ui-server [--host HOST] [--port PORT]",
+    "update": "Usage: harness update [--repo URL] [--ref REF] [--skip-venv] [--dry-run]",
+    "reset": "Usage: harness reset (--runs|--workflow-artifacts|--all) [--apply]",
+}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -114,21 +177,52 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="harness")
+    parser = argparse.ArgumentParser(
+        prog="harness",
+        description="Harness runtime for ChangeSet and use-case workflows.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_format_command_list(),
+    )
     parser.add_argument("--repo-root", default=".")
-    subparsers = parser.add_subparsers(required=True)
+    subparsers = parser.add_subparsers(required=True, metavar="command")
+
+    help_parser = subparsers.add_parser(
+        "help",
+        description="Show runtime command help.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    help_parser.add_argument("topic", nargs="?", choices=tuple(TOPIC_HELP))
+    help_parser.set_defaults(func=help_command)
 
     init = subparsers.add_parser("init")
     init.add_argument("--description", default="")
     init.add_argument("--force", action="store_true")
     init.add_argument("--no-llm", action="store_true")
     init.set_defaults(func=init_command)
-    update = subparsers.add_parser("update")
+
+    update = subparsers.add_parser(
+        "update",
+        description="Update the installed harness-codex runtime in this project.",
+    )
     update.add_argument(
-        "--shell",
-        choices=("auto", "zsh", "bash", "all"),
-        default="auto",
-        help="Shell completion target to update. Defaults to the current shell.",
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"harness-codex repository URL. Default: {DEFAULT_REPO}",
+    )
+    update.add_argument(
+        "--ref",
+        default=DEFAULT_REF,
+        help="branch, tag, or commit to install. Defaults to origin/main.",
+    )
+    update.add_argument(
+        "--skip-venv",
+        action="store_true",
+        help="Skip venv creation and dependency installation.",
+    )
+    update.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the installer command without running it.",
     )
     update.set_defaults(func=update_command)
 
@@ -257,7 +351,27 @@ def build_parser() -> argparse.ArgumentParser:
     ui_server.add_argument("--port", type=int, default=8765)
     ui_server.set_defaults(func=ui_server_command)
 
+    reset = subparsers.add_parser(
+        "reset",
+        description="Reset local harness runtime artifacts explicitly.",
+    )
+    reset_scope = reset.add_mutually_exclusive_group(required=True)
+    reset_scope.add_argument("--runs", action="store_true")
+    reset_scope.add_argument("--workflow-artifacts", action="store_true")
+    reset_scope.add_argument("--all", action="store_true")
+    reset.add_argument("--apply", action="store_true")
+    reset.set_defaults(func=reset_command)
+
     return parser
+
+
+def _format_command_list() -> str:
+    width = max(len(command) for command, _ in COMMAND_HELP)
+    lines = ["Commands:"]
+    lines.extend(f"  {command.ljust(width)}  {summary}" for command, summary in COMMAND_HELP)
+    lines.append("")
+    lines.append("Use `harness help <command>` for command usage.")
+    return "\n".join(lines)
 
 
 def _add_procedure_stage_parser(
@@ -277,13 +391,23 @@ def _add_procedure_stage_parser(
 
 
 def update_command(args: argparse.Namespace, repo_root: Path) -> str:
-    results = install_completion(repo_root, shell=args.shell)
-    lines = ["UPDATED: harness local assets", "Shell completion:"]
-    for result in results:
-        lines.append(f"- {result.shell}: {result.target}")
-        lines.append(f"  {result.note}")
-    lines.append("Restart the shell or reload completion to use updated candidates.")
-    return "\n".join(lines)
+    return run_self_update(repo_root, args)
+
+
+def reset_command(args: argparse.Namespace, repo_root: Path) -> str:
+    return format_reset_result(run_reset(repo_root, args))
+
+
+def help_command(args: argparse.Namespace, repo_root: Path) -> str:
+    if not args.topic:
+        return "\n".join(
+            [
+                "Harness runtime commands",
+                "",
+                _format_command_list(),
+            ]
+        )
+    return TOPIC_HELP[args.topic]
 
 
 def init_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/harness_codex/runtime/shell_completion.py
+++ b/harness_codex/runtime/shell_completion.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from harness_codex.runtime.changes import ChangeSet, ChangeSetResolver, NoActiveChangeSetsError
+from harness_codex.runtime.procedure_stages import PROCEDURE_STAGES
 
 
 @dataclass(frozen=True)
@@ -66,6 +67,107 @@ def change_set_candidates(
         for change_set in change_sets
         if not normalized_prefix or change_set.change_set_id.startswith(normalized_prefix)
     )
+
+
+def use_case_candidates(
+    repo_root: Path | str,
+    change_set_id: str,
+    prefix: str = "",
+) -> tuple[CompletionCandidate, ...]:
+    """Return affected use-case IDs for one ChangeSet."""
+
+    change_set = _load_change_set_by_id(repo_root, change_set_id)
+    if change_set is None:
+        return ()
+    normalized_prefix = prefix.strip()
+    return tuple(
+        CompletionCandidate(use_case.uc_id, use_case.name or "-")
+        for use_case in change_set.affected_use_cases
+        if not normalized_prefix or use_case.uc_id.startswith(normalized_prefix)
+    )
+
+
+def work_item_candidates(
+    repo_root: Path | str,
+    change_set_id: str,
+    prefix: str = "",
+) -> tuple[CompletionCandidate, ...]:
+    """Return affected work item IDs for one ChangeSet."""
+
+    change_set = _load_change_set_by_id(repo_root, change_set_id)
+    if change_set is None:
+        return ()
+    normalized_prefix = prefix.strip()
+    return tuple(
+        CompletionCandidate(item.work_item_id, item.name or item.work_item_type.value)
+        for item in change_set.ordered_work_items()
+        if not normalized_prefix or item.work_item_id.startswith(normalized_prefix)
+    )
+
+
+def use_case_directory_candidates(
+    repo_root: Path | str,
+    prefix: str = "",
+) -> tuple[CompletionCandidate, ...]:
+    """Return canonical use-case directory IDs."""
+
+    normalized_prefix = prefix.strip()
+    use_case_dir = Path(repo_root) / "docs/use-cases"
+    if not use_case_dir.exists():
+        return ()
+    return tuple(
+        CompletionCandidate(path.name)
+        for path in sorted(use_case_dir.iterdir())
+        if path.is_dir() and (not normalized_prefix or path.name.startswith(normalized_prefix))
+    )
+
+
+def run_id_candidates(repo_root: Path | str, prefix: str = "") -> tuple[CompletionCandidate, ...]:
+    """Return persisted runtime run IDs."""
+
+    normalized_prefix = prefix.strip()
+    run_dir = Path(repo_root) / ".harness/runs"
+    if not run_dir.exists():
+        return ()
+    return tuple(
+        CompletionCandidate(path.name)
+        for path in sorted(run_dir.iterdir())
+        if path.is_dir() and (not normalized_prefix or path.name.startswith(normalized_prefix))
+    )
+
+
+def stage_candidates(
+    repo_root: Path | str,
+    change_set_id: str,
+    prefix: str = "",
+) -> tuple[CompletionCandidate, ...]:
+    """Return built-in and persisted runtime stage IDs."""
+
+    normalized_prefix = prefix.strip()
+    stage_ids = {stage.stage_id for stage in PROCEDURE_STAGES}
+    stage_dir = Path(repo_root) / ".harness/stages" / change_set_id
+    if stage_dir.exists():
+        stage_ids.update(path.stem for path in stage_dir.glob("*.md"))
+    return tuple(
+        CompletionCandidate(stage_id)
+        for stage_id in sorted(stage_ids)
+        if not normalized_prefix or stage_id.startswith(normalized_prefix)
+    )
+
+
+def _load_change_set_by_id(repo_root: Path | str, change_set_id: str) -> ChangeSet | None:
+    normalized_id = change_set_id.strip()
+    if not normalized_id:
+        return None
+    root = Path(repo_root)
+    resolver = ChangeSetResolver(root)
+    for path in (
+        root / "docs/changes/active" / f"{normalized_id}.md",
+        root / "docs/changes/completed" / f"{normalized_id}.md",
+    ):
+        if path.exists():
+            return resolver.load(path)
+    return None
 
 
 def _change_set_description(change_set: ChangeSet) -> str:
@@ -143,6 +245,39 @@ def build_parser() -> argparse.ArgumentParser:
     )
     change_set.set_defaults(func=change_set_completion_command)
 
+    use_case = subparsers.add_parser("use-case")
+    use_case.add_argument("change_set_id")
+    use_case.add_argument("--repo-root", default=".")
+    use_case.add_argument("--prefix", default="")
+    use_case.add_argument("--format", choices=("bash", "zsh", "tsv"), default="tsv")
+    use_case.set_defaults(func=use_case_completion_command)
+
+    use_case_dir = subparsers.add_parser("use-case-directory")
+    use_case_dir.add_argument("--repo-root", default=".")
+    use_case_dir.add_argument("--prefix", default="")
+    use_case_dir.add_argument("--format", choices=("bash", "zsh", "tsv"), default="tsv")
+    use_case_dir.set_defaults(func=use_case_directory_completion_command)
+
+    work_item = subparsers.add_parser("work-item")
+    work_item.add_argument("change_set_id")
+    work_item.add_argument("--repo-root", default=".")
+    work_item.add_argument("--prefix", default="")
+    work_item.add_argument("--format", choices=("bash", "zsh", "tsv"), default="tsv")
+    work_item.set_defaults(func=work_item_completion_command)
+
+    run = subparsers.add_parser("run")
+    run.add_argument("--repo-root", default=".")
+    run.add_argument("--prefix", default="")
+    run.add_argument("--format", choices=("bash", "zsh", "tsv"), default="tsv")
+    run.set_defaults(func=run_completion_command)
+
+    stage = subparsers.add_parser("stage")
+    stage.add_argument("change_set_id")
+    stage.add_argument("--repo-root", default=".")
+    stage.add_argument("--prefix", default="")
+    stage.add_argument("--format", choices=("bash", "zsh", "tsv"), default="tsv")
+    stage.set_defaults(func=stage_completion_command)
+
     install = subparsers.add_parser("install")
     install.add_argument("--repo-root", default=".")
     install.add_argument("--shell", choices=("auto", "zsh", "bash", "all"), default="auto")
@@ -160,6 +295,38 @@ def change_set_completion_command(args: argparse.Namespace) -> str:
 def change_set_completion_command(args: argparse.Namespace) -> str:
     return format_candidates(
         change_set_candidates(args.repo_root, args.prefix, scope=args.scope),
+        shell_format=args.format,
+    )
+
+
+def use_case_completion_command(args: argparse.Namespace) -> str:
+    return format_candidates(
+        use_case_candidates(args.repo_root, args.change_set_id, args.prefix),
+        shell_format=args.format,
+    )
+
+
+def use_case_directory_completion_command(args: argparse.Namespace) -> str:
+    return format_candidates(
+        use_case_directory_candidates(args.repo_root, args.prefix),
+        shell_format=args.format,
+    )
+
+
+def work_item_completion_command(args: argparse.Namespace) -> str:
+    return format_candidates(
+        work_item_candidates(args.repo_root, args.change_set_id, args.prefix),
+        shell_format=args.format,
+    )
+
+
+def run_completion_command(args: argparse.Namespace) -> str:
+    return format_candidates(run_id_candidates(args.repo_root, args.prefix), shell_format=args.format)
+
+
+def stage_completion_command(args: argparse.Namespace) -> str:
+    return format_candidates(
+        stage_candidates(args.repo_root, args.change_set_id, args.prefix),
         shell_format=args.format,
     )
 

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -4,6 +4,11 @@ from harness_codex.runtime.shell_completion import (
     change_set_candidates,
     format_candidates,
     install_completion,
+    run_id_candidates,
+    stage_candidates,
+    use_case_candidates,
+    use_case_directory_candidates,
+    work_item_candidates,
 )
 
 
@@ -25,6 +30,12 @@ CHANGESET_A = """# Add note analysis
 | Before | After |
 |---|---|
 | Before A | After A |
+
+## 5. Affected Use Cases
+
+| UC ID | Use Case Name | Impact Type | Slice Path | Status |
+|---|---|---|---|---|
+| `UC-001` | Payment approval | update | `docs/use-cases/UC-001/` | planned |
 """
 
 CHANGESET_B = """# Improve runtime completion
@@ -115,6 +126,31 @@ def test_change_set_candidates_include_completed_status_and_title(tmp_path: Path
     ]
 
 
+def test_use_case_and_work_item_candidates_read_changeset_items(tmp_path: Path):
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-20260522-001.md").write_text(CHANGESET_A, encoding="utf-8")
+
+    assert [(item.value, item.description) for item in use_case_candidates(tmp_path, "CHG-20260522-001")] == [
+        ("UC-001", "Payment approval")
+    ]
+    assert [(item.value, item.description) for item in work_item_candidates(tmp_path, "CHG-20260522-001")] == [
+        ("UC-001", "Payment approval")
+    ]
+
+
+def test_directory_run_and_stage_candidates(tmp_path: Path):
+    (tmp_path / "docs/use-cases/UC-001").mkdir(parents=True)
+    (tmp_path / ".harness/runs/run-001").mkdir(parents=True)
+    (tmp_path / ".harness/stages/CHG-001").mkdir(parents=True)
+    (tmp_path / ".harness/stages/CHG-001/custom-stage.md").write_text("# Stage\n", encoding="utf-8")
+
+    assert [item.value for item in use_case_directory_candidates(tmp_path)] == ["UC-001"]
+    assert [item.value for item in run_id_candidates(tmp_path)] == ["run-001"]
+    assert "custom-stage" in [item.value for item in stage_candidates(tmp_path, "CHG-001")]
+    assert "requirements-definition" in [item.value for item in stage_candidates(tmp_path, "CHG-001")]
+
+
 def test_install_completion_copies_zsh_completion(tmp_path: Path):
     repo = tmp_path / "repo"
     source_dir = repo / "completions"
@@ -143,3 +179,21 @@ def test_install_completion_copies_bash_completion(tmp_path: Path):
     assert target.read_text(encoding="utf-8") == "# bash completion\n"
     assert result[0].shell == "bash"
     assert result[0].target == target
+
+
+def test_bash_completion_lists_supported_runtime_commands_only():
+    text = Path("completions/harness.bash").read_text(encoding="utf-8")
+
+    assert "help init update reset agent-context changes contracts" in text
+    assert "--repo --ref --skip-venv --dry-run" in text
+    assert "--shell" not in text
+
+
+def test_zsh_completion_lists_delete_and_reset_commands():
+    text = Path("completions/_harness").read_text(encoding="utf-8")
+
+    assert "'help:Show runtime help'" in text
+    assert "'reset:Reset local runtime artifacts'" in text
+    assert "'delete:Delete one active ChangeSet'" in text
+    assert "'update:Update installed runtime files'" in text
+    assert "--shell" not in text

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -900,6 +900,26 @@ def test_interactive_content_review_json_contract_validation() -> None:
     assert result["findings"] == ["f1"]
 
 
+def test_help_command_outputs_curated_runtime_commands(tmp_path: Path, capsys) -> None:
+    exit_code = main(["--repo-root", str(tmp_path), "help"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Harness runtime commands" in output
+    assert "update" in output
+    assert "reset" in output
+    assert "Shell completion target" not in output
+
+
+def test_help_command_outputs_command_topic(tmp_path: Path, capsys) -> None:
+    exit_code = main(["--repo-root", str(tmp_path), "help", "update"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Usage: harness update [--repo URL] [--ref REF] [--skip-venv] [--dry-run]" in output
+    assert "--shell" not in output
+
+
 def test_procedure_stage_apply_records_changeset_status(tmp_path: Path, capsys) -> None:
     write_changeset(tmp_path)
 


### PR DESCRIPTION
## 구현 의도

Harness 런타임 CLI의 도움말, 업데이트, 리셋, 셸 자동완성 흐름을 현재 지원되는 명령 체계에 맞게 정리합니다.

기존 `harness update`는 셸 자동완성 설치 동작에 머물러 있었고, 자동완성 스크립트는 일부 명령과 인자 후보를 충분히 제공하지 못했습니다. 이번 변경은 사용자가 ChangeSet, run, stage 같은 런타임 식별자를 외우지 않고도 Bash/Zsh 자동완성으로 선택할 수 있게 만드는 데 목적이 있습니다.

## 구현 접근

`harness_codex/cli.py`에 `harness help [command]`를 추가해 현재 등록된 런타임 명령과 각 명령의 사용법을 출력하도록 했습니다.

`harness update`는 `run_self_update()`를 호출하는 self-update 명령으로 변경했습니다. 옵션은 `--repo`, `--ref`, `--skip-venv`, `--dry-run`으로 정리했고 기존 자동완성 설치용 `--shell` 옵션은 제거했습니다.

`harness reset` 명령을 추가해 로컬 런타임 산출물을 `--runs`, `--workflow-artifacts`, `--all` 범위로 명시적으로 초기화할 수 있게 했습니다. 실제 적용은 `--apply`가 있을 때만 수행합니다.

`shell_completion.py`에는 ChangeSet 문서와 저장소 디렉터리를 읽는 후보 조회 함수를 추가했습니다. Bash/Zsh completion script는 현재 입력 위치와 prefix를 기준으로 completion runtime을 호출하고, completion runtime은 `docs/changes`, `docs/use-cases`, `.harness/runs`, `.harness/stages`를 읽어 bash/zsh/tsv 형식 후보를 반환합니다.

Bash/Zsh completion script는 현재 `main`에서 지원되는 명령만 노출하도록 조정했습니다. `changes`, `contracts`, 절차 stage, `ultrawork`, `evolution`, `stages`, `artifacts`, `resume`, `report`, `update`, `reset` 후보 처리를 보강했습니다.

`docs/runtime-shell-completion.md`는 현재 completion 파일 경로와 후보 산출 규칙에 맞춰 영어 문서로 갱신했습니다.

## 검증 방법

다음 검증을 실행했습니다.

```bash
python3 -m py_compile harness_codex/cli.py harness_codex/runtime/shell_completion.py
bash -n completions/harness.bash
/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_shell_completion.py tests/test_cli_commands.py
```

결과:

```text
37 passed in 8.92s
```

## 위험 및 롤백

주요 위험은 completion script가 현재 작업 디렉터리를 저장소 루트로 가정한다는 점입니다. 저장소 루트 밖에서 completion을 실행하면 후보가 비어 있을 수 있습니다. 문서에 저장소 루트에서 completion을 사용하도록 명시했습니다.

또 다른 위험은 `harness update`의 의미가 기존 completion 설치 동작에서 self-update 동작으로 바뀐다는 점입니다. 롤백이 필요하면 `harness_codex/cli.py`의 `update_command`와 completion script의 `update` 옵션 목록을 이전 구현으로 되돌리면 됩니다.