### PR TITLE
[codex] changes continue 자동완성 수정

### DIFF
--- a/completions/_harness
+++ b/completions/_harness
@@ -60,7 +60,7 @@ _harness_stage_ids() {
 }
 
 _harness() {
-  local -a harness_commands changes_commands contracts_commands completion_commands completion_options agent_context_commands evolution_commands stages_commands artifacts_commands modes procedure_options ultrawork_options reset_scopes reset_options
+  local -a harness_commands changes_commands contracts_commands completion_commands completion_options agent_context_commands evolution_commands stages_commands artifacts_commands modes changes_continue_options procedure_options ultrawork_options reset_scopes reset_options
   harness_commands=(
     'help:Show runtime help'
     'init:Initialize agent context files'
@@ -125,6 +125,12 @@ _harness() {
     '--preview:show preview without side effects'
     '--apply:run and apply side effects'
   )
+  changes_continue_options=(
+    '--uc:use case id'
+    '--plan:show execution plan without side effects'
+    '--preview:show preview without side effects'
+    '--apply:run and apply side effects'
+  )
   procedure_options=(
     '--uc:use case id'
     '--title:change title'
@@ -162,7 +168,7 @@ _harness() {
       elif (( CURRENT == 4 )) && [[ "$words[3]" == (delete|continue|document-delta) ]]; then
         _harness_changeset_ids active
       elif (( CURRENT == 5 )) && [[ "$words[3]" == continue ]]; then
-        _describe 'mode' modes
+        _describe 'option' changes_continue_options
       fi
       ;;
     contracts)

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -227,6 +227,10 @@ words=(harness use-case-definition CHG-001 --)
 CURRENT=4
 PREFIX="--"
 _harness
+words=(harness changes continue CHG-001 --)
+CURRENT=5
+PREFIX="--"
+_harness
 """
 
     result = subprocess.run(
@@ -241,6 +245,7 @@ _harness
     assert "command:help:Show runtime help" in result.stdout
     assert "option:--uc:use case id" in result.stdout
     assert "--apply:run and apply side effects" in result.stdout
+    assert "option:--uc:use case id --plan:show execution plan without side effects --preview:show preview without side effects --apply:run and apply side effects" in result.stdout
     assert "--apply[run and apply side effects]" not in result.stdout
 
 


### PR DESCRIPTION
## 구현 의도

`harness changes continue` 명령에서 ChangeSet ID 뒤 옵션 자동완성이 누락된 문제를 수정합니다.

## 구현 접근

zsh completion의 `changes continue` 분기에 전용 옵션 목록을 추가해 `--uc`, `--plan`, `--preview`, `--apply`가 함께 제안되도록 했습니다. 기존 Bash completion과 CLI 인자 정의는 이미 해당 옵션을 지원하므로 zsh completion 스크립트만 동기화했습니다.

## 검증 방법

`./venv/bin/python3 -m pytest -q tests/runtime/test_shell_completion.py`

결과: 13개 테스트 통과. zsh completion 직접 호출로 `changes continue CHG-001 --` 입력 시 `--uc --plan --preview --apply`가 출력되는 것도 확인했습니다.

## 위험 및 롤백

위험은 낮습니다. zsh completion 후보 목록만 변경하며 런타임 실행 로직은 건드리지 않습니다. 문제 발생 시 이 커밋을 되돌리면 기존 completion 동작으로 복구됩니다.