### PR TITLE
[codex] 구현 실행 재개와 검증 재사용 추가

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -172,7 +172,10 @@ TOPIC_HELP: Mapping[str, str] = {
     "ddd-architecture-definition": "Usage: harness ddd-architecture-definition <CHG-ID> --uc UC-ID",
     "technical-decisions": "Usage: harness technical-decisions <CHG-ID> --uc UC-ID",
     "plan-writing": "Usage: harness plan-writing <CHG-ID> --uc UC-ID --plan|--preview|--apply",
-    "implementation": "Usage: harness implementation <CHG-ID> --plan|--preview|--apply",
+    "implementation": (
+        "Usage: harness implementation <CHG-ID> "
+        "[--force-verification] --plan|--preview|--apply"
+    ),
     "ultrawork": (
         "Usage: harness ultrawork [--title TEXT] [--change-set-id ID] "
         "[--uc UC-ID] [--force] [--plan|--preview|--apply]"
@@ -312,6 +315,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--resolution-prompt",
         default="",
         help="Prompt used when --blocker-resolution use-case is selected.",
+    )
+    changes_continue.add_argument(
+        "--force-verification",
+        action="store_true",
+        help="Run all implementation verification commands instead of reusing PASS evidence.",
     )
     _add_mode_options(changes_continue)
     changes_continue.set_defaults(func=changes_continue_command)
@@ -463,6 +471,12 @@ def _add_procedure_stage_parser(
         action="store_true",
         help="Rerun the stage even when the ChangeSet table marks it verified.",
     )
+    if stage.stage_id == "implementation":
+        command.add_argument(
+            "--force-verification",
+            action="store_true",
+            help="Run all verification commands instead of reusing compatible PASS evidence.",
+        )
     if stage.stage_id in DESIGN_STAGE_IDS:
         command.set_defaults(plan=False, preview=False, apply=True)
     else:
@@ -640,6 +654,7 @@ def changes_continue_command(args: argparse.Namespace, repo_root: Path) -> str:
         plan=mode == RunMode.PLAN,
         preview=mode == RunMode.PREVIEW,
         apply=mode == RunMode.APPLY,
+        force_verification=args.force_verification,
     )
     header = [
         f"Continue: {change_set.change_set_id}",
@@ -2343,11 +2358,26 @@ def run_change_command(args: argparse.Namespace, repo_root: Path) -> str:
             f"active_changeset_moved=true completed_path={completed_path}"
         )
 
-    state, result = _apply_workflow(repo_root, change_set, scopes)
+    state, result = _apply_workflow(
+        repo_root,
+        change_set,
+        scopes,
+        force_verification=bool(getattr(args, "force_verification", False)),
+    )
+    execution = _implementation_execution_summary(result)
     return (
         f"APPLY started: run_id={state.run_id} status={result.status.value} "
-        "active_changeset_moved=false"
+        f"active_changeset_moved=false{execution}"
     )
+
+
+def _implementation_execution_summary(result: RunResult) -> str:
+    for step_result in reversed(result.step_results):
+        mode = step_result.metadata.get("execution_mode")
+        if mode:
+            attempt = step_result.metadata.get("attempt", 1)
+            return f" execution_mode={mode} attempt={attempt}"
+    return ""
 
 
 def evolution_propose_command(args: argparse.Namespace, repo_root: Path) -> str:
@@ -2704,7 +2734,13 @@ def _completed_plan_path(work_item_id: str) -> Path:
     return Path(f"docs/plans/completed/{work_item_id}/plan.md")
 
 
-def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
+def _apply_workflow(
+    repo_root: Path,
+    change_set: ChangeSet,
+    scopes: tuple,
+    *,
+    force_verification: bool = False,
+):
     run_id = f"run-{uuid4().hex[:12]}"
     affected_use_cases = tuple(
         scope.use_case.uc_id for scope in scopes if scope.use_case is not None
@@ -2762,6 +2798,7 @@ def _apply_workflow(repo_root: Path, change_set: ChangeSet, scopes: tuple):
                     if scope.verification_goal_path
                     else None
                 ),
