### PR TITLE
[codex] 설계 단계 실행 모드 옵션 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,30 +43,29 @@ Start from the first runtime stage. This creates a temporary ChangeSet early, re
 ```bash
 ./harness requirements-definition \
   --title "change title" \
-  --idea "short product or engineering goal" \
-  --apply
+  --idea "short product or engineering goal"
 ```
 
 Continue through staged workflow:
 
 ```bash
-./harness ubiquitous-language-definition CHG-YYYYMMDD-001 --apply
-./harness use-case-definition CHG-YYYYMMDD-001 --apply
-./harness event-storming CHG-YYYYMMDD-001 --uc UC-001 --apply
-./harness ddd-architecture-definition CHG-YYYYMMDD-001 --uc UC-001 --apply
-./harness technical-decisions CHG-YYYYMMDD-001 --uc UC-001 --apply
+./harness ubiquitous-language-definition CHG-YYYYMMDD-001
+./harness use-case-definition CHG-YYYYMMDD-001
+./harness event-storming CHG-YYYYMMDD-001 --uc UC-001
+./harness ddd-architecture-definition CHG-YYYYMMDD-001 --uc UC-001
+./harness technical-decisions CHG-YYYYMMDD-001 --uc UC-001
 ./harness plan-writing CHG-YYYYMMDD-001 --uc UC-001 --apply
 ./harness implementation CHG-YYYYMMDD-001 --uc UC-001 --apply
 ```
 
-Use non-mutating modes before writing changes:
+Design stages run directly. Planning and implementation stages retain explicit modes:
 
 ```bash
-./harness event-storming CHG-YYYYMMDD-001 --uc UC-001 --preview
 ./harness plan-writing CHG-YYYYMMDD-001 --uc UC-001 --plan
+./harness implementation CHG-YYYYMMDD-001 --uc UC-001 --preview
 ```
 
-Command modes:
+Planning and implementation modes:
 
 - `--plan`: show intended work.
 - `--preview`: verify current inputs and outputs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -233,12 +233,12 @@ Maintenance plan은 `docs/plans/completed/<MAINT-ID>/plan.md`로 이동한다.
 ```bash
 ./harness changes list
 ./harness changes show <CHG-ID>
-./harness requirements-definition <CHG-ID> --plan|--preview|--apply
-./harness ubiquitous-language-definition <CHG-ID> --plan|--preview|--apply
-./harness use-case-definition <CHG-ID> --plan|--preview|--apply
-./harness event-storming <CHG-ID> --uc <UC-ID> --plan|--preview|--apply
-./harness ddd-architecture-definition <CHG-ID> --uc <UC-ID> --plan|--preview|--apply
-./harness technical-decisions <CHG-ID> --uc <UC-ID> --plan|--preview|--apply
+./harness requirements-definition <CHG-ID>
+./harness ubiquitous-language-definition <CHG-ID>
+./harness use-case-definition <CHG-ID>
+./harness event-storming <CHG-ID> --uc <UC-ID>
+./harness ddd-architecture-definition <CHG-ID> --uc <UC-ID>
+./harness technical-decisions <CHG-ID> --uc <UC-ID>
 ./harness plan-writing <CHG-ID> --uc <UC-ID> --plan|--preview|--apply
 ./harness implementation <CHG-ID> --uc <UC-ID> --plan|--preview|--apply
 ./harness stages list <CHG-ID>

--- a/docs/agent/commands.md
+++ b/docs/agent/commands.md
@@ -7,8 +7,8 @@
 - Show ChangeSet: `python3 -m harness_codex changes show <CHG-ID>`
 - Delete active ChangeSet: `python3 -m harness_codex changes delete <CHG-ID>`
 - Create ChangeSet and run affected workflows: `python3 -m harness_codex ultrawork --title "<title>" --preview`
-- Preview requirements stage: `python3 -m harness_codex requirements-definition <CHG-ID> --preview`
-- Preview use-case stage: `python3 -m harness_codex use-case-definition <CHG-ID> --preview`
+- Run requirements stage: `python3 -m harness_codex requirements-definition <CHG-ID>`
+- Run use-case stage: `python3 -m harness_codex use-case-definition <CHG-ID>`
 - Preview UC-scoped implementation stage: `python3 -m harness_codex implementation <CHG-ID> --uc <UC-ID> --preview`
 - Show run report: `python3 -m harness_codex report <RUN-ID>`
 - Initialize target repo agent context: `python3 -m harness_codex init --description "<repo description>"`

--- a/docs/runtime-shell-completion.md
+++ b/docs/runtime-shell-completion.md
@@ -73,8 +73,8 @@ Completion reads from `HARNESS_REPO_ROOT` when it is set. Otherwise it reads fro
 ## Examples
 
 ```bash
