### PR TITLE
[codex] 대화형 codex exec 타임아웃 연장

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -94,6 +94,8 @@ INTERACTIVE_GRILL_ME_STAGE_IDS = frozenset(
     }
 )
 
+INTERACTIVE_CODEX_EXEC_TIMEOUT_SECONDS = 3600
+
 
 COMMAND_HELP: tuple[tuple[str, str], ...] = (
     ("help", "Show runtime help."),
@@ -1462,7 +1464,12 @@ def _exec_stage_grill_me_prompt(root: Path, step_dir: Path, prompt: str, label: 
         str(final_message_path),
         "-",
     ]
-    timeout = int(os.environ.get("HARNESS_CODEX_EXEC_TIMEOUT_SECONDS", "900"))
+    timeout = int(
+        os.environ.get(
+            "HARNESS_CODEX_EXEC_TIMEOUT_SECONDS",
+            str(INTERACTIVE_CODEX_EXEC_TIMEOUT_SECONDS),
+        )
+    )
     try:
         with stdout_path.open("w", encoding="utf-8") as stdout_file, stderr_path.open(
             "w", encoding="utf-8"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -1095,6 +1096,57 @@ def test_interactive_grill_me_blocked_records_blocker(
     assert "requirements contradict actor goal" in (
         tmp_path / "docs/changes/active/CHG-001.md"
     ).read_text(encoding="utf-8")
+
+
+def test_exec_stage_grill_me_prompt_uses_one_hour_timeout_by_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    observed: dict[str, object] = {}
+    monkeypatch.delenv("HARNESS_CODEX_EXEC_TIMEOUT_SECONDS", raising=False)
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed["timeout"] = kwargs["timeout"]
+        observed["input"] = kwargs["input"]
+        final_message_path = Path(command[command.index("--output-last-message") + 1])
+        final_message_path.write_text('{"status":"complete"}', encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    output = cli._exec_stage_grill_me_prompt(
+        tmp_path,
+        tmp_path / ".harness/runs/run-test/turn-01",
+        "prompt text",
+        "use-case-definition Grill-Me turn",
+    )
+
+    assert observed["timeout"] == 3600
+    assert observed["input"] == "prompt text"
+    assert output == '{"status":"complete"}'
+
+
+def test_exec_stage_grill_me_prompt_reports_configured_timeout(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HARNESS_CODEX_EXEC_TIMEOUT_SECONDS", "7")
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    step_dir = tmp_path / ".harness/runs/run-test/turn-01"
+    with pytest.raises(ValueError, match="use-case-definition Grill-Me turn timed out after 7 seconds"):
+        cli._exec_stage_grill_me_prompt(
+            tmp_path,
+            step_dir,
+            "prompt text",
+            "use-case-definition Grill-Me turn",
+        )
+
+    assert "timed out after 7 seconds" in (step_dir / "stderr.txt").read_text(encoding="utf-8")
 
 
 def test_interactive_stage_json_contract_validation() -> None:


### PR DESCRIPTION
## 구현 의도 (Implementation intent)

`use-case-definition --apply`의 대화형 Grill-Me 실행이 300초 제한으로 중단되어 원시 `TimeoutExpired` 트레이스가 노출되는 문제를 막습니다. 대화형 `codex exec` 기본 제한을 런타임 단계 제한과 맞춰 긴 유스케이스 정의 작업이 완료될 시간을 확보합니다.

## 구현 방식 (Implementation approach)

`_exec_stage_grill_me_prompt`의 기본 타임아웃을 상수 `INTERACTIVE_CODEX_EXEC_TIMEOUT_SECONDS=3600`으로 분리하고, 기존 `HARNESS_CODEX_EXEC_TIMEOUT_SECONDS` 환경 변수 오버라이드는 유지했습니다. 타임아웃 발생 시 기존처럼 stdout/stderr 파일을 남기고 간결한 `ValueError`를 반환합니다.

## 검증 방법 (Verification method)

- `python3 -m py_compile harness_codex/cli.py tests/test_cli_commands.py`
- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py`

## 위험 및 롤백 (Risks and rollback)

기본 대기 시간이 길어져 실패 감지가 늦어질 수 있습니다. 필요하면 `HARNESS_CODEX_EXEC_TIMEOUT_SECONDS`로 짧게 조정할 수 있고, 롤백은 이 커밋을 되돌리면 됩니다.