### PR TITLE
zsh 자동완성 경고 수정

### DIFF
--- a/completions/_harness
+++ b/completions/_harness
@@ -60,8 +60,8 @@ _harness_stage_ids() {
 }
 
 _harness() {
-  local -a commands changes_commands modes procedure_options ultrawork_options reset_scopes reset_options
-  commands=(
+  local -a harness_commands changes_commands contracts_commands completion_commands completion_options agent_context_commands evolution_commands stages_commands artifacts_commands modes procedure_options ultrawork_options reset_scopes reset_options
+  harness_commands=(
     'help:Show runtime help'
     'init:Initialize agent context files'
     'update:Update installed runtime files'
@@ -94,6 +94,30 @@ _harness() {
     'contents:Show ChangeSet contents'
     'delete:Delete one active ChangeSet'
     'document-delta:Apply document delta to ChangeSet work item'
+  )
+  contracts_commands=(
+    'validate:Validate contract registry'
+  )
+  completion_commands=(
+    'install:Install shell completion'
+  )
+  completion_options=(
+    '--shell[completion shell]'
+  )
+  agent_context_commands=(
+    'init:Initialize agent context files'
+  )
+  evolution_commands=(
+    'propose:Create evolution proposal'
+    'accept:Accept evolution proposal'
+    'reject:Reject evolution proposal'
+  )
+  stages_commands=(
+    'list:List runtime stages'
+  )
+  artifacts_commands=(
+    'show:Show stage artifact'
+    'accept:Accept stage artifact'
   )
   modes=(
     '--plan:show execution plan without side effects'
@@ -139,26 +163,26 @@ _harness() {
       ;;
     contracts)
       if (( CURRENT == 3 )); then
-        _describe 'contracts command' ('validate:Validate contract registry')
+        _describe 'contracts command' contracts_commands
       elif (( CURRENT == 4 )) && [[ "$words[3]" == validate ]]; then
         _harness_changeset_ids all
       fi
       ;;
     completion)
       if (( CURRENT == 3 )); then
-        _describe 'completion command' ('install:Install shell completion')
+        _describe 'completion command' completion_commands
       elif (( CURRENT == 4 )) && [[ "$words[3]" == install ]]; then
-        _describe 'completion option' ('--shell[completion shell]')
+        _describe 'completion option' completion_options
       fi
       ;;
     agent-context)
       if (( CURRENT == 3 )); then
-        _describe 'agent-context command' ('init:Initialize agent context files')
+        _describe 'agent-context command' agent_context_commands
       fi
       ;;
     evolution)
       if (( CURRENT == 3 )); then
-        _describe 'evolution command' ('propose:Create evolution proposal' 'accept:Accept evolution proposal' 'reject:Reject evolution proposal')
+        _describe 'evolution command' evolution_commands
       fi
       ;;
     requirements-definition)
@@ -184,14 +208,14 @@ _harness() {
       ;;
     stages)
       if (( CURRENT == 3 )); then
-        _describe 'stages command' ('list:List runtime stages')
+        _describe 'stages command' stages_commands
       elif (( CURRENT == 4 )) && [[ "$words[3]" == list ]]; then
         _harness_changeset_ids all
       fi
       ;;
     artifacts)
       if (( CURRENT == 3 )); then
-        _describe 'artifacts command' ('show:Show stage artifact' 'accept:Accept stage artifact')
+        _describe 'artifacts command' artifacts_commands
       elif (( CURRENT == 4 )) && [[ "$words[3]" == (show|accept) ]]; then
         _harness_changeset_ids all
       elif (( CURRENT == 5 )) && [[ "$words[3]" == (show|accept) ]]; then
@@ -200,7 +224,7 @@ _harness() {
       ;;
     help)
       if (( CURRENT == 3 )); then
-        _describe 'help topic' commands
+        _describe 'help topic' harness_commands
       fi
       ;;
     reset)
@@ -217,7 +241,7 @@ _harness() {
       ;;
     *)
       if (( CURRENT == 2 )); then
-        _describe 'command' commands
+        _describe 'command' harness_commands
       fi
       ;;
   esac

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -1,3 +1,5 @@
+import shutil
+import subprocess
 from pathlib import Path
 
 from harness_codex.runtime.shell_completion import (
@@ -200,6 +202,39 @@ def test_zsh_completion_lists_delete_and_reset_commands():
     assert "'delete:Delete one active ChangeSet'" in text
     assert "'update:Update installed runtime files'" in text
     assert "--shell" in text
+
+
+def test_zsh_completion_uses_named_describe_arrays():
+    if shutil.which("zsh") is None:
+        return
+
+    script = """
+source completions/_harness
+_describe() {
+  local label="$1"
+  local array_name="$2"
+  print -- "${label}:${(P)array_name[*]}"
+}
+words=(harness completion "")
+CURRENT=3
+PREFIX=""
+_harness
+words=(harness "")
+CURRENT=2
+PREFIX=""
+_harness
+"""
+
+    result = subprocess.run(
+        ["zsh", "-fc", script],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "completion command:install:Install shell completion" in result.stdout
+    assert "command:help:Show runtime help" in result.stdout
 
 
 def test_shell_completion_cli_change_set_parser_accepts_scope(tmp_path: Path, capsys):


### PR DESCRIPTION
## 구현 의도
- `./harness completion <TAB>` 실행 시 zsh가 `_harness` 자동완성 파일에서 `unknown file attribute: i` 경고를 출력하지 않도록 수정합니다.

## 구현 접근
- zsh 특수 파라미터인 `commands`와 충돌하지 않도록 루트 명령 후보 배열을 `harness_commands`로 변경했습니다.
- `_describe` 호출에 인라인 배열 리터럴을 넘기던 부분을 이름 있는 배열로 분리해 zsh가 후보 문자열을 glob 한정자로 해석하지 않도록 했습니다.
- 실제 zsh에서 `_harness`를 source하고 `completion` 및 루트 명령 후보를 호출하는 회귀 테스트를 추가했습니다.

## 검증 방법
- `zsh -n completions/_harness`
- `zsh -fc 'source /home/jiwoo/.zfunc/_harness; _describe(){ local label="$1"; local array_name="$2"; print -- "${label}:${(P)array_name[*]}"; }; words=(harness completion ""); CURRENT=3; PREFIX=""; _harness'`\n- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_shell_completion.py` → `13 passed`\n\n## 위험 및 롤백\n- 위험: zsh 자동완성 후보 배열 이름 변경으로 일부 후보 표시가 누락될 수 있습니다. 회귀 테스트로 `completion` 및 루트 명령 후보 출력을 확인했습니다.\n- 롤백: 이 PR 커밋을 revert하면 기존 자동완성 파일로 복구됩니다.