### PR TITLE
[codex] OWASP 보안 계획 검토와 표준 갱신 절차 추가

### DIFF
--- a/.codex/agents/references/artifact_reviewer.md
+++ b/.codex/agents/references/artifact_reviewer.md
@@ -27,6 +27,7 @@ Plan review checklist:
 - Plan stays inside the active ChangeSet and one work-item scope.
 - Required inputs are present: ChangeSet, work-item slice, E2E or maintenance verification goal, architecture, repository settings when required, and approved technical decisions for use-case work.
 - Plan has small unchecked implementation and test tasks.
+- Plan records an OWASP security review with attack-surface evidence, applicable standards, concrete security tasks, tests, verification criteria, and justified exclusions.
 - Verification tasks cover build, focused tests, E2E or maintenance goal, runtime server verification or explicit non-applicability, static analysis, and `.codex/test-gate.yaml` stages when configured.
 - Plan does not ask the executor to resolve upstream design, approval, or scope conflicts silently.
 

--- a/.codex/agents/references/security_plan_reviewer.md
+++ b/.codex/agents/references/security_plan_reviewer.md
@@ -1,0 +1,48 @@
+# security_plan_reviewer Agent Reference
+
+- Agent config: `.codex/agents/security_plan_reviewer.toml`
+- Required skill: `.codex/skills/harness-security-plan-reviewer/SKILL.md`
+- Security baseline: `.codex/skills/harness-security-plan-reviewer/references/owasp-baseline.md`
+- Version registry: `.codex/security/owasp-standards.json`
+
+## Role
+
+- Review exactly one active work-item implementation plan after planning and before independent artifact review.
+- Add applicable OWASP security controls as concrete implementation, test, and verification checkboxes.
+- Edit only the runtime-declared `docs/plans/active/<WORK-ITEM-ID>/plan.md`.
+- Do not implement code or alter upstream requirements, design, architecture, or technical decisions.
+
+## Required Outcome
+
+The plan must contain:
+
+- `OWASP Security Review` with applicability, exposed assets, trust boundaries, abuse cases, selected standards, and exclusions.
+- Security implementation tasks near the feature tasks they constrain.
+- Security tests covering positive authorization and important negative or abuse paths.
+- Security verification commands or procedures with measurable success criteria.
+- Traceability from each added control to a feature risk and an OWASP source.
+
+Use OWASP ASVS 5.0.0 as the verification baseline for web applications and services. Use OWASP Top 10:2025 for risk coverage. Add OWASP API Security Top 10:2023 only when APIs are in scope. Use OWASP MASVS 2.1.0 only for native mobile scope.
+
+Before reviewing a plan:
+
+- Read `.codex/security/owasp-standards.json`.
+- Use only versions pinned in that registry.
+- If the registry's `last_reviewed_on` is older than `review_interval_days`, stop and report that OWASP baseline review is overdue.
+- If a supplied scheduled standards report indicates `update_available`, stop until a human reviews and updates or explicitly retains the pinned baseline.
+- Do not perform live version discovery during plan review. Scheduled checking owns network access and update detection.
+
+## Fail-Closed Rules
+
+- Do not mark a control applicable without evidence from the declared inputs.
+- Do not fabricate ASVS requirement identifiers. Use a versioned identifier only when verified against an official OWASP source.
+- Do not accept generic tasks such as "secure the endpoint" or "test OWASP."
+- If authentication, authorization, sensitive data, cryptography, external requests, file handling, deserialization, or trust-boundary behavior is required but unresolved, record a blocking security decision in the plan and report blocked.
+- If no security-specific task is applicable, still record the reviewed attack surface, standards considered, exclusions, and rationale.
+
+## Ownership
+
+- Preserve existing plan content and checkbox state.
+- Add only tasks needed to make the existing scope secure and verifiable.
+- Never expand product behavior under the label of security.
+- Never weaken or remove an existing security control.

--- a/.codex/agents/security_plan_reviewer.toml
+++ b/.codex/agents/security_plan_reviewer.toml
@@ -1,0 +1,20 @@
+name = "security_plan_reviewer"
+description = "Review active implementation plans and add applicable OWASP security tasks"
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the security_plan_reviewer agent.
+
+Hot-path contract:
+- Role: Review one active work-item plan against applicable OWASP standards and add missing security implementation, test, and verification tasks.
+- Load `.codex/agents/references/security_plan_reviewer.md` before making workflow decisions.
+- Use `.codex/skills/harness-security-plan-reviewer/SKILL.md` as the required skill entrypoint.
+- Read only the workflow-declared plan and its declared ChangeSet, work-item slice, architecture, repository settings, and technical decisions.
+- Keep writes limited to the runtime-declared active plan path.
+- Preserve unrelated worktree changes.
+- Do not implement production or test code.
+- Stop and report the blocker when required inputs, write scope, or security-relevant decisions are missing.
+- Report applicable standards, added plan tasks, changed files, and blockers clearly.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -34,6 +34,10 @@ config_file = "agents/technical_decisions.toml"
 description = "Create executor-ready implementation plan without editing code"
 config_file = "agents/implementation_planner.toml"
 
