### PR TITLE
[codex] 불필요한 gitignore 문자열 테스트 제거

### DIFF
--- a/tests/test_skill_evaluation_contract.py
+++ b/tests/test_skill_evaluation_contract.py
@@ -87,9 +87,3 @@ def test_assertion_schema_is_machine_checkable() -> None:
         "metric_at_least",
     } <= assertion_types
     assert assertion_schema["additionalProperties"] is False
-
-
-def test_generated_skill_evaluation_output_is_ignored() -> None:
-    gitignore = read_text(".gitignore")
-
-    assert ".harness/skill-evaluations/" in gitignore


### PR DESCRIPTION
## 구현 의도

`.gitignore` 파일에 특정 문자열이 존재하는지만 확인하던 저가치 테스트를 제거합니다. 실제 Git 무시 동작이나 런타임 동작을 검증하지 않는 테스트 유지 비용을 줄이는 것이 목적입니다.

## 구현 접근

`tests/test_skill_evaluation_contract.py`에서 `test_generated_skill_evaluation_output_is_ignored` 테스트만 삭제했습니다. 프롬프트 코퍼스와 assertion schema 계약 테스트는 유지했습니다. 생성 결과 경로의 실제 무시 동작은 Git 자체의 `git check-ignore`로 확인했습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_skill_evaluation_contract.py` -> 3 passed
- `git check-ignore -v .harness/skill-evaluations/example/result.json` -> `.gitignore:9` 규칙 적용 확인
- `./venv/bin/python3 -m pytest -q -s` -> 429 passed
- `git diff --check` -> 통과

## 위험 및 롤백

위험은 `.gitignore` 규칙 회귀를 pytest가 직접 감지하지 않는 점입니다. 다만 삭제된 테스트도 문자열 존재만 확인해 실제 Git 동작을 보장하지 못했습니다. 회귀가 발생하면 커밋 `c5b9ec5`를 되돌려 테스트를 복원할 수 있습니다.