### PR TITLE
[codex] 임시 ChangeSet 확정 추적성 보강

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -49,6 +49,7 @@ from harness_codex.runtime.changes import (
     PlanningBlocked,
     create_changeset_from_design,
 )
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
 from harness_codex.runtime.contracts import contract_dashboard_projection_json
 from harness_codex.runtime.contract_validators import (
     contract_results_to_json,
@@ -1187,8 +1188,13 @@ def _finalize_temporary_changeset(
         return None
 
     old_text = old_absolute.read_text(encoding="utf-8")
-    final_title = _title_from_design(repo_root) or change_set_id
+    final_title = _final_changeset_title(repo_root, old_text, old_id=change_set_id)
     final_id = _suggest_next_change_set_id(repo_root)
+    retargeted_old_text = _retarget_changeset_references(
+        old_text,
+        old_id=change_set_id,
+        final_id=final_id,
+    )
     if include_design_use_cases and _design_docs_exist(repo_root):
         result = create_changeset_from_design(
             repo_root,
@@ -1200,7 +1206,7 @@ def _finalize_temporary_changeset(
         final_absolute = repo_root / final_path
         final_text = final_absolute.read_text(encoding="utf-8")
         final_absolute.write_text(
-            _append_runtime_procedure_state(final_text, old_text),
+            _append_runtime_procedure_state(final_text, retargeted_old_text),
             encoding="utf-8",
         )
     else:
@@ -1208,7 +1214,7 @@ def _finalize_temporary_changeset(
         final_absolute = repo_root / final_path
         final_absolute.write_text(
             _rewrite_temporary_changeset_text(
-                old_text,
+                retargeted_old_text,
                 old_id=change_set_id,
                 final_id=final_id,
                 final_title=final_title,
@@ -1216,6 +1222,11 @@ def _finalize_temporary_changeset(
             encoding="utf-8",
         )
     old_absolute.unlink()
+    _retarget_design_doc_changeset_references(
+        repo_root,
+        old_id=change_set_id,
+        final_id=final_id,
+    )
     _retarget_run_state(repo_root, run_id=run_id, change_set_id=final_id)
     return final_id, final_path
 
@@ -1237,11 +1248,7 @@ def _rewrite_temporary_changeset_text(
         text,
         count=1,
     )
-    updated = updated.replace(
-        f"|ChangeSet ID|`{old_id}`|",
-        f"|ChangeSet ID|`{final_id}`|",
-        1,
-    )
+    updated = _retarget_changeset_references(updated, old_id=old_id, final_id=final_id)
     if final_title:
         updated = re.sub(
             r"(?m)^- Request summary: .*$",
@@ -1252,7 +1259,63 @@ def _rewrite_temporary_changeset_text(
     return updated
 
 
+def _retarget_changeset_references(text: str, *, old_id: str, final_id: str) -> str:
+    return text.replace(
+        f"docs/changes/active/{old_id}.md",
+        f"docs/changes/active/{final_id}.md",
+    ).replace(old_id, final_id)
+
+
+def _retarget_design_doc_changeset_references(
+    repo_root: Path,
+    *,
+    old_id: str,
+    final_id: str,
+) -> None:
+    for relative_path in (
+        Path("docs/design/요구사항.md"),
+        Path("docs/design/유스케이스.md"),
+        Path("context.md"),
+    ):
+        path = repo_root / relative_path
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        updated = _retarget_changeset_references(text, old_id=old_id, final_id=final_id)
+        if updated != text:
+            path.write_text(updated, encoding="utf-8")
+
+
+def _final_changeset_title(repo_root: Path, change_set_text: str, *, old_id: str) -> str:
+    for candidate in (
+        _title_from_design(repo_root),
+        _title_from_changeset_text(change_set_text, old_id=old_id),
+    ):
+        title = _normalize_changeset_title(candidate, old_id=old_id)
+        if title:
+            return title
+    return old_id
+
+
+def _title_from_changeset_text(text: str, *, old_id: str) -> str:
+    change_set = parse_changeset_markdown(text)
+    for candidate in (change_set.title, change_set.intent_summary):
+        title = _normalize_changeset_title(candidate, old_id=old_id)
+        if title:
+            return title
+    return ""
+
+
 def _title_from_design(repo_root: Path) -> str:
+    preferred_labels = (
+        "Initial idea",
+        "Change title",
+        "MVP use case",
+        "Goal",
+        "User-visible success condition",
+        "Request summary",
+    )
+    fallback = ""
     for relative_path in (Path("docs/design/요구사항.md"), Path("docs/design/유스케이스.md")):
         path = repo_root / relative_path
         if not path.exists():
@@ -1264,9 +1327,31 @@ def _title_from_design(repo_root: Path) -> str:
             if stripped.startswith(("-", "*")):
                 stripped = stripped.lstrip("-* ").strip()
             if ":" in stripped:
-                stripped = stripped.split(":", maxsplit=1)[1].strip()
-            return stripped.rstrip(".")
-    return ""
+                label, value = stripped.split(":", maxsplit=1)
+                if label.strip() in preferred_labels:
+                    return value.strip().rstrip(".")
+                fallback = fallback or value.strip().rstrip(".")
+                continue
+            fallback = fallback or stripped.rstrip(".")
+    return fallback
+
+
+def _normalize_changeset_title(value: str, *, old_id: str) -> str:
+    title = (value or "").strip().strip("`").rstrip(".")
+    if not title:
+        return ""
+    if title in {
+        old_id,
+        f"ChangeSet {old_id}",
+        f"Temporary ChangeSet {old_id}",
+        "temporary",
+        "Temporary",
+        "-",
+    }:
+        return ""
+    if title.startswith("CHG-TEMP-"):
+        return ""
+    return title
 
 
 def _append_runtime_procedure_state(final_text: str, old_text: str) -> str:

--- a/harness_codex/runtime/changes/parser.py
+++ b/harness_codex/runtime/changes/parser.py
@@ -140,9 +140,15 @@ def _first_heading(text: str) -> str:
 
 
 def _human_title(title: str, change_set_id: str, intent_summary: str) -> str:
-    if title in {change_set_id, f"ChangeSet {change_set_id}"}:
-        return intent_summary or title
-    return title
+    if title in {
+        change_set_id,
+        f"ChangeSet {change_set_id}",
+        "temporary",
+        "Temporary",
+        "-",
+    } or title.startswith("CHG-TEMP-"):
+        return (intent_summary or title).rstrip(".")
+    return title.rstrip(".")
 
 
 def _sections(text: str) -> dict[str, str]:

--- a/tests/runtime/test_shell_completion.py
+++ b/tests/runtime/test_shell_completion.py
@@ -61,6 +61,20 @@ CHANGESET_B = """# Improve runtime completion
 | Before B | After B |
 """
 
+CHANGESET_FINALIZED_FROM_TEMP = """# CHG-TEMP-20260522-001
+
+## 1. Metadata
+
+| Item | Value |
+|---|---|
+| ChangeSet ID | `CHG-20260522-003` |
+| Status | active |
+
+## 2. Implementation Intent
+
+- Request summary: Build an AI-assisted Zettelkasten note-writing service.
+"""
+
 
 def test_change_set_candidates_returns_active_changeset_ids_and_titles(tmp_path: Path):
     active_dir = tmp_path / "docs/changes/active"
@@ -135,6 +149,29 @@ def test_change_set_candidates_include_completed_status_and_title(tmp_path: Path
             "CHG-20260522-002",
             "completed - Improve runtime completion (CHG-20260522-002)",
         ),
+    ]
+
+
+def test_change_set_candidates_use_meaningful_name_when_heading_is_stale_temp(
+    tmp_path: Path,
+) -> None:
+    active_dir = tmp_path / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / "CHG-20260522-003.md").write_text(
+        CHANGESET_FINALIZED_FROM_TEMP,
+        encoding="utf-8",
+    )
+
+    candidates = change_set_candidates(tmp_path, scope="active")
+
+    assert [(item.value, item.description) for item in candidates] == [
+        (
+            "CHG-20260522-003",
+            (
+                "active - Build an AI-assisted Zettelkasten note-writing service "
+                "(CHG-20260522-003)"
+            ),
+        )
     ]
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -494,7 +494,14 @@ def test_requirements_definition_finalizes_temporary_changeset_without_id(
         design_dir = tmp_path / "docs/design"
         design_dir.mkdir(parents=True, exist_ok=True)
         (design_dir / "요구사항.md").write_text(
-            "# Requirements\n\n- Initial idea: simple calculator app.\n",
+            "---\n"
+            "change_set_id: CHG-TEMP-20260507-001\n"
+            "doc_id: \"CHG-TEMP-20260507-001:requirements\"\n"
+            "source_docs:\n"
+            "  - docs/changes/active/CHG-TEMP-20260507-001.md\n"
+            "---\n"
+            "# Requirements\n\n"
+            "- Initial idea: simple calculator app.\n",
             encoding="utf-8",
         )
         return _complete_stage_json()
@@ -527,6 +534,57 @@ def test_requirements_definition_finalizes_temporary_changeset_without_id(
     assert "|ChangeSet ID|`CHG-20260507-001`|" in final_text
     assert "- Request summary: simple calculator app" in final_text
     assert "|requirements-definition|Requirements Definition|verified|" in final_text
+    assert "CHG-TEMP-20260507-001" not in final_text
+    requirements_text = (tmp_path / "docs/design/요구사항.md").read_text(
+        encoding="utf-8"
+    )
+    assert "change_set_id: CHG-20260507-001" in requirements_text
+    assert "doc_id: \"CHG-20260507-001:requirements\"" in requirements_text
+    assert "docs/changes/active/CHG-20260507-001.md" in requirements_text
+    assert "CHG-TEMP-20260507-001" not in requirements_text
+
+
+def test_requirements_definition_uses_requirements_title_when_temp_changeset_is_generic(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    def complete_requirements_stage(*_args) -> str:
+        design_dir = tmp_path / "docs/design"
+        design_dir.mkdir(parents=True, exist_ok=True)
+        (design_dir / "요구사항.md").write_text(
+            "# Requirements\n\n"
+            "- Initial idea: Build an AI-assisted Zettelkasten note-writing service.\n",
+            encoding="utf-8",
+        )
+        return _complete_stage_json()
+
+    monkeypatch.setattr(cli, "_exec_stage_grill_me_prompt", complete_requirements_stage)
+    monkeypatch.setattr(cli, "verify_procedure_stage", lambda *_, **__: (True, ()))
+    monkeypatch.setattr(cli, "datetime", FakeDateTime)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "requirements-definition",
+            "--idea",
+            "CHG-TEMP-20260507-001",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    final_path = tmp_path / "docs/changes/active/CHG-20260507-001.md"
+    final_text = final_path.read_text(encoding="utf-8")
+    assert exit_code == 0
+    assert "Finalized ChangeSet: CHG-TEMP-20260507-001 -> CHG-20260507-001" in output
+    assert "# Build an AI-assisted Zettelkasten note-writing service\n" in final_text
+    assert (
+        "- Request summary: Build an AI-assisted Zettelkasten note-writing service"
+        in final_text
+    )
+    assert "CHG-TEMP-20260507-001" not in final_text
 
 
 def test_requirements_definition_keeps_temporary_changeset_without_requirements_doc(
@@ -600,6 +658,7 @@ def test_use_case_definition_finalizes_temporary_changeset_from_design(
     assert "# simple calculator app\n" in final_text
     assert "|ChangeSet ID|`CHG-20260507-001`|" in final_text
     assert "|use-case-definition|Use Case Definition|verified|" in final_text
+    assert "CHG-TEMP-20260507-001" not in final_text
 
 
 def test_procedure_stage_plan_has_no_side_effects(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## 구현 의도

requirements-definition 완료 후 임시 ChangeSet을 실제 ChangeSet으로 확정할 때, ChangeSet ID뿐 아니라 사람이 읽을 수 있는 의미 있는 제목과 문서 추적성을 함께 확정한다.

## 구현 방식

- 임시 ChangeSet 확정 시 requirements/design 문서에서 `Initial idea`, `Change title`, `MVP use case`, `Goal` 등 의미 있는 값을 우선 추출해 최종 제목과 요청 요약으로 사용한다.
- `CHG-TEMP-*` 참조를 최종 `CHG-*` ID로 일괄 재지정해 ChangeSet 본문, requirements/design/context 문서의 추적성이 깨지지 않게 했다.
- ChangeSet 파서가 stale temp heading이나 generic heading을 만나면 `Request summary`를 표시 제목으로 사용하도록 보강했다.
- shell completion의 ChangeSet 후보 설명은 기존 parser title을 사용하므로, 모든 completion 표시에서 의미 있는 이름이 노출된다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py tests/runtime/test_shell_completion.py` → 55 passed
- `./venv/bin/python3 -m py_compile harness_codex/cli.py harness_codex/runtime/changes/parser.py`
- `git diff --check`
- `--repo-root /home/jiwoo/workspace/zeten`으로 requirements-definition을 직접 실행해 `CHG-TEMP-20260608-001`이 `CHG-20260608-002`로 확정되고 제목이 `Build an AI-assisted Zettelkasten note-writing service`로 변경되는 것을 확인했다.
- 같은 ChangeSet으로 ubiquitous-language-definition과 use-case-definition을 직접 실행했고, 세 단계 모두 `verified` 및 content review `complete`를 확인했다.
- `changes show CHG-20260608-002`, completion TSV/Zsh 출력에서 동일한 의미 기반 제목을 확인했다.
- 실제 Zsh completion 경로인 `changes show`, `changes contents`, `changes continue`, `contracts validate`, `use-case-definition`, `stages list`, `artifacts show` 모두 의미 기반 제목을 표시하는 것을 확인했다.
- 최종 ChangeSet, requirements, use-case, context 문서에서 `CHG-TEMP-20260608-001` 참조가 남지 않은 것을 확인했다.

## 위험 및 롤백

- 위험: 기존에 temp heading을 의도적으로 표시하던 ChangeSet은 completion 표시가 `Request summary` 중심으로 바뀐다.
- 롤백: 이 커밋을 revert하면 기존 temp 확정 및 completion 표시 동작으로 돌아간다.
