### PR TITLE
[codex] 유스케이스 단계 빠른 차단 및 단일 UC 범위 지원

### DIFF
--- a/.codex/agents/references/harness_usecases.md
+++ b/.codex/agents/references/harness_usecases.md
@@ -40,6 +40,7 @@ Readiness:
 - Write or update the current use-case draft before asking questions.
 - Ask up to three focused Grill-Me questions when blocking ambiguity must be resolved before use-case documents can be correct.
 - Include `Recommended answer:` with every blocking question.
+- When runtime metadata includes `target_uc` or `uc_id` for `use-case-definition`, keep `docs/design/유스케이스.md` coherent but write or update only that matching `docs/use-cases/<UC-ID>/use-case.md` and `docs/use-cases/<UC-ID>/e2e-goal.md` slice. Preserve other use-case slice directories.
 - Foundational Technical Decisions may remain unresolved if actor goals, business policies, and language are clear.
 
 Ubiquitous language rules:
@@ -69,6 +70,7 @@ Use case rules:
 Runtime slice rules:
 - Every use case listed in docs/design/유스케이스.md must have a matching docs/use-cases/<UC-ID>/ directory.
 - Every docs/use-cases/<UC-ID>/ directory must contain use-case.md and e2e-goal.md.
+- In target-UC mode, the same slice-document rules apply only to the requested UC ID.
 - use-case.md must contain exactly one detailed use case for the same UC ID.
 - e2e-goal.md must define a concrete E2E goal using Given/When/Then sections for the same UC ID.
 - If a use case is not fully confirmed, still create the slice docs and mark blocked details as Needs confirmation.

--- a/.codex/skills/harness-usecases/references/detailed-instructions.md
+++ b/.codex/skills/harness-usecases/references/detailed-instructions.md
@@ -156,6 +156,7 @@ Rules:
    For every canonical use case, write or update:
    - `docs/use-cases/<UC-ID>/use-case.md`
    - `docs/use-cases/<UC-ID>/e2e-goal.md`
+   If runtime metadata includes `target_uc` or `uc_id`, write or update only that matching runtime slice while keeping `docs/design/유스케이스.md` coherent and preserving other slice directories.
 
 8. **Confirm completion**
    If any use case still has multiple goals, mixed command/policy wording, multi-meaning event-storming candidates, non-canonical language, or Forbidden Terms, mark it as `Needs confirmation`.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -69,6 +69,7 @@ from harness_codex.runtime.procedure_stages import (
     procedure_stage,
     render_initial_changeset,
     replace_stage_placeholders,
+    stage_outputs_for_run,
     update_changeset_stage_status,
     verify_procedure_stage,
 )
@@ -1015,6 +1016,14 @@ def procedure_stage_command(args: argparse.Namespace, repo_root: Path) -> str:
             "idea": args.idea,
         },
     )
+    step_metadata: dict[str, object] = {"procedure_stage": stage.stage_id}
+    if stage.stage_id == "use-case-definition" and uc_id:
+        step_metadata["target_uc"] = uc_id
+        step_metadata["slice_outputs"] = {
+            "root": "docs/use-cases",
+            "required_per_use_case": ["use-case.md", "e2e-goal.md"],
+        }
+
     step = Step(
         id=stage.stage_id,
         kind=StepKind.AGENT,
@@ -1026,13 +1035,13 @@ def procedure_stage_command(args: argparse.Namespace, repo_root: Path) -> str:
             change_set_id=args.change_set_id,
             uc_id=uc_id,
         ),