-harness requirements-definition CHG-20260507-001 --preview
-harness event-storming CHG-20260507-001 --uc UC-001 --preview
+harness requirements-definition CHG-20260507-001
+harness event-storming CHG-20260507-001 --uc UC-001
 harness implementation CHG-20260507-001 --uc UC-001 --apply
 harness artifacts show CHG-20260507-001 technical-decisions
 ```

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -154,25 +154,25 @@ Primary staged workflow:
 | `plan-writing` | Executor-ready plan | `docs/plans/active/<WORK-ITEM-ID>/plan.md` |
 | `implementation` | Code, tests, verification evidence | updated repo files and completed plan state |
 
-Common command form:
+Design stage command form:
 
 ```bash
-./harness <stage> <CHG-ID> --uc <UC-ID> --apply
+./harness <design-stage> <CHG-ID> --uc <UC-ID>
 ```
 
 Stages before UC slicing may not need `--uc`.
 
-Use `--preview` to check whether current artifacts satisfy a stage. Use `--plan` to inspect intended work without writing files.
+`plan-writing` and `implementation` retain `--plan`, `--preview`, and `--apply`.
 
 ## 5. Interactive Main-Flow Stages
 
-The first four main-flow `--apply` stages run draft-first Grill-Me loops:
+The first four main-flow stages run draft-first Grill-Me loops:
 
 ```bash
