### PR TITLE
[codex] Grill-Me UTF-8 및 자동완성 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Equivalent module form:
 ./venv/bin/python3 -m harness_codex --help
 ```
 
+Install shell completion:
+
+```bash
+./venv/bin/python3 -m harness_codex completion install --shell zsh
+# In an installed target repository, use: ./harness completion install --shell zsh
+exec zsh
+```
+
 ## Main Workflow
 
 Start from the first runtime stage. This creates a temporary ChangeSet early, records stage state in the ChangeSet, and lets later commands resume from durable files. After use-case design is verified, the runtime finalizes the temporary ChangeSet into a normal `CHG-YYYYMMDD-NNN` ChangeSet generated from the design.

--- a/completions/_harness
+++ b/completions/_harness
@@ -60,7 +60,7 @@ _harness_stage_ids() {
 }
 
 _harness() {
-  local -a commands changes_commands modes ultrawork_options reset_scopes reset_options
+  local -a commands changes_commands modes procedure_options ultrawork_options reset_scopes reset_options
   commands=(
     'help:Show runtime help'
     'init:Initialize agent context files'
@@ -69,6 +69,7 @@ _harness() {
     'agent-context:Initialize agent context files'
     'changes:List and create ChangeSets'
     'contracts:Validate document handoff contracts'
+    'completion:Install shell completion'
     'requirements-definition:Define requirements and create temp ChangeSet when needed'
     'ubiquitous-language-definition:Define project ubiquitous language'
     'use-case-definition:Define use cases and finalize temp ChangeSet'
@@ -98,6 +99,14 @@ _harness() {
     '--plan:show execution plan without side effects'
     '--preview:show preview without side effects'
     '--apply:run and apply side effects'
+  )
+  procedure_options=(
+    '--uc[use case id]'
+    '--title[change title]'
+    '--idea[initial idea]'
+    '--plan[show execution plan]'
+    '--preview[show preview]'
+    '--apply[run and apply side effects]'
   )
   ultrawork_options=(
     '--title[change title]'
@@ -135,6 +144,13 @@ _harness() {
         _harness_changeset_ids all
       fi
       ;;
+    completion)
+      if (( CURRENT == 3 )); then
+        _describe 'completion command' ('install:Install shell completion')
+      elif (( CURRENT == 4 )) && [[ "$words[3]" == install ]]; then
+        _describe 'completion option' ('--shell[completion shell]')
+      fi
+      ;;
     agent-context)
       if (( CURRENT == 3 )); then
         _describe 'agent-context command' ('init:Initialize agent context files')
@@ -146,14 +162,18 @@ _harness() {
       fi
       ;;
     requirements-definition)
-      if (( CURRENT == 3 )); then
+      if [[ "$PREFIX" == --* ]]; then
+        _describe 'option' procedure_options
+      elif (( CURRENT == 3 )); then
         _harness_changeset_ids active
       elif (( CURRENT == 4 )); then
         _describe 'mode' modes
       fi
       ;;
     ubiquitous-language-definition|use-case-definition|event-storming|ddd-architecture-definition|technical-decisions|plan-writing|implementation)
-      if (( CURRENT == 3 )); then
+      if [[ "$PREFIX" == --* ]]; then
+        _describe 'option' procedure_options
+      elif (( CURRENT == 3 )); then
         _harness_changeset_ids active
       elif (( CURRENT == 4 )); then
         _describe 'mode' modes

--- a/completions/harness.bash
+++ b/completions/harness.bash
@@ -59,14 +59,15 @@ _harness_completion() {
   local command="${COMP_WORDS[1]:-}"
   local subcommand="${COMP_WORDS[2]:-}"
   local current_word="${COMP_WORDS[COMP_CWORD]}"
+  local procedure_options="--uc --title --idea --plan --preview --apply"
 
   if [[ $COMP_CWORD -eq 1 ]]; then
-    COMPREPLY=( $(compgen -W "help init update reset agent-context changes contracts requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation ultrawork evolution stages artifacts resume report dashboard ui-server" -- "$current_word") )
+    COMPREPLY=( $(compgen -W "help init update reset agent-context changes contracts completion requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation ultrawork evolution stages artifacts resume report dashboard ui-server" -- "$current_word") )
     return 0
   fi
 
   if [[ "$command" == "help" && $COMP_CWORD -eq 2 ]]; then
-    COMPREPLY=( $(compgen -W "help init agent-context changes contracts requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation ultrawork evolution stages artifacts resume report dashboard ui-server update reset" -- "$current_word") )
+    COMPREPLY=( $(compgen -W "help init agent-context changes contracts completion requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation ultrawork evolution stages artifacts resume report dashboard ui-server update reset" -- "$current_word") )
     return 0
   fi
 
@@ -95,6 +96,16 @@ _harness_completion() {
     return 0
   fi
 
+  if [[ "$command" == "completion" && $COMP_CWORD -eq 2 ]]; then
+    COMPREPLY=( $(compgen -W "install" -- "$current_word") )
+    return 0
+  fi
+
+  if [[ "$command" == "completion" && "$subcommand" == "install" && "$current_word" == --* ]]; then
+    COMPREPLY=( $(compgen -W "--shell" -- "$current_word") )
+    return 0
+  fi
+
   if [[ "$command" == "agent-context" && $COMP_CWORD -eq 2 ]]; then
     COMPREPLY=( $(compgen -W "init" -- "$current_word") )
     return 0
@@ -105,13 +116,18 @@ _harness_completion() {
     return 0
   fi
 
+  if [[ "$command" =~ ^(requirements-definition|ubiquitous-language-definition|use-case-definition|event-storming|ddd-architecture-definition|technical-decisions|plan-writing|implementation)$ && "$current_word" == --* ]]; then
+    COMPREPLY=( $(compgen -W "$procedure_options" -- "$current_word") )
+    return 0
+  fi
+
   if [[ "$command" =~ ^(requirements-definition|ubiquitous-language-definition|use-case-definition|event-storming|ddd-architecture-definition|technical-decisions|plan-writing|implementation)$ && $COMP_CWORD -eq 2 ]]; then
     _harness_complete_changeset_ids active
     return 0
   fi
 
   if [[ "$command" =~ ^(requirements-definition|ubiquitous-language-definition|use-case-definition|event-storming|ddd-architecture-definition|technical-decisions|plan-writing|implementation)$ && $COMP_CWORD -eq 3 ]]; then
-    COMPREPLY=( $(compgen -W "--plan --preview --apply" -- "$current_word") )
+    COMPREPLY=( $(compgen -W "$procedure_options" -- "$current_word") )
     return 0
   fi
 

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -74,6 +74,7 @@ from harness_codex.runtime.procedure_stages import (
 from harness_codex.runtime.reset import format_result as format_reset_result
 from harness_codex.runtime.reset import run_reset
 from harness_codex.runtime.self_update import DEFAULT_REF, DEFAULT_REPO, run_self_update
+from harness_codex.runtime.shell_completion import install_completion as install_shell_completion
 from harness_codex.runtime.ui_server import run_ui_server
 from harness_codex.runtime.workflows import (
     WorkflowMaterializationError,
@@ -99,6 +100,7 @@ COMMAND_HELP: tuple[tuple[str, str], ...] = (
     ("agent-context", "Initialize repo-local agent context files."),
     ("changes", "List, inspect, create, or delete ChangeSets."),
     ("contracts", "Validate document handoff contracts."),
+    ("completion", "Install shell completion."),
     ("requirements-definition", "Define requirements and create temp ChangeSet when needed."),
     ("ubiquitous-language-definition", "Define project ubiquitous language."),
     ("use-case-definition", "Define use cases and finalize temp ChangeSet."),
@@ -130,6 +132,7 @@ TOPIC_HELP: Mapping[str, str] = {
         "       harness changes document-delta <CHG-ID> --uc UC-ID --summary TEXT --plan|--preview|--apply"
     ),
     "contracts": "Usage: harness contracts validate <CHG-ID> [--work-item ID] [--json]",
+    "completion": "Usage: harness completion install [--shell auto|zsh|bash|all]",
     "requirements-definition": "Usage: harness requirements-definition [CHG-ID] --plan|--preview|--apply",
     "ubiquitous-language-definition": "Usage: harness ubiquitous-language-definition <CHG-ID> --plan|--preview|--apply",
     "use-case-definition": "Usage: harness use-case-definition <CHG-ID> --plan|--preview|--apply",
@@ -276,6 +279,12 @@ def build_parser() -> argparse.ArgumentParser:
     contracts_validate.add_argument("--json", action="store_true")
     contracts_validate.set_defaults(func=contracts_validate_command)
 
+    completion = subparsers.add_parser("completion")
+    completion_subparsers = completion.add_subparsers(required=True)
+    completion_install = completion_subparsers.add_parser("install")
+    completion_install.add_argument("--shell", choices=("auto", "zsh", "bash", "all"), default="auto")
+    completion_install.set_defaults(func=completion_install_command)
+
     for stage in PROCEDURE_STAGES:
         _add_procedure_stage_parser(subparsers, stage)
 
@@ -396,6 +405,15 @@ def update_command(args: argparse.Namespace, repo_root: Path) -> str:
 
 def reset_command(args: argparse.Namespace, repo_root: Path) -> str:
     return format_reset_result(run_reset(repo_root, args))
+
+
+def completion_install_command(args: argparse.Namespace, repo_root: Path) -> str:
+    results = install_shell_completion(repo_root, shell=args.shell)
+    lines = ["Installed harness shell completion:"]
+    for result in results:
+        lines.append(f"- {result.shell}: {result.source} -> {result.target}")
+        lines.append(f"  {result.note}")
+    return "\n".join(lines)
 
 
 def help_command(args: argparse.Namespace, repo_root: Path) -> str:
@@ -1165,6 +1183,14 @@ def _run_interactive_procedure_stage(
     return "\n".join(lines)
 
 
+def _utf8_safe_text(value: object) -> str:
+    return str(value).encode("utf-8", errors="replace").decode("utf-8")
+
+
+def _json_dumps_utf8_safe(value: object) -> str:
+    return _utf8_safe_text(json.dumps(value, ensure_ascii=False, indent=2))
+
+
 def _read_interactive_stage_answers(
     stage: ProcedureStage,
     questions: list[dict[str, str]],
@@ -1179,12 +1205,13 @@ def _read_interactive_stage_answers(
             answer = input(f"Answer {index}: ").strip()
         except EOFError as exc:
             raise ValueError("answer is required for interactive Grill-Me question") from exc
+        answer = _utf8_safe_text(answer)
         if not answer:
             raise ValueError("answer is required for interactive Grill-Me question")
         answers.append(
             {
-                "question": question["question"],
-                "recommended": question["recommended"],
+                "question": _utf8_safe_text(question["question"]),
+                "recommended": _utf8_safe_text(question["recommended"]),
                 "answer": answer,
             }
         )
@@ -1229,7 +1256,7 @@ Stage boundary:
 
 ChangeSet: {args.change_set_id}
 UC: {uc_id or "-"}
-Idea: {args.idea or "-"}
+Idea: {_utf8_safe_text(args.idea or "-")}
 
 Inputs:
 {chr(10).join(f"- {path}" for path in inputs)}
@@ -1238,7 +1265,7 @@ Outputs:
 {chr(10).join(f"- {path}" for path in outputs)}
 
 Answer history:
-{json.dumps(session.get("answers", []), ensure_ascii=False, indent=2)}
+{_json_dumps_utf8_safe(session.get("answers", []))}
 
 JSON examples:
 {{"status":"needs_input","questions":[{{"question":"What decision is needed?","recommended":"Recommended answer."}}],"changed_files":["docs/design/요구사항.md"],"blocker":""}}
@@ -1303,10 +1330,10 @@ Outputs to review:
 {chr(10).join(f"- {path}" for path in outputs)}
 
 Stage changed files:
-{json.dumps(stage_result.get("changed_files", []), ensure_ascii=False, indent=2)}
+{_json_dumps_utf8_safe(stage_result.get("changed_files", []))}
 
 Answer history:
-{json.dumps(session.get("answers", []), ensure_ascii=False, indent=2)}
+{_json_dumps_utf8_safe(session.get("answers", []))}
 
 JSON examples:
 {{"status":"complete","questions":[],"review_file":"{review_relative}","findings":[],"blocker":""}}
@@ -1342,6 +1369,7 @@ def _exec_stage_grill_me_prompt(root: Path, step_dir: Path, prompt: str, label: 
     step_dir.mkdir(parents=True, exist_ok=True)
     final_message_path = step_dir / "final-message.md"
     prompt_path = step_dir / "prompt.md"
+    prompt = _utf8_safe_text(prompt)
     prompt_path.write_text(prompt, encoding="utf-8")
     command = [
         "codex",
@@ -1366,12 +1394,12 @@ def _exec_stage_grill_me_prompt(root: Path, step_dir: Path, prompt: str, label: 
         timeout=300,
         check=False,
     )
-    (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
-    (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    (step_dir / "stdout.txt").write_text(_utf8_safe_text(completed.stdout), encoding="utf-8")
+    (step_dir / "stderr.txt").write_text(_utf8_safe_text(completed.stderr), encoding="utf-8")
     if completed.returncode != 0:
-        error = completed.stderr.strip() or completed.stdout.strip()
+        error = _utf8_safe_text(completed.stderr).strip() or _utf8_safe_text(completed.stdout).strip()
         raise ValueError(f"{label} failed: {error}")
-    return final_message_path.read_text(encoding="utf-8")
+    return _utf8_safe_text(final_message_path.read_text(encoding="utf-8"))
 
 
 def _exec_stage_review_prompt(root: Path, step_dir: Path, prompt: str, label: str) -> str:
@@ -1401,8 +1429,8 @@ def _parse_interactive_stage_json(text: str) -> dict:
     for item in raw_questions[:3]:
         if not isinstance(item, dict):
             continue
-        question = str(item.get("question", "") or "").strip()
-        recommended = str(item.get("recommended", "") or "").strip()
+        question = _utf8_safe_text(item.get("question", "") or "").strip()
+        recommended = _utf8_safe_text(item.get("recommended", "") or "").strip()
         if question:
             questions.append({"question": question, "recommended": recommended})
     if status == "needs_input" and not questions:
@@ -1414,8 +1442,8 @@ def _parse_interactive_stage_json(text: str) -> dict:
     return {
         "status": status,
         "questions": questions,
-        "changed_files": [str(item) for item in changed_files],
-        "blocker": str(data.get("blocker", "") or "").strip(),
+        "changed_files": [_utf8_safe_text(item) for item in changed_files],
+        "blocker": _utf8_safe_text(data.get("blocker", "") or "").strip(),
     }
 
 
@@ -1442,8 +1470,8 @@ def _parse_interactive_review_json(text: str) -> dict:
     for item in raw_questions[:3]:
         if not isinstance(item, dict):
             continue
-        question = str(item.get("question", "") or "").strip()
-        recommended = str(item.get("recommended", "") or "").strip()
+        question = _utf8_safe_text(item.get("question", "") or "").strip()
+        recommended = _utf8_safe_text(item.get("recommended", "") or "").strip()
         if question:
             questions.append({"question": question, "recommended": recommended})
     if status == "needs_input" and not questions:
@@ -1456,16 +1484,16 @@ def _parse_interactive_review_json(text: str) -> dict:
     return {
         "status": status,
         "questions": questions,
-        "review_file": str(data.get("review_file", "") or "").strip(),
-        "findings": [str(item) for item in raw_findings],
-        "blocker": str(data.get("blocker", "") or "").strip(),
+        "review_file": _utf8_safe_text(data.get("review_file", "") or "").strip(),
+        "findings": [_utf8_safe_text(item) for item in raw_findings],
+        "blocker": _utf8_safe_text(data.get("blocker", "") or "").strip(),
     }
 
 
 def _save_interactive_stage_session(run_dir: Path, session: dict) -> None:
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "grill-me-session.json").write_text(
-        json.dumps(session, ensure_ascii=False, indent=2),
+        _json_dumps_utf8_safe(session),
         encoding="utf-8",
     )
 
@@ -1483,8 +1511,8 @@ def _create_initial_procedure_changeset(
     target.write_text(
         render_initial_changeset(
             change_set_id=change_set_id,
-            title=title,
-            request_summary=idea or title,
+            title=_utf8_safe_text(title),
+            request_summary=_utf8_safe_text(idea or title),
         ),
         encoding="utf-8",
     )

--- a/harness_codex/runtime/shell_completion.py
+++ b/harness_codex/runtime/shell_completion.py
@@ -32,12 +32,6 @@ class CompletionInstallResult:
     note: str
 
 
-def change_set_candidates(repo_root: Path | str, prefix: str = "") -> tuple[CompletionCandidate, ...]:
-    """Return active ChangeSet IDs for current staged workflow completion."""
-
-    return change_set_candidates(repo_root, prefix, scope="active")
-
-
 def change_set_candidates(
     repo_root: Path | str,
     prefix: str = "",
@@ -227,16 +221,6 @@ def build_parser() -> argparse.ArgumentParser:
     change_set = subparsers.add_parser("change-set")
     change_set.add_argument("--repo-root", default=".")
     change_set.add_argument("--prefix", default="")
-    change_set.add_argument(
-        "--format",
-        choices=("bash", "zsh", "tsv"),
-        default="tsv",
-    )
-    change_set.set_defaults(func=change_set_completion_command)
-
-    change_set = subparsers.add_parser("change-set")
-    change_set.add_argument("--repo-root", default=".")
-    change_set.add_argument("--prefix", default="")
     change_set.add_argument("--scope", choices=("active", "completed", "all"), default="all")
     change_set.add_argument(
         "--format",
@@ -283,13 +267,6 @@ def build_parser() -> argparse.ArgumentParser:
     install.add_argument("--shell", choices=("auto", "zsh", "bash", "all"), default="auto")
     install.set_defaults(func=install_completion_command)
     return parser
-
-
-def change_set_completion_command(args: argparse.Namespace) -> str:
-    return format_candidates(
-        change_set_candidates(args.repo_root, args.prefix),
-        shell_format=args.format,
-    )
 
 
 def change_set_completion_command(args: argparse.Namespace) -> str:

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -4,6 +4,7 @@ from harness_codex.runtime.shell_completion import (
     change_set_candidates,
     format_candidates,
     install_completion,
+    main,
     run_id_candidates,
     stage_candidates,
     use_case_candidates,
@@ -184,9 +185,10 @@ def test_install_completion_copies_bash_completion(tmp_path: Path):
 def test_bash_completion_lists_supported_runtime_commands_only():
     text = Path("completions/harness.bash").read_text(encoding="utf-8")
 
-    assert "help init update reset agent-context changes contracts" in text
+    assert "help init update reset agent-context changes contracts completion" in text
     assert "--repo --ref --skip-venv --dry-run" in text
-    assert "--shell" not in text
+    assert "completion" in text
+    assert "--shell" in text
 
 
 def test_zsh_completion_lists_delete_and_reset_commands():
@@ -194,6 +196,18 @@ def test_zsh_completion_lists_delete_and_reset_commands():
 
     assert "'help:Show runtime help'" in text
     assert "'reset:Reset local runtime artifacts'" in text
+    assert "'completion:Install shell completion'" in text
     assert "'delete:Delete one active ChangeSet'" in text
     assert "'update:Update installed runtime files'" in text
-    assert "--shell" not in text
+    assert "--shell" in text
+
+
+def test_shell_completion_cli_change_set_parser_accepts_scope(tmp_path: Path, capsys):
+    (tmp_path / "docs/changes/active").mkdir(parents=True)
+    (tmp_path / "docs/changes/active/CHG-001.md").write_text(CHANGESET_A, encoding="utf-8")
+
+    exit_code = main(["change-set", "--repo-root", str(tmp_path), "--scope", "active", "--format", "bash"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "CHG-20260522-001" in output

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -863,6 +863,30 @@ def test_interactive_stage_json_contract_validation() -> None:
     assert [item["question"] for item in result["questions"]] == ["q1", "q2", "q3"]
 
 
+def test_interactive_stage_answers_are_utf8_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("builtins.input", lambda _prompt: "fleeting note \udcff")
+
+    answers = cli._read_interactive_stage_answers(
+        cli.procedure_stage("requirements-definition"),
+        [{"question": "Question \udcff", "recommended": "Recommended \udcff"}],
+    )
+
+    dumped = json.dumps(answers, ensure_ascii=False)
+    assert "\udcff" not in dumped
+    dumped.encode("utf-8")
+
+
+def test_save_interactive_stage_session_accepts_lone_surrogates(tmp_path: Path) -> None:
+    cli._save_interactive_stage_session(
+        tmp_path,
+        {"answers": [{"question": "Question", "recommended": "", "answer": "Graph note \udcff"}]},
+    )
+
+    text = (tmp_path / "grill-me-session.json").read_text(encoding="utf-8")
+    assert "\udcff" not in text
+    assert "Graph note ?" in text
+
+
 def test_interactive_content_review_json_contract_validation() -> None:
     with pytest.raises(ValueError, match="non-JSON"):
         cli._parse_interactive_review_json("not json")


### PR DESCRIPTION
## 구현 의도 (Implementation intent)

requirements-definition Grill-Me 입력에 터미널 붙여넣기에서 생긴 잘못된 유니코드 surrogate가 포함되어도 세션, 프롬프트, 실행 로그 저장이 실패하지 않도록 수정합니다. 또한 다른 저장소에서 harness update 후 ./harness completion install --shell zsh가 completion source file not found로 실패하지 않도록 completion 원본 파일을 설치 대상에 포함합니다.

## 구현 방식 (Implementation approach)

CLI의 interactive stage 경계에서 사용자 답변, 질문, 추천 답변, JSON 직렬화, child codex stdout/stderr를 UTF-8 안전 문자열로 정규화합니다. shell_completion의 중복 change-set parser/handler를 제거하고, zsh/bash completion에 completion 명령 및 stage 옵션(--idea, --title, --uc, --plan, --preview, --apply)을 추가했습니다. 설치 스크립트는 harness_codex, .harness, .codex와 함께 completions 디렉터리도 target repo로 복사합니다. README에는 completion 설치 절차를 추가했습니다.

## 검증 방법 (Verification method)

- ./venv/bin/python3 -m py_compile harness_codex/cli.py harness_codex/runtime/shell_completion.py
- ./venv/bin/python3 -m pytest -q -s tests/runtime/test_shell_completion.py tests/test_cli_commands.py
- ./venv/bin/python3 -m pytest -q -s tests/runtime/test_install_update_preservation.py tests/runtime/test_shell_completion.py tests/test_cli_commands.py::test_help_command_outputs_curated_runtime_commands
- 결과: shell completion/CLI focused suite 40 passed, installer/completion focused suite 17 passed

## 위험 및 롤백 (Risks and rollback)

위험은 이미 업데이트한 저장소에는 completions 디렉터리가 아직 없을 수 있다는 점입니다. 이 PR이 merge된 뒤 다시 ./harness update를 실행하면 completions가 복사되고, 이후 ./harness completion install --shell zsh를 실행하면 됩니다. 문제가 있으면 이 커밋을 revert하고 기존 completion 파일을 다시 설치하면 됩니다.