### PR TITLE
[codex] ChangeSet continue 라우팅 추가

### DIFF
--- a/completions/_harness
+++ b/completions/_harness
@@ -93,6 +93,7 @@ _harness() {
     'show:Show one ChangeSet'
     'contents:Show ChangeSet contents'
     'delete:Delete one active ChangeSet'
+    'continue:Run the next ChangeSet procedure stage'
     'document-delta:Apply document delta to ChangeSet work item'
   )
   contracts_commands=(
@@ -128,6 +129,7 @@ _harness() {
     '--uc[use case id]'
     '--title[change title]'
     '--idea[initial idea]'
+    '--force[rerun even when already verified]'
     '--plan[show execution plan]'
     '--preview[show preview]'
     '--apply[run and apply side effects]'
@@ -157,8 +159,10 @@ _harness() {
         _describe 'changes command' changes_commands
       elif (( CURRENT == 4 )) && [[ "$words[3]" == (show|contents) ]]; then
         _harness_changeset_ids all
-      elif (( CURRENT == 4 )) && [[ "$words[3]" == (delete|document-delta) ]]; then
+      elif (( CURRENT == 4 )) && [[ "$words[3]" == (delete|continue|document-delta) ]]; then
         _harness_changeset_ids active
+      elif (( CURRENT == 5 )) && [[ "$words[3]" == continue ]]; then
+        _describe 'mode' modes
       fi
       ;;
     contracts)

--- a/completions/harness.bash
+++ b/completions/harness.bash
@@ -59,7 +59,7 @@ _harness_completion() {
   local command="${COMP_WORDS[1]:-}"
   local subcommand="${COMP_WORDS[2]:-}"
   local current_word="${COMP_WORDS[COMP_CWORD]}"
-  local procedure_options="--uc --title --idea --plan --preview --apply"
+  local procedure_options="--uc --title --idea --force --plan --preview --apply"
 
   if [[ $COMP_CWORD -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "help init update reset agent-context changes contracts completion requirements-definition ubiquitous-language-definition use-case-definition event-storming ddd-architecture-definition technical-decisions plan-writing implementation ultrawork evolution stages artifacts resume report dashboard ui-server" -- "$current_word") )
@@ -72,7 +72,7 @@ _harness_completion() {
   fi
 
   if [[ "$command" == "changes" && $COMP_CWORD -eq 2 ]]; then
-    COMPREPLY=( $(compgen -W "list active show contents delete document-delta" -- "$current_word") )
+    COMPREPLY=( $(compgen -W "list active show contents delete continue document-delta" -- "$current_word") )
     return 0
   fi
 
@@ -81,8 +81,13 @@ _harness_completion() {
     return 0
   fi
 
-  if [[ "$command" == "changes" && ("$subcommand" == "delete" || "$subcommand" == "document-delta") && $COMP_CWORD -eq 3 ]]; then
+  if [[ "$command" == "changes" && ("$subcommand" == "delete" || "$subcommand" == "continue" || "$subcommand" == "document-delta") && $COMP_CWORD -eq 3 ]]; then
     _harness_complete_changeset_ids active
+    return 0
+  fi
+
+  if [[ "$command" == "changes" && "$subcommand" == "continue" && $COMP_CWORD -eq 4 ]]; then
+    COMPREPLY=( $(compgen -W "--uc --plan --preview --apply" -- "$current_word") )
     return 0
   fi
 

--- a/docs/runtime-shell-completion.md
+++ b/docs/runtime-shell-completion.md
@@ -38,6 +38,7 @@ autoload -Uz compinit && compinit
 | `harness changes show <TAB>` | ChangeSet IDs from `docs/changes/active/*.md` and `docs/changes/completed/*.md` |
 | `harness changes contents <TAB>` | ChangeSet IDs from `docs/changes/active/*.md` and `docs/changes/completed/*.md` |
 | `harness changes delete <TAB>` | Active ChangeSet IDs |
+| `harness changes continue <TAB>` | Active ChangeSet IDs |
 | `harness changes document-delta <TAB>` | Active ChangeSet IDs |
 | `harness contracts validate <TAB>` | ChangeSet IDs from active and completed ChangeSets |
 | `harness requirements-definition <TAB>` | Active ChangeSet IDs |

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -101,7 +101,7 @@ COMMAND_HELP: tuple[tuple[str, str], ...] = (
     ("help", "Show runtime help."),
     ("init", "Initialize repo-local agent context files."),
     ("agent-context", "Initialize repo-local agent context files."),
-    ("changes", "List, inspect, create, or delete ChangeSets."),
+    ("changes", "List, inspect, create, delete, or continue ChangeSets."),
     ("contracts", "Validate document handoff contracts."),
     ("completion", "Install shell completion."),
     ("requirements-definition", "Define requirements and create temp ChangeSet when needed."),
@@ -131,7 +131,7 @@ TOPIC_HELP: Mapping[str, str] = {
     "agent-context": "Usage: harness agent-context init [--description TEXT] [--force] [--llm|--no-llm]",
     "changes": (
         "Usage: harness changes list|active\n"
-        "       harness changes show|delete|contents <CHG-ID>\n"
+        "       harness changes show|delete|contents|continue <CHG-ID>\n"
         "       harness changes document-delta <CHG-ID> --uc UC-ID --summary TEXT --plan|--preview|--apply"
     ),
     "contracts": "Usage: harness contracts validate <CHG-ID> [--work-item ID] [--json]",
@@ -261,6 +261,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print the raw ChangeSet markdown file instead of the structured summary.",
     )
     changes_contents.set_defaults(func=changes_contents_command)
+    changes_continue = changes_subparsers.add_parser("continue")
+    changes_continue.add_argument("change_set_id")
+    changes_continue.add_argument(
+        "--uc",
+        default="",
+        help="Use a specific affected UC for the next UC-scoped stage.",
+    )
+    _add_mode_options(changes_continue)
+    changes_continue.set_defaults(func=changes_continue_command)
     changes_document_delta = changes_subparsers.add_parser("document-delta")
     changes_document_delta.add_argument("change_set_id")
     changes_document_delta.add_argument("--uc", required=True)
@@ -398,6 +407,11 @@ def _add_procedure_stage_parser(
     command.add_argument("--uc", default="")
     command.add_argument("--title", default="")
     command.add_argument("--idea", default="")
+    command.add_argument(
+        "--force",
+        action="store_true",
+        help="Rerun the stage even when the ChangeSet table marks it verified.",
+    )
     _add_mode_options(command)
     command.set_defaults(func=procedure_stage_command, procedure_stage_id=stage.stage_id)
 
@@ -507,6 +521,153 @@ def changes_contents_command(args: argparse.Namespace, repo_root: Path) -> str:
             raise ValueError(f"ChangeSet file not found: {path}")
         return absolute_path.read_text(encoding="utf-8").strip()
     return _format_change_set_contents(change_set)
+
+
+def changes_continue_command(args: argparse.Namespace, repo_root: Path) -> str:
+    mode = _selected_mode(args)
+    change_set = _load_change_set(repo_root, args.change_set_id)
+    decision = _decide_changes_continue_target(
+        repo_root,
+        change_set,
+        uc_override=args.uc.strip() or None,
+    )
+    if decision["blocked"]:
+        return f"BLOCKED: {decision['reason']}"
+
+    stage = procedure_stage(decision["stage_id"])
+    stage_args = argparse.Namespace(
+        procedure_stage_id=stage.stage_id,
+        change_set_id=change_set.change_set_id,
+        uc=decision["uc_id"] or "",
+        title="",
+        idea="",
+        force=decision["force"],
+        plan=mode == RunMode.PLAN,
+        preview=mode == RunMode.PREVIEW,
+        apply=mode == RunMode.APPLY,
+    )
+    header = [
+        f"Continue: {change_set.change_set_id}",
+        f"Target stage: {stage.stage_id}",
+        f"UC: {decision['uc_id'] or '-'}",
+        f"Reason: {decision['reason']}",
+    ]
+    result = procedure_stage_command(stage_args, repo_root)
+    return "\n".join([*header, result])
+
+
+def _decide_changes_continue_target(
+    repo_root: Path,
+    change_set: ChangeSet,
+    *,
+    uc_override: str | None,
+) -> dict[str, object]:
+    rows = _procedure_table_rows_for_change_set(repo_root, change_set.change_set_id)
+    rows_by_stage = {row.get("id", ""): row for row in rows}
+    blocked = _first_procedure_row_with_status(rows_by_stage, "blocked")
+    if blocked is not None:
+        stage_id = blocked.get("id", "")
+        notes = blocked.get("notes", "")
+        if stage_id == "use-case-definition" and _notes_require_requirements_rerun(notes):
+            requirements_row = rows_by_stage.get("requirements-definition")
+            if _stage_updated_after(requirements_row, blocked):
+                return {
+                    "stage_id": "use-case-definition",
+                    "uc_id": None,
+                    "force": True,
+                    "blocked": False,
+                    "reason": "requirements-definition was rerun after the upstream blocker",
+                }
+            return {
+                "stage_id": "requirements-definition",
+                "uc_id": None,
+                "force": True,
+                "blocked": False,
+                "reason": "use-case-definition is blocked by an upstream requirements decision",
+            }
+        return {
+            "stage_id": stage_id,
+            "uc_id": _continue_uc_for_stage(change_set, stage_id, uc_override),
+            "force": True,
+            "blocked": False,
+            "reason": f"{stage_id} is blocked and should be rerun",
+        }
+
+    for stage in PROCEDURE_STAGES:
+        row = rows_by_stage.get(stage.stage_id)
+        if row is None or row.get("status") != "verified":
+            uc_id = _continue_uc_for_stage(change_set, stage.stage_id, uc_override)
+            if stage.requires_uc and not uc_id:
+                return {
+                    "stage_id": stage.stage_id,
+                    "uc_id": None,
+                    "force": False,
+                    "blocked": True,
+                    "reason": f"{stage.stage_id} requires an affected UC or --uc",
+                }
+            return {
+                "stage_id": stage.stage_id,
+                "uc_id": uc_id,
+                "force": False,
+                "blocked": False,
+                "reason": f"{stage.stage_id} is the next incomplete stage",
+            }
+
+    return {
+        "stage_id": "",
+        "uc_id": None,
+        "force": False,
+        "blocked": True,
+        "reason": "all procedure stages are verified",
+    }
+
+
+def _first_procedure_row_with_status(
+    rows_by_stage: Mapping[str, dict[str, str]],
+    status: str,
+) -> dict[str, str] | None:
+    for stage in PROCEDURE_STAGES:
+        row = rows_by_stage.get(stage.stage_id)
+        if row is not None and row.get("status") == status:
+            return row
+    return None
+
+
+def _notes_require_requirements_rerun(notes: str) -> bool:
+    normalized = notes.lower()
+    return (
+        "requirements do not define" in normalized
+        or "upstream requirements decision" in normalized
+        or "requirements decision" in normalized
+        or "requirements omit" in normalized
+        or "requirements missing" in normalized
+    )
+
+
+def _stage_updated_after(
+    newer_row: dict[str, str] | None,
+    older_row: dict[str, str],
+) -> bool:
+    if newer_row is None:
+        return False
+    newer = newer_row.get("verified_at", "")
+    older = older_row.get("verified_at", "")
+    return bool(newer and older and newer > older)
+
+
+def _continue_uc_for_stage(
+    change_set: ChangeSet,
+    stage_id: str,
+    uc_override: str | None,
+) -> str | None:
+    stage = procedure_stage(stage_id)
+    if not stage.requires_uc:
+        return None
+    if uc_override:
+        return uc_override
+    if change_set.affected_use_cases:
+        return change_set.affected_use_cases[0].uc_id
+    return None
 
 
 def changes_document_delta_command(args: argparse.Namespace, repo_root: Path) -> str:
@@ -819,15 +980,16 @@ def procedure_stage_command(args: argparse.Namespace, repo_root: Path) -> str:
         )
         return _format_procedure_stage_verification(stage, passed, problems)
 
-    already_verified = _format_already_verified_procedure_stage(
-        repo_root,
-        change_set_path,
-        stage,
-        change_set_id=args.change_set_id,
-        uc_id=uc_id,
-    )
-    if already_verified:
-        return already_verified
+    if not getattr(args, "force", False):
+        already_verified = _format_already_verified_procedure_stage(
+            repo_root,
+            change_set_path,
+            stage,
+            change_set_id=args.change_set_id,
+            uc_id=uc_id,
+        )
+        if already_verified:
+            return already_verified
 
     if stage.stage_id in INTERACTIVE_GRILL_ME_STAGE_IDS:
         return _run_interactive_procedure_stage(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,4 +1,5 @@
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -596,6 +597,224 @@ def test_procedure_stage_preview_limits_to_selected_uc(tmp_path: Path, capsys) -
     assert exit_code == 0
     assert "Stage: event-storming" in output
     assert "Verification: passed" in output
+
+
+def test_changes_continue_routes_use_case_upstream_blocker_to_requirements(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    text = change_set_path.read_text(encoding="utf-8")
+    text = cli.update_changeset_stage_status(
+        text,
+        stage=cli.procedure_stage("requirements-definition"),
+        status="verified",
+        notes="existing requirements",
+    )
+    text = cli.update_changeset_stage_status(
+        text,
+        stage=cli.procedure_stage("use-case-definition"),
+        status="blocked",
+        notes="Requirements do not define what approval saves.",
+    )
+    change_set_path.write_text(text, encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_procedure_stage_command(args, _repo_root):
+        captured["stage"] = args.procedure_stage_id
+        captured["force"] = args.force
+        captured["apply"] = args.apply
+        return "stage command called"
+
+    monkeypatch.setattr(cli, "procedure_stage_command", fake_procedure_stage_command)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "continue",
+            "CHG-001",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Target stage: requirements-definition" in output
+    assert "upstream requirements decision" in output
+    assert captured == {
+        "stage": "requirements-definition",
+        "force": True,
+        "apply": True,
+    }
+
+
+def test_changes_continue_retries_use_case_after_requirements_rerun(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    text = change_set_path.read_text(encoding="utf-8")
+    text = cli.update_changeset_stage_status(
+        text,
+        stage=cli.procedure_stage("requirements-definition"),
+        status="verified",
+        notes="updated requirements decision",
+    )
+    text = cli.update_changeset_stage_status(
+        text,
+        stage=cli.procedure_stage("use-case-definition"),
+        status="blocked",
+        notes="Requirements do not define what approval saves.",
+    )
+    text = re.sub(
+        r"\|requirements-definition\|Requirements Definition\|verified\|[^|]+\|",
+        "|requirements-definition|Requirements Definition|verified|2026-01-02T00:00:00Z|",
+        text,
+    )
+    text = re.sub(
+        r"\|use-case-definition\|Use Case Definition\|blocked\|[^|]+\|",
+        "|use-case-definition|Use Case Definition|blocked|2026-01-01T00:00:00Z|",
+        text,
+    )
+    change_set_path.write_text(text, encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_procedure_stage_command(args, _repo_root):
+        captured["stage"] = args.procedure_stage_id
+        captured["force"] = args.force
+        return "stage command called"
+
+    monkeypatch.setattr(cli, "procedure_stage_command", fake_procedure_stage_command)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "continue",
+            "CHG-001",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Target stage: use-case-definition" in output
+    assert "requirements-definition was rerun" in output
+    assert captured == {
+        "stage": "use-case-definition",
+        "force": True,
+    }
+
+
+def test_changes_continue_runs_next_incomplete_stage(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    text = cli.update_changeset_stage_status(
+        change_set_path.read_text(encoding="utf-8"),
+        stage=cli.procedure_stage("requirements-definition"),
+        status="verified",
+        notes="existing requirements",
+    )
+    change_set_path.write_text(text, encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_procedure_stage_command(args, _repo_root):
+        captured["stage"] = args.procedure_stage_id
+        captured["force"] = args.force
+        captured["preview"] = args.preview
+        return "stage command called"
+
+    monkeypatch.setattr(cli, "procedure_stage_command", fake_procedure_stage_command)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "continue",
+            "CHG-001",
+            "--preview",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Target stage: ubiquitous-language-definition" in output
+    assert "next incomplete stage" in output
+    assert captured == {
+        "stage": "ubiquitous-language-definition",
+        "force": False,
+        "preview": True,
+    }
+
+
+def test_changes_continue_reruns_blocked_uc_scoped_stage(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    text = change_set_path.read_text(encoding="utf-8")
+    for stage_id in (
+        "requirements-definition",
+        "ubiquitous-language-definition",
+        "use-case-definition",
+    ):
+        text = cli.update_changeset_stage_status(
+            text,
+            stage=cli.procedure_stage(stage_id),
+            status="verified",
+            notes=f"{stage_id} complete",
+        )
+    text = cli.update_changeset_stage_status(
+        text,
+        stage=cli.procedure_stage("event-storming"),
+        status="blocked",
+        notes="event storming needs rerun",
+    )
+    change_set_path.write_text(text, encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_procedure_stage_command(args, _repo_root):
+        captured["stage"] = args.procedure_stage_id
+        captured["uc"] = args.uc
+        captured["force"] = args.force
+        return "stage command called"
+
+    monkeypatch.setattr(cli, "procedure_stage_command", fake_procedure_stage_command)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "continue",
+            "CHG-001",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Target stage: event-storming" in output
+    assert "UC: UC-001" in output
+    assert captured == {
+        "stage": "event-storming",
+        "uc": "UC-001",
+        "force": True,
+    }
 
 
 def test_interactive_grill_me_stages_use_shared_runner(


### PR DESCRIPTION
## 구현 의도
ChangeSet 상태를 보고 다음에 실행할 절차 스테이지를 자동으로 선택하는 `harness changes continue <CHG-ID>` 명령을 추가합니다. 사용자가 `requirements-definition`, `use-case-definition` 같은 개별 스테이지 명령을 직접 고르지 않아도 흐름을 재개할 수 있게 합니다.

## 구현 접근
`changes continue` 서브커맨드를 추가하고 ChangeSet의 Runtime Procedure State 행을 읽어 라우팅 대상을 결정합니다. 차단된 스테이지가 있으면 기본적으로 해당 스테이지를 `--force`로 재실행하고, `use-case-definition`이 요구사항 결정 누락으로 차단된 경우에는 `requirements-definition`으로 되돌립니다. 이후 요구사항 스테이지가 차단 시점보다 늦게 갱신되어 있으면 다시 `use-case-definition`을 재시도합니다. UC 범위 스테이지는 명시된 `--uc` 또는 첫 번째 영향 UC를 사용합니다. Bash/Zsh completion과 completion 문서도 새 명령에 맞춰 갱신했습니다.

## 검증 방법
- `./venv/bin/python3 -m pytest -q tests/test_cli_commands.py tests/runtime/test_shell_completion.py`
- `./venv/bin/python3 -m py_compile harness_codex/cli.py harness_codex/runtime/shell_completion.py`
- `./venv/bin/python3 -m harness_codex.cli help changes`로 `continue` 도움말 노출 확인

## 위험 및 롤백
라우팅 판단은 ChangeSet 절차 테이블의 상태와 timestamp에 의존하므로 오래된 수동 편집이 있으면 예상과 다른 스테이지가 선택될 수 있습니다. 문제가 생기면 이 변경을 되돌리고 기존 개별 스테이지 명령 실행 방식으로 복귀하면 됩니다.