-./harness requirements-definition CHG-YYYYMMDD-001 --apply
-./harness ubiquitous-language-definition CHG-YYYYMMDD-001 --apply
-./harness use-case-definition CHG-YYYYMMDD-001 --apply
-./harness event-storming CHG-YYYYMMDD-001 --uc UC-001 --apply
+./harness requirements-definition CHG-YYYYMMDD-001
+./harness ubiquitous-language-definition CHG-YYYYMMDD-001
+./harness use-case-definition CHG-YYYYMMDD-001
+./harness event-storming CHG-YYYYMMDD-001 --uc UC-001
 ```
 
 Each loop writes or updates draft artifacts first, asks up to three terminal questions when input is required, stores answers in `.harness/runs/<RUN-ID>/grill-me-session.json`, and reruns the same stage until it completes, blocks, or verification passes.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -96,6 +96,17 @@ INTERACTIVE_GRILL_ME_STAGE_IDS = frozenset(
     }
 )
 
+DESIGN_STAGE_IDS = frozenset(
+    {
+        "requirements-definition",
+        "ubiquitous-language-definition",
+        "use-case-definition",
+        "event-storming",
+        "ddd-architecture-definition",
+        "technical-decisions",
+    }
+)
+
 INTERACTIVE_CODEX_EXEC_TIMEOUT_SECONDS = 3600
 PROCEDURE_STAGE_TIMEOUT_SECONDS = 3600
 IMPLEMENTATION_STAGE_TIMEOUT_SECONDS = 7200
@@ -151,12 +162,12 @@ TOPIC_HELP: Mapping[str, str] = {
     ),
     "contracts": "Usage: harness contracts validate <CHG-ID> [--work-item ID] [--json]",
     "completion": "Usage: harness completion install [--shell auto|zsh|bash|all]",
-    "requirements-definition": "Usage: harness requirements-definition [CHG-ID] --plan|--preview|--apply",
-    "ubiquitous-language-definition": "Usage: harness ubiquitous-language-definition <CHG-ID> --plan|--preview|--apply",
-    "use-case-definition": "Usage: harness use-case-definition <CHG-ID> --plan|--preview|--apply",
-    "event-storming": "Usage: harness event-storming <CHG-ID> --uc UC-ID --plan|--preview|--apply",
-    "ddd-architecture-definition": "Usage: harness ddd-architecture-definition <CHG-ID> --uc UC-ID --plan|--preview|--apply",
-    "technical-decisions": "Usage: harness technical-decisions <CHG-ID> --uc UC-ID --plan|--preview|--apply",
+    "requirements-definition": "Usage: harness requirements-definition [CHG-ID]",
+    "ubiquitous-language-definition": "Usage: harness ubiquitous-language-definition <CHG-ID>",
+    "use-case-definition": "Usage: harness use-case-definition <CHG-ID>",
+    "event-storming": "Usage: harness event-storming <CHG-ID> --uc UC-ID",
+    "ddd-architecture-definition": "Usage: harness ddd-architecture-definition <CHG-ID> --uc UC-ID",
+    "technical-decisions": "Usage: harness technical-decisions <CHG-ID> --uc UC-ID",
     "plan-writing": "Usage: harness plan-writing <CHG-ID> --uc UC-ID --plan|--preview|--apply",
     "implementation": "Usage: harness implementation <CHG-ID> --uc UC-ID --plan|--preview|--apply",
     "ultrawork": (
@@ -441,7 +452,10 @@ def _add_procedure_stage_parser(
         action="store_true",
         help="Rerun the stage even when the ChangeSet table marks it verified.",
     )
-    _add_mode_options(command)
+    if stage.stage_id in DESIGN_STAGE_IDS:
+        command.set_defaults(plan=False, preview=False, apply=True)
+    else:
+        _add_mode_options(command)
     command.set_defaults(func=procedure_stage_command, procedure_stage_id=stage.stage_id)
 
 

--- a/harness_codex/runtime/agent_context.py
+++ b/harness_codex/runtime/agent_context.py
@@ -255,11 +255,11 @@ def _render_commands(analysis: RepoAnalysis, llm_summary: LlmRepoSummary) -> str
 
 ## Harness Commands
 
-- Start requirements stage: `python3 -m harness_codex requirements-definition <CHG-ID> --title "<title>" --idea "<idea>" --plan`
+- Start requirements stage: `python3 -m harness_codex requirements-definition <CHG-ID> --title "<title>" --idea "<idea>"`
 - List active ChangeSets: `python3 -m harness_codex changes list`
 - Initialize repo context: `python3 -m harness_codex init --description "<repo description>"`
 - Create ChangeSet and run affected workflows: `python3 -m harness_codex ultrawork --title "<title>" --preview`
-- Preview use-case stage: `python3 -m harness_codex use-case-definition <CHG-ID> --preview`
+- Run use-case stage: `python3 -m harness_codex use-case-definition <CHG-ID>`
 - Preview implementation stage: `python3 -m harness_codex implementation <CHG-ID> --uc <UC-ID> --preview`
 - Bootstrap agent context: `python3 -m harness_codex agent-context init --description "<repo description>"`
 {llm_notes}

--- a/harness_codex/runtime/changes/design_bridge.py
+++ b/harness_codex/runtime/changes/design_bridge.py
@@ -402,7 +402,7 @@ def _render_change_set(
 |Command/Check|Result|Evidence|
 |---|---|---|
 |`python3 -m harness_codex changes list`|pending||
-|`python3 -m harness_codex use-case-definition {change_set_id} --preview`|pending||
+|`python3 -m harness_codex use-case-definition {change_set_id}`|pending||
 
 ## 12. Blockers / Conflicts
 

--- a/harness_codex/runtime/interactive_harvest.py
+++ b/harness_codex/runtime/interactive_harvest.py
@@ -579,7 +579,7 @@ def _format_completion(root: Path, result: HarvestUiResult, session_id: str) -> 
         "Generated artifacts:",
         *generated,
         "Next step:",
-        './harness requirements-definition CHG-YYYYMMDD-001 --title "<change title>" --idea "<idea>" --apply',
+        './harness requirements-definition CHG-YYYYMMDD-001 --title "<change title>" --idea "<idea>"',
     ])
 
 
@@ -601,7 +601,7 @@ def _completed_session_message(session_id: str) -> str:
         f"harvest session already completed: {session_id}",
         "Current stage: useCases",
         "Next step:",
-        './harness requirements-definition CHG-YYYYMMDD-001 --title "<change title>" --idea "<idea>" --apply',
+        './harness requirements-definition CHG-YYYYMMDD-001 --title "<change title>" --idea "<idea>"',
     ])
 
 

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -24,7 +24,7 @@ def test_procedure_stage_plan_uses_explicit_process_name(
         [
             "--repo-root",
             str(tmp_path),
-            "event-storming",
+            "plan-writing",
             "CHG-001",
             "--uc",
             "UC-001",
@@ -34,9 +34,9 @@ def test_procedure_stage_plan_uses_explicit_process_name(
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Stage: event-storming" in output
-    assert "Procedure: Event Storming" in output
-    assert "docs/use-cases/UC-001/event-storming.md" in output
+    assert "Stage: plan-writing" in output
+    assert "Procedure: plan.md Writing" in output
+    assert "docs/plans/active/UC-001/plan.md" in output
 
 
 def test_procedure_stages_split_requirements_language_before_use_cases() -> None:
@@ -82,7 +82,7 @@ def test_procedure_stage_preview_verifies_outputs(
         [
             "--repo-root",
             str(tmp_path),
-            "event-storming",
+            "implementation",
             "CHG-001",
             "--uc",
             "UC-001",
@@ -93,7 +93,7 @@ def test_procedure_stage_preview_verifies_outputs(
     output = capsys.readouterr().out
     assert exit_code == 0
     assert "Verification: failed" in output
-    assert "missing output: docs/use-cases/UC-001/event-storming.md" in output
+    assert "missing output: docs/plans/completed/UC-001/plan.md" in output
 
 
 def test_procedure_stage_verifier_rejects_placeholder_content(tmp_path: Path) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -232,6 +232,38 @@ def test_legacy_workflow_commands_are_not_registered(tmp_path: Path) -> None:
         assert exc.value.code == 2
 
 
+@pytest.mark.parametrize(
+    ("stage_id", "stage_args"),
+    (
+        ("requirements-definition", []),
+        ("ubiquitous-language-definition", []),
+        ("use-case-definition", []),
+        ("event-storming", ["--uc", "UC-001"]),
+        ("ddd-architecture-definition", ["--uc", "UC-001"]),
+        ("technical-decisions", ["--uc", "UC-001"]),
+    ),
+)
+def test_design_stage_commands_default_to_apply(
+    stage_id: str,
+    stage_args: list[str],
+) -> None:
+    args = cli.build_parser().parse_args([stage_id, "CHG-001", *stage_args])
+
+    assert args.plan is False
+    assert args.preview is False
+    assert args.apply is True
+
+
+@pytest.mark.parametrize("mode", ("--plan", "--preview", "--apply"))
+def test_design_stage_commands_reject_mode_flags(mode: str) -> None:
+    with pytest.raises(SystemExit) as exc:
+        cli.build_parser().parse_args(
+            ["event-storming", "CHG-001", "--uc", "UC-001", mode]
+        )
+
+    assert exc.value.code == 2
+
+
 def test_agent_context_init_creates_expected_files(
     tmp_path: Path,
     capsys,
@@ -636,7 +668,6 @@ def test_requirements_definition_finalizes_temporary_changeset_without_id(
             "requirements-definition",
             "--idea",
             "Build note capture",
-            "--apply",
         ]
     )
 
@@ -689,7 +720,6 @@ def test_requirements_definition_uses_requirements_title_when_temp_changeset_is_
             "requirements-definition",
             "--idea",
             "CHG-TEMP-20260507-001",
-            "--apply",
         ]
     )
 
@@ -722,7 +752,6 @@ def test_requirements_definition_keeps_temporary_changeset_without_requirements_
             "requirements-definition",
             "--idea",
             "Build note capture",
-            "--apply",
         ]
     )
 
@@ -763,7 +792,6 @@ def test_use_case_definition_finalizes_temporary_changeset_from_design(
             str(tmp_path),
             "use-case-definition",
             "CHG-TEMP-20260507-001",
-            "--apply",
         ]
     )
 
@@ -787,7 +815,7 @@ def test_procedure_stage_plan_has_no_side_effects(tmp_path: Path, capsys) -> Non
         [
             "--repo-root",
             str(tmp_path),
-            "event-storming",
+            "plan-writing",
             "CHG-001",
             "--uc",
             "UC-001",
@@ -797,11 +825,11 @@ def test_procedure_stage_plan_has_no_side_effects(tmp_path: Path, capsys) -> Non
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Stage: event-storming" in output
+    assert "Stage: plan-writing" in output
     assert not (tmp_path / ".harness/runs").exists()
 
 
-def test_use_case_definition_plan_limits_outputs_to_selected_uc(
+def test_plan_writing_plan_limits_outputs_to_selected_uc(
     tmp_path: Path,
     capsys,
 ) -> None:
@@ -811,7 +839,7 @@ def test_use_case_definition_plan_limits_outputs_to_selected_uc(
         [
             "--repo-root",
             str(tmp_path),
-            "use-case-definition",
+            "plan-writing",
             "CHG-001",
             "--uc",
             "UC-001",
@@ -821,7 +849,6 @@ def test_use_case_definition_plan_limits_outputs_to_selected_uc(
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "docs/design/유스케이스.md" in output
     assert "docs/use-cases/UC-001/use-case.md" in output
     assert "docs/use-cases/UC-001/e2e-goal.md" in output
     assert "- docs/use-cases\n" not in output
@@ -835,7 +862,7 @@ def test_procedure_stage_preview_limits_to_selected_uc(tmp_path: Path, capsys) -
         [
             "--repo-root",
             str(tmp_path),
-            "event-storming",
+            "implementation",
             "CHG-001",
             "--uc",
             "UC-001",
@@ -845,8 +872,9 @@ def test_procedure_stage_preview_limits_to_selected_uc(tmp_path: Path, capsys) -
 
     output = capsys.readouterr().out
     assert exit_code == 0
-    assert "Stage: event-storming" in output
-    assert "Verification: passed" in output
+    assert "Stage: implementation" in output
+    assert "Verification: failed" in output
+    assert "docs/plans/completed/UC-001/plan.md" in output
 
 
 def test_changes_continue_routes_use_case_upstream_blocker_to_requirements(
@@ -1243,10 +1271,10 @@ def test_interactive_grill_me_stages_use_shared_runner(
     monkeypatch.setattr(cli, "verify_procedure_stage", lambda *_, **__: (True, ()))
 
     commands = (
-        ["requirements-definition", "CHG-001", "--apply"],
-        ["ubiquitous-language-definition", "CHG-001", "--apply"],
-        ["use-case-definition", "CHG-001", "--apply"],
-        ["event-storming", "CHG-001", "--uc", "UC-001", "--apply"],
+        ["requirements-definition", "CHG-001"],
+        ["ubiquitous-language-definition", "CHG-001"],
+        ["use-case-definition", "CHG-001"],
+        ["event-storming", "CHG-001", "--uc", "UC-001"],
     )
 
     for command in commands:
@@ -1302,7 +1330,6 @@ def test_verified_interactive_stage_skips_nested_agent(
             str(tmp_path),
             "requirements-definition",
             "CHG-001",
-            "--apply",
         ]
     )
 
@@ -1356,7 +1383,6 @@ def test_interactive_grill_me_answers_are_saved_and_passed_to_next_turn(
             str(tmp_path),
             "requirements-definition",
             "CHG-001",
-            "--apply",
         ]
     )
 
@@ -1434,7 +1460,6 @@ def test_interactive_content_review_questions_rerun_stage_agent(
             str(tmp_path),
             "requirements-definition",
             "CHG-001",
-            "--apply",
         ]
     )
 
@@ -1503,7 +1528,6 @@ def test_interactive_content_review_blocked_reruns_stage_agent(
             str(tmp_path),
             "requirements-definition",
             "CHG-001",
-            "--apply",
         ]
     )
 
@@ -1552,7 +1576,6 @@ def test_ubiquitous_language_skips_content_review_after_completion(
             str(tmp_path),
             "ubiquitous-language-definition",
             "CHG-001",
-            "--apply",
         ]
     )
 
@@ -1609,7 +1632,6 @@ def test_ubiquitous_language_stage_asks_language_questions(
             str(tmp_path),
             "ubiquitous-language-definition",
             "CHG-001",
-            "--apply",
         ]
     )
 
@@ -1656,7 +1678,6 @@ def test_ubiquitous_language_stage_blocks_requirement_questions_without_user_inp
             str(tmp_path),
             "ubiquitous-language-definition",
             "CHG-001",
-            "--apply",
         ]
     )
 
@@ -1693,7 +1714,6 @@ def test_interactive_grill_me_blocked_records_blocker(
             str(tmp_path),
             "use-case-definition",
             "CHG-001",
-            "--apply",
         ]
     )
 


### PR DESCRIPTION
## 구현 의도

설계 산출물을 직접 작성하는 단계에서 의미가 약한 `--plan`, `--preview`, `--apply` 선택을 제거해 CLI 사용 흐름을 단순화합니다.

## 구현 접근

- `requirements-definition`, `ubiquitous-language-definition`, `use-case-definition`, `event-storming`, `ddd-architecture-definition`, `technical-decisions`를 설계 단계로 명시했습니다.
- 설계 단계는 모드 옵션 없이 호출하면 내부적으로 apply 모드로 실행됩니다.
- 설계 단계에 `--plan`, `--preview`, `--apply`를 전달하면 argparse가 거부합니다.
- 실제 실행 계획과 구현 검증 의미가 있는 `plan-writing`, `implementation`은 기존 세 모드를 유지합니다.
- 최신 `main`의 ChangeSet 단위 implementation 실행 계약을 보존했습니다.
- CLI 도움말, 생성되는 에이전트 안내, harvest 안내, 설계 브리지, 문서 예제를 새 계약에 맞췄습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s`
  - 최신 `main` 병합 후 결과: `443 passed`
- `git diff --check`
- 설계 단계 명령에서 제거된 모드 옵션 참조가 남지 않았는지 `rg`로 확인했습니다.
- `event-storming --help`에는 모드 옵션이 없고 `plan-writing --help`에는 세 모드가 유지되는지 확인했습니다.

## 위험 및 롤백

- 기존 자동화가 설계 단계에 `--apply`를 명시했다면 명령이 실패하므로 호출부 변경이 필요합니다.
- 롤백은 관련 커밋을 되돌려 모든 절차 단계에 공통 모드 옵션을 다시 등록하면 됩니다.