+                "force_verification": force_verification,
                 "affected_work_items": [
                     {
                         "id": item.display_id,

--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -363,6 +363,18 @@ class RunnerEngine:
             for result in step_results
             if "decision" in result.metadata
         )
+        agent_attempts = tuple(
+            {
+                "step_id": result.step_id,
+                "execution_mode": result.metadata.get("execution_mode"),
+                "attempt": result.metadata.get("attempt"),
+                "provider_session_id": result.metadata.get("provider_session_id"),
+                "termination_reason": result.metadata.get("termination_reason"),
+                "checkpoint_path": result.metadata.get("checkpoint_path"),
+            }
+            for result in step_results
+            if "execution_mode" in result.metadata
+        )
 
         metadata: dict[str, object] = {
             "mode": context.mode.value,
@@ -371,6 +383,7 @@ class RunnerEngine:
             "side_effects": context.mode == RunMode.APPLY,
             "policy_decisions": policy_decisions,
             "decisions": decisions,
+            "agent_attempts": agent_attempts,
         }
         if extra:
             metadata.update(extra)

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import re
 import shutil
 import subprocess
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Mapping, Protocol, Sequence
 
@@ -45,6 +46,8 @@ from harness_codex.runtime.validate_scope_diff import (
 
 
 SUCCESS_STDERR_TAIL_BYTES = 16_384
+IMPLEMENTATION_ATTEMPT_SCHEMA_VERSION = 1
+IMPLEMENTATION_CHECKPOINT_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -59,6 +62,7 @@ class AgentRunRequest:
     skill_path: Path | None = None
     skill_body: str | None = None
     prompt_suffix: str = ""
+    resume_session_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -105,6 +109,15 @@ class ConfigurableCliAgentAdapter:
         )
         if request.prompt_suffix:
             prompt = f"{prompt.rstrip()}\n\n{request.prompt_suffix.strip()}\n"
+        attempt = _implementation_attempt(request)
+        if attempt["execution_mode"] == "resumed":
+            checkpoint = attempt.get("previous_checkpoint")
+            if isinstance(checkpoint, Mapping):
+                prompt = (
+                    f"{prompt.rstrip()}\n\n"
+                    "## Durable implementation checkpoint\n\n"
+                    f"{json.dumps(checkpoint, ensure_ascii=False, indent=2)}\n"
+                )
         prompt_path.write_text(prompt, encoding="utf-8")
         _write_run_root_artifact_reference(
             request,
@@ -112,8 +125,16 @@ class ConfigurableCliAgentAdapter:
             prompt_path,
         )
 
-        provider_result = _resolve_provider_command(
+        provider_request = replace(
             request,
+            resume_session_id=(
+                str(attempt["provider_session_id"])
+                if attempt.get("execution_mode") == "resumed"
+                else None
+            ),
+        )
+        provider_result = _resolve_provider_command(
+            provider_request,
             final_message_path,
             default_codex_binary=self._codex_binary,
         )
@@ -127,6 +148,14 @@ class ConfigurableCliAgentAdapter:
             return provider_result
 
         command, provider_metadata = provider_result
+        provider_metadata = {
+            **provider_metadata,
+            "execution_mode": attempt["execution_mode"],
+            "attempt": attempt["attempt"],
+            "checkpoint_path": str(
+                _relative_to_repo(request.step_dir / "checkpoint.json", request.context)
+            ),
+        }
         command_path.write_text(
             json.dumps(command, ensure_ascii=False, indent=2) + "\n",
             encoding="utf-8",
@@ -156,7 +185,16 @@ class ConfigurableCliAgentAdapter:
                 metadata={
                     **_agent_metadata(request, prompt_path, final_message_path, error=str(exc)),
                     **provider_metadata,
+                    "termination_reason": "provider_not_found",
                 },
+            )
+            _write_implementation_attempt_and_checkpoint(
+                request,
+                attempt=attempt,
+                provider_metadata=provider_metadata,
+                stdout="",
+                termination_reason="provider_not_found",
+                status="blocked",
             )
             _mirror_agent_artifacts(request, stdout_path, stderr_path, None, result)
             return result
@@ -174,7 +212,24 @@ class ConfigurableCliAgentAdapter:
                 metadata={
                     **_agent_metadata(request, prompt_path, final_message_path, error=str(exc)),
                     **provider_metadata,
+                    "termination_reason": "timeout",
                 },
+            )
+            provider_session_id = _codex_session_id(stdout)
+            if provider_session_id:
+                result = AgentRunResult(
+                    status=result.status,
+                    exit_code=result.exit_code,
+                    error=result.error,
+                    metadata={**result.metadata, "provider_session_id": provider_session_id},
+                )
+            _write_implementation_attempt_and_checkpoint(
+                request,
+                attempt=attempt,
+                provider_metadata=result.metadata,
+                stdout=stdout,
+                termination_reason="timeout",
+                status="failed",
             )
             _mirror_agent_artifacts(request, stdout_path, stderr_path, None, result)
             return result
@@ -182,6 +237,12 @@ class ConfigurableCliAgentAdapter:
         stdout_path = request.step_dir / "stdout.txt"
         stderr_path = request.step_dir / "stderr.txt"
         stdout_path.write_text(completed.stdout, encoding="utf-8")
+        provider_session_id = _codex_session_id(completed.stdout)
+        if provider_session_id:
+            provider_metadata = {
+                **provider_metadata,
+                "provider_session_id": provider_session_id,
+            }
         if provider_metadata["provider"] == "custom_cli":
             final_message_path.write_text(completed.stdout, encoding="utf-8")
 
@@ -197,7 +258,16 @@ class ConfigurableCliAgentAdapter:
                 metadata={
                     **_agent_metadata(request, prompt_path, final_message_path),
                     **provider_metadata,
+                    "termination_reason": "process_error",
                 },
+            )
+            _write_implementation_attempt_and_checkpoint(
+                request,
+                attempt=attempt,
+                provider_metadata=result.metadata,
+                stdout=completed.stdout,
+                termination_reason="process_error",
+                status=status.value,
             )
             _mirror_agent_artifacts(request, stdout_path, stderr_path, final_message_path, result)
             return result
@@ -209,7 +279,16 @@ class ConfigurableCliAgentAdapter:
             metadata={
                 **_agent_metadata(request, prompt_path, final_message_path),
                 **provider_metadata,
+                "termination_reason": "completed",
             },
+        )
+        _write_implementation_attempt_and_checkpoint(
+            request,
+            attempt=attempt,
+            provider_metadata=result.metadata,
+            stdout=completed.stdout,
+            termination_reason="completed",
+            status="succeeded",
         )
         _mirror_agent_artifacts(request, stdout_path, stderr_path, final_message_path, result)
         return result
@@ -471,8 +550,11 @@ class BasicStepRunner:
     def _run_command(self, step: Step, context: RunContext, step_dir: Path) -> StepResult:
         if not step.command:
             return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error="command is required")