-        outputs=replace_stage_placeholders(
-            stage.outputs,
+        outputs=stage_outputs_for_run(
+            stage,
             change_set_id=args.change_set_id,
             uc_id=uc_id,
         ),
         timeout_sec=3600,
-        metadata={"procedure_stage": stage.stage_id},
+        metadata=step_metadata,
     )
     result = BasicStepRunner().run(step, context)
     passed, problems = verify_procedure_stage(
@@ -2031,8 +2040,8 @@ def _format_procedure_stage_plan(
         change_set_id=change_set_id,
         uc_id=uc_id,
     )
-    outputs = replace_stage_placeholders(
-        stage.outputs,
+    outputs = stage_outputs_for_run(
+        stage,
         change_set_id=change_set_id,
         uc_id=uc_id,
     )

--- a/harness_codex/runtime/procedure_stages.py
+++ b/harness_codex/runtime/procedure_stages.py
@@ -164,6 +164,25 @@ def replace_stage_placeholders(
     )
 
 
+def stage_outputs_for_run(
+    stage: ProcedureStage,
+    *,
+    change_set_id: str,
+    uc_id: str | None = None,
+) -> tuple[Path, ...]:
+    if stage.stage_id == "use-case-definition" and uc_id:
+        return (
+            Path("docs/design/유스케이스.md"),
+            Path("docs/use-cases") / uc_id / "use-case.md",
+            Path("docs/use-cases") / uc_id / "e2e-goal.md",
+        )
+    return replace_stage_placeholders(
+        stage.outputs,
+        change_set_id=change_set_id,
+        uc_id=uc_id,
+    )
+
+
 def verify_procedure_stage(
     repo_root: Path,
     stage: ProcedureStage,
@@ -175,8 +194,8 @@ def verify_procedure_stage(
         return False, (f"{stage.stage_id} requires --uc",)
 
     problems: list[str] = []
-    outputs = replace_stage_placeholders(
-        stage.outputs,
+    outputs = stage_outputs_for_run(
+        stage,
         change_set_id=change_set_id,
         uc_id=uc_id,
     )

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -300,6 +300,10 @@ class BasicStepRunner:
                 f"missing agent config: {_relative_to_repo(agent_config_path, context)}",
             )
 
+        input_preflight_error = _agent_input_preflight(step, context, step_dir)
+        if input_preflight_error is not None:
+            return _blocked_agent_result(step, context, step_dir, input_preflight_error)
+
         agent_config = _load_agent_config(agent_config_path)
         preflight_error = _implementation_environment_preflight(step, context, step_dir, agent_config)
         if preflight_error is not None:
@@ -992,6 +996,29 @@ def _implementation_environment_preflight(
     return "implementation environment preflight failed: " + " ".join(problems)
 
 
+def _agent_input_preflight(step: Step, context: RunContext, step_dir: Path) -> str | None:
+    missing = [
+        str(path)
+        for path in step.inputs
+        if not (context.repo_root / path).exists()
+    ]
+    payload = {
+        "step_id": step.id,
+        "agent_id": step.agent_id,
+        "status": "blocked" if missing else "passed",
+        "missing_inputs": missing,
+    }
+    preflight_path = step_dir / "input-preflight.json"
+    preflight_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    if not missing:
+        return None
+    return "agent input preflight failed: missing inputs: " + ", ".join(missing)
+
+
 def _validate_agent_outputs(step: Step, context: RunContext) -> str | None:
     missing: list[str] = []
     for output in step.outputs:
@@ -1011,8 +1038,7 @@ def _validate_agent_outputs(step: Step, context: RunContext) -> str | None:
     if not isinstance(required_value, Sequence) or isinstance(required_value, (str, bytes)):
         return None
 
-    slice_root = context.repo_root / root_value
-    uc_dirs = sorted(path for path in slice_root.glob("UC-*") if path.is_dir())
+    uc_dirs = _slice_output_dirs(context.repo_root / root_value, step, context)
     if not uc_dirs:
         return f"missing required use-case slices under {root_value}"
 
@@ -1026,6 +1052,25 @@ def _validate_agent_outputs(step: Step, context: RunContext) -> str | None:
                 missing_slice_files.append(str(target.relative_to(context.repo_root)))
     if missing_slice_files:
         return "missing required use-case slice outputs: " + ", ".join(missing_slice_files)
+    return None
+
+
+def _slice_output_dirs(slice_root: Path, step: Step, context: RunContext) -> list[Path]:
+    target_uc = _target_use_case_id(step, context)
+    if target_uc:
+        return [slice_root / target_uc]
+    return sorted(path for path in slice_root.glob("UC-*") if path.is_dir())
+
+
+def _target_use_case_id(step: Step, context: RunContext) -> str | None:
+    for value in (
+        step.metadata.get("target_uc"),
+        step.metadata.get("uc_id"),
+        context.metadata.get("target_uc"),
+        context.metadata.get("uc_id"),
+    ):
+        if isinstance(value, str) and value.startswith("UC-"):
+            return value
     return None
 
 

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -390,6 +390,9 @@ def test_basic_step_runner_invokes_agent_adapter_and_writes_result(
     tmp_path: Path,
 ) -> None:
     write_agent_config(tmp_path)
+    change_set = tmp_path / "docs/changes/active/CHG-001.md"
+    change_set.parent.mkdir(parents=True)
+    change_set.write_text("# ChangeSet CHG-001\n", encoding="utf-8")
     fake_adapter = FakeAgentAdapter()
     runner = BasicStepRunner(agent_adapter=fake_adapter)
     step = Step(
@@ -610,6 +613,9 @@ def test_basic_step_runner_blocks_unsupported_decision_step(tmp_path: Path) -> N
 def test_basic_step_runner_records_skill_invocation_manifest(tmp_path: Path) -> None:
     write_agent_config(tmp_path)
     write_skill(tmp_path)
+    change_set = tmp_path / "docs/changes/active/CHG-001.md"
+    change_set.parent.mkdir(parents=True)
+    change_set.write_text("# ChangeSet CHG-001\n", encoding="utf-8")
     fake_adapter = FakeAgentAdapter()
     runner = BasicStepRunner(agent_adapter=fake_adapter)
     step = Step(
@@ -960,6 +966,68 @@ def test_basic_step_runner_blocks_implementation_executor_on_gradle_workspace_sa
     )
     assert preflight["status"] == "blocked"
     assert preflight["gradlew_present"] is True
+
+
+def test_basic_step_runner_blocks_agent_with_missing_inputs_before_adapter(
+    tmp_path: Path,
+) -> None:
+    write_agent_config(tmp_path, agent_id="harness_usecases")
+    fake_adapter = FakeAgentAdapter()
+    runner = BasicStepRunner(agent_adapter=fake_adapter)
+    step = Step(
+        id="harvest-use-cases",
+        kind=StepKind.AGENT,
+        name="Harvest use cases",
+        agent_id="harness_usecases",
+        inputs=(Path("context.md"), Path("docs/design/요구사항.md")),
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "agent input preflight failed" in (result.error or "")
+    assert "context.md" in (result.error or "")
+    assert "docs/design/요구사항.md" in (result.error or "")
+    assert fake_adapter.requests == []
+    preflight = json.loads(
+        (tmp_path / ".harness/runs/run-001/steps/harvest-use-cases/input-preflight.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert preflight["status"] == "blocked"
+    assert preflight["missing_inputs"] == ["context.md", "docs/design/요구사항.md"]
+
+
+def test_basic_step_runner_validates_only_target_use_case_slice(
+    tmp_path: Path,
+) -> None:
+    write_agent_config(tmp_path, agent_id="harness_usecases")
+    (tmp_path / "docs/use-cases/UC-002").mkdir(parents=True)
+    fake_adapter = FakeAgentAdapter()
+    runner = BasicStepRunner(agent_adapter=fake_adapter)
+    step = Step(
+        id="use-case-definition",
+        kind=StepKind.AGENT,
+        name="Use Case Definition",
+        agent_id="harness_usecases",
+        outputs=(
+            Path("docs/design/유스케이스.md"),
+            Path("docs/use-cases/UC-001/use-case.md"),
+            Path("docs/use-cases/UC-001/e2e-goal.md"),
+        ),
+        metadata={
+            "target_uc": "UC-001",
+            "slice_outputs": {
+                "root": "docs/use-cases",
+                "required_per_use_case": ["use-case.md", "e2e-goal.md"],
+            },
+        },
+    )
+
+    result = runner.run(step, context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert len(fake_adapter.requests) == 1
 
 
 def test_basic_step_runner_allows_implementation_executor_with_full_access(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -623,6 +623,33 @@ def test_procedure_stage_plan_has_no_side_effects(tmp_path: Path, capsys) -> Non
     assert not (tmp_path / ".harness/runs").exists()
 
 
+def test_use_case_definition_plan_limits_outputs_to_selected_uc(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    write_changeset(tmp_path)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "use-case-definition",
+            "CHG-001",
+            "--uc",
+            "UC-001",
+            "--plan",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "docs/design/유스케이스.md" in output
+    assert "docs/use-cases/UC-001/use-case.md" in output
+    assert "docs/use-cases/UC-001/e2e-goal.md" in output
+    assert "- docs/use-cases\n" not in output
+    assert not (tmp_path / ".harness/runs").exists()
+
+
 def test_procedure_stage_preview_limits_to_selected_uc(tmp_path: Path, capsys) -> None:
     write_changeset(tmp_path)
 


### PR DESCRIPTION
## 구현 의도

유스케이스 단계가 필수 입력 누락 상태에서 중첩 `codex exec`까지 진입하지 않도록 빠르게 차단하고, `use-case-definition --uc <UC-ID>` 실행 시 전체 유스케이스 슬라이스 대신 선택한 UC 슬라이스만 검증하도록 개선합니다.

## 구현 접근

- 에이전트 실행 전에 선언된 입력 파일 존재 여부를 검사하는 입력 프리플라이트를 추가했습니다. 누락 입력은 `.harness/runs/.../input-preflight.json`에 기록하고 어댑터 호출 없이 BLOCKED 결과를 반환합니다.
- `use-case-definition` 단계에 `--uc`가 전달되면 출력 범위를 `docs/design/유스케이스.md`, `docs/use-cases/<UC-ID>/use-case.md`, `docs/use-cases/<UC-ID>/e2e-goal.md`로 좁히도록 절차 단계 출력 계산을 분리했습니다.
- 런타임 출력 검증은 `target_uc`/`uc_id` 메타데이터가 있으면 해당 UC 디렉터리만 확인하고, 유스케이스 에이전트 지침에도 target UC 모드를 명시했습니다.
- 입력 프리플라이트와 target UC 검증 동작을 테스트로 고정했습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q tests/runtime/test_agent_runner.py::test_basic_step_runner_blocks_agent_with_missing_inputs_before_adapter tests/runtime/test_agent_runner.py::test_basic_step_runner_validates_only_target_use_case_slice tests/test_cli_commands.py::test_use_case_definition_plan_limits_outputs_to_selected_uc`
- `./venv/bin/python3 -m pytest -q tests/runtime/test_agent_runner.py tests/test_cli_commands.py`
- `./venv/bin/python3 -m py_compile harness_codex/runtime/runner.py harness_codex/runtime/procedure_stages.py harness_codex/cli.py tests/runtime/test_agent_runner.py tests/test_cli_commands.py`
- 참고: 전체 `./venv/bin/python3 -m pytest -q`는 기존 dashboard 문서 테스트 `tests/runtime/test_document_dashboard.py::test_completed_change_set_documents_are_not_editable` 1건 실패, 이번 변경 파일과 무관합니다.

## 위험 및 롤백

위험은 기존 전체 유스케이스 생성 흐름과 `--uc` 범위 실행의 의미가 달라지는 부분입니다. 문제가 생기면 입력 프리플라이트 호출과 `stage_outputs_for_run` 적용을 되돌리면 기존 동작으로 복구됩니다.