### PR TITLE
[codex] 구현 단계 롬복 및 생성자 주입 규칙 추가

### DIFF
--- a/.codex/agents/references/implementation_executor.md
+++ b/.codex/agents/references/implementation_executor.md
@@ -64,6 +64,8 @@ Execution rules:
 
 Implementation constraints:
 - Follow ARCHITECTURE.md module and package boundaries.
+- In Java/Spring code, use Lombok for boilerplate accessors and constructors, including `@Getter` and `@RequiredArgsConstructor`, when the required Lombok dependency and annotation processing are available or can be added within the approved plan scope.
+- Use constructor injection for dependencies. Prefer `private final` dependency fields with Lombok `@RequiredArgsConstructor`; do not use field injection or setter injection.
 - Keep bootstrapping/configuration separate from domain logic.
 - Put business rules in the owning domain model, aggregate, or domain service.
 - Put orchestration in application services.

--- a/tests/test_executor_use_case_scope.py
+++ b/tests/test_executor_use_case_scope.py
@@ -53,3 +53,12 @@ def test_executor_records_environment_blocker_for_e2e_limits() -> None:
     assert "same-origin proxy or CORS behavior" in executor
     assert "A CORS-blocked request is an implementation failure" in executor
     assert "environment blocker" in executor
+
+
+def test_executor_uses_lombok_and_constructor_injection_for_java_spring() -> None:
+    executor = read_executor()
+
+    assert "`@Getter` and `@RequiredArgsConstructor`" in executor
+    assert "Use constructor injection for dependencies" in executor
+    assert "`private final` dependency fields" in executor
+    assert "do not use field injection or setter injection" in executor


### PR DESCRIPTION
## 구현 의도

Java/Spring 구현 단계에서 반복적인 접근자 및 생성자 코드를 Lombok으로 처리하고, 의존성 주입 방식을 생성자 주입으로 통일합니다.

## 구현 접근 방식

- `implementation_executor` 지침에 `@Getter`, `@RequiredArgsConstructor` 사용 규칙을 추가했습니다.
- 의존성 필드를 `private final`로 선언하고 `@RequiredArgsConstructor`를 통한 생성자 주입을 우선하도록 명시했습니다.
- 필드 주입과 세터 주입을 사용하지 않도록 명시했습니다.
- 실행기 지침에 해당 규칙이 유지되는지 검증하는 회귀 테스트를 추가했습니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q -s tests/test_executor_use_case_scope.py`
- 결과: `4 passed in 0.31s`
- `git diff --check`

## 위험 및 롤백

- Lombok 의존성 또는 annotation processing을 사용할 수 없는 범위에서는 규칙이 적용되지 않도록 조건을 명시해 기존 프로젝트 호환성을 유지합니다.
- 문제 발생 시 본 커밋을 되돌리면 기존 구현 실행기 지침으로 복구됩니다.