+[agents.security_plan_reviewer]
+description = "Review active implementation plans and add applicable OWASP security tasks"
+config_file = "agents/security_plan_reviewer.toml"
+
 [agents.implementation_executor]
 description = "Implement active plan tasks without replanning"
 config_file = "agents/implementation_executor.toml"

--- a/.codex/security/owasp-standards.json
+++ b/.codex/security/owasp-standards.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "review_interval_days": 90,
+  "last_reviewed_on": "2026-06-10",
+  "standards": [
+    {
+      "id": "asvs",
+      "name": "OWASP Application Security Verification Standard",
+      "expected_version": "5.0.0",
+      "discovery": "github_stable_release",
+      "source": "https://api.github.com/repos/OWASP/ASVS/releases",
+      "release_pattern": "^v?(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)_release$",
+      "reference": "https://owasp.org/www-project-application-security-verification-standard/"
+    },
+    {
+      "id": "top-ten",
+      "name": "OWASP Top 10",
+      "expected_version": "2025",
+      "discovery": "text_pattern",
+      "source": "https://raw.githubusercontent.com/OWASP/www-project-top-ten/master/index.md",
+      "version_pattern": "most current released version is the .*?OWASP Top Ten (?P<version>[0-9]{4})",
+      "reference": "https://owasp.org/www-project-top-ten/"
+    },
+    {
+      "id": "api-security",
+      "name": "OWASP API Security Top 10",
+      "expected_version": "2023",
+      "discovery": "github_directory_year",
+      "source": "https://api.github.com/repos/OWASP/API-Security/contents/editions",
+      "reference": "https://owasp.org/API-Security/"
+    },
+    {
+      "id": "masvs",
+      "name": "OWASP Mobile Application Security Verification Standard",
+      "expected_version": "2.1.0",
+      "discovery": "github_stable_release",
+      "source": "https://api.github.com/repos/OWASP/owasp-masvs/releases",
+      "release_pattern": "^v?(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$",
+      "reference": "https://mas.owasp.org/MASVS/"
+    }
+  ]
+}

--- a/.codex/skills/harness-code-planner/references/detailed-instructions.md
+++ b/.codex/skills/harness-code-planner/references/detailed-instructions.md
@@ -186,6 +186,7 @@ The work-item plan must include:
 - A structural task to use `spring-package-structure` to create or verify the Spring module/package skeleton against `ARCHITECTURE.md` before feature code.
 - Implementation checklist using markdown checkboxes.
 - Matching test tasks.
+- An `OWASP Security Review` section reserved for the post-planning `security_plan_reviewer` agent. The planner may record known attack-surface facts, but must not invent security decisions.
 - Verification tasks for build, tests, E2E or maintenance verification, test gate, runtime server verification, and static analysis.
 - When browser-accessible web UI work calls a backend on another origin during local verification, include a task to define and verify the development request path: same-origin proxy or backend CORS configuration for the frontend origin, methods, and request headers.
 - Runtime server verification after build/test tasks. The plan must specify the local run command, usually `./gradlew bootRun` or the repository's existing command, and concrete behavior checks through HTTP/API/UI when the feature has a runtime surface.
@@ -282,6 +283,12 @@ Use these standards when writing the plan. Do not read blog posts at runtime.
 ## 5.3 호환성 확인
 - 기존 유스케이스 영향:
 - 같은 도메인 요소를 수정하는 active ChangeSet 충돌 여부:
+
+## 5.4 OWASP Security Review
+- Status: pending `security_plan_reviewer`
+- Attack surface:
+- Applicable standards:
+- Exclusions and rationale:
 
 ## 6. 구현 계획
 - [ ] 필요 시 `spring-initializer`를 사용해 Spring Boot 프로젝트 기준 설정 또는 신규 모듈을 초기화한다.

