### PR TITLE
[codex] 유비쿼터스 언어 질문 경계 강화

### DIFF
--- a/.codex/agents/references/ubiquitous_language_reviewer.md
+++ b/.codex/agents/references/ubiquitous_language_reviewer.md
@@ -14,6 +14,7 @@ Your job:
 
 Do not reopen requirements:
 - Do not ask broad actor, goal, success-condition, failure-policy, or hard-scope questions.
+- Do not ask whether a domain object, note type, source rule, MVP policy, actor goal, success condition, failure policy, or hard scope belongs in the product.
 - If requirements contradict each other or omit a decision that blocks language confirmation, report an upstream requirements blocker and stop.
 - Do not rewrite `docs/design/요구사항.md`.
 
@@ -36,6 +37,7 @@ Question loop:
 - Write or update the current `context.md` draft before asking questions.
 - Ask up to three focused Grill-Me questions at a time.
 - Ask only language blockers required before this stage can be correct.
+- Ask only wording and meaning questions. Valid: canonical term, labels, aliases, forbidden terms, exact meaning boundary. Invalid: whether a Literature Note must cite an identifiable external source.
 - Include `Recommended answer:` with every question.
 - Run at most 3 rounds.
 - Do not continue asking until terminology is perfect.

--- a/.codex/skills/harness-ubiquitous-language/references/agent-prompt.md
+++ b/.codex/skills/harness-ubiquitous-language/references/agent-prompt.md
@@ -25,6 +25,8 @@ Rules:
 - Do not continue asking until terminology is perfect.
 - Clarify canonical term, Korean label, English/code-facing label, aliases, forbidden terms, and meaning boundary.
 - Do not ask broad requirements questions about actor, goal, success condition, failure policy, or hard scope unless reporting an upstream requirements blocker.
+- Do not ask whether a domain object, note type, source rule, MVP policy, actor goal, success condition, failure policy, or hard scope belongs in the product.
+- Ask only wording and meaning questions. Example valid topic: whether "Literature Note" or "Reference Note" is the canonical term and exact definition. Example invalid topic: whether a Literature Note must cite an identifiable external source.
 - Do not ask aggregate, domain event, or state-transition naming questions in this stage.
 - After the final round, update context.md with confirmed terms and explicit open language questions.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.

--- a/.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md
+++ b/.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md
@@ -41,7 +41,7 @@ Ubiquitous-language-definition owns:
 - meaning boundary
 - use-case-facing command, input, output, result, policy, and scope-boundary terminology
 
-Do not ask broad requirements questions unless a contradiction blocks language confirmation. If blocked, report an upstream requirements blocker and stop.
+Do not ask broad requirements questions unless a contradiction blocks language confirmation. Do not ask whether a domain object, note type, source rule, MVP policy, actor goal, success condition, failure policy, or hard scope belongs in the product. Those decisions belong upstream in requirements or use-case definition. If blocked, report an upstream requirements blocker and stop.
 
 ## Deferred Naming
 
@@ -52,6 +52,8 @@ Do not ask aggregate naming, domain event naming, or state-transition naming que
 - Write or update the current `context.md` draft before asking questions.
 - Ask up to three focused Grill-Me questions per turn.
 - Ask only language blockers needed before the ubiquitous language stage can be correct.
+- Ask about wording only: canonical term, Korean label, English/code-facing label, aliases, forbidden terms, or exact meaning boundary.
+- Do not ask product-policy questions such as whether a note must cite an external source; record those as upstream requirements blockers when they prevent language confirmation.
 - Run at most 3 rounds.
 - Include `Recommended answer:` with every question.
 - After each round, summarize what has been clarified and what remains unresolved.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -1351,7 +1351,10 @@ def _interactive_stage_boundary(stage_id: str) -> str:
         ),
         "ubiquitous-language-definition": (
             "- Owns canonical term, Korean label, English/code-facing label, aliases, forbidden terms, and meaning boundary.\n"
-            "- Do not reopen broad requirements decisions unless contradiction blocks language confirmation."
+            "- Do not ask whether a domain object, note type, source rule, MVP policy, actor goal, success condition, "
+            "failure policy, or hard scope belongs in the product; those are upstream requirements/use-case decisions.\n"
+            "- If upstream requirements omit or contradict a decision needed for language confirmation, report a blocker instead of asking a Grill-Me question.\n"
+            "- Ask only when canonical wording, labels, aliases, forbidden terms, or exact term meaning are unclear."
         ),
         "use-case-definition": (
             "- Owns use-case correctness, actor goal flow, runtime slice readiness, and E2E goal clarity.\n"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -651,6 +651,9 @@ def test_interactive_grill_me_stages_use_shared_runner(
     assert len(review_calls) == 4
     assert all("Return only JSON with keys: status, questions, changed_files, blocker" in prompt for prompt in calls)
     assert all("artifact_reviewer" in prompt for prompt in review_calls)
+    assert "Do not ask whether a domain object, note type, source rule, MVP policy" in calls[1]
+    assert "If upstream requirements omit or contradict a decision needed for language confirmation" in calls[1]
+    assert "Ask only when canonical wording, labels, aliases, forbidden terms, or exact term meaning are unclear" in calls[1]
 
 
 def test_interactive_grill_me_answers_are_saved_and_passed_to_next_turn(


### PR DESCRIPTION
## 구현 의도
유비쿼터스 언어 정의 단계에서 제품 정책이나 요구사항 결정을 Grill-Me 질문으로 묻지 않도록 단계 경계를 강화합니다.

## 구현 접근
런타임 단계 경계와 유비쿼터스 언어 스킬/에이전트 지침에 source rule, MVP policy, actor goal, success condition 같은 상위 단계 결정을 질문하지 말라는 금지 규칙을 추가했습니다. 언어 단계는 canonical term, Korean label, English/code-facing label, aliases, forbidden terms, exact meaning boundary만 질문하도록 제한했습니다. 관련 회귀 테스트는 런타임 프롬프트에 새 경계 문구가 포함되는지 확인합니다.

## 검증 방법
- python3 -m py_compile harness_codex/cli.py
- ./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py::test_interactive_grill_me_stages_use_shared_runner tests/test_harvester_skill_instructions.py::test_ubiquitous_language_skill_owns_context_language

## 위험 및 롤백
위험은 낮습니다. 프롬프트와 지침 경계만 좁히며 런타임 실행 구조는 바꾸지 않습니다. 문제가 생기면 이 커밋을 revert하여 이전 질문 경계로 되돌릴 수 있습니다.