+        command = step.command
+        if step.id == "verify-work-item" and context.metadata.get("force_verification"):
+            command = f"{command} --force-verification"
         completed = subprocess.run(
-            step.command,
+            command,
             cwd=context.workdir,
             shell=True,
             text=True,
@@ -1237,7 +1319,12 @@ def _metadata_status_for_output(output: Path) -> str:
     return ""
 
 
-def _resolve_provider_command(request: AgentRunRequest, final_message_path: Path, *, default_codex_binary: str) -> tuple[list[str], dict[str, Any]] | AgentRunResult:
+def _resolve_provider_command(
+    request: AgentRunRequest,
+    final_message_path: Path,
+    *,
+    default_codex_binary: str,
+) -> tuple[list[str], dict[str, Any]] | AgentRunResult:
     config = request.agent_config
     provider = config.get("provider", "codex")
     if not isinstance(provider, str) or not provider.strip():
@@ -1247,7 +1334,12 @@ def _resolve_provider_command(request: AgentRunRequest, final_message_path: Path
         binary = config.get("provider_binary", default_codex_binary)
         if not isinstance(binary, str) or not binary.strip():
             return _blocked_provider_result(request, "codex provider_binary must be a non-empty string", provider=provider)
-        command = _codex_command(request, final_message_path, binary.strip())
+        command = _codex_command(
+            request,
+            final_message_path,
+            binary.strip(),
+            session_id=request.resume_session_id,
+        )
         return command, {"provider": provider, "provider_command": command}
     if provider == "custom_cli":
         command = _custom_provider_command(config.get("provider_command"))
@@ -1257,19 +1349,29 @@ def _resolve_provider_command(request: AgentRunRequest, final_message_path: Path
     return _blocked_provider_result(request, f"unsupported agent provider: {provider}", provider=provider)
 
 
-def _codex_command(request: AgentRunRequest, final_message_path: Path, codex_binary: str) -> list[str]:
+def _codex_command(
+    request: AgentRunRequest,
+    final_message_path: Path,
+    codex_binary: str,
+    *,
+    session_id: str | None = None,
+) -> list[str]:
     config = request.agent_config
-    command = [
-        codex_binary,
-        "exec",
+    command = [codex_binary, "exec"]
+    if session_id:
+        command.extend(["resume", session_id])
+    command.extend(
+        [
         "--skip-git-repo-check",
-        "--cd",
-        str(request.context.workdir),
         "-c",
         'approval_policy="never"',
+        "--json",
         "--output-last-message",
         str(final_message_path),
-    ]
+        ]
+    )
+    if not session_id:
+        command.extend(["--cd", str(request.context.workdir)])
     model = config.get("model")
     if isinstance(model, str) and model:
         command.extend(["--model", model])
@@ -1278,9 +1380,270 @@ def _codex_command(request: AgentRunRequest, final_message_path: Path, codex_bin
         command.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
     sandbox_mode = config.get("sandbox_mode")
     if isinstance(sandbox_mode, str) and sandbox_mode:
-        command.extend(["--sandbox", sandbox_mode])
+        if session_id:
+            command.extend(["-c", f'sandbox_mode="{sandbox_mode}"'])
+        else:
+            command.extend(["--sandbox", sandbox_mode])
     command.append("-")
     return command
+
+
+def _implementation_attempt(request: AgentRunRequest) -> dict[str, Any]:
+    if request.step.agent_id != "implementation_executor":
+        return {"execution_mode": "fresh", "attempt": 1}
+    compatibility = _implementation_compatibility(request)
+    candidates: list[tuple[int, dict[str, Any], Path]] = []
+    runs_root = request.context.repo_root / ".harness/runs"
+    if runs_root.exists():
+        for path in runs_root.glob(f"**/steps/{request.step.id}/attempt.json"):
+            if path == request.step_dir / "attempt.json":
+                continue
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError, TypeError):
+                continue
+            if (
+                payload.get("schema_version") == IMPLEMENTATION_ATTEMPT_SCHEMA_VERSION
+                and payload.get("compatibility") == compatibility
+                and isinstance(payload.get("provider_session_id"), str)
+                and payload["provider_session_id"]
+            ):
+                candidates.append((int(payload.get("attempt", 0)), payload, path))
+    if not candidates:
+        return {
+            "execution_mode": "fresh",
+            "attempt": 1,
+            "compatibility": compatibility,
+        }
+    previous_attempt, previous, path = max(candidates, key=lambda item: item[0])
+    checkpoint_path = path.with_name("checkpoint.json")
+    checkpoint: dict[str, Any] | None = None
+    try:
+        loaded = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        if loaded.get("schema_version") == IMPLEMENTATION_CHECKPOINT_SCHEMA_VERSION:
+            checkpoint = loaded
+    except (OSError, ValueError, TypeError):
+        pass
+    return {
+        "execution_mode": "resumed",
+        "attempt": previous_attempt + 1,
+        "compatibility": compatibility,
+        "provider_session_id": previous["provider_session_id"],
+        "previous_attempt_path": str(path),
+        "previous_checkpoint": checkpoint,
+    }
+
+
+def _implementation_compatibility(request: AgentRunRequest) -> dict[str, str]:
+    scope = {
+        "repo_root": str(request.context.repo_root.resolve()),
+        "repository_head": _repository_head(request.context.repo_root),
+        "change_set_id": _context_string(request.context, "change_set_id") or "",
+        "work_item_id": _context_string(request.context, "active_work_item_id") or "",
+        "agent_id": request.step.agent_id or "",
+    }
+    contract = json.dumps(
+        {
+            "scope": scope,
+            "agent_config": dict(request.agent_config),
+            "inputs": {
+                str(path): _path_content_hash(request.context.repo_root / path)
+                for path in request.step.inputs
+            },
+            "outputs": [str(path) for path in request.step.outputs],
+            "agent_config_hash": _path_content_hash(request.agent_config_path),
+            "skill_hash": (
+                _path_content_hash(request.skill_path)
+                if request.skill_path is not None
+                else ""
+            ),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        default=str,
+    )
+    return {
+        **scope,
+        "prompt_contract_hash": hashlib.sha256(contract.encode("utf-8")).hexdigest(),
+    }
+
+
+def _path_content_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        if path.is_file():
+            digest.update(path.read_bytes())
+        elif path.is_dir():
+            for child in sorted(item for item in path.rglob("*") if item.is_file()):
+                digest.update(str(child.relative_to(path)).encode("utf-8"))
+                digest.update(child.read_bytes())
+        else:
+            digest.update(b"<missing>")
+    except OSError:
+        digest.update(b"<unreadable>")
+    return digest.hexdigest()
+
+
+def _repository_head(repo_root: Path) -> str:
+    try:
+        dot_git = repo_root / ".git"
+        git_dir = dot_git
+        if dot_git.is_file():
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir:"):
+                return ""
+            git_dir = (repo_root / marker.split(":", 1)[1].strip()).resolve()
+        head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
+        if not head.startswith("ref:"):
+            return head
+        reference = head.split(":", 1)[1].strip()
+        direct = git_dir / reference
+        if direct.exists():
+            return direct.read_text(encoding="utf-8").strip()
+        common_dir_path = git_dir / "commondir"
+        if common_dir_path.exists():
+            common_dir = (
+                git_dir / common_dir_path.read_text(encoding="utf-8").strip()
+            ).resolve()
+            shared = common_dir / reference
+            if shared.exists():
+                return shared.read_text(encoding="utf-8").strip()
+        return head
+    except OSError:
+        return ""
+
+
+def _codex_session_id(stdout: str) -> str | None:
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        for key in ("session_id", "thread_id", "conversation_id"):
+            value = event.get(key)
+            if isinstance(value, str) and value:
+                return value
+        payload = event.get("payload")
+        if isinstance(payload, Mapping):
+            for key in ("session_id", "thread_id", "conversation_id", "id"):
+                value = payload.get(key)
+                if isinstance(value, str) and value and "started" in str(event.get("type", "")):
+                    return value
+    return None
+
+
+def _write_implementation_attempt_and_checkpoint(
+    request: AgentRunRequest,
+    *,
+    attempt: Mapping[str, Any],
+    provider_metadata: Mapping[str, Any],
+    stdout: str,
+    termination_reason: str,
+    status: str,
+) -> None:
+    if request.step.agent_id != "implementation_executor":
+        return
+    session_id = provider_metadata.get("provider_session_id") or _codex_session_id(stdout)
+    attempt_payload = {
+        "schema_version": IMPLEMENTATION_ATTEMPT_SCHEMA_VERSION,
+        "attempt": attempt.get("attempt", 1),
+        "execution_mode": attempt.get("execution_mode", "fresh"),
+        "provider_session_id": session_id,
+        "termination_reason": termination_reason,
+        "compatibility": attempt.get("compatibility", _implementation_compatibility(request)),
+    }
+    commands = _codex_command_records(stdout)
+    completed_phases = _completed_implementation_phases(commands)
+    next_phase = _next_implementation_phase(completed_phases)
+    checkpoint_payload = {
+        "schema_version": IMPLEMENTATION_CHECKPOINT_SCHEMA_VERSION,
+        "phase": "closure" if status == "succeeded" else "implementation",
+        "status": status,
+        "completed_tasks": completed_phases,
+        "commands": commands,
+        "evidence_paths": [
+            str(_relative_to_repo(request.step_dir / "stdout.txt", request.context)),
+            str(_relative_to_repo(request.step_dir / "final-message.md", request.context)),
+        ],
+        "next_phase": None if status == "succeeded" else next_phase,
+        "compatibility": attempt_payload["compatibility"],
+    }
+    _atomic_write_json(request.step_dir / "attempt.json", attempt_payload)
+    _atomic_write_json(request.step_dir / "checkpoint.json", checkpoint_payload)
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _codex_command_records(stdout: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        stack: list[Any] = [event]
+        while stack:
+            value = stack.pop()
+            if isinstance(value, Mapping):
+                command = value.get("command")
+                if isinstance(command, str) and command:
+                    exit_code = value.get("exit_code")
+                    records.append(
+                        {
+                            "command": command,
+                            "exit_code": exit_code if isinstance(exit_code, int) else None,
+                            "status": value.get("status"),
+                        }
+                    )
+                stack.extend(value.values())
+            elif isinstance(value, list):
+                stack.extend(value)
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, Any]] = set()
+    for record in records:
+        key = (record["command"], record["exit_code"])
+        if key not in seen:
+            seen.add(key)
+            deduped.append(record)
+    return deduped
+
+
+def _completed_implementation_phases(
+    commands: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    completed: list[str] = []
+    for command in commands:
+        if command.get("exit_code") != 0:
+            continue
+        text = str(command.get("command", "")).casefold()
+        phase = "implementation"
+        if any(term in text for term in ("playwright", "e2e", "run app", "bootrun")):
+            phase = "runtime-e2e"
+        elif any(term in text for term in ("build", "assemble", "compile")):
+            phase = "build"
+        elif any(term in text for term in ("pytest", "test", "gradlew")):
+            phase = "focused-tests"
+        if phase != "implementation" and "implementation" not in completed:
+            completed.append("implementation")
+        if phase not in completed:
+            completed.append(phase)
+    return completed
+
+
+def _next_implementation_phase(completed: Sequence[str]) -> str:
+    phases = ("implementation", "focused-tests", "build", "runtime-e2e", "closure")
+    for phase in phases:
+        if phase not in completed:
+            return phase
+    return "closure"
 
 
 def _custom_provider_command(value: Any) -> list[str] | None:

--- a/harness_codex/runtime/verify_work_item.py
+++ b/harness_codex/runtime/verify_work_item.py
@@ -8,9 +8,11 @@ test gate, then records command evidence under `.harness/runs/<RUN-ID>/`.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,6 +36,8 @@ class WorkItemCommandResult:
     exit_code: int
     stdout_path: Path
     stderr_path: Path
+    duration_seconds: float = 0.0
+    reused: bool = False
 
     @property
     def passed(self) -> bool:
@@ -85,6 +89,7 @@ def verify_work_item(
     change_set_id: str,
     work_item_id: str,
     run_id: str,
+    force_verification: bool = False,
 ) -> WorkItemVerificationResult:
     root = Path(repo_root)
     plan_path = Path("docs/plans/active") / work_item_id / "plan.md"
@@ -121,6 +126,12 @@ def verify_work_item(
             *_commands_from_test_gate(root / test_gate_path),
         )
     )
+    verification_fingerprint = _verification_fingerprint(
+        root,
+        plan_path=plan_path,
+        goal_path=goal_path,
+        test_gate_path=test_gate_path,
+    )
 
     if not commands:
         result = WorkItemVerificationResult(
@@ -137,8 +148,22 @@ def verify_work_item(
         _write_reports(root, result)
         return result
 
+    reusable = (
+        {}
+        if force_verification
+        else _reusable_command_results(
+            root,
+            work_item_id=work_item_id,
+            run_id=run_id,
+            fingerprint=verification_fingerprint,
+        )
+    )
     command_results = tuple(
-        _run_command(root, absolute_evidence_dir, index, command)
+        (
+            reusable[command.command]
+            if command.source != str(test_gate_path) and command.command in reusable
+            else _run_command(root, absolute_evidence_dir, index, command)
+        )
         for index, command in enumerate(commands, start=1)
     )
     result = WorkItemVerificationResult(
@@ -156,7 +181,7 @@ def verify_work_item(
             else None
         ),
     )
-    _write_reports(root, result)
+    _write_reports(root, result, fingerprint=verification_fingerprint)
     return result
 
 
@@ -168,6 +193,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--change-set", required=True)
     parser.add_argument("--work-item", required=True)
     parser.add_argument("--run-id", required=True)
+    parser.add_argument(
+        "--force-verification",
+        action="store_true",
+        help="Run every verification command instead of reusing compatible PASS evidence.",
+    )
     args = parser.parse_args(argv)
 
     result = verify_work_item(
@@ -175,6 +205,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         change_set_id=args.change_set,
         work_item_id=args.work_item,
         run_id=args.run_id,
+        force_verification=args.force_verification,
     )
     status = "PASS" if result.passed else "FAIL"
     print(f"{status} work-item verification: {result.evidence_dir / 'report.json'}")
@@ -345,6 +376,7 @@ def _run_command(
         + "\n",
         encoding="utf-8",
     )
+    started = time.monotonic()
     completed = subprocess.run(
         command.command,
         cwd=repo_root,
@@ -353,6 +385,7 @@ def _run_command(
         capture_output=True,
         check=False,
     )
+    duration_seconds = time.monotonic() - started
     stdout_path = command_dir / "stdout.txt"
     stderr_path = command_dir / "stderr.txt"
     stdout_path.write_text(completed.stdout, encoding="utf-8")
@@ -364,10 +397,16 @@ def _run_command(
         exit_code=completed.returncode,
         stdout_path=stdout_path.relative_to(repo_root),
         stderr_path=stderr_path.relative_to(repo_root),
+        duration_seconds=duration_seconds,
     )
 
 
-def _write_reports(repo_root: Path, result: WorkItemVerificationResult) -> None:
+def _write_reports(
+    repo_root: Path,
+    result: WorkItemVerificationResult,
+    *,
+    fingerprint: str = "",
+) -> None:
     evidence_dir = repo_root / result.evidence_dir
     payload = {
         "change_set_id": result.change_set_id,
@@ -379,6 +418,7 @@ def _write_reports(repo_root: Path, result: WorkItemVerificationResult) -> None:
         "test_gate_path": str(result.test_gate_path),
         "evidence_dir": str(result.evidence_dir),
         "missing_obligations": list(result.missing_obligations),
+        "verification_fingerprint": fingerprint,
         "commands": [
             {
                 "name": command.name,
@@ -387,6 +427,8 @@ def _write_reports(repo_root: Path, result: WorkItemVerificationResult) -> None:
                 "exit_code": command.exit_code,
                 "stdout_path": str(command.stdout_path),
                 "stderr_path": str(command.stderr_path),
+                "duration_seconds": command.duration_seconds,
+                "reused": command.reused,
             }
             for command in result.command_results
         ],
@@ -416,11 +458,114 @@ def _write_reports(repo_root: Path, result: WorkItemVerificationResult) -> None:
         lines.append("## Commands")
         for command in result.command_results:
             state = "PASS" if command.passed else "FAIL"
-            lines.append(f"- {state}: `{command.command}` ({command.source})")
+            reuse = ", reused" if command.reused else ""
+            lines.append(f"- {state}: `{command.command}` ({command.source}{reuse})")
     (evidence_dir / "verification.md").write_text(
         "\n".join(lines) + "\n",
         encoding="utf-8",
     )
+
+
+def _verification_fingerprint(
+    repo_root: Path,
+    *,
+    plan_path: Path,
+    goal_path: Path,
+    test_gate_path: Path,
+) -> str:
+    digest = hashlib.sha256()
+    for path in (plan_path, goal_path, test_gate_path):
+        digest.update(str(path).encode("utf-8"))
+        absolute = repo_root / path
+        digest.update(absolute.read_bytes() if absolute.exists() else b"<missing>")
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    digest.update(
+        completed.stdout.strip().encode("utf-8")
+        if completed.returncode == 0
+        else b"<no-head>"
+    )
+    diff = subprocess.run(
+        ["git", "diff", "--binary", "HEAD"],
+        cwd=repo_root,
+        text=False,
+        capture_output=True,
+        check=False,
+    )
+    if diff.returncode == 0:
+        digest.update(diff.stdout)
+        untracked = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+            cwd=repo_root,
+            text=False,
+            capture_output=True,
+            check=False,
+        )
+        if untracked.returncode == 0:
+            for raw_path in untracked.stdout.split(b"\0"):
+                if not raw_path:
+                    continue
+                relative = Path(raw_path.decode("utf-8", errors="surrogateescape"))
+                if relative.parts[:1] == (".harness",):
+                    continue
+                digest.update(raw_path)
+                absolute = repo_root / relative
+                if absolute.is_file():
+                    digest.update(absolute.read_bytes())
+    return digest.hexdigest()
+
+
+def _reusable_command_results(
+    repo_root: Path,
+    *,
+    work_item_id: str,
+    run_id: str,
+    fingerprint: str,
+) -> dict[str, WorkItemCommandResult]:
+    runs_root = repo_root / ".harness/runs"
+    candidates: list[Path] = []
+    if runs_root.exists():
+        candidates = sorted(
+            runs_root.glob(f"*/work-items/{work_item_id}/verification/report.json"),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+    for report_path in candidates:
+        if run_id in report_path.parts:
+            continue
+        try:
+            payload = json.loads(report_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            continue
+        if (
+            payload.get("status") != "PASS"
+            or payload.get("verification_fingerprint") != fingerprint
+        ):
+            continue
+        reusable: dict[str, WorkItemCommandResult] = {}
+        for command in payload.get("commands", []):
+            if not isinstance(command, Mapping) or command.get("exit_code") != 0:
+                continue
+            command_text = command.get("command")
+            if not isinstance(command_text, str) or not command_text:
+                continue
+            reusable[command_text] = WorkItemCommandResult(
+                name=str(command.get("name", command_text)),
+                command=command_text,
+                source=str(command.get("source", "")),
+                exit_code=0,
+                stdout_path=Path(str(command.get("stdout_path", ""))),
+                stderr_path=Path(str(command.get("stderr_path", ""))),
+                duration_seconds=float(command.get("duration_seconds", 0.0)),
+                reused=True,
+            )
+        return reusable
+    return {}
 
 
 if __name__ == "__main__":

--- a/implementation-executor-performance-plan.md
+++ b/implementation-executor-performance-plan.md
@@ -1,0 +1,197 @@
+# Implementation Executor Performance Remediation Plan
+
+## Status
+
+- Plan type: standalone remediation plan
+- Formal ChangeSet plan: blocked because no active ChangeSet or maintenance work item exists
+- Target repository: `harness`
+- Primary runtime surface: implementation-stage agent execution
+
+## Problem
+
+One implementation workflow required six `implementation_executor` sessions and about 217 minutes of active executor time. Two sessions terminated near the historical one-hour timeout. Each retry started a fresh Codex session, repeated repository analysis and browser verification, and repaired evidence that did not match the deterministic verifier contract.
+
+Measured impact:
+
+- Six executor sessions
+- About 6.8 million model tokens
+- Repeated Spring Boot, Vite, and browser E2E startup
+- No product-code edits during the measured retries
+- Completion delayed by timeout, lost progress, and evidence reconciliation
+
+## Goal
+
+Make implementation retries continue from durable progress instead of repeating completed analysis and verification.
+
+Success criteria:
+
+- A timed-out implementation step can continue using its previous Codex session when supported.
+- Completed commands and verification evidence survive timeout and process termination.
+- A retry skips unchanged, already-passed verification phases.
+- Runtime-generated evidence satisfies `verify_work_item.py` without agent-authored format repair.
+- Existing fresh-run behavior remains available when resume state is absent or invalid.
+
+## Non-Goals
+
+- Changing requirements, use-case, DDD, or planning workflow boundaries.
+- Removing deterministic completion or test-gate checks.
+- Treating a longer timeout as the primary solution.
+- Reusing verification after relevant source, configuration, command, or E2E-goal changes.
+- Caching failed or incomplete browser verification.
+
+## Scope
+
+Primary files:
+
+- `harness_codex/runtime/runner.py`
+- `harness_codex/runtime/state.py`
+- `harness_codex/runtime/models.py`
+- `harness_codex/runtime/verify_work_item.py`
+- `harness_codex/runtime/reports.py`
+- `harness_codex/cli.py`
+- `.codex/agents/references/implementation_executor.md`
+- `.codex/skills/harness-plan-executor/references/detailed-instructions.md`
+
+Primary tests:
+
+- `tests/runtime/test_agent_runner.py`
+- `tests/runtime/test_run_state_resume.py`
+- `tests/runtime/test_verify_work_item.py`
+- `tests/runtime/test_verifier_contract.py`
+- `tests/runtime/test_procedure_stage_runtime.py`
+- `tests/test_cli_commands.py`
+- `tests/test_plan_executor_use_case_loop.py`
+
+## Technical Approach
+
+### Phase 1: Resumable Agent Execution
+
+- [ ] Inspect locally installed `codex exec` resume capabilities and define a provider-neutral resume contract.
+- [ ] Extend agent result metadata with provider session ID, resume eligibility, attempt number, and termination reason.
+- [ ] Persist provider session metadata under the implementation step run directory before returning step status.
+- [ ] On implementation retry, locate the latest compatible failed or timed-out attempt for the same ChangeSet, work item, agent, and repository.
+- [ ] Resume the prior Codex session when metadata is valid.
+- [ ] Fall back to a fresh session when resume is unsupported, missing, corrupt, or explicitly disabled.
+- [ ] Prevent resume across different repositories, ChangeSets, work items, agents, or incompatible prompt contracts.
+- [ ] Report `fresh` versus `resumed` execution in CLI output and run reports.
+
+### Phase 2: Durable Phase Checkpoints
+
+- [ ] Add implementation checkpoint schema containing phase, completed task IDs, executed commands, results, evidence paths, relevant hashes, and remaining actions.
+- [ ] Store checkpoints atomically under `.harness/runs/<run-id>/steps/<step-id>/`.
+- [ ] Update checkpoint after focused tests, build, runtime startup, browser E2E, and artifact closure.
+- [ ] Include checkpoint summary in resumed prompts.
+- [ ] Treat checkpoint as execution evidence, not authority to bypass current verifier checks.
+- [ ] Ignore checkpoints with unsupported schema versions or mismatched scope hashes.
+
+### Phase 3: Runtime-Owned Verification Evidence
+
+- [ ] Capture every executed verification command, exit code, duration, and output artifact path as structured data.
+- [ ] Map structured command results to plan verification obligations and `.codex/test-gate.yaml`.
+- [ ] Generate verifier-compatible evidence from structured command results.
+- [ ] Remove need for the executor to reproduce evidence syntax manually.
+- [ ] Keep the verifier authoritative: incomplete mappings remain blocking.
+- [ ] Record clear diagnostics for unmatched obligations and stale evidence.
+
+### Phase 4: Verification-Only Retry Mode
+
+- [ ] Compute hashes for implementation scope, plan obligations, E2E goal, test-gate configuration, and runtime configuration.
+- [ ] Detect retries where product implementation is already present and no relevant implementation hash changed.
+- [ ] Enter verification-only mode instead of repeating broad product-code analysis.
+- [ ] Skip passed focused phases whose command and input hashes still match.
+- [ ] Re-run failed, incomplete, stale, or environment-sensitive phases.
+- [ ] Always re-run deterministic final completion and scope-diff checks.
+
+### Phase 5: Browser E2E Reuse
+
+- [ ] Persist successful browser scenario evidence with source, frontend, backend, E2E-goal, command, and runtime configuration hashes.
+- [ ] Reuse browser evidence only when all hashes match and required artifacts remain available.
+- [ ] Invalidate evidence after relevant source/configuration changes or changed acceptance criteria.
+- [ ] Keep an explicit force-rerun option for diagnosis and release validation.
+
+## Test Plan
+
+### Unit Tests
+
+- [ ] Timed-out agent result persists provider session ID and checkpoint metadata.
+- [ ] Compatible retry selects resume command.
+- [ ] Missing or invalid session metadata selects fresh command.
+- [ ] Scope mismatch prevents session reuse.
+- [ ] Checkpoint writes are atomic and malformed checkpoints are ignored safely.
+- [ ] Evidence mapper accepts successful matching commands and rejects missing obligations.
+- [ ] Verification-only mode invalidates correctly after source, plan, E2E, or configuration changes.
+
+### Runtime Integration Tests
+
+- [ ] Simulate timeout after successful focused tests; retry resumes and does not repeat focused tests.
+- [ ] Simulate timeout after browser success; retry performs artifact closure without browser replay.
+- [ ] Simulate failed browser check; retry reruns browser phase.
+- [ ] Verify fresh retry remains functional when provider resume is unavailable.
+- [ ] Verify implementation completion still blocks on unchecked tasks, failed test gate, missing evidence, or scope violations.
+- [ ] Verify run report exposes attempt history, resume state, checkpoint phase, and reused evidence.
+
+### Regression Tests
+
+- [ ] `./venv/bin/python3 -m pytest -q -s tests/runtime/test_agent_runner.py`
+- [ ] `./venv/bin/python3 -m pytest -q -s tests/runtime/test_run_state_resume.py`
+- [ ] `./venv/bin/python3 -m pytest -q -s tests/runtime/test_verify_work_item.py tests/runtime/test_verifier_contract.py`
+- [ ] `./venv/bin/python3 -m pytest -q -s tests/runtime/test_procedure_stage_runtime.py tests/test_cli_commands.py`
+- [ ] `./venv/bin/python3 -m pytest -q -s tests/test_plan_executor_use_case_loop.py`
+- [ ] `./venv/bin/python3 -m pytest -q -s`
+
+## Runtime Verification
+
+- [ ] Create a fixture ChangeSet with one implementation work item and deterministic slow executor behavior.
+- [ ] Start implementation and force termination after a completed verification phase.
+- [ ] Continue the same ChangeSet.
+- [ ] Confirm CLI reports resumed execution.
+- [ ] Confirm completed phase command is not repeated.
+- [ ] Confirm final verifier and test gate still execute and pass.
+- [ ] Confirm run artifacts contain attempt history, checkpoint, structured evidence, and final report.
+
+## Static Analysis
+
+- [ ] Run existing repository lint or static-analysis command when defined.
+- [ ] Run `./venv/bin/python3 -m compileall -q harness_codex`.
+- [ ] Confirm new persisted JSON uses typed parsing and schema-version validation.
+
+## Rollout
+
+1. Ship Phase 1 behind a default-on provider capability check.
+2. Ship Phase 2 before enabling phase skipping.
+3. Enable runtime-owned evidence after parity tests against current verifier behavior.
+4. Enable verification-only mode with explicit report diagnostics.
+5. Enable browser evidence reuse last, initially opt-in.
+
+Rollback:
+
+- Disable resume and reuse through configuration.
+- Preserve fresh execution path.
+- Ignore checkpoint/cache artifacts without deleting them.
+- Keep deterministic verifier and test gate unchanged.
+
+## Risks
+
+- Resuming an incompatible session could apply stale assumptions.
+  Mitigation: strict repository, ChangeSet, work-item, agent, prompt-contract, and schema hashes.
+- Reused evidence could hide regressions.
+  Mitigation: conservative invalidation and mandatory final deterministic checks.
+- Checkpoint corruption could block execution.
+  Mitigation: atomic writes, versioned schema, and fresh-run fallback.
+- Provider-specific session behavior could leak into runtime orchestration.
+  Mitigation: provider-neutral resume metadata and capability interface.
+
+## Recommended Delivery Slices
+
+1. `MAINT-IMPLEMENTATION-RESUME`: provider session persistence, compatible resume, attempt reporting.
+2. `MAINT-IMPLEMENTATION-CHECKPOINT`: durable phases and retry prompt summary.
+3. `MAINT-VERIFICATION-EVIDENCE`: structured command capture and verifier mapping.
+4. `MAINT-VERIFICATION-REUSE`: verification-only mode and conservative E2E reuse.
+
+## Formal Planning Prerequisite
+
+Before implementation, create an active maintenance ChangeSet and one maintenance slice for the first delivery item. Then move the selected slice into:
+
+`docs/plans/active/<MAINT-ID>/plan.md`
+
+Run security plan review and artifact review before executor use.

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 from harness_codex.runtime.models import (
@@ -1195,6 +1196,7 @@ def test_configurable_agent_adapter_uses_codex_provider_by_default(
     assert "--ask-for-approval" not in command
     assert 'approval_policy="never"' in command
     assert "--output-last-message" in command
+    assert "--json" in command
     assert "--model" in command
     assert (request.step_dir / "stdout.txt").read_text(encoding="utf-8") == (
         "agent stdout"
@@ -1314,6 +1316,83 @@ def test_configurable_agent_adapter_keeps_large_failed_stderr(
     stored = (request.step_dir / "stderr.txt").read_text(encoding="utf-8")
     assert result.status == StepStatus.FAILED
     assert stored == stderr
+
+
+def test_configurable_agent_adapter_resumes_compatible_timed_out_implementation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    session_id = "019eb4b0-1111-7222-8333-444455556666"
+    first = agent_request(
+        tmp_path,
+        {
+            "name": "implementation_executor",
+            "description": "test agent",
+            "sandbox_mode": "danger-full-access",
+        },
+    )
+    first.step_dir.mkdir(parents=True)
+    calls: list[list[str]] = []
+
+    def timeout_run(command: list[str], **kwargs: object):
+        calls.append(command)
+        raise subprocess.TimeoutExpired(
+            command,
+            timeout=30,
+            output=(
+                f'{{"type":"thread.started","thread_id":"{session_id}"}}\n'
+                '{"type":"item.completed","item":{"type":"command_execution",'
+                '"command":"python3 -m pytest tests/unit","exit_code":0}}\n'
+            ),
+        )
+
+    monkeypatch.setattr(subprocess, "run", timeout_run)
+
+    timed_out = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(first)
+
+    assert timed_out.status == StepStatus.FAILED
+    attempt = json.loads((first.step_dir / "attempt.json").read_text(encoding="utf-8"))
+    checkpoint = json.loads(
+        (first.step_dir / "checkpoint.json").read_text(encoding="utf-8")
+    )
+    assert attempt["provider_session_id"] == session_id
+    assert attempt["termination_reason"] == "timeout"
+    assert checkpoint["completed_tasks"] == ["implementation", "focused-tests"]
+    assert checkpoint["next_phase"] == "build"
+
+    second_context = replace(
+        first.context,
+        run_id="run-002",
+        run_dir=tmp_path / ".harness/runs/run-002",
+    )
+    second = replace(
+        first,
+        context=second_context,
+        step_dir=second_context.run_dir / "steps/execute-work-item",
+    )
+
+    def success_run(command: list[str], **kwargs: object):
+        calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=f'{{"type":"thread.started","thread_id":"{session_id}"}}\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", success_run)
+
+    resumed = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(second)
+
+    assert resumed.status == StepStatus.SUCCEEDED
+    assert resumed.metadata["execution_mode"] == "resumed"
+    assert resumed.metadata["attempt"] == 2
+    assert resumed.metadata["provider_session_id"] == session_id
+    command = json.loads((second.step_dir / "command.json").read_text(encoding="utf-8"))
+    assert command[:4] == ["codex-test", "exec", "resume", session_id]
+    assert "Durable implementation checkpoint" in (
+        second.step_dir / "prompt.md"
+    ).read_text(encoding="utf-8")
 
 
 def test_configurable_agent_adapter_uses_explicit_codex_binary(

--- a/tests/runtime/test_verify_work_item.py
+++ b/tests/runtime/test_verify_work_item.py
@@ -108,6 +108,69 @@ def test_work_item_verifier_runs_test_gate_when_plan_and_goal_reference_gate(
     ]
 
 
+def test_work_item_verifier_reuses_matching_pass_evidence_but_reruns_test_gate(
+    tmp_path: Path,
+) -> None:
+    plan_counter = tmp_path / "plan-count.txt"
+    gate_counter = tmp_path / "gate-count.txt"
+    plan_command = (
+        "python3 -c \"from pathlib import Path; "
+        f"p=Path('{plan_counter}'); p.write_text(str(int(p.read_text())+1) "
+        "if p.exists() else '1')\""
+    )
+    gate_command = (
+        "python3 -c \"from pathlib import Path; "
+        f"p=Path('{gate_counter}'); p.write_text(str(int(p.read_text())+1) "
+        "if p.exists() else '1')\""
+    )
+    _write_work_item_files(
+        tmp_path,
+        plan=(
+            f"- [x] Tests: `{plan_command}`\n"
+            "- [x] Test gate: `.codex/test-gate.yaml`\n"
+        ),
+        goal="|Step|Command|Success|Required|\n|---|---|---|---|\n",
+    )
+    gate_dir = tmp_path / ".codex"
+    gate_dir.mkdir(exist_ok=True)
+    gate_dir.joinpath("test-gate.yaml").write_text(
+        f"required:\n  - name: unit\n    command: {gate_command}\n",
+        encoding="utf-8",
+    )
+
+    first = verify_work_item(
+        tmp_path,
+        change_set_id="CHG-1",
+        work_item_id="UC-1",
+        run_id="run-001",
+    )
+    second = verify_work_item(
+        tmp_path,
+        change_set_id="CHG-1",
+        work_item_id="UC-1",
+        run_id="run-002",
+    )
+
+    assert first.passed is True
+    assert second.passed is True
+    assert plan_counter.read_text(encoding="utf-8") == "1"
+    assert gate_counter.read_text(encoding="utf-8") == "2"
+    assert [result.reused for result in second.command_results] == [True, False]
+
+    forced = verify_work_item(
+        tmp_path,
+        change_set_id="CHG-1",
+        work_item_id="UC-1",
+        run_id="run-003",
+        force_verification=True,
+    )
+
+    assert forced.passed is True
+    assert plan_counter.read_text(encoding="utf-8") == "2"
+    assert gate_counter.read_text(encoding="utf-8") == "3"
+    assert all(not result.reused for result in forced.command_results)
+
+
 def _write_work_item_files(tmp_path: Path, *, plan: str, goal: str) -> None:
     plan_dir = tmp_path / "docs/plans/active/UC-1"
     goal_dir = tmp_path / "docs/use-cases/UC-1"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1836,6 +1836,26 @@ def test_procedure_implementation_stage_uses_two_hour_timeout(
     assert cli._procedure_stage_timeout_sec("event-storming") == 3600
 
 
+def test_implementation_parser_accepts_force_verification() -> None:
+    args = cli.build_parser().parse_args(
+        ["implementation", "CHG-001", "--apply", "--force-verification"]
+    )
+
+    assert args.force_verification is True
+
+
+def test_implementation_execution_summary_reports_resume_attempt() -> None:
+    result = SimpleNamespace(
+        step_results=(
+            SimpleNamespace(metadata={"execution_mode": "resumed", "attempt": 2}),
+        )
+    )
+
+    assert cli._implementation_execution_summary(result) == (
+        " execution_mode=resumed attempt=2"
+    )
+
+
 def test_procedure_stage_timeout_can_be_overridden(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## 구현 의도 (Implementation intent)

구현 단계가 타임아웃되거나 재시도될 때 기존 Codex 실행과 검증 결과를 재사용해 반복 분석, 테스트, 브라우저 검증 비용을 줄입니다.

기존에는 구현 코드 변경이 없더라도 새 에이전트 세션이 시작되어 전체 컨텍스트 로딩과 검증을 반복했습니다. 이 변경은 재개 가능한 실행, 내구성 있는 체크포인트, 구조화된 검증 증거 재사용을 추가합니다.

## 구현 방식 (Implementation approach)

- Codex 실행을 JSONL 모드로 실행하고 세션 UUID를 추출합니다.
- 구현 단계 디렉터리에 버전이 있는 `attempt.json`과 `checkpoint.json`을 원자적으로 기록합니다.
- 저장소, HEAD, ChangeSet, 작업 항목, 에이전트 설정, 입력 문서와 프롬프트 계약 해시가 일치할 때만 `codex exec resume`을 사용합니다.
- 타임아웃 전 성공한 명령을 체크포인트 단계로 변환해 재개 프롬프트에 전달합니다.
- 검증 보고서에 명령 실행 시간과 재사용 여부, 검증 지문을 기록합니다.
- 동일한 코드 및 검증 계약의 이전 PASS 명령만 재사용하며 `.codex/test-gate.yaml` 명령과 최종 완료/범위 검사는 항상 다시 실행합니다.
- `--force-verification`으로 모든 검증 재실행을 강제할 수 있습니다.
- 실행 모드와 시도 횟수를 CLI 및 런 메타데이터에 노출합니다.

## 검증 방법 (Verification method)

- `./venv/bin/python3 -m pytest -q -s`
  - 결과: 464 passed
- 관련 런타임/CLI 집중 회귀 테스트
  - 결과: 128 passed
- `./venv/bin/python3 -m compileall -q harness_codex`
- `git diff --check`

추가된 테스트는 타임아웃 세션 UUID 저장, 호환 실행 재개, 체크포인트 단계 복원, PASS 증거 재사용, 테스트 게이트 재실행, 강제 검증 옵션을 확인합니다.

## 위험 및 롤백 (Risks and rollback)

- 잘못된 세션이나 증거 재사용 위험이 있습니다. 저장소/HEAD/작업 범위/입력/설정 해시를 모두 비교하고 불일치 시 새 실행으로 폴백합니다.
- 검증 누락 위험을 줄이기 위해 테스트 게이트, 최종 완료 검증, 범위 diff 검사는 재사용하지 않습니다.
- 이전 실행에는 새 메타데이터가 없으므로 자동으로 기존 fresh 실행 경로를 사용합니다.
- 문제 발생 시 `--force-verification`으로 검증 재사용을 끌 수 있으며, attempt/checkpoint 파일을 무시해도 기존 실행 경로가 유지됩니다.