--- a/.codex/skills/harness-security-plan-reviewer/SKILL.md
+++ b/.codex/skills/harness-security-plan-reviewer/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: harness-security-plan-reviewer
+description: Review one active ChangeSet work-item implementation plan against applicable OWASP standards and add missing security implementation, test, and verification tasks before executor use. Use after harness-code-planner creates or updates an active work-item plan and before artifact review or implementation execution.
+---
+
+# Harness Security Plan Reviewer
+
+## Hot Path
+
+- Read `.codex/agents/references/security_plan_reviewer.md`.
+- Read `references/owasp-baseline.md`.
+- Read `.codex/security/owasp-standards.json` and use its pinned versions.
+- Read only inputs declared by the runtime payload.
+- Edit only the declared active work-item `plan.md`.
+- Preserve existing content and checkbox state.
+- Add risk-specific, testable security tasks. Do not add generic security boilerplate.
+- Do not implement code or change upstream artifacts.
+- Report blockers when security-relevant decisions are unresolved.
+
+## Review Flow
+
+1. Identify attack surface from feature scope, data, actors, trust boundaries, protocols, dependencies, and deployment shape.
+2. Select applicable standards:
+   - OWASP ASVS 5.0.0 for web applications and services.
+   - OWASP Top 10:2025 for risk coverage.
+   - OWASP API Security Top 10:2023 for API scope.
+   - OWASP MASVS 2.1.0 for native mobile scope.
+3. Map each applicable risk to an implementation control, focused test, verification procedure, and success criterion.
+4. Add an `OWASP Security Review` section to the plan.
+5. Add checkboxes near relevant implementation, test, and verification sections.
+6. Record excluded standards or controls with rationale.
+7. Stop when a security-critical decision cannot be derived from approved inputs.
+
+## Task Quality
+
+- Name protected asset and threat.
+- Name enforcement layer and expected behavior.
+- Include success, denied, malformed, boundary, and replay or idempotency cases when applicable.
+- Prefer existing repository security tools and commands.
+- When tooling is absent, add a scoped setup task only when required by the identified risk.
+- Treat SAST, dependency scanning, secret scanning, and DAST as evidence sources, not substitutes for behavior tests.
+
+## Output Contract
+
+Add or update:
+
+- Security applicability and attack-surface summary.
+- OWASP source and version mapping.
+- Security implementation checkboxes.
+- Security test checkboxes.
+- Security verification checkboxes and success criteria.
+- Security assumptions, exclusions, and unresolved blockers.
+
+Do not create a separate report. The updated active plan is the workflow artifact consumed by the independent artifact reviewer.

--- a/.codex/skills/harness-security-plan-reviewer/agents/openai.yaml
+++ b/.codex/skills/harness-security-plan-reviewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Security Plan Reviewer"
+  short_description: "Add OWASP security controls to plans."
+  default_prompt: "Review one active work-item plan against applicable OWASP standards and add concrete security implementation, test, and verification tasks."

--- a/.codex/skills/harness-security-plan-reviewer/references/owasp-baseline.md
+++ b/.codex/skills/harness-security-plan-reviewer/references/owasp-baseline.md
@@ -1,0 +1,75 @@
+# OWASP Planning Baseline
+
+Version source of truth: `.codex/security/owasp-standards.json`. This file explains application rules; it must not independently choose newer versions.
+
+## Update Process
+
+- `.github/workflows/check-owasp-standards.yml` runs monthly and on manual dispatch.
+- `scripts/check_owasp_standards.py` checks only official OWASP or OWASP GitHub sources.
+- A discovered version change or review age over 90 days creates or refreshes one GitHub review issue.
+- Network or source parsing failures fail the workflow but do not claim that a new standard exists.
+- Never update this baseline automatically. Review release notes, control changes, identifier migrations, tests, and one real-plan smoke before updating the registry and `last_reviewed_on`.
+
+## Versioned Sources
+
+- OWASP Application Security Verification Standard 5.0.0:
+  `https://owasp.org/www-project-application-security-verification-standard/`
+- OWASP Top 10:2025:
+  `https://owasp.org/www-project-top-ten/`
+- OWASP API Security Top 10:2023:
+  `https://owasp.org/API-Security/editions/2023/en/0x11-t10/`
+- OWASP MASVS 2.1.0:
+  `https://mas.owasp.org/MASVS/`
+- OWASP Cheat Sheet Series:
+  `https://cheatsheetseries.owasp.org/`
+
+ASVS is the normative verification baseline for web applications and services. Top 10 documents help identify risk coverage but do not replace testable requirements.
+
+## Applicability Matrix
+
+|Feature evidence|Required planning focus|
+|---|---|
+|Identity, sessions, tokens, credentials|Authentication lifecycle, session invalidation, credential storage, brute-force resistance, recovery paths|
+|Roles, ownership, tenant or object access|Deny-by-default authorization at function, object, and property levels; privilege-transition tests|
+|Untrusted input or rendered output|Canonicalization, allow-list validation, context-aware encoding, parameterized queries, injection tests|
+|Sensitive or regulated data|Classification, minimization, encryption in transit and at rest when required, masking, retention, deletion, log exclusion|
+|Browser UI|CSRF where cookie auth exists, XSS prevention, security headers, clickjacking policy, CORS and origin policy|
+|HTTP or public API|Schema validation, method and content-type restrictions, object and property authorization, resource limits, inventory and version policy|
+|External URL, webhook, callback, import|SSRF controls, destination allow-listing, redirect and DNS handling, timeout and response-size limits|
+|File upload or download|Type and size validation, generated names, storage isolation, malware handling where justified, authorization, content disposition|
+|Serialization, templates, expressions, XML|Safe parsers, disabled dangerous features, type restrictions, payload limits|
+|Cryptography, signatures, secrets|Approved algorithms and libraries, key ownership and rotation, secret storage, failure behavior; no custom cryptography|
+|State-changing workflow or money-like value|Replay resistance, idempotency, concurrency controls, invariant and abuse tests, audit events|
+|Dependencies, build, deployment|Governed dependencies, vulnerability review, artifact integrity, least-privilege configuration, secret scanning|
+|Security-significant events|Structured audit logging without secrets, correlation, tamper resistance where required, alert criteria|
+
+## Plan Mapping Rules
+
+For every applicable row:
+
+1. State evidence from the ChangeSet, work-item slice, architecture, or technical decisions.
+2. Add one or more concrete implementation tasks.
+3. Add focused tests for allowed and denied behavior.
+4. Add a verification command or manual procedure with measurable success criteria.
+5. Map to an OWASP source and version. Use chapter or risk names when exact ASVS IDs were not verified.
+
+## Minimum Abuse Cases
+
+Add only those relevant to the feature:
+
+- unauthenticated request
+- authenticated wrong role, owner, or tenant
+- object ID or property tampering
+- malformed, oversized, encoded, or duplicate input
+- replayed or concurrent state-changing request
+- secret or sensitive value reaching logs, errors, browser storage, or responses
+- dependency or configuration failure
+- external service timeout, redirect, or attacker-controlled destination
+
+## Prohibited Output
+
+- Generic "follow OWASP" checkbox.
+- Security tool run without defined pass criteria.
+- Exact ASVS requirement ID inferred from memory.
+- New product requirement disguised as a security control.
+- Claim that Top 10 coverage alone proves security.

