### PR TITLE
[codex] 유스케이스 실행 피드백 출력 추가

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -2564,7 +2564,17 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
     result_by_work_item = {}
     final_result = None
     final_scope = None
+    use_case_count = sum(scope.use_case is not None for scope in scopes)
+    use_case_index = 0
     for scope in scopes:
+        if scope.use_case is not None:
+            use_case_index += 1
+            print(
+                f"Use case execution start: "
+                f"{_use_case_execution_label(scope.use_case.uc_id, scope.use_case.name)} "
+                f"({use_case_index}/{use_case_count})",
+                flush=True,
+            )
         materialized_workflow = materialize_workflow_for_scope(workflow, change_set, scope)
         write_materialized_workflow_manifest(
             materialized_workflow,
@@ -2618,6 +2628,15 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
         result_by_work_item[scope.display_id] = scope_result
         final_result = scope_result
         final_scope = scope
+        if scope.use_case is not None:
+            print(
+                _format_use_case_execution_result(
+                    scope.use_case.uc_id,
+                    scope.use_case.name,
+                    scope_result,
+                ),
+                flush=True,
+            )
         if scope_result.status != RunStatus.SUCCEEDED:
             break
 
@@ -2700,6 +2719,29 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
         )
     )
     return state, final_result
+
+
+def _format_use_case_execution_result(
+    uc_id: str,
+    use_case_name: str,
+    result: RunResult,
+) -> str:
+    details = [
+        f"Use case execution result: {_use_case_execution_label(uc_id, use_case_name)}",
+        f"status={result.status.value}",
+    ]
+    if result.failed_step_id:
+        details.append(f"failed_step={result.failed_step_id}")
+    if result.failure_kind:
+        details.append(f"failure_kind={result.failure_kind.value}")
+    if result.blocker:
+        details.append(f"blocker={' '.join(result.blocker.split())}")
+    return " ".join(details)
+
+
+def _use_case_execution_label(uc_id: str, use_case_name: str) -> str:
+    normalized_name = " ".join(use_case_name.split())
+    return f"{uc_id} - {normalized_name}" if normalized_name else uc_id
 
 
 def _run_failure_kind(failure_kind: FailureKind | None) -> RunFailureKind | None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -2,11 +2,18 @@ import json
 import re
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import harness_codex.cli as cli
 from harness_codex.cli import main
+from harness_codex.runtime import FailureKind, RunMode, RunResult, RunStatus
+from harness_codex.runtime.changes.models import (
+    AffectedUseCase,
+    ChangeSet,
+    PlanningInputScope,
+)
 from harness_codex.runtime.procedure_stages import render_initial_changeset
 
 
