### PR TITLE
[codex] 업데이트 후 셸 자동완성 설치 보강

### DIFF
--- a/completions/_harness
+++ b/completions/_harness
@@ -10,7 +10,7 @@
 _harness_changeset_ids() {
   local scope="${1:-all}"
   local -a candidates
-  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion change-set --repo-root . --prefix "$PREFIX" --scope "$scope" --format zsh 2>/dev/null)}")
+  candidates=("${(@f)$(_harness_completion_command change-set --prefix "$PREFIX" --scope "$scope" --format zsh)}")
   if (( ${#candidates[@]} )); then
     _describe 'ChangeSet' candidates
   fi
@@ -19,7 +19,7 @@ _harness_changeset_ids() {
 _harness_use_case_ids() {
   local change_set_id="$1"
   local -a candidates
-  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion use-case "$change_set_id" --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  candidates=("${(@f)$(_harness_completion_command use-case "$change_set_id" --prefix "$PREFIX" --format zsh)}")
   if (( ${#candidates[@]} )); then
     _describe 'use case' candidates
   fi
@@ -27,7 +27,7 @@ _harness_use_case_ids() {
 
 _harness_use_case_dirs() {
   local -a candidates
-  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion use-case-directory --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  candidates=("${(@f)$(_harness_completion_command use-case-directory --prefix "$PREFIX" --format zsh)}")
   if (( ${#candidates[@]} )); then
     _describe 'use case' candidates
   fi
@@ -36,7 +36,7 @@ _harness_use_case_dirs() {
 _harness_work_item_ids() {
   local change_set_id="$1"
   local -a candidates
-  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion work-item "$change_set_id" --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  candidates=("${(@f)$(_harness_completion_command work-item "$change_set_id" --prefix "$PREFIX" --format zsh)}")
   if (( ${#candidates[@]} )); then
     _describe 'work item' candidates
   fi
@@ -44,7 +44,7 @@ _harness_work_item_ids() {
 
 _harness_run_ids() {
   local -a candidates
-  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion run --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  candidates=("${(@f)$(_harness_completion_command run --prefix "$PREFIX" --format zsh)}")
   if (( ${#candidates[@]} )); then
     _describe 'run' candidates
   fi
@@ -53,10 +53,35 @@ _harness_run_ids() {
 _harness_stage_ids() {
   local change_set_id="$1"
   local -a candidates
-  candidates=("${(@f)$(python3 -m harness_codex.runtime.shell_completion stage "$change_set_id" --repo-root . --prefix "$PREFIX" --format zsh 2>/dev/null)}")
+  candidates=("${(@f)$(_harness_completion_command stage "$change_set_id" --prefix "$PREFIX" --format zsh)}")
   if (( ${#candidates[@]} )); then
     _describe 'stage' candidates
   fi
+}
+
+_harness_repo_root() {
+  if [[ -n "${HARNESS_REPO_ROOT:-}" ]]; then
+    print -r -- "$HARNESS_REPO_ROOT"
+  else
+    print -r -- "."
+  fi
+}
+
+_harness_runtime_root() {
+  local repo_root="$(_harness_repo_root)"
+  if [[ -d "$repo_root/harness_codex" ]]; then
+    print -r -- "$repo_root"
+  elif [[ -d "./harness_codex" ]]; then
+    print -r -- "."
+  else
+    print -r -- "$repo_root"
+  fi
+}
+
+_harness_completion_command() {
+  local repo_root="$(_harness_repo_root)"
+  local runtime_root="$(_harness_runtime_root)"
+  PYTHONPATH="$runtime_root${PYTHONPATH:+:$PYTHONPATH}" python3 -m harness_codex.runtime.shell_completion "$@" --repo-root "$repo_root" 2>/dev/null
 }
 
 _harness() {

--- a/completions/harness.bash
+++ b/completions/harness.bash
@@ -9,7 +9,7 @@ _harness_complete_changeset_ids() {
   COMPREPLY=()
   while IFS= read -r candidate; do
     COMPREPLY+=("$candidate")
-  done < <(python3 -m harness_codex.runtime.shell_completion change-set --repo-root . --prefix "$current_word" --scope "$scope" --format bash 2>/dev/null)
+  done < <(_harness_completion_command change-set --prefix "$current_word" --scope "$scope" --format bash)
 }
 
 _harness_complete_use_case_ids() {
@@ -18,7 +18,7 @@ _harness_complete_use_case_ids() {
   COMPREPLY=()
   while IFS= read -r candidate; do
     COMPREPLY+=("$candidate")
-  done < <(python3 -m harness_codex.runtime.shell_completion use-case "$change_set_id" --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+  done < <(_harness_completion_command use-case "$change_set_id" --prefix "$current_word" --format bash)
 }
 
 _harness_complete_use_case_dirs() {
@@ -26,7 +26,7 @@ _harness_complete_use_case_dirs() {
   COMPREPLY=()
   while IFS= read -r candidate; do
     COMPREPLY+=("$candidate")
-  done < <(python3 -m harness_codex.runtime.shell_completion use-case-directory --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+  done < <(_harness_completion_command use-case-directory --prefix "$current_word" --format bash)
 }
 
 _harness_complete_work_item_ids() {
@@ -35,7 +35,7 @@ _harness_complete_work_item_ids() {
   COMPREPLY=()
   while IFS= read -r candidate; do
     COMPREPLY+=("$candidate")
-  done < <(python3 -m harness_codex.runtime.shell_completion work-item "$change_set_id" --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+  done < <(_harness_completion_command work-item "$change_set_id" --prefix "$current_word" --format bash)
 }
 
 _harness_complete_run_ids() {
@@ -43,7 +43,7 @@ _harness_complete_run_ids() {
   COMPREPLY=()
   while IFS= read -r candidate; do
     COMPREPLY+=("$candidate")
-  done < <(python3 -m harness_codex.runtime.shell_completion run --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+  done < <(_harness_completion_command run --prefix "$current_word" --format bash)
 }
 
 _harness_complete_stage_ids() {
@@ -52,7 +52,34 @@ _harness_complete_stage_ids() {
   COMPREPLY=()
   while IFS= read -r candidate; do
     COMPREPLY+=("$candidate")
-  done < <(python3 -m harness_codex.runtime.shell_completion stage "$change_set_id" --repo-root . --prefix "$current_word" --format bash 2>/dev/null)
+  done < <(_harness_completion_command stage "$change_set_id" --prefix "$current_word" --format bash)
+}
+
+_harness_repo_root() {
+  if [[ -n "${HARNESS_REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$HARNESS_REPO_ROOT"
+  else
+    printf '%s\n' "."
+  fi
+}
+
+_harness_runtime_root() {
+  local repo_root
+  repo_root="$(_harness_repo_root)"
+  if [[ -d "$repo_root/harness_codex" ]]; then
+    printf '%s\n' "$repo_root"
+  elif [[ -d "./harness_codex" ]]; then
+    printf '%s\n' "."
+  else
+    printf '%s\n' "$repo_root"
+  fi
+}
+
+_harness_completion_command() {
+  local repo_root runtime_root
+  repo_root="$(_harness_repo_root)"
+  runtime_root="$(_harness_runtime_root)"
+  PYTHONPATH="$runtime_root${PYTHONPATH:+:$PYTHONPATH}" python3 -m harness_codex.runtime.shell_completion "$@" --repo-root "$repo_root" 2>/dev/null
 }
 
 _harness_completion() {

--- a/docs/runtime-shell-completion.md
+++ b/docs/runtime-shell-completion.md
@@ -59,7 +59,7 @@ autoload -Uz compinit && compinit
 
 ## Lookup Root
 
-Completion reads from the current working directory. Start completion from the repository root so candidates match the target project.
+Completion reads from `HARNESS_REPO_ROOT` when it is set. Otherwise it reads from the current working directory. Set `HARNESS_REPO_ROOT=/path/to/project` when running a harness command from a different directory than the target project.
 
 ## Candidate Rules
 

--- a/docs/runtime-update-command.md
+++ b/docs/runtime-update-command.md
@@ -32,15 +32,17 @@ The workflow requires `contents: write` permission for `GITHUB_TOKEN`. If reposi
 
 ## Preservation policy
 
-`./harness update` refreshes runtime-managed files while preserving workflow-generated artifacts and project-local configuration.
+`./harness update` refreshes runtime-managed files while preserving workflow-generated artifacts and project-local configuration. After a successful update, it also installs the bundled shell completion for the detected shell so user-level completion stays aligned with the refreshed runtime.
 
 Update may replace:
 
 - `harness_codex/`
 - bundled `.harness/` runtime/workflow files
 - bundled `.codex/` agents and skills
+- `completions/`
 - `tests/runtime/`
 - `./harness`
+- user-level shell completion such as `~/.zfunc/_harness` or `~/.local/share/bash-completion/completions/harness`
 
 Update must preserve existing workflow outputs and local project state, including:
 

--- a/harness_codex/runtime/self_update.py
+++ b/harness_codex/runtime/self_update.py
@@ -7,9 +7,11 @@ import ast
 import shlex
 import subprocess
 from pathlib import Path
+from collections.abc import Callable, Sequence
 from typing import Protocol
 
 from harness_codex import __version__
+from harness_codex.runtime.shell_completion import CompletionInstallResult, install_completion
 
 DEFAULT_REPO = "https://github.com/omegafrog/harness-codex"
 DEFAULT_REF = "origin/main"
@@ -75,6 +77,7 @@ def run_self_update(
     args: argparse.Namespace,
     *,
     runner: Runner = subprocess.run,
+    completion_installer: Callable[[Path], Sequence[CompletionInstallResult]] = install_completion,
 ) -> str:
     version_before = _installed_runtime_version(repo_root)
     command = build_update_command(
@@ -108,11 +111,17 @@ def run_self_update(
             + (f":\n{output}" if output else f" with exit code {completed.returncode}")
         )
     version_after = _installed_runtime_version(repo_root)
+    completion_results = completion_installer(repo_root)
+    completion_lines = ["Installed shell completion:"]
+    for result in completion_results:
+        completion_lines.append(f"- {result.shell}: {result.source} -> {result.target}")
+        completion_lines.append(f"  {result.note}")
     return "\n".join(
         [
             warning,
             f"Runtime version: {version_before} -> {version_after}",
             output,
+            "\n".join(completion_lines),
             "harness-codex update completed.",
         ]
     ).strip()
@@ -181,7 +190,8 @@ def _warning(repo: str, ref: str) -> str:
         f"Update source: {source}\n"
         "Update will refresh runtime-managed files but preserves workflow-generated "
         "artifacts: .harness runs/sessions/state/ui, ChangeSets, work-item docs, plans, "
-        "harvested docs, and project-local config."
+        "harvested docs, and project-local config. After a successful installer run, "
+        "update installs shell completion for the detected shell."
     )
 
 

--- a/tests/runtime/test_self_update.py
+++ b/tests/runtime/test_self_update.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from harness_codex import __version__
 from harness_codex.runtime.self_update import build_update_command, run_self_update
+from harness_codex.runtime.shell_completion import CompletionInstallResult
 
 
 def test_build_update_command_defaults_to_origin_main_download_ref(tmp_path: Path) -> None:
@@ -48,11 +49,13 @@ def test_run_self_update_dry_run_does_not_call_runner(tmp_path: Path) -> None:
     assert "Dry run. Command:" in output
     assert "--skip-venv" in output
     assert "preserves workflow-generated artifacts" in output
+    assert "update installs shell completion for the detected shell" in output
     assert f"Installed runtime version: {__version__}" in output
 
 
 def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
     calls = []
+    completion_calls = []
     runtime_package = tmp_path / "harness_codex"
     runtime_package.mkdir()
     (runtime_package / "__init__.py").write_text('__version__ = "0.1.0"\n', encoding="utf-8")
@@ -61,6 +64,17 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
         calls.append((args, kwargs))
         (runtime_package / "__init__.py").write_text('__version__ = "0.1.1"\n', encoding="utf-8")
         return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="installed", stderr="")
+
+    def completion_installer(repo_root: Path):
+        completion_calls.append(repo_root)
+        return (
+            CompletionInstallResult(
+                shell="zsh",
+                source=repo_root / "completions" / "_harness",
+                target=tmp_path / "home" / ".zfunc" / "_harness",
+                note="reload zsh completion",
+            ),
+        )
 
     output = run_self_update(
         tmp_path,
@@ -71,9 +85,11 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
             dry_run=False,
         ),
         runner=runner,
+        completion_installer=completion_installer,
     )
 
     assert calls
+    assert completion_calls == [tmp_path]
     command = calls[0][0][0]
     assert "--force" in command
     assert f"--target {tmp_path}" in command
@@ -81,6 +97,8 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
     assert calls[0][1]["cwd"] == tmp_path
     assert calls[0][1]["shell"] is True
     assert "Runtime version: 0.1.0 -> 0.1.1" in output
+    assert "Installed shell completion:" in output
+    assert "reload zsh completion" in output
     assert output.endswith("harness-codex update completed.")
 
 

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -247,6 +248,64 @@ _harness
     assert "--apply:run and apply side effects" in result.stdout
     assert "option:--uc:use case id --plan:show execution plan without side effects --preview:show preview without side effects --apply:run and apply side effects" in result.stdout
     assert "--apply[run and apply side effects]" not in result.stdout
+
+
+def test_bash_completion_uses_harness_repo_root_env(tmp_path: Path):
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-20260522-001.md").write_text(CHANGESET_A, encoding="utf-8")
+
+    script = """
+source completions/harness.bash
+COMP_WORDS=(harness changes continue "")
+COMP_CWORD=3
+_harness_completion
+printf '%s\n' "${COMPREPLY[@]}"
+"""
+
+    result = subprocess.run(
+        ["bash", "-lc", script],
+        check=False,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "HARNESS_REPO_ROOT": str(tmp_path)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "CHG-20260522-001" in result.stdout
+
+
+def test_zsh_completion_uses_harness_repo_root_env(tmp_path: Path):
+    if shutil.which("zsh") is None:
+        return
+
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-20260522-001.md").write_text(CHANGESET_A, encoding="utf-8")
+
+    script = """
+source completions/_harness
+_describe() {
+  local label="$1"
+  local array_name="$2"
+  print -- "${label}:${(P)array_name[*]}"
+}
+words=(harness changes continue "")
+CURRENT=4
+PREFIX=""
+_harness
+"""
+
+    result = subprocess.run(
+        ["zsh", "-fc", script],
+        check=False,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "HARNESS_REPO_ROOT": str(tmp_path)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "CHG-20260522-001:active - Add note analysis" in result.stdout
 
 
 def test_shell_completion_cli_change_set_parser_accepts_scope(tmp_path: Path, capsys):


### PR DESCRIPTION
## 구현 의도 (Implementation intent)

`harness changes continue` 자동완성이 대상 프로젝트의 활성 ChangeSet을 안정적으로 찾도록 수정합니다. 또한 `harness update` 이후 사용자 셸 자동완성 파일도 같이 갱신되도록 해, 업데이트와 자동완성 설치가 분리되어 생기는 버전 불일치를 줄입니다.

## 구현 방식 (Implementation approach)

Bash/Zsh completion 스크립트가 `HARNESS_REPO_ROOT`를 우선 사용하고, 없으면 현재 디렉터리를 사용하도록 변경했습니다. completion 후보 조회는 런타임 패키지가 있는 경로를 `PYTHONPATH`에 넣어 실행하므로, harness 소스 디렉터리에서 zeten 같은 외부 repo-root를 대상으로 자동완성해도 활성 ChangeSet을 읽을 수 있습니다.

`run_self_update`는 설치 스크립트가 성공한 뒤 `install_completion(repo_root)`를 호출합니다. dry-run 안내와 업데이트 문서에는 업데이트 후 자동완성 설치가 포함된다는 내용을 추가했습니다.

## 검증 방법 (Verification method)

- `./venv/bin/python3 -m pytest -q -s tests/runtime/test_self_update.py tests/runtime/test_shell_completion.py`
- `./venv/bin/python3 -m py_compile harness_codex/runtime/self_update.py tests/runtime/test_self_update.py tests/runtime/test_shell_completion.py`
- `HARNESS_REPO_ROOT=/home/jiwoo/workspace/zeten` 환경에서 installed Zsh completion이 `CHG-20260608-001`을 반환하는지 확인했습니다.
- `/home/jiwoo/workspace/zeten/harness update --dry-run --skip-venv` 출력에 자동완성 설치 안내가 포함되는지 확인했습니다.

## 위험 및 롤백 (Risks and rollback)

위험은 completion 스크립트가 `HARNESS_REPO_ROOT`가 잘못 지정된 경우 다른 프로젝트의 후보를 보여줄 수 있다는 점입니다. 환경 변수를 unset하면 기존처럼 현재 디렉터리 기준으로 동작합니다. 문제 발생 시 이 커밋을 되돌리고 `./harness completion install --shell zsh` 또는 `--shell bash`를 수동 실행하면 이전 흐름으로 복구할 수 있습니다.