--- a/.github/workflows/check-owasp-standards.yml
+++ b/.github/workflows/check-owasp-standards.yml
@@ -1,0 +1,62 @@
+name: Check OWASP standards
+
+on:
+  schedule:
+    - cron: "17 3 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Check official OWASP sources
+        id: check
+        continue-on-error: true
+        run: |
+          set +e
+          python3 scripts/check_owasp_standards.py \
+            --report owasp-standards-report.md
+          exit_code="$?"
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Upload check report
+        uses: actions/upload-artifact@v4
+        with:
+          name: owasp-standards-report
+          path: owasp-standards-report.md
+
+      - name: Create or update review issue
+        if: steps.check.outputs.exit_code == '2'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Review available OWASP standards updates"
+          existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file owasp-standards-report.md
+          else
+            gh issue create --title "$title" --body-file owasp-standards-report.md
+          fi
+
+      - name: Fail on source errors
+        if: steps.check.outputs.exit_code == '3'
+        run: |
+          echo "Official OWASP source check failed. See uploaded report."
+          exit 1
+
+      - name: Fail on unexpected checker error
+        if: steps.check.outputs.exit_code != '0' && steps.check.outputs.exit_code != '2' && steps.check.outputs.exit_code != '3'
+        run: |
+          echo "OWASP checker exited unexpectedly: ${{ steps.check.outputs.exit_code }}"
+          exit 1

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -36,10 +36,30 @@ steps:
       stage: plan
       scope: work_item
 
+  - id: secure-work-item-plan
+    kind: agent
+    name: Add applicable OWASP security controls to the work item plan
+    needs: [plan-work-item]
+    agent_id: security_plan_reviewer
+    skill_id: harness-security-plan-reviewer
+    inputs:
+      - docs/changes/active/<CHG-ID>.md
+      - docs/plans/active/<WORK-ITEM-ID>/plan.md
+      - docs/use-cases/<UC-ID>
+      - docs/maintenance/<MAINT-ID>
+      - ARCHITECTURE.md
+      - .codex/repository-settings.md
+    outputs:
+      - docs/plans/active/<WORK-ITEM-ID>/plan.md
+    metadata:
+      stage: security-review
+      scope: work_item
+      baseline: OWASP ASVS 5.0.0
+
   - id: review-work-item-plan
     kind: agent
     name: Review the work item implementation plan before execution
