### PR TITLE
[codex] 유스케이스 블로커 해결 선택지 추가

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -270,6 +270,20 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="Use a specific affected UC for the next UC-scoped stage.",
     )
+    changes_continue.add_argument(
+        "--blocker-resolution",
+        choices=("requirements", "use-case"),
+        default="",
+        help=(
+            "Resolve an upstream use-case blocker by returning to requirements "
+            "or updating current use-case artifacts."
+        ),
+    )
+    changes_continue.add_argument(
+        "--resolution-prompt",
+        default="",
+        help="Prompt used when --blocker-resolution use-case is selected.",
+    )
     _add_mode_options(changes_continue)
     changes_continue.set_defaults(func=changes_continue_command)
     changes_document_delta = changes_subparsers.add_parser("document-delta")
@@ -533,6 +547,40 @@ def changes_continue_command(args: argparse.Namespace, repo_root: Path) -> str:
         change_set,
         uc_override=args.uc.strip() or None,
     )
+    resolution_prompt = ""
+    if decision.get("requires_blocker_resolution"):
+        resolution = args.blocker_resolution
+        if not resolution:
+            if mode != RunMode.APPLY:
+                return _format_use_case_blocker_resolution_required(change_set.change_set_id)
+            resolution = _read_use_case_blocker_resolution()
+
+        if resolution == "requirements":
+            decision = {
+                "stage_id": "requirements-definition",
+                "uc_id": None,
+                "force": True,
+                "blocked": False,
+                "reason": "user chose to supplement upstream requirements",
+            }
+        else:
+            resolution_prompt = args.resolution_prompt.strip()
+            if not resolution_prompt:
+                if mode != RunMode.APPLY:
+                    return (
+                        "BLOCKED: --resolution-prompt is required with "
+                        "--blocker-resolution use-case"
+                    )
+                resolution_prompt = input("Prompt for use-case artifact update: ").strip()
+            if not resolution_prompt:
+                raise ValueError("resolution prompt is required")
+            decision = {
+                "stage_id": "use-case-definition",
+                "uc_id": None,
+                "force": True,
+                "blocked": False,
+                "reason": "user chose to update current use-case artifacts",
+            }
     if decision["blocked"]:
         return f"BLOCKED: {decision['reason']}"
 
@@ -542,7 +590,7 @@ def changes_continue_command(args: argparse.Namespace, repo_root: Path) -> str:
         change_set_id=change_set.change_set_id,
         uc=decision["uc_id"] or "",
         title="",
-        idea="",
+        idea=resolution_prompt,
         force=decision["force"],
         plan=mode == RunMode.PLAN,
         preview=mode == RunMode.PREVIEW,
@@ -556,6 +604,32 @@ def changes_continue_command(args: argparse.Namespace, repo_root: Path) -> str:
     ]
     result = procedure_stage_command(stage_args, repo_root)
     return "\n".join([*header, result])
