### PR TITLE
[codex] ui-server 엔드포인트와 요청 로그 출력

### DIFF
--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -49,6 +49,36 @@ from harness_codex.runtime.harvest_ui import (
 from harness_codex.runtime.procedure_stages import render_initial_changeset
 
 
+_SERVER_ENDPOINTS: tuple[tuple[str, str, str], ...] = (
+    ("GET", "/", "dashboard"),
+    ("GET", "/dashboard", "dashboard"),
+    ("GET", "/assets/dashboard.css", "dashboard stylesheet"),
+    ("GET", "/assets/dashboard.js", "dashboard script"),
+    ("GET", "/api/endpoints", "endpoint discovery"),
+    ("GET", "/api/harvest", "harvest session state"),
+    ("GET", "/api/dashboard", "dashboard document state"),
+    ("GET", "/api/dashboard/change-sets/{change_set_id}/resume", "resume scoped ChangeSet"),
+    ("GET", "/api/dashboard/documents/{document_id}", "read dashboard document"),
+    ("POST", "/api/change-sets/requirements/start", "start requirements ChangeSet"),
+    ("POST", "/api/change-sets/requirements/answer", "answer requirements question"),
+    ("POST", "/api/requirements/start", "start requirements"),
+    ("POST", "/api/requirements/answer", "answer requirements"),
+    ("POST", "/api/use-cases/start", "start use-case generation"),
+    ("POST", "/api/use-cases/answer", "answer use-case question"),
+    ("POST", "/api/use-cases/complete", "complete use-case generation"),
+    ("POST", "/api/event-storming/start", "start event storming"),
+    ("POST", "/api/event-storming/advance", "advance event storming"),
+    ("POST", "/api/event-storming/answer", "answer event storming question"),
+    ("POST", "/api/ddd-architecture/start", "start DDD architecture"),
+    ("POST", "/api/ddd-architecture/restart", "restart DDD architecture"),
+    ("POST", "/api/ddd-architecture/advance", "advance DDD architecture"),
+    ("POST", "/api/ddd-architecture/rerun-step", "rerun DDD architecture step"),
+    ("POST", "/api/ddd-architecture/answer", "answer DDD architecture question"),
+    ("PUT", "/api/dashboard/documents/{document_id}", "save dashboard document"),
+    ("DELETE", "/api/dashboard/change-sets/{change_set_id}", "delete active ChangeSet"),
+)
+
+
 def _ui_server_pid_path(repo_root: Path) -> Path:
     return repo_root / ".harness" / "ui-server.pid"
 
@@ -88,6 +118,22 @@ def _create_http_server(
 
 def _exit_on_terminate(_signum: int, _frame: object) -> None:
     raise SystemExit(0)
+
+
+def _format_bind_url(host: str, port: int) -> str:
+    display_host = f"[{host}]" if ":" in host and not host.startswith("[") else host
+    return f"http://{display_host}:{port}"
+
+
+def _print_startup_log(repo_root: Path, host: str, port: int, *, restarted: bool) -> None:
+    base_url = _format_bind_url(host, port)
+    print(f"Harness UI server running at {base_url}", flush=True)
+    print(f"Repo root: {repo_root}", flush=True)
+    if restarted:
+        print("Restarted previous UI server for this repo.", flush=True)
+    print("Exposed endpoints:", flush=True)
+    for method, path, description in _SERVER_ENDPOINTS:
+        print(f"  {method:<6} {base_url}{path} - {description}", flush=True)
 
 
 def _suggest_change_set_id(repo_root: Path) -> str:
@@ -273,6 +319,7 @@ def run_ui_server(
 
     restart_pending = _terminate_previous_ui_server(root)
     server = _create_http_server(host, port, Handler, wait_for_restart=restart_pending)
+    _print_startup_log(root, host, port, restarted=restart_pending)
     pid_path = _ui_server_pid_path(root)
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
@@ -297,6 +344,17 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         path = self._path()
+        if path == "/api/endpoints":
+            self._write_json(
+                HTTPStatus.OK,
+                {
+                    "endpoints": [
+                        {"method": method, "path": endpoint_path, "description": description}
+                        for method, endpoint_path, description in _SERVER_ENDPOINTS
+                    ]
+                },
+            )
+            return
         if path == "/api/harvest":
             self._write_json(HTTPStatus.OK, load_harvest_ui(self.repo_root).as_dict())
             return
@@ -491,7 +549,8 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
         self._write_json(HTTPStatus.OK, result)
 
     def log_message(self, format: str, *args: object) -> None:
-        return
+        message = format % args
+        print(f"[{self.log_date_time_string()}] {self.address_string()} {message}", flush=True)
 
     def _path(self) -> str:
         return urlparse(self.path).path

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -759,7 +759,14 @@ def test_ui_server_serves_dashboard_and_edit_api(tmp_path: Path) -> None:
             assert "loadDashboard" in response.read().decode("utf-8")
         with urlopen(f"{base}/api/dashboard") as response:
             payload = json.loads(response.read().decode("utf-8"))
+        with urlopen(f"{base}/api/endpoints") as response:
+            endpoints_payload = json.loads(response.read().decode("utf-8"))
         assert payload["change_sets"][0]["id"] == "CHG-001"
+        assert {
+            "method": "GET",
+            "path": "/api/dashboard",
+            "description": "dashboard document state",
+        } in endpoints_payload["endpoints"]
         document_url = f"{base}/api/dashboard/documents/requirements%3ACHG-001"
         with urlopen(document_url) as response:
             loaded = json.loads(response.read().decode("utf-8"))
@@ -785,6 +792,60 @@ def test_ui_server_serves_dashboard_and_edit_api(tmp_path: Path) -> None:
         server.shutdown()
         thread.join()
         server.server_close()
+
+
+def test_run_ui_server_prints_bind_url_and_endpoint_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FakeServer:
+        def serve_forever(self) -> None:
+            return
+
+        def server_close(self) -> None:
+            return
+
+    monkeypatch.setattr(ui_server, "_terminate_previous_ui_server", lambda _root: True)
+    monkeypatch.setattr(
+        ui_server,
+        "_create_http_server",
+        lambda _host, _port, _handler, *, wait_for_restart: FakeServer(),
+    )
+
+    ui_server.run_ui_server(tmp_path, host="127.0.0.1", port=43210)
+
+    output = capsys.readouterr().out
+    assert "Harness UI server running at http://127.0.0.1:43210" in output
+    assert f"Repo root: {tmp_path.resolve()}" in output
+    assert "Restarted previous UI server for this repo." in output
+    assert "Exposed endpoints:" in output
+    assert "http://127.0.0.1:43210/api/endpoints - endpoint discovery" in output
+    assert "http://127.0.0.1:43210/api/dashboard - dashboard document state" in output
+    assert "http://127.0.0.1:43210/api/ddd-architecture/answer" in output
+
+
+def test_ui_server_logs_requests_to_stdout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class Handler(HarvestUiRequestHandler):
+        repo_root = tmp_path
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        with urlopen(f"{base}/api/dashboard") as response:
+            assert response.status == 200
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+    output = capsys.readouterr().out
+    assert '"GET /api/dashboard HTTP/1.1" 200 -' in output
 
 
 def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Path) -> None:


### PR DESCRIPTION
## 구현 의도
`harness ui-server` 실행 시 접근 가능한 엔드포인트를 바로 확인하고, 대시보드/API 요청 흐름을 서버 로그로 추적할 수 있게 합니다.

## 구현 방식
엔드포인트 메타데이터를 `_SERVER_ENDPOINTS`로 모아 시작 로그와 `GET /api/endpoints` 응답에서 재사용합니다. 서버 시작 후 바인드 URL, repo root, 엔드포인트 목록을 stdout에 출력하고, `BaseHTTPRequestHandler.log_message`를 복원해 요청별 timestamp, client, method/path/status를 stdout에 남깁니다.

## 검증 방법
- `./venv/bin/python3 -m py_compile harness_codex/runtime/ui_server.py tests/runtime/test_document_dashboard.py`
- `./venv/bin/python3 -m pytest tests/runtime/test_document_dashboard.py tests/runtime/test_ui_server_restart.py -q -s`
- 결과: `29 passed`

## 위험 및 롤백
요청 로그가 stdout에 추가되어 서버 실행 콘솔 출력이 늘어납니다. 문제가 있으면 `log_message` override와 시작 로그 호출, `/api/endpoints` 추가를 되돌리면 기존 무로그 동작으로 복구됩니다.