@@ -462,6 +469,118 @@ def test_ultrawork_preview_creates_changeset_without_starting_run(
     assert "Workflow run:" in output
     assert "Mode: preview" in output
     assert not (tmp_path / ".harness/runs").exists()
+
+
+def test_apply_workflow_reports_each_use_case_before_and_after_execution(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    change_set, scopes = _workflow_feedback_fixture()
+    results = iter(
+        (
+            RunResult("run-test", RunStatus.SUCCEEDED, (), mode=RunMode.APPLY),
+            RunResult("run-test", RunStatus.SUCCEEDED, (), mode=RunMode.APPLY),
+        )
+    )
+    _stub_workflow_execution(monkeypatch, results)
+
+    cli._apply_workflow(tmp_path, change_set, scopes)
+
+    assert capsys.readouterr().out.splitlines() == [
+        "Use case execution start: UC-001 - Capture a fleeting note (1/2)",
+        "Use case execution result: UC-001 - Capture a fleeting note status=succeeded",
+        "Use case execution start: UC-002 - Revise a fleeting note (2/2)",
+        "Use case execution result: UC-002 - Revise a fleeting note status=succeeded",
+    ]
+
+
+def test_apply_workflow_reports_failure_details_and_stops_next_use_case(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    change_set, scopes = _workflow_feedback_fixture()
+    results = iter(
+        (
+            RunResult(
+                "run-test",
+                RunStatus.BLOCKED,
+                (),
+                mode=RunMode.APPLY,
+                failed_step_id="verify-work-item",
+                failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
+                blocker="test database unavailable",
+            ),
+        )
+    )
+    _stub_workflow_execution(monkeypatch, results)
+
+    cli._apply_workflow(tmp_path, change_set, scopes)
+
+    assert capsys.readouterr().out.splitlines() == [
+        "Use case execution start: UC-001 - Capture a fleeting note (1/2)",
+        (
+            "Use case execution result: UC-001 - Capture a fleeting note status=blocked "
+            "failed_step=verify-work-item failure_kind=environment_blocker "
+            "blocker=test database unavailable"
+        ),
+    ]
+
+
+def _workflow_feedback_fixture() -> tuple[ChangeSet, tuple[PlanningInputScope, ...]]:
+    use_cases = tuple(
+        AffectedUseCase(
+            uc_id=uc_id,
+            name=name,
+            impact_type="update",
+            slice_path=Path("docs/use-cases") / uc_id,
+        )
+        for uc_id, name in (
+            ("UC-001", "Capture a fleeting note"),
+            ("UC-002", "Revise a fleeting note"),
+        )
+    )
+    change_set = ChangeSet(
+        change_set_id="CHG-001",
+        title="Runtime feedback",
+        path=Path("docs/changes/active/CHG-001.md"),
+        affected_use_cases=use_cases,
+    )
+    scopes = tuple(
+        PlanningInputScope(
+            change_set_path=change_set.path,
+            use_case=use_case,
+            planner_inputs=(),
+            executor_inputs=(),
+            e2e_goal_path=use_case.slice_path / "e2e-goal.md",
+            work_item_id=use_case.uc_id,
+            plan_path=Path("docs/plans/active") / use_case.uc_id / "plan.md",
+            verification_goal_path=use_case.slice_path / "e2e-goal.md",
+        )
+        for use_case in use_cases
+    )
+    return change_set, scopes
+
+
+def _stub_workflow_execution(monkeypatch, results) -> None:
+    workflow = SimpleNamespace(name="changeset-use-case-workflow")
+
+    class FakeRunnerEngine:
+        def __init__(self, _step_runner) -> None:
+            pass
+
+        def run(self, _workflow, _context):
+            return next(results)
+
+    monkeypatch.setattr(cli, "load_named_workflow", lambda *_args, **_kwargs: workflow)
+    monkeypatch.setattr(
+        cli,
+        "materialize_workflow_for_scope",
+        lambda _workflow, _change_set, _scope: workflow,
+    )
+    monkeypatch.setattr(cli, "write_materialized_workflow_manifest", lambda *_args: None)
+    monkeypatch.setattr(cli, "RunnerEngine", FakeRunnerEngine)
 
 
 class FakeDateTime:


### PR DESCRIPTION
## 구현 의도

ChangeSet 전체 구현 실행 중 각 유스케이스의 실행 시작과 완료 결과를 콘솔에 즉시 출력한다. UC ID와 유스케이스 이름을 함께 표시해 사용자가 현재 실행 중인 작업 내용과 각 UC의 성공, 차단, 실패 결과를 런타임 종료 전에도 확인할 수 있다.

## 구현 접근

- ChangeSet 워크아이템 반복 루프에서 UC 실행 직전에 UC ID, 유스케이스 이름, 전체 진행 순서를 출력한다.
- 각 UC 워크플로우가 반환한 `RunResult`를 실행 직후 출력한다.
- 유스케이스 이름의 개행과 중복 공백을 정규화해 콘솔 피드백을 한 줄로 유지한다.
- 실패 시 `failed_step`, `failure_kind`, `blocker`를 같은 결과 줄에 포함한다.
- `flush=True`를 사용해 장시간 실행에서도 피드백이 즉시 콘솔에 노출되도록 한다.
- 첫 UC가 실패하거나 차단되면 기존 중단 동작을 유지하고 다음 UC 시작 메시지를 출력하지 않는다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py`
  - 결과: `44 passed`
- `./venv/bin/python3 -m py_compile harness_codex/cli.py tests/test_cli_commands.py`
  - 결과: 통과
- `git diff --check origin/main...HEAD`
  - 결과: 통과
- 전체 테스트 실행 결과: `418 passed`, `1 failed`
  - 기존 비관련 실패: `tests/runtime/test_document_dashboard.py::test_completed_change_set_documents_are_not_editable`
  - 완료 ChangeSet 문서 제목 fixture 기대값 불일치이며 이번 변경 파일과 무관하다.

## 위험 및 롤백

- 위험: UC마다 두 줄의 콘솔 출력이 추가되어 기존 콘솔 출력을 엄격히 파싱하는 외부 도구에 영향을 줄 수 있다.
- 완화: 기존 최종 `APPLY` 결과 형식은 변경하지 않았고, 새 출력은 명시적인 `Use case execution` 접두사를 사용한다.
- 롤백: 커밋 `36fb13c`을 되돌리면 기존 출력 동작으로 복구된다.