+
+
+def _format_use_case_blocker_resolution_required(change_set_id: str) -> str:
+    return "\n".join(
+        [
+            f"BLOCKED: {change_set_id} use-case-definition needs user resolution",
+            "Options:",
+            "1. Return to requirements-definition and supplement requirements.",
+            "2. Stay in use-case-definition and update current artifacts using a prompt.",
+            "Apply with --blocker-resolution requirements, or",
+            "apply with --blocker-resolution use-case --resolution-prompt TEXT.",
+        ]
+    )
+
+
+def _read_use_case_blocker_resolution() -> str:
+    print("Use-case stage is blocked by an upstream requirements decision.")
+    print("1. Return to requirements-definition and supplement requirements.")
+    print("2. Stay in use-case-definition and update current artifacts using a prompt.")
+    while True:
+        answer = input("Selection [1/2]: ").strip().lower()
+        if answer in {"1", "requirements"}:
+            return "requirements"
+        if answer in {"2", "use-case", "usecase"}:
+            return "use-case"
+        print("Enter 1 or 2.")
 
 
 def _decide_changes_continue_target(
@@ -581,11 +655,12 @@ def _decide_changes_continue_target(
                     "reason": "requirements-definition was rerun after the upstream blocker",
                 }
             return {
-                "stage_id": "requirements-definition",
+                "stage_id": "",
                 "uc_id": None,
-                "force": True,
+                "force": False,
                 "blocked": False,
-                "reason": "use-case-definition is blocked by an upstream requirements decision",
+                "requires_blocker_resolution": True,
+                "reason": "use-case-definition needs user blocker resolution",
             }
         return {
             "stage_id": stage_id,

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -760,6 +760,7 @@ def test_changes_continue_routes_use_case_upstream_blocker_to_requirements(
         return "stage command called"
 
     monkeypatch.setattr(cli, "procedure_stage_command", fake_procedure_stage_command)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
 
     exit_code = main(
         [
@@ -775,12 +776,99 @@ def test_changes_continue_routes_use_case_upstream_blocker_to_requirements(
     output = capsys.readouterr().out
     assert exit_code == 0
     assert "Target stage: requirements-definition" in output
-    assert "upstream requirements decision" in output
+    assert "user chose to supplement upstream requirements" in output
     assert captured == {
         "stage": "requirements-definition",
         "force": True,
         "apply": True,
     }
+
+
+def test_changes_continue_updates_use_case_with_user_prompt(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    text = change_set_path.read_text(encoding="utf-8")
+    text = cli.update_changeset_stage_status(
+        text,
+        stage=cli.procedure_stage("requirements-definition"),
+        status="verified",
+        notes="existing requirements",
+    )
+    text = cli.update_changeset_stage_status(
+        text,
+        stage=cli.procedure_stage("use-case-definition"),
+        status="blocked",
+        notes="Requirements do not define what approval saves.",
+    )
+    change_set_path.write_text(text, encoding="utf-8")
+    captured: dict[str, object] = {}
+    answers = iter(["2", "Add approval retention details to current use-case artifacts."])
+
+    def fake_procedure_stage_command(args, _repo_root):
+        captured["stage"] = args.procedure_stage_id
+        captured["force"] = args.force
+        captured["idea"] = args.idea
+        return "stage command called"
+
+    monkeypatch.setattr(cli, "procedure_stage_command", fake_procedure_stage_command)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "continue",
+            "CHG-001",
+            "--apply",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Target stage: use-case-definition" in output
+    assert "user chose to update current use-case artifacts" in output
+    assert captured == {
+        "stage": "use-case-definition",
+        "force": True,
+        "idea": "Add approval retention details to current use-case artifacts.",
+    }
+
+
+def test_changes_continue_preview_reports_use_case_blocker_choices(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    write_changeset(tmp_path)
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    text = cli.update_changeset_stage_status(
+        change_set_path.read_text(encoding="utf-8"),
+        stage=cli.procedure_stage("use-case-definition"),
+        status="blocked",
+        notes="Requirements missing approval behavior.",
+    )
+    change_set_path.write_text(text, encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "continue",
+            "CHG-001",
+            "--preview",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "needs user resolution" in output
+    assert "--blocker-resolution requirements" in output
+    assert "--blocker-resolution use-case --resolution-prompt TEXT" in output
 
 
 def test_changes_continue_retries_use_case_after_requirements_rerun(


### PR DESCRIPTION
## 구현 의도

유스케이스 정의 단계가 상위 요구사항 결정 누락으로 차단됐을 때 자동으로 요구사항 단계로 되돌아가지 않고, 사용자가 해결 경로를 선택할 수 있게 한다.

사용자는 다음 중 하나를 선택한다.

- 요구사항 정의 단계로 돌아가 누락 내용을 보충한다.
- 현재 유스케이스 산출물을 유지하고 추가 프롬프트로 내용을 보완한다.

## 구현 접근

`harness changes continue <CHG-ID> --apply`가 상위 요구사항 블로커를 감지하면 선택 프롬프트를 출력한다.

- `1` 또는 `requirements` 선택: `requirements-definition`을 강제 재실행한다.
- `2` 또는 `use-case` 선택: 추가 프롬프트를 입력받아 `use-case-definition`의 `idea`로 전달하고 현재 유스케이스 산출물을 갱신한다.
- 잘못된 선택 입력은 올바른 값이 들어올 때까지 다시 요청한다.
- `--plan`과 `--preview`에서는 대화형 입력 없이 필요한 선택지와 실행 플래그를 출력한다.
- 자동화 환경에서는 `--blocker-resolution requirements|use-case`와 `--resolution-prompt`를 사용할 수 있다.

데이터 흐름은 `Runtime Procedure State` 블로커 감지 → 사용자 해결 방식 선택 → 대상 단계 결정 → 기존 `procedure_stage_command` 실행 순서다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py -k 'changes_continue'`
  - 6개 통과
- `./venv/bin/python3 -m pytest -q tests/test_cli_commands.py`
  - 44개 통과
- `./venv/bin/python3 -m pytest -q tests/runtime/test_shell_completion.py`
  - 16개 통과
- 실제 CLI 도움말에서 신규 옵션 노출 확인
- 실제 선택 프롬프트에 잘못된 입력 후 재요청 및 `2` 선택 결과 확인
- 전체 테스트: 418개 통과, 기존 대시보드 문서 테스트 1개 실패
  - 실패: `tests/runtime/test_document_dashboard.py::test_completed_change_set_documents_are_not_editable`
  - 이번 변경 파일과 무관하며 단독 재실행에서도 동일하게 실패함

## 위험 및 롤백

- 위험: `--apply`를 비대화형 환경에서 선택 플래그 없이 실행하면 사용자 입력을 기다린다.
- 완화: 자동화용 `--blocker-resolution`과 `--resolution-prompt`를 제공한다.
- 롤백: 이 커밋을 되돌리면 기존처럼 상위 요구사항 블로커가 자동으로 `requirements-definition`으로 라우팅된다.