### PR TITLE
[codex] zsh completion option description insertion 수정

### DIFF
--- a/completions/_harness
+++ b/completions/_harness
@@ -102,7 +102,7 @@ _harness() {
     'install:Install shell completion'
   )
   completion_options=(
-    '--shell[completion shell]'
+    '--shell:completion shell'
   )
   agent_context_commands=(
     'init:Initialize agent context files'
@@ -125,12 +125,12 @@ _harness() {
     '--apply:run and apply side effects'
   )
   procedure_options=(
-    '--uc[use case id]'
-    '--title[change title]'
-    '--idea[initial idea]'
-    '--plan[show execution plan]'
-    '--preview[show preview]'
-    '--apply[run and apply side effects]'
+    '--uc:use case id'
+    '--title:change title'
+    '--idea:initial idea'
+    '--plan:show execution plan'
+    '--preview:show preview'
+    '--apply:run and apply side effects'
   )
   ultrawork_options=(
     '--title[change title]'

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -223,6 +223,10 @@ words=(harness "")
 CURRENT=2
 PREFIX=""
 _harness
+words=(harness use-case-definition CHG-001 --)
+CURRENT=4
+PREFIX="--"
+_harness
 """
 
     result = subprocess.run(
@@ -235,6 +239,9 @@ _harness
     assert result.returncode == 0, result.stderr
     assert "completion command:install:Install shell completion" in result.stdout
     assert "command:help:Show runtime help" in result.stdout
+    assert "option:--uc:use case id" in result.stdout
+    assert "--apply:run and apply side effects" in result.stdout
+    assert "--apply[run and apply side effects]" not in result.stdout
 
 
 def test_shell_completion_cli_change_set_parser_accepts_scope(tmp_path: Path, capsys):


### PR DESCRIPTION
## 구현 의도

zsh completion에서 `--apply[run and apply side effects]`처럼 설명 문자열까지 명령줄에 삽입되는 문제를 수정합니다.

## 구현 방식

`completions/_harness`의 zsh `_describe` 정적 옵션 후보를 `value[description]` 형식에서 `value:description` 형식으로 바꿨습니다. `_describe`가 후보 값과 설명을 분리해서 처리하므로 탭 완료 시 옵션 값만 삽입되고 설명은 표시 용도로만 남습니다.

회귀 테스트는 `use-case-definition` 옵션 완료를 호출해 `--apply:run and apply side effects` 형식이 유지되고, 잘못된 `--apply[run and apply side effects]` 문자열이 출력되지 않는지 확인합니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_shell_completion.py`

## 위험 및 롤백

위험은 zsh completion 표시 형식 변경에 한정됩니다. 문제가 생기면 이 커밋을 되돌리면 기존 completion 동작으로 복구됩니다.