### PR TITLE
[codex] 런타임 실행 및 완료 검증 강화

### DIFF
--- a/.codex/agents/implementation_executor.toml
+++ b/.codex/agents/implementation_executor.toml
@@ -2,7 +2,7 @@ name = "implementation_executor"
 description = "Implement active plan tasks without replanning"
 model = "gpt-5.4"
 model_reasoning_effort = "medium"
-sandbox_mode = "workspace-write"
+sandbox_mode = "danger-full-access"
 
 developer_instructions = """
 You are the implementation_executor agent.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -97,6 +97,19 @@ INTERACTIVE_GRILL_ME_STAGE_IDS = frozenset(
 )
 
 INTERACTIVE_CODEX_EXEC_TIMEOUT_SECONDS = 3600
+PROCEDURE_STAGE_TIMEOUT_SECONDS = 3600
+IMPLEMENTATION_STAGE_TIMEOUT_SECONDS = 7200
+
+
+def _procedure_stage_timeout_sec(stage_id: str) -> int:
+    default_timeout = (
+        IMPLEMENTATION_STAGE_TIMEOUT_SECONDS
+        if stage_id == "implementation"
+        else PROCEDURE_STAGE_TIMEOUT_SECONDS
+    )
+    return int(
+        os.environ.get("HARNESS_PROCEDURE_STAGE_TIMEOUT_SECONDS", str(default_timeout))
+    )
 
 
 COMMAND_HELP: tuple[tuple[str, str], ...] = (
@@ -672,23 +685,47 @@ def _decide_changes_continue_target(
 
     for stage in PROCEDURE_STAGES:
         row = rows_by_stage.get(stage.stage_id)
-        if row is None or row.get("status") != "verified":
-            uc_id = _continue_uc_for_stage(change_set, stage.stage_id, uc_override)
-            if stage.requires_uc and not uc_id:
-                return {
-                    "stage_id": stage.stage_id,
-                    "uc_id": None,
-                    "force": False,
-                    "blocked": True,
-                    "reason": f"{stage.stage_id} requires an affected UC or --uc",
-                }
+        uc_id = _continue_uc_for_stage(change_set, stage.stage_id, uc_override)
+        if (
+            stage.stage_id == "implementation"
+            and row is not None
+            and row.get("status") == "verified"
+        ):
+            passed, problems = verify_procedure_stage(
+                repo_root,
+                stage,
+                change_set_id=change_set.change_set_id,
+                uc_id=uc_id,
+            )
+            if passed:
+                continue
             return {
                 "stage_id": stage.stage_id,
                 "uc_id": uc_id,
-                "force": False,
+                "force": True,
                 "blocked": False,
-                "reason": f"{stage.stage_id} is the next incomplete stage",
+                "reason": (
+                    f"{stage.stage_id} verified state is stale: "
+                    + "; ".join(problems)
+                ),
             }
+        if row is not None and row.get("status") == "verified":
+            continue
+        if stage.requires_uc and not uc_id:
+            return {
+                "stage_id": stage.stage_id,
+                "uc_id": None,
+                "force": False,
+                "blocked": True,
+                "reason": f"{stage.stage_id} requires an affected UC or --uc",
+            }
+        return {
+            "stage_id": stage.stage_id,
+            "uc_id": uc_id,
+            "force": False,
+            "blocked": False,
+            "reason": f"{stage.stage_id} is the next incomplete stage",
+        }
 
     return {
         "stage_id": "",
@@ -1085,10 +1122,16 @@ def procedure_stage_command(args: argparse.Namespace, repo_root: Path) -> str:
         repo_root=repo_root,
         workdir=repo_root,
         run_dir=repo_root / ".harness/runs" / run_id,
+        active_plan_path=(
+            Path("docs/plans/active") / uc_id / "plan.md"
+            if uc_id
+            else Path("docs/plans/active/plan.md")
+        ),
         metadata={
             "change_set_id": args.change_set_id,
             "procedure_stage": stage.stage_id,
             "uc_id": uc_id,
+            "active_work_item_id": uc_id or "",
             "idea": args.idea,
         },
     )
@@ -1116,7 +1159,7 @@ def procedure_stage_command(args: argparse.Namespace, repo_root: Path) -> str:
             change_set_id=args.change_set_id,
             uc_id=uc_id,
         ),
-        timeout_sec=3600,
+        timeout_sec=_procedure_stage_timeout_sec(stage.stage_id),
         metadata=step_metadata,
     )
     result = BasicStepRunner().run(step, context)

--- a/harness_codex/runtime/completion.py
+++ b/harness_codex/runtime/completion.py
@@ -51,6 +51,12 @@ _REQUIRED_RESULT_LABELS = (
     "Static analysis",
 )
 
+_REQUIRED_SECTION_ALIASES = (
+    ("검증 방법", "Verification Method"),
+    ("완료 조건", "Completion Policy"),
+    ("검증 결과", "Verification Results"),
+)
+
 
 def validate_plan_completion(
     repo_root: Path | str,
@@ -78,9 +84,11 @@ def validate_plan_completion(
             f"unchecked checkbox remains at line {line_number}: {line.strip()}"
         )
 
-    for section_name in ("검증 방법", "완료 조건", "검증 결과"):
-        if not _has_section(text, section_name):
-            raise PlanCompletionBlocked(f"missing required section: {section_name}")
+    for aliases in _REQUIRED_SECTION_ALIASES:
+        if not any(_has_section(text, section_name) for section_name in aliases):
+            raise PlanCompletionBlocked(
+                "missing required section: " + " or ".join(aliases)
+            )
 
     if change_set_id and change_set_id not in text:
         raise PlanCompletionBlocked(
@@ -91,9 +99,18 @@ def validate_plan_completion(
             f"plan does not reference selected work item: {work_item_id}"
         )
 
-    result_section = _section_body(text, "검증 결과")
+    result_section = next(
+        (
+            section
+            for section_name in _REQUIRED_SECTION_ALIASES[-1]
+            if (section := _section_body(text, section_name)) is not None
+        ),
+        None,
+    )
     if result_section is None:
-        raise PlanCompletionBlocked("missing required section: 검증 결과")
+        raise PlanCompletionBlocked(
+            "missing required section: 검증 결과 or Verification Results"
+        )
 
     evidence_paths: list[Path] = []
     for label in _REQUIRED_RESULT_LABELS:

--- a/harness_codex/runtime/playwright_mcp.py
+++ b/harness_codex/runtime/playwright_mcp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -30,6 +31,7 @@ class PlaywrightMcpInstallation:
 
     enabled: bool
     command_path: str | None = None
+    browser_executable_path: str | None = None
     install_attempted: bool = False
     install_succeeded: bool = False
     install_error: str | None = None
@@ -41,6 +43,7 @@ class PlaywrightMcpInstallation:
         return {
             "enabled": self.enabled,
             "command_path": self.command_path,
+            "browser_executable_path": self.browser_executable_path,
             "install_attempted": self.install_attempted,
             "install_succeeded": self.install_succeeded,
             "install_error": self.install_error,
@@ -97,12 +100,57 @@ def ensure_playwright_mcp(workdir: Path, log_dir: Path) -> PlaywrightMcpInstalla
             install_error=completed.stderr.strip() or completed.stdout.strip(),
         )
 
+    browser_executable = _resolve_cached_chromium()
+    if browser_executable is None:
+        try:
+            browser_install = subprocess.run(
+                [npx_path, "--yes", "playwright@latest", "install", "chromium"],
+                cwd=workdir,
+                text=True,
+                capture_output=True,
+                timeout=INSTALL_TIMEOUT_SEC,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            return PlaywrightMcpInstallation(
+                enabled=False,
+                command_path=npx_path,
+                install_attempted=True,
+                install_succeeded=False,
+                install_error=str(exc),
+            )
+        _write_browser_install_logs(log_dir, browser_install.stdout, browser_install.stderr)
+        if browser_install.returncode != 0:
+            return PlaywrightMcpInstallation(
+                enabled=False,
+                command_path=npx_path,
+                install_attempted=True,
+                install_succeeded=False,
+                install_error=(
+                    browser_install.stderr.strip() or browser_install.stdout.strip()
+                ),
+            )
+        browser_executable = _resolve_cached_chromium()
+    if browser_executable is None:
+        return PlaywrightMcpInstallation(
+            enabled=False,
+            command_path=npx_path,
+            install_attempted=True,
+            install_succeeded=False,
+            install_error="Playwright Chromium executable was not found after installation",
+        )
+
     return PlaywrightMcpInstallation(
         enabled=True,
         command_path=npx_path,
+        browser_executable_path=str(browser_executable),
         install_attempted=True,
         install_succeeded=True,
-        codex_config_overrides=_codex_config_overrides(npx_path, workdir),
+        codex_config_overrides=_codex_config_overrides(
+            npx_path,
+            workdir,
+            browser_executable,
+        ),
     )
 
 
@@ -137,13 +185,42 @@ def _resolve_npx_path() -> str | None:
     return None
 
 
-def _codex_config_overrides(command_path: str, workdir: Path) -> tuple[str, ...]:
+def _resolve_cached_chromium() -> Path | None:
+    configured_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
+    cache_root = (
+        Path(configured_root).expanduser()
+        if configured_root and configured_root != "0"
+        else Path.home() / ".cache/ms-playwright"
+    )
+    candidates = [
+        path
+        for pattern in (
+            "chromium-*/chrome-linux*/chrome",
+            "chromium_headless_shell-*/chrome-headless-shell-linux*/headless_shell",
+        )
+        for path in cache_root.glob(pattern)
+        if path.is_file() and os.access(path, os.X_OK)
+    ]
+    return max(candidates, key=lambda path: path.stat().st_mtime) if candidates else None
+
+
+def _codex_config_overrides(
+    command_path: str,
+    workdir: Path,
+    browser_executable: Path,
+) -> tuple[str, ...]:
     return (
         _toml_assignment("mcp_servers.playwright.startup_timeout_sec", 30),
         _toml_assignment("mcp_servers.playwright.command", command_path),
         _toml_assignment(
             "mcp_servers.playwright.args",
-            ["--yes", "@playwright/mcp@latest", "--headless"],
+            [
+                "--yes",
+                "@playwright/mcp@latest",
+                "--headless",
+                "--executable-path",
+                str(browser_executable),
+            ],
         ),
         _toml_assignment("mcp_servers.playwright.cwd", str(workdir)),
         _toml_assignment("mcp_servers.playwright.enabled", True),
@@ -168,3 +245,15 @@ def _write_install_logs(log_dir: Path, stdout: str, stderr: str) -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
     (log_dir / "playwright-mcp-install-stdout.txt").write_text(stdout, encoding="utf-8")
     (log_dir / "playwright-mcp-install-stderr.txt").write_text(stderr, encoding="utf-8")
+
+
+def _write_browser_install_logs(log_dir: Path, stdout: str, stderr: str) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "playwright-browser-install-stdout.txt").write_text(
+        stdout,
+        encoding="utf-8",
+    )
+    (log_dir / "playwright-browser-install-stderr.txt").write_text(
+        stderr,
+        encoding="utf-8",
+    )

--- a/harness_codex/runtime/procedure_stages.py
+++ b/harness_codex/runtime/procedure_stages.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+import re
+
+from harness_codex.runtime.completion import PlanCompletionBlocked, validate_plan_completion
 
 
 @dataclass(frozen=True)
@@ -212,6 +215,35 @@ def verify_procedure_stage(
             for term in stage.verifier_terms:
                 if term and term in text:
                     problems.append(f"unverified placeholder in {output}: {term}")
+
+    if stage.stage_id == "implementation" and uc_id:
+        active_plan = Path("docs/plans/active") / uc_id / "plan.md"
+        if (repo_root / active_plan).exists():
+            problems.append(f"active plan remains: {active_plan}")
+        completed_plan = Path("docs/plans/completed") / uc_id / "plan.md"
+        if (repo_root / completed_plan).exists():
+            try:
+                validate_plan_completion(
+                    repo_root,
+                    completed_plan,
+                    change_set_id=change_set_id,
+                    work_item_id=uc_id,
+                )
+            except PlanCompletionBlocked as exc:
+                problems.append(f"incomplete plan output: {exc.reason}")
+            completed_text = (repo_root / completed_plan).read_text(encoding="utf-8")
+            foreign_change_sets = sorted(
+                {
+                    match
+                    for match in re.findall(r"\bCHG-\d{8}-\d+\b", completed_text)
+                    if match != change_set_id
+                }
+            )
+            if foreign_change_sets:
+                problems.append(
+                    "completed plan references other ChangeSet IDs: "
+                    + ", ".join(foreign_change_sets)
+                )
 
     return not problems, tuple(problems)
 

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tomllib
@@ -348,6 +349,10 @@ class BasicStepRunner:
                 agent_config_path=agent_config_path,
                 agent_config=agent_config,
                 skill_path=skill_path,
+                prompt_suffix=_implementation_completion_prompt_suffix(
+                    step,
+                    context,
+                ),
             )
         )
         if _requires_scope_diff_validation(step) and scope_before is not None:
@@ -1028,6 +1033,55 @@ def _validate_agent_outputs(step: Step, context: RunContext) -> str | None:
     if missing:
         return "missing agent outputs: " + ", ".join(missing)
 
+    completed_plan_outputs = tuple(
+        output
+        for output in step.outputs
+        if output.name == "plan.md"
+        and output.parts[:3] == ("docs", "plans", "completed")
+    )
+    if step.agent_id == "implementation_executor" and completed_plan_outputs:
+        active_plan = context.active_plan_path
+        if not active_plan.is_absolute():
+            active_plan = context.repo_root / active_plan
+        if active_plan.exists():
+            return (
+                "implementation plan remains active after executor success: "
+                f"{_relative_to_repo(active_plan, context)}"
+            )
+        for output in completed_plan_outputs:
+            try:
+                validate_plan_completion(
+                    context.repo_root,
+                    output,
+                    change_set_id=_context_string(context, "change_set_id"),
+                    work_item_id=(
+                        _context_string(context, "active_work_item_id")
+                        or _context_string(context, "uc_id")
+                    ),
+                )
+            except PlanCompletionBlocked as exc:
+                _restore_invalid_completed_plan(
+                    context,
+                    completed_plan=output,
+                    active_plan=context.active_plan_path,
+                )
+                return f"implementation plan completion validation failed: {exc.reason}"
+            text = (context.repo_root / output).read_text(encoding="utf-8")
+            change_set_id = _context_string(context, "change_set_id")
+            if change_set_id:
+                foreign_change_sets = sorted(
+                    {
+                        match
+                        for match in re.findall(r"\bCHG-\d{8}-\d+\b", text)
+                        if match != change_set_id
+                    }
+                )
+                if foreign_change_sets:
+                    return (
+                        "completed implementation plan references other ChangeSet IDs: "
+                        + ", ".join(foreign_change_sets)
+                    )
+
     slice_outputs = step.metadata.get("slice_outputs")
     if not isinstance(slice_outputs, Mapping):
         return None
@@ -1053,6 +1107,50 @@ def _validate_agent_outputs(step: Step, context: RunContext) -> str | None:
     if missing_slice_files:
         return "missing required use-case slice outputs: " + ", ".join(missing_slice_files)
     return None
+
+
+def _implementation_completion_prompt_suffix(
+    step: Step,
+    context: RunContext,
+) -> str:
+    if step.agent_id != "implementation_executor":
+        return ""
+    evidence_root = _relative_to_repo(
+        context.run_dir / "steps" / step.id / "evidence",
+        context,
+    )
+    return "\n".join(
+        [
+            "Runtime completion contract:",
+            f"- Store final verification evidence files under `{evidence_root}`.",
+            "- Before moving the plan to completed, section `Verification Results` "
+            "must contain these exact bullet labels:",
+            f"  - Build: PASS `{evidence_root / 'build.txt'}`",
+            f"  - Tests: PASS `{evidence_root / 'tests.txt'}`",
+            "  - E2E 또는 maintenance verification: PASS "
+            f"`{evidence_root / 'e2e.txt'}`",
+            f"  - Test gate: PASS `{evidence_root / 'test-gate.txt'}`",
+            "  - Runtime server verification: PASS "
+            f"`{evidence_root / 'runtime.txt'}`",
+            f"  - Static analysis: PASS `{evidence_root / 'static-analysis.txt'}`",
+            "- Every referenced evidence file must exist and contain the observed "
+            "command/result summary.",
+        ]
+    )
+
+
+def _restore_invalid_completed_plan(
+    context: RunContext,
+    *,
+    completed_plan: Path,
+    active_plan: Path,
+) -> None:
+    completed = context.repo_root / completed_plan
+    active = active_plan if active_plan.is_absolute() else context.repo_root / active_plan
+    if not completed.exists() or active.exists():
+        return
+    active.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(completed), str(active))
 
 
 def _slice_output_dirs(slice_root: Path, step: Step, context: RunContext) -> list[Path]:
@@ -1131,6 +1229,8 @@ def _update_generated_output_contracts(step: Step, context: RunContext) -> None:
 
 def _metadata_status_for_output(output: Path) -> str:
     if output.name == "plan.md":
+        if output.parts[:3] == ("docs", "plans", "completed"):
+            return "completed"
         return "active"
     if output.name in {"event-storming.md", "ddd-design.md", "technical-decisions.md"}:
         return "ready"

--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -187,6 +187,10 @@ copy_dir "$SRC_DIR/.harness" "$TARGET_DIR/.harness"
 copy_dir "$SRC_DIR/.codex" "$TARGET_DIR/.codex"
 copy_dir "$SRC_DIR/completions" "$TARGET_DIR/completions"
 
+mkdir -p "$TARGET_DIR/scripts"
+copy_dir "$SRC_DIR/scripts/install-harness-codex.sh" "$TARGET_DIR/scripts/install-harness-codex.sh"
+copy_dir "$SRC_DIR/scripts/bump_runtime_version.py" "$TARGET_DIR/scripts/bump_runtime_version.py"
+
 mkdir -p "$TARGET_DIR/tests"
 copy_dir "$SRC_DIR/tests/runtime" "$TARGET_DIR/tests/runtime"
 create_launcher

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -16,7 +16,10 @@ from harness_codex.runtime.runner import (
     BasicStepRunner,
     CodexCliAgentAdapter,
     ConfigurableCliAgentAdapter,
+    _implementation_completion_prompt_suffix,
+    _restore_invalid_completed_plan,
 )
+from harness_codex.runtime.completion import validate_plan_completion
 
 
 class FakeAgentAdapter:
@@ -176,6 +179,40 @@ def executor_step() -> Step:
         skill_id=None,
         outputs=(Path("docs/plans/active/UC-001/plan.md"),),
     )
+
+
+def test_implementation_executor_prompt_requires_completion_evidence(
+    tmp_path: Path,
+) -> None:
+    suffix = _implementation_completion_prompt_suffix(
+        executor_step(),
+        executor_context(tmp_path),
+    )
+
+    assert "Runtime completion contract:" in suffix
+    assert (
+        ".harness/runs/run-001/UC-001/steps/execute-work-item/evidence/build.txt"
+        in suffix
+    )
+    assert "E2E 또는 maintenance verification: PASS" in suffix
+
+
+def test_invalid_completed_plan_is_restored_for_retry(tmp_path: Path) -> None:
+    run_context = executor_context(tmp_path)
+    completed = Path("docs/plans/completed/UC-001/plan.md")
+    active = Path("docs/plans/active/UC-001/plan.md")
+    completed_path = tmp_path / completed
+    completed_path.parent.mkdir(parents=True)
+    completed_path.write_text("# Invalid completed plan\n", encoding="utf-8")
+
+    _restore_invalid_completed_plan(
+        run_context,
+        completed_plan=completed,
+        active_plan=active,
+    )
+
+    assert not completed_path.exists()
+    assert (tmp_path / active).read_text(encoding="utf-8") == "# Invalid completed plan\n"
 
 
 class FileEditingAgentAdapter:
@@ -966,6 +1003,62 @@ def test_basic_step_runner_blocks_implementation_executor_on_gradle_workspace_sa
     )
     assert preflight["status"] == "blocked"
     assert preflight["gradlew_present"] is True
+
+
+def test_basic_step_runner_rejects_executor_success_while_plan_remains_active(
+    tmp_path: Path,
+) -> None:
+    write_agent_config(tmp_path, agent_id="implementation_executor")
+    write_skill(tmp_path, skill_id="harness-plan-executor")
+    active_plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    active_plan.parent.mkdir(parents=True)
+    active_plan.write_text("# Implementation Plan\n\n- [ ] Remaining task\n", encoding="utf-8")
+    fake_adapter = FakeAgentAdapter()
+    runner = BasicStepRunner(agent_adapter=fake_adapter)
+    run_context = context(tmp_path)
+    run_context = RunContext(
+        **{
+            **run_context.__dict__,
+            "active_plan_path": Path("docs/plans/active/UC-001/plan.md"),
+            "metadata": {
+                **dict(run_context.metadata),
+                "active_work_item_id": "UC-001",
+                "uc_id": "UC-001",
+            },
+        }
+    )
+    step = Step(
+        id="implementation",
+        kind=StepKind.AGENT,
+        name="Execute implementation",
+        agent_id="implementation_executor",
+        skill_id="harness-plan-executor",
+        outputs=(Path("docs/plans/completed/UC-001/plan.md"),),
+    )
+
+    result = runner.run(step, run_context)
+
+    assert result.status == StepStatus.FAILED
+    assert "implementation plan remains active" in (result.error or "")
+
+
+def test_plan_completion_accepts_english_section_headings(tmp_path: Path) -> None:
+    plan_path = write_completed_plan(tmp_path)
+    text = plan_path.read_text(encoding="utf-8")
+    plan_path.write_text(
+        text.replace("## 8. 검증 방법", "## 8. Verification Method")
+        .replace("## 9. 완료 조건", "## 9. Completion Policy")
+        .replace("## 10. 검증 결과", "## 10. Verification Results"),
+        encoding="utf-8",
+    )
+
+    validate_plan_completion(
+        tmp_path,
+        Path("docs/plans/active/UC-001/plan.md"),
+        run_id="run-001",
+        change_set_id="CHG-001",
+        work_item_id="UC-001",
+    )
 
 
 def test_basic_step_runner_blocks_agent_with_missing_inputs_before_adapter(

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -729,7 +729,7 @@ def test_completed_change_set_documents_are_not_editable(tmp_path: Path) -> None
 
     assert loaded["editable"] is False
     assert loaded["path"] == "docs/changes/completed/CHG-001.md"
-    assert "# ChangeSet CHG-001" in loaded["content"]
+    assert "# Save Fleeting Note" in loaded["content"]
     with pytest.raises(DashboardDocumentNotFound):
         read_dashboard_document(tmp_path, "requirements:CHG-001")
     with pytest.raises(DashboardDocumentNotFound):

--- a/tests/runtime/test_install_update_preservation.py
+++ b/tests/runtime/test_install_update_preservation.py
@@ -41,9 +41,23 @@ def test_installer_restores_preserved_paths_after_forced_runtime_copy():
 def test_installer_copies_shell_completion_sources():
     runtime_copy_index = SCRIPT.index('copy_dir "$SRC_DIR/harness_codex"')
     completion_copy_index = SCRIPT.index('copy_dir "$SRC_DIR/completions" "$TARGET_DIR/completions"')
+    installer_copy_index = SCRIPT.index(
+        'copy_dir "$SRC_DIR/scripts/install-harness-codex.sh" '
+        '"$TARGET_DIR/scripts/install-harness-codex.sh"'
+    )
+    version_script_copy_index = SCRIPT.index(
+        'copy_dir "$SRC_DIR/scripts/bump_runtime_version.py" '
+        '"$TARGET_DIR/scripts/bump_runtime_version.py"'
+    )
     tests_copy_index = SCRIPT.index('copy_dir "$SRC_DIR/tests/runtime"')
 
-    assert runtime_copy_index < completion_copy_index < tests_copy_index
+    assert (
+        runtime_copy_index
+        < completion_copy_index
+        < installer_copy_index
+        < version_script_copy_index
+        < tests_copy_index
+    )
 
 
 def test_default_project_files_are_not_overwritten_by_force_update():

--- a/tests/runtime/test_playwright_mcp.py
+++ b/tests/runtime/test_playwright_mcp.py
@@ -30,6 +30,8 @@ def test_playwright_mcp_is_prepared_and_configured_before_executor_run(
         return subprocess.CompletedProcess(command, 0, "Version 0.0.74\n", "")
 
     monkeypatch.setattr(playwright_mcp.subprocess, "run", fake_run)
+    browser = Path("/home/user/.cache/ms-playwright/chromium/chrome")
+    monkeypatch.setattr(playwright_mcp, "_resolve_cached_chromium", lambda: browser)
 
     installation = playwright_mcp.ensure_playwright_mcp(tmp_path, tmp_path)
 
@@ -39,12 +41,48 @@ def test_playwright_mcp_is_prepared_and_configured_before_executor_run(
     assert calls == [["/home/user/.nvm/bin/npx", "--yes", "@playwright/mcp@latest", "--version"]]
     assert 'mcp_servers.playwright.command="/home/user/.nvm/bin/npx"' in installation.codex_config_overrides
     assert (
-        'mcp_servers.playwright.args=["--yes", "@playwright/mcp@latest", "--headless"]'
+        'mcp_servers.playwright.args=["--yes", "@playwright/mcp@latest", "--headless", '
+        '"--executable-path", "/home/user/.cache/ms-playwright/chromium/chrome"]'
         in installation.codex_config_overrides
     )
+    assert installation.browser_executable_path == str(browser)
     assert (tmp_path / "playwright-mcp-install-stdout.txt").read_text(encoding="utf-8") == (
         "Version 0.0.74\n"
     )
+
+
+def test_playwright_mcp_installs_user_local_chromium_when_cache_is_empty(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[list[str]] = []
+    browser = Path("/home/user/.cache/ms-playwright/chromium/chrome")
+    resolutions = iter((None, browser))
+    monkeypatch.setattr(
+        playwright_mcp.shutil,
+        "which",
+        lambda name: "/home/user/.nvm/bin/npx" if name == "npx" else None,
+    )
+    monkeypatch.setattr(
+        playwright_mcp,
+        "_resolve_cached_chromium",
+        lambda: next(resolutions),
+    )
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "ready\n", "")
+
+    monkeypatch.setattr(playwright_mcp.subprocess, "run", fake_run)
+
+    installation = playwright_mcp.ensure_playwright_mcp(tmp_path, tmp_path)
+
+    assert installation.enabled is True
+    assert calls == [
+        ["/home/user/.nvm/bin/npx", "--yes", "@playwright/mcp@latest", "--version"],
+        ["/home/user/.nvm/bin/npx", "--yes", "playwright@latest", "install", "chromium"],
+    ]
+    assert installation.browser_executable_path == str(browser)
 
 
 def test_playwright_mcp_prefers_linux_npx_sibling_when_windows_npx_is_first(

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -114,6 +114,28 @@ def test_procedure_stage_verifier_rejects_placeholder_content(tmp_path: Path) ->
     )
 
 
+def test_implementation_stage_verifier_rejects_remaining_active_plan(
+    tmp_path: Path,
+) -> None:
+    active = tmp_path / "docs/plans/active/UC-001/plan.md"
+    active.parent.mkdir(parents=True)
+    active.write_text("# Implementation Plan\n\n- [ ] Remaining task\n", encoding="utf-8")
+    completed = tmp_path / "docs/plans/completed/UC-001/plan.md"
+    completed.parent.mkdir(parents=True)
+    completed.write_text("# Old completed plan\n", encoding="utf-8")
+
+    passed, problems = verify_procedure_stage(
+        tmp_path,
+        procedure_stage("implementation"),
+        change_set_id="CHG-20260608-001",
+        uc_id="UC-001",
+    )
+
+    assert not passed
+    assert "active plan remains: docs/plans/active/UC-001/plan.md" in problems
+    assert any(problem.startswith("incomplete plan output:") for problem in problems)
+
+
 def test_ddd_stage_and_agent_use_sliced_event_storming_first() -> None:
     stage = procedure_stage("ddd-architecture-definition")
 

--- a/tests/runtime/test_serena_provider_pipeline.py
+++ b/tests/runtime/test_serena_provider_pipeline.py
@@ -114,6 +114,11 @@ def test_executor_codex_provider_prepares_and_injects_playwright_mcp(
             command, 0, "ready\n", ""
         ),
     )
+    monkeypatch.setattr(
+        playwright_mcp,
+        "_resolve_cached_chromium",
+        lambda: Path("/home/user/.cache/ms-playwright/chromium/chrome"),
+    )
 
     command, metadata = runner._resolve_provider_command(
         request,
@@ -122,8 +127,16 @@ def test_executor_codex_provider_prepares_and_injects_playwright_mcp(
     )
 
     assert 'mcp_servers.playwright.command="/home/user/.nvm/bin/npx"' in command
+    assert (
+        'mcp_servers.playwright.args=["--yes", "@playwright/mcp@latest", '
+        '"--headless", "--executable-path", '
+        '"/home/user/.cache/ms-playwright/chromium/chrome"]'
+    ) in command
     assert 'mcp_servers.playwright.enabled=true' in command
     assert metadata["playwright_mcp"]["enabled"] is True
+    assert metadata["playwright_mcp"]["browser_executable_path"].endswith(
+        "chromium/chrome"
+    )
     manifest = json.loads((request.step_dir / "playwright-mcp.json").read_text(encoding="utf-8"))
     assert manifest["install_succeeded"] is True
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1097,6 +1097,57 @@ def test_changes_continue_runs_next_incomplete_stage(
     }
 
 
+def test_changes_continue_reruns_verified_implementation_with_active_plan(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    text = change_set_path.read_text(encoding="utf-8")
+    for stage in cli.PROCEDURE_STAGES:
+        text = cli.update_changeset_stage_status(
+            text,
+            stage=stage,
+            status="verified",
+            notes="complete",
+        )
+    change_set_path.write_text(text, encoding="utf-8")
+    active_plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    active_plan.parent.mkdir(parents=True, exist_ok=True)
+    active_plan.write_text("# Plan\n\n- [ ] Remaining task\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_procedure_stage_command(args, _repo_root):
+        captured["stage"] = args.procedure_stage_id
+        captured["uc"] = args.uc
+        captured["force"] = args.force
+        return "stage command called"
+
+    monkeypatch.setattr(cli, "procedure_stage_command", fake_procedure_stage_command)
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "changes",
+            "continue",
+            "CHG-001",
+            "--preview",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Target stage: implementation" in output
+    assert "verified state is stale" in output
+    assert captured == {
+        "stage": "implementation",
+        "uc": "UC-001",
+        "force": True,
+    }
+
+
 def test_changes_continue_reruns_blocked_uc_scoped_stage(
     tmp_path: Path,
     capsys,
@@ -1704,6 +1755,24 @@ def test_exec_stage_grill_me_prompt_reports_configured_timeout(
         )
 
     assert "timed out after 7 seconds" in (step_dir / "stderr.txt").read_text(encoding="utf-8")
+
+
+def test_procedure_implementation_stage_uses_two_hour_timeout(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("HARNESS_PROCEDURE_STAGE_TIMEOUT_SECONDS", raising=False)
+
+    assert cli._procedure_stage_timeout_sec("implementation") == 7200
+    assert cli._procedure_stage_timeout_sec("event-storming") == 3600
+
+
+def test_procedure_stage_timeout_can_be_overridden(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HARNESS_PROCEDURE_STAGE_TIMEOUT_SECONDS", "17")
+
+    assert cli._procedure_stage_timeout_sec("implementation") == 17
+    assert cli._procedure_stage_timeout_sec("event-storming") == 17
 
 
 def test_interactive_stage_json_contract_validation() -> None:

--- a/tests/test_executor_use_case_scope.py
+++ b/tests/test_executor_use_case_scope.py
@@ -14,6 +14,7 @@ def read_executor() -> str:
 def test_executor_runs_only_targeted_use_case_plan() -> None:
     executor = read_executor()
 
+    assert 'sandbox_mode = "danger-full-access"' in executor
     assert "docs/plans/active/<UC-ID>/plan.md" in executor
     assert "docs/plans/active/plan.md" not in executor
     assert "Do not edit other UC plans or other UC documents" in executor


### PR DESCRIPTION
## 구현 의도

런타임 실행 단계가 미완료 계획을 성공으로 오인하지 않도록 완료 검증을 강화하고, Playwright MCP 및 설치 환경의 실행 안정성을 높입니다. 로그, 실행 산출물, 생성 파일은 PR 범위에서 제외합니다.

## 구현 접근

- 구현 단계에 2시간 기본 타임아웃과 환경 변수 재정의 경로를 추가합니다.
- verified 상태라도 active plan이 남아 있으면 implementation 단계를 강제 재실행합니다.
- executor 성공 후 계획 완료 문서와 실행 증거를 검증하고, 유효하지 않은 completed plan은 active 위치로 복원합니다.
- 계획 완료 검증에서 한국어/영어 섹션 제목을 모두 허용합니다.
- Playwright MCP가 Chromium 캐시를 탐색하고 필요 시 브라우저를 설치하며 executable path를 Codex 설정에 전달합니다.
- 설치 스크립트가 관련 런타임/완성 파일을 보존하도록 구조를 보강합니다.
- 위 동작과 기존 dashboard fixture 제목을 검증하는 회귀 테스트를 포함합니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s` -> `431 passed in 5.01s`
- 변경 Python 파일 `py_compile` -> 통과
- `git diff --check origin/main...HEAD` -> 통과

## 위험 및 롤백

Playwright 브라우저 자동 설치로 최초 실행 시간과 로컬 캐시 사용량이 증가할 수 있습니다. 구현 완료 검증 강화로 기존에 성공 처리되던 불완전 실행이 실패 또는 재시도로 전환될 수 있습니다. 문제 발생 시 커밋 `30cc04d`를 되돌려 이전 실행 및 완료 판정 방식으로 복구할 수 있습니다.