### PR TITLE
[codex] 리뷰 피드백을 Grill-Me 루프에 반영

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -1046,6 +1046,7 @@ def _run_interactive_procedure_stage(
         "idea": args.idea,
         "answers": [],
         "reviews": [],
+        "review_feedback": [],
         "turns": [],
         "status": "running",
     }
@@ -1107,6 +1108,15 @@ def _run_interactive_procedure_stage(
             _save_interactive_stage_session(run_dir, session)
 
             if review["status"] == "needs_input":
+                session["review_feedback"].append(
+                    {
+                        "turn": turn,
+                        "status": review["status"],
+                        "review_file": review["review_file"],
+                        "findings": review["findings"],
+                        "blocker": review["blocker"],
+                    }
+                )
                 answers = _read_interactive_stage_answers(stage, review["questions"])
                 session["answers"].extend(
                     {
@@ -1120,13 +1130,18 @@ def _run_interactive_procedure_stage(
                 continue
 
             if review["status"] == "blocked":
-                result = {
-                    **result,
-                    "status": "blocked",
-                    "blocker": review["blocker"] or "content review rejected stage artifacts",
-                    "review_file": review["review_file"],
-                }
-                final_result = result
+                session["review_feedback"].append(
+                    {
+                        "turn": turn,
+                        "status": review["status"],
+                        "review_file": review["review_file"],
+                        "findings": review["findings"],
+                        "blocker": review["blocker"]
+                        or "content review rejected stage artifacts",
+                    }
+                )
+                _save_interactive_stage_session(run_dir, session)
+                continue
 
         session["status"] = result["status"]
         _save_interactive_stage_session(run_dir, session)
@@ -1237,6 +1252,7 @@ def _interactive_stage_prompt(
     return f"""Use ${stage.skill_id} to run the `{stage.stage_id}` stage.
 
 You are running inside the main harness workflow. Draft or update the stage artifacts first, then decide whether the draft has blocking ambiguity.
+If content review feedback exists, revise the stage artifacts to address it before returning `complete`.
 
 Return only JSON with keys: status, questions, changed_files, blocker.
 
@@ -1266,6 +1282,9 @@ Outputs:
 
 Answer history:
 {_json_dumps_utf8_safe(session.get("answers", []))}
+
+Content review feedback:
+{_json_dumps_utf8_safe(session.get("review_feedback", []))}
 
 JSON examples:
 {{"status":"needs_input","questions":[{{"question":"What decision is needed?","recommended":"Recommended answer."}}],"changed_files":["docs/design/요구사항.md"],"blocker":""}}

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -790,6 +790,76 @@ def test_interactive_content_review_questions_rerun_stage_agent(
     assert session["reviews"][0]["status"] == "needs_input"
 
 
+def test_interactive_content_review_blocked_reruns_stage_agent(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    stage_prompts: list[str] = []
+    review_calls = 0
+
+    def fake_exec(_root, _step_dir, prompt, _label):
+        stage_prompts.append(prompt)
+        return json.dumps(
+            {
+                "status": "complete",
+                "questions": [],
+                "changed_files": ["docs/design/요구사항.md"],
+                "blocker": "",
+            }
+        )
+
+    def fake_review_exec(_root, _step_dir, _prompt, _label):
+        nonlocal review_calls
+        review_calls += 1
+        if review_calls == 1:
+            return json.dumps(
+                {
+                    "status": "blocked",
+                    "questions": [],
+                    "review_file": ".harness/runs/run-test/reviews/requirements-definition-content-review.md",
+                    "findings": ["Stage-boundary violation remains."],
+                    "blocker": "Requirements include downstream technical decisions.",
+                }
+            )
+        return json.dumps(
+            {
+                "status": "complete",
+                "questions": [],
+                "review_file": ".harness/runs/run-test/reviews/requirements-definition-content-review.md",
+                "findings": [],
+                "blocker": "",
+            }
+        )
+
+    monkeypatch.setattr(cli, "_exec_stage_grill_me_prompt", fake_exec)
+    monkeypatch.setattr(cli, "_exec_stage_review_prompt", fake_review_exec)
+    monkeypatch.setattr(cli, "verify_procedure_stage", lambda *_, **__: (True, ()))
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "requirements-definition",
+            "CHG-001",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Content review: complete" in output
+    assert review_calls == 2
+    assert len(stage_prompts) == 2
+    assert "Stage-boundary violation remains." in stage_prompts[1]
+    assert "Requirements include downstream technical decisions." in stage_prompts[1]
+    session_path = next((tmp_path / ".harness/runs").glob("*/grill-me-session.json"))
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    assert session["review_feedback"][0]["status"] == "blocked"
+    assert session["reviews"][0]["status"] == "blocked"
+
+
 def test_interactive_grill_me_blocked_records_blocker(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## 구현 의도

requirements-definition 같은 대화형 Grill-Me 단계가 산출물 작성만으로 종료되지 않고, content review 결과까지 반영해 승인된 산출물 상태에서만 완료되도록 수정합니다.

## 구현 접근

content review가 `needs_input` 또는 `blocked`를 반환하면 해당 리뷰 파일, findings, blocker를 세션의 `review_feedback`에 저장합니다. 다음 Grill-Me producer 프롬프트에 이 피드백을 포함해 산출물을 다시 수정하도록 했고, reviewer가 `complete`를 반환할 때만 단계가 최종 완료됩니다.

`blocked` 리뷰는 더 이상 즉시 터미널 blocked로 변환하지 않습니다. 대신 리뷰 피드백 기반 재시도 루프로 돌아가며, 12턴 제한은 기존 안전장치 그대로 유지합니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py -k 'interactive_content_review or interactive_grill_me'`
  - `6 passed, 23 deselected`
- `./venv/bin/python3 -m py_compile harness_codex/cli.py tests/test_cli_commands.py`
  - `py_compile_ok`
- `git diff --check`
  - 통과

## 리스크 및 롤백

리뷰가 반복해서 `blocked`를 반환하면 기존 12턴 제한까지 재시도한 뒤 실패합니다. 문제가 생기면 이 커밋을 되돌려 기존처럼 `blocked` 리뷰를 즉시 종료 처리하도록 롤백할 수 있습니다.