-    needs: [plan-work-item]
+    needs: [secure-work-item-plan]
     agent_id: artifact_reviewer
     skill_id: harness-artifact-reviewer
     inputs:

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -388,10 +388,35 @@ HARNESS_FULL_WORKFLOW = Workflow(
             },
         ),
         Step(
+            id="secure-use-case-plan",
+            kind=StepKind.AGENT,
+            name="Add applicable OWASP security controls to one use-case plan",
+            needs=("planner-create-use-case-plan",),
+            agent_id="security_plan_reviewer",
+            skill_id="harness-security-plan-reviewer",
+            inputs=(
+                Path("docs/changes/active/<CHG-ID>.md"),
+                Path("docs/plans/active/<UC-ID>/plan.md"),
+                Path("docs/use-cases/<UC-ID>"),
+                Path("ARCHITECTURE.md"),
+                Path(".codex/repository-settings.md"),
+            ),
+            outputs=(Path("docs/plans/active/<UC-ID>/plan.md"),),
+            metadata={
+                "stage": "security-review",
+                "scope": "use_case",
+                "baseline": "OWASP ASVS 5.0.0",
+                "purpose": (
+                    "Add risk-specific OWASP implementation, test, and verification "
+                    "tasks before independent plan review."
+                ),
+            },
+        ),
+        Step(
             id="review-use-case-plan",
             kind=StepKind.AGENT,
             name="Review one use-case implementation plan before execution",
-            needs=("planner-create-use-case-plan",),
+            needs=("secure-use-case-plan",),
             agent_id="artifact_reviewer",
             skill_id="harness-artifact-reviewer",
             inputs=(

--- a/scripts/check_owasp_standards.py
+++ b/scripts/check_owasp_standards.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Check pinned OWASP standards against official release sources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_REGISTRY = Path(".codex/security/owasp-standards.json")
+USER_AGENT = "harness-owasp-standards-checker/1"
+
+
+@dataclass(frozen=True)
+class StandardResult:
+    standard_id: str
+    name: str
+    expected: str
+    discovered: str | None
+    status: str
+    source: str
+    reference: str
+    error: str = ""
+
+
+Fetcher = Callable[[str], Any]
+
+
+def fetch_json(url: str) -> Any:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urlopen(request, timeout=20) as response:
+        return json.load(response)
+
+
+def fetch_text(url: str) -> str:
+    request = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(request, timeout=20) as response:
+        return response.read().decode("utf-8")
+
+
+def semantic_key(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+
+def discover_version(
+    standard: dict[str, Any],
+    *,
+    json_fetcher: Fetcher = fetch_json,
+    text_fetcher: Fetcher = fetch_text,
+) -> str:
+    discovery = standard["discovery"]
+    source = standard["source"]
+    if discovery == "github_stable_release":
+        releases = json_fetcher(source)
+        pattern = re.compile(standard["release_pattern"])
+        versions = []
+        for release in releases:
+            if release.get("draft") or release.get("prerelease"):
+                continue
+            match = pattern.fullmatch(str(release.get("tag_name") or ""))
+            if match:
+                versions.append(match.group("version"))
+        if not versions:
+            raise ValueError("no stable release matched release_pattern")
+        return max(versions, key=semantic_key)
+    if discovery == "text_pattern":
+        match = re.search(
+            standard["version_pattern"],
+            text_fetcher(source),
+            flags=re.IGNORECASE,
+        )
+        if not match:
+            raise ValueError("version_pattern did not match official source")
+        return match.group("version")
+    if discovery == "github_directory_year":
+        entries = json_fetcher(source)
+        years = [
+            str(entry.get("name"))
+            for entry in entries
+            if re.fullmatch(r"[0-9]{4}", str(entry.get("name") or ""))
+        ]
+        if not years:
+            raise ValueError("no edition year directory found")
+        return max(years, key=int)
+    raise ValueError(f"unsupported discovery strategy: {discovery}")
+
+
+def check_registry(
+    registry: dict[str, Any],
+    *,
+    today: date,
+    json_fetcher: Fetcher = fetch_json,
+    text_fetcher: Fetcher = fetch_text,
+) -> tuple[list[StandardResult], bool]:
+    results: list[StandardResult] = []
+    for standard in registry["standards"]:
+        try:
+            discovered = discover_version(
+                standard,
+                json_fetcher=json_fetcher,
+                text_fetcher=text_fetcher,
+            )
+            status = (
+                "current"
+                if discovered == standard["expected_version"]
+                else "update_available"
+            )
+            error = ""
+        except (HTTPError, URLError, TimeoutError, ValueError, json.JSONDecodeError) as exc:
+            discovered = None
+            status = "source_error"
+            error = str(exc)
+        results.append(
+            StandardResult(
+                standard_id=standard["id"],
+                name=standard["name"],
+                expected=standard["expected_version"],
+                discovered=discovered,
+                status=status,
+                source=standard["source"],
+                reference=standard["reference"],
+                error=error,
+            )
+        )
+
+    reviewed = date.fromisoformat(registry["last_reviewed_on"])
+    stale = (today - reviewed).days > int(registry["review_interval_days"])
+    return results, stale
+
+
+def render_report(
+    registry: dict[str, Any],
+    results: list[StandardResult],
+    *,
+    checked_at: datetime,
+    stale: bool,
+) -> str:
+    overall = "source_error" if any(r.status == "source_error" for r in results) else (
+        "review_required"
+        if stale or any(r.status == "update_available" for r in results)
+        else "current"
+    )
+    lines = [
+        "# OWASP Standards Update Check",
+        "",
+        f"- Checked at: `{checked_at.isoformat()}`",
+        f"- Overall status: `{overall}`",
+        f"- Last human review: `{registry['last_reviewed_on']}`",
+        f"- Review interval: `{registry['review_interval_days']} days`",
+        f"- Review stale: `{'yes' if stale else 'no'}`",
+        "",
+        "|Standard|Pinned|Discovered|Status|",
+        "|---|---|---|---|",
+    ]
+    for result in results:
+        lines.append(
+            f"|[{result.name}]({result.reference})|`{result.expected}`|"
+            f"`{result.discovered or '-'}`|`{result.status}`|"
+        )
+    errors = [result for result in results if result.error]
+    if errors:
+        lines.extend(["", "## Source Errors", ""])
+        lines.extend(
+            f"- `{result.standard_id}`: {result.error}" for result in errors
+        )
+    if overall == "review_required":
+        lines.extend(
+            [
+                "",
+                "## Required Review",
+                "",
+                "1. Read official release notes and migration guidance.",
+                "2. Compare changed controls and identifiers with the reviewer baseline.",
+                "3. Update the registry, OWASP baseline, agent contract, and contract tests.",
+                "4. Run focused tests and a real-plan smoke test.",
+                "5. Set `last_reviewed_on` only after human approval.",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--today", type=date.fromisoformat)
+    args = parser.parse_args()
+
+    registry = json.loads(args.registry.read_text(encoding="utf-8"))
+    today = args.today or datetime.now(timezone.utc).date()
+    checked_at = datetime.combine(today, datetime.min.time(), tzinfo=timezone.utc)
+    results, stale = check_registry(registry, today=today)
+    report = render_report(registry, results, checked_at=checked_at, stale=stale)
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(report, encoding="utf-8")
+    print(report, end="")
+    if any(result.status == "source_error" for result in results):
+        return 3
+    if stale or any(result.status == "update_available" for result in results):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -120,6 +120,7 @@ def test_harness_full_workflow_models_top_level_harness_lifecycle() -> None:
         "storm-affected-use-case",
         "design-affected-use-case",
         "planner-create-use-case-plan",
+        "secure-use-case-plan",
         "review-use-case-plan",
         "executor-implement-use-case-plan",
         "verifier-run-implementation-e2e",
@@ -179,6 +180,7 @@ def test_harness_full_workflow_orchestrates_use_case_scoped_loop() -> (
     storming = HARNESS_FULL_WORKFLOW.step_by_id("storm-affected-use-case")
     design = HARNESS_FULL_WORKFLOW.step_by_id("design-affected-use-case")
     planner = HARNESS_FULL_WORKFLOW.step_by_id("planner-create-use-case-plan")
+    security = HARNESS_FULL_WORKFLOW.step_by_id("secure-use-case-plan")
     reviewer = HARNESS_FULL_WORKFLOW.step_by_id("review-use-case-plan")
     executor = HARNESS_FULL_WORKFLOW.step_by_id("executor-implement-use-case-plan")
     verification = HARNESS_FULL_WORKFLOW.step_by_id("verifier-run-implementation-e2e")
@@ -198,10 +200,16 @@ def test_harness_full_workflow_orchestrates_use_case_scoped_loop() -> (
     assert planner.needs == ("design-affected-use-case",)
     assert Path("docs/plans/active/<UC-ID>/plan.md") in planner.outputs
 
+    assert security.kind == StepKind.AGENT
+    assert security.agent_id == "security_plan_reviewer"
+    assert security.skill_id == "harness-security-plan-reviewer"
+    assert security.needs == ("planner-create-use-case-plan",)
+    assert Path("docs/plans/active/<UC-ID>/plan.md") in security.outputs
+
     assert reviewer.kind == StepKind.AGENT
     assert reviewer.agent_id == "artifact_reviewer"
     assert reviewer.skill_id == "harness-artifact-reviewer"
-    assert reviewer.needs == ("planner-create-use-case-plan",)
+    assert reviewer.needs == ("secure-use-case-plan",)
     assert reviewer.metadata["review_gate"]["approved_status"] == "approved"
 
     assert executor.kind == StepKind.AGENT

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -121,10 +121,14 @@ def test_default_changeset_work_item_workflow_loads() -> None:
     assert workflow.name == "changeset-use-case-workflow"
     assert workflow.step_by_id("plan-work-item").agent_id == "implementation_planner"
     assert workflow.step_by_id("plan-work-item").skill_id == "harness-code-planner"
+    security = workflow.step_by_id("secure-work-item-plan")
+    assert security.agent_id == "security_plan_reviewer"
+    assert security.skill_id == "harness-security-plan-reviewer"
+    assert security.needs == ("plan-work-item",)
     review = workflow.step_by_id("review-work-item-plan")
     assert review.agent_id == "artifact_reviewer"
     assert review.skill_id == "harness-artifact-reviewer"
-    assert review.needs == ("plan-work-item",)
+    assert review.needs == ("secure-work-item-plan",)
     assert review.metadata["review_gate"]["approved_status"] == "approved"
     assert workflow.step_by_id("execute-work-item").skill_id == (
         "harness-plan-executor"

--- a/tests/test_owasp_standards_update.py
+++ b/tests/test_owasp_standards_update.py
@@ -1,0 +1,144 @@
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from scripts.check_owasp_standards import check_registry, render_report
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = REPO_ROOT / ".codex/security/owasp-standards.json"
+
+
+def registry() -> dict:
+    return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def official_json(url: str):
+    if "ASVS" in url:
+        return [
+            {"tag_name": "latest", "draft": False, "prerelease": False},
+            {"tag_name": "v5.0.0_release", "draft": False, "prerelease": False},
+        ]
+    if "API-Security" in url:
+        return [{"name": "2019"}, {"name": "2023"}, {"name": "README.md"}]
+    if "owasp-masvs" in url:
+        return [
+            {"tag_name": "v2.1.0", "draft": False, "prerelease": False},
+            {"tag_name": "v2.2.0-beta", "draft": False, "prerelease": True},
+        ]
+    raise AssertionError(url)
+
+
+def official_text(url: str) -> str:
+    assert "www-project-top-ten" in url
+    return (
+        "The most current released version is the "
+        "[OWASP Top Ten 2025](https://owasp.org/Top10/2025/)."
+    )
+
+
+def test_current_registry_passes_with_official_versions() -> None:
+    results, stale = check_registry(
+        registry(),
+        today=date(2026, 6, 10),
+        json_fetcher=official_json,
+        text_fetcher=official_text,
+    )
+
+    assert stale is False
+    assert {result.status for result in results} == {"current"}
+
+
+def test_new_release_requires_review_without_mutating_registry() -> None:
+    def newer_json(url: str):
+        if "ASVS" in url:
+            return [
+                {"tag_name": "v5.0.1_release", "draft": False, "prerelease": False}
+            ]
+        return official_json(url)
+
+    current = registry()
+    results, stale = check_registry(
+        current,
+        today=date(2026, 6, 10),
+        json_fetcher=newer_json,
+        text_fetcher=official_text,
+    )
+
+    asvs = next(result for result in results if result.standard_id == "asvs")
+    assert stale is False
+    assert asvs.expected == "5.0.0"
+    assert asvs.discovered == "5.0.1"
+    assert asvs.status == "update_available"
+    assert current["standards"][0]["expected_version"] == "5.0.0"
+
+
+def test_stale_human_review_requires_review_even_without_new_release() -> None:
+    current = registry()
+    results, stale = check_registry(
+        current,
+        today=date(2026, 9, 9),
+        json_fetcher=official_json,
+        text_fetcher=official_text,
+    )
+    report = render_report(
+        current,
+        results,
+        checked_at=datetime(2026, 9, 9, tzinfo=timezone.utc),
+        stale=stale,
+    )
+
+    assert stale is True
+    assert "Overall status: `review_required`" in report
+
+
+def test_network_failure_is_source_error_not_update_claim() -> None:
+    def failing_json(url: str):
+        raise TimeoutError(url)
+
+    results, _ = check_registry(
+        registry(),
+        today=date(2026, 6, 10),
+        json_fetcher=failing_json,
+        text_fetcher=official_text,
+    )
+
+    assert any(result.status == "source_error" for result in results)
+    assert all(result.status != "update_available" for result in results)
+
+
+def test_schedule_and_reviewer_reference_registry() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/check-owasp-standards.yml").read_text(
+        encoding="utf-8"
+    )
+    reviewer = (
+        REPO_ROOT / ".codex/agents/references/security_plan_reviewer.md"
+    ).read_text(encoding="utf-8")
+
+    assert 'cron: "17 3 1 * *"' in workflow
+    assert "issues: write" in workflow
+    assert ".codex/security/owasp-standards.json" in reviewer
+
+
+def test_baseline_versions_match_registry() -> None:
+    current = registry()
+    baseline = (
+        REPO_ROOT
+        / ".codex/skills/harness-security-plan-reviewer/references/owasp-baseline.md"
+    ).read_text(encoding="utf-8")
+    reviewer = (
+        REPO_ROOT / ".codex/agents/references/security_plan_reviewer.md"
+    ).read_text(encoding="utf-8")
+
+    expected = {
+        standard["id"]: standard["expected_version"]
+        for standard in current["standards"]
+    }
+    assert f"ASVS {expected['asvs']}" in reviewer
+    assert f"Top 10:{expected['top-ten']}" in reviewer
+    assert f"Top 10:{expected['api-security']}" in reviewer
+    assert f"MASVS {expected['masvs']}" in reviewer
+    assert expected["asvs"] in baseline
+    assert expected["top-ten"] in baseline
+    assert expected["api-security"] in baseline
+    assert expected["masvs"] in baseline

--- a/tests/test_security_plan_reviewer_contract.py
+++ b/tests/test_security_plan_reviewer_contract.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from harness_codex.runtime.models import HARNESS_FULL_WORKFLOW
+from harness_codex.runtime.workflows.loader import load_named_workflow
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_security_plan_reviewer_agent_and_skill_are_registered() -> None:
+    config = read(".codex/config.toml")
+    agent = read(".codex/agents/security_plan_reviewer.toml")
+    skill = read(".codex/skills/harness-security-plan-reviewer/SKILL.md")
+
+    assert "[agents.security_plan_reviewer]" in config
+    assert 'name = "security_plan_reviewer"' in agent
+    assert "harness-security-plan-reviewer" in agent
+    assert "OWASP ASVS 5.0.0" in skill
+    assert "OWASP Top 10:2025" in skill
+    assert "OWASP API Security Top 10:2023" in skill
+
+
+def test_changeset_workflow_secures_plan_before_independent_review() -> None:
+    workflow = load_named_workflow("changeset-use-case-workflow")
+    security = workflow.step_by_id("secure-work-item-plan")
+    review = workflow.step_by_id("review-work-item-plan")
+
+    assert security.agent_id == "security_plan_reviewer"
+    assert security.skill_id == "harness-security-plan-reviewer"
+    assert security.needs == ("plan-work-item",)
+    assert security.outputs == (
+        Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),
+    )
+    assert review.needs == ("secure-work-item-plan",)
+
+
+def test_full_workflow_secures_plan_before_independent_review() -> None:
+    security = HARNESS_FULL_WORKFLOW.step_by_id("secure-use-case-plan")
+    review = HARNESS_FULL_WORKFLOW.step_by_id("review-use-case-plan")
+
+    assert security.agent_id == "security_plan_reviewer"
+    assert security.skill_id == "harness-security-plan-reviewer"
+    assert security.needs == ("planner-create-use-case-plan",)
+    assert security.outputs == (Path("docs/plans/active/<UC-ID>/plan.md"),)
+    assert review.needs == ("secure-use-case-plan",)
+
+
+def test_security_reviewer_is_plan_only_and_requires_traceable_tasks() -> None:
+    reference = read(".codex/agents/references/security_plan_reviewer.md")
+    baseline = read(
+        ".codex/skills/harness-security-plan-reviewer/references/owasp-baseline.md"
+    )
+
+    assert "Edit only the runtime-declared" in reference
+    assert "Do not implement code" in reference
+    assert "Do not fabricate ASVS requirement identifiers" in reference
+    assert "implementation tasks" in baseline
+    assert "focused tests" in baseline
+    assert "verification command" in baseline


### PR DESCRIPTION
## 구현 의도

구현 계획이 실행되기 전에 OWASP 기준으로 공격 표면과 보안 통제를 검토하고, 누락된 구현·테스트·검증 작업을 계획에 추가하도록 전담 에이전트를 도입합니다. OWASP 표준 버전 변경도 주기적으로 탐지해 오래된 기준이 계획 검토에 계속 사용되는 문제를 방지합니다.

## 구현 접근 방식

- `security_plan_reviewer` 에이전트와 `harness-security-plan-reviewer` 스킬을 추가했습니다.
- 워크플로를 `implementation_planner → security_plan_reviewer → artifact_reviewer → implementation_executor` 순서로 연결했습니다.
- ASVS, Top 10, API Security Top 10, MASVS 적용 여부를 기능의 공격 표면과 신뢰 경계에 따라 선택하고 구체적인 구현·테스트·검증 체크박스로 변환합니다.
- `.codex/security/owasp-standards.json`을 버전 기준점으로 사용합니다.
- 월간 GitHub Actions 작업이 공식 OWASP/GitHub 소스에서 최신 버전을 확인합니다.
- 버전 변경 또는 90일 검토 기한 초과 시 검토 이슈를 생성하거나 갱신합니다. 네트워크 오류는 신규 버전으로 오인하지 않으며, 기준 파일은 자동 수정하지 않습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s` → `441 passed`
- `./venv/bin/python3 -m pytest -q -s tests/test_owasp_standards_update.py tests/test_security_plan_reviewer_contract.py tests/runtime/test_workflow_loader.py tests/runtime/test_models.py` → `35 passed`
- `python3 .../skill-creator/scripts/quick_validate.py .codex/skills/harness-security-plan-reviewer` → 통과
- JSON/TOML/YAML 파싱 및 `git diff --check` → 통과
- `./venv/bin/python3 scripts/check_owasp_standards.py` 실시간 공식 소스 확인 → ASVS 5.0.0, Top 10 2025, API Security 2023, MASVS 2.1.0 모두 current
- `/home/jiwoo/workspace/zeten`의 실제 UC-001 계획으로 에이전트 실행 → OWASP 검토 섹션, 구현 통제 4개, 테스트 그룹 3개, 검증 그룹 3개 추가 확인 후 산출물 원복

## 위험 및 롤백

- 공식 문서 형식이나 GitHub API 응답이 바뀌면 버전 탐지가 실패할 수 있습니다. 이 경우 워크플로는 `source_error`로 실패하며 신규 버전으로 판단하지 않습니다.
- 보안 검토가 기존 계획에 새로운 미완료 작업을 추가하므로 실행 준비 상태가 이전보다 엄격해집니다.
- 롤백은 보안 검토 워크플로 단계, 에이전트/스킬, 버전 레지스트리와 월간 체크 워크플로를 함께 제거하면 됩니다.