### PR TITLE
[codex] 요구사항 질문 3개 일괄 응답 UI 구현

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -83,6 +83,9 @@ details { margin-top: 10px; }
 .requirements-document .markdown-preview { max-height: 460px; overflow-y: auto; }
 .grill-panel { margin-top: 24px; position: sticky; bottom: 14px; box-shadow: 0 -4px 18px rgba(25,34,28,.06); }
 .question { font-size: 17px; font-weight: 600; margin-bottom: 0; }
+.grill-question { border-top: 1px solid var(--line); display: grid; gap: 10px; padding-top: 14px; }
+.grill-question:first-of-type { border-top: 0; padding-top: 0; }
+.question-number { align-items: center; background: var(--active); border-radius: 50%; color: var(--accent); display: inline-flex; font-size: 12px; height: 24px; justify-content: center; margin-right: 9px; vertical-align: 2px; width: 24px; }
 .recommended { background: #eef1e8; border-radius: 8px; color: var(--muted); padding: 10px 12px; }
 .grill-form textarea { min-height: 82px; }
 .completion { background: var(--active); border-radius: 8px; color: var(--accent); padding: 13px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -320,17 +320,22 @@ function renderBusyState() {
 }
 
 function renderRequirementsTab() {
-  const question = app.harvest?.current_question;
+  const questions = app.harvest?.current_questions?.length
+    ? app.harvest.current_questions
+    : app.harvest?.current_question ? [app.harvest.current_question] : [];
   const questionPanel = app.harvest?.requirements_gate_passed
     ? `<p class="completion">Requirements clarification complete.</p>
        <button class="primary next-stage" id="start-use-cases" type="button" ${app.busy ? "disabled" : ""}>Continue to Use Case Definition</button>`
-    : question
+    : questions.length
       ? `<form id="grill-form" class="grill-form">
-          <p class="question">${escapeHtml(question.question)}</p>
-          ${question.recommended ? `<p class="recommended">Recommended answer: ${escapeHtml(question.recommended)}</p>` : ""}
-          <label for="grill-answer">Your answer</label>
-          <textarea id="grill-answer" required></textarea>
-          <button class="primary" type="submit" ${app.busy ? "disabled" : ""}>${app.busy ? "Processing..." : "Submit answer"}</button>
+          <p class="small">Answer all ${questions.length} questions, then submit them together.</p>
+          ${questions.map((question, index) => `<section class="grill-question">
+            <p class="question"><span class="question-number">${index + 1}</span>${escapeHtml(question.question)}</p>
+            ${question.recommended ? `<p class="recommended">Recommended answer: ${escapeHtml(question.recommended)}</p>` : ""}
+            <label for="grill-answer-${index}">Your answer</label>
+            <textarea id="grill-answer-${index}" data-grill-answer required></textarea>
+          </section>`).join("")}
+          <button class="primary" type="submit" ${app.busy ? "disabled" : ""}>${app.busy ? "Processing..." : "Submit all answers"}</button>
         </form>`
       : "<p>No current question.</p>";
   return `
@@ -460,8 +465,8 @@ async function openRequirementsDocument() {
 
 async function submitRequirementAnswer(event) {
   event.preventDefault();
-  const answer = document.querySelector("#grill-answer").value.trim();
-  if (!answer) return;
+  const answers = [...document.querySelectorAll("[data-grill-answer]")].map((input) => input.value.trim());
+  if (!answers.length || answers.some((answer) => !answer)) return;
   app.busy = true;
   app.busyLabel = "Submitting answer";
   render();
@@ -469,7 +474,7 @@ async function submitRequirementAnswer(event) {
     const response = await fetch("/api/change-sets/requirements/answer", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ change_set_id: app.requirementsChangeSet, answer }),
+      body: JSON.stringify({ change_set_id: app.requirementsChangeSet, answers }),
     });
     const result = await response.json();
     if (!response.ok) throw new Error(result.error || "Unable to submit answer.");

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -79,25 +79,29 @@ def start_requirements(root: Path | str, prompt: str) -> HarvestUiResult:
     return _result(root_path, session)
 
 
-def answer_requirements(root: Path | str, answer: str) -> HarvestUiResult:
+def answer_requirements(root: Path | str, answer: str | list[str]) -> HarvestUiResult:
     root_path = Path(root)
     session = _load_or_recover_session(root_path)
-    normalized_answer = answer.strip()
-    if not normalized_answer:
-        raise ValueError("answer is required")
-    current_question = _current_question(session)
-    if current_question is None:
+    current_questions = _current_questions(session)
+    if not current_questions:
         raise ValueError("no active Grill-Me question")
-    session["clarifications"].append(
+    raw_answers = answer if isinstance(answer, list) else [answer]
+    normalized_answers = [str(item).strip() for item in raw_answers]
+    if len(normalized_answers) != len(current_questions):
+        raise ValueError("one answer is required for each active Grill-Me question")
+    if any(not item for item in normalized_answers):
+        raise ValueError("answer is required")
+    session["clarifications"].extend(
         {
             "questions": [
                 {
-                    "question": current_question.get("question", ""),
-                    "recommended": current_question.get("recommended", ""),
+                    "question": question.get("question", ""),
+                    "recommended": question.get("recommended", ""),
                 }
             ],
             "answer": normalized_answer,
         }
+        for question, normalized_answer in zip(current_questions, normalized_answers, strict=True)
     )
     session["current_questions"] = []
     session["current_question"] = None
@@ -512,13 +516,16 @@ def _normalize_session(session: dict[str, Any]) -> None:
     session.setdefault("event_storming", None)
     session.setdefault("ddd_architecture", None)
     current = session.get("current_question")
-    current_questions = session.get("current_questions") or []
+    current_questions = [
+        item
+        for item in (session.get("current_questions") or [])
+        if isinstance(item, dict) and item.get("question")
+    ][:3]
     if current is None and current_questions:
         session["current_question"] = current_questions[0]
-    if session.get("current_question"):
-        session["current_questions"] = [session["current_question"]]
-    else:
-        session["current_questions"] = []
+    elif current and not current_questions:
+        current_questions = [current]
+    session["current_questions"] = current_questions
     use_case_current = session.get("use_case_current_question")
     use_case_current_questions = session.get("use_case_current_questions") or []
     if use_case_current is None and use_case_current_questions:
@@ -715,7 +722,10 @@ def _result(root: Path, session: dict[str, Any], *, artifact_root: Path | None =
         current_question = _current_ddd_question(session)
     else:
         current_question = None
-    current_questions = (current_question,) if current_question else ()
+    if session_started and not gate_passed:
+        current_questions = tuple(_current_questions(session))
+    else:
+        current_questions = (current_question,) if current_question else ()
     return HarvestUiResult(
         initial_prompt=session["initial_prompt"],
         status=status,
@@ -830,6 +840,18 @@ def _current_question(session: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def _current_questions(session: dict[str, Any]) -> list[dict[str, Any]]:
+    questions = [
+        item
+        for item in (session.get("current_questions") or [])
+        if isinstance(item, dict) and item.get("question")
+    ]
+    if questions:
+        return questions[:3]
+    current = _current_question(session)
+    return [current] if current else []
+
+
 def _current_use_case_question(session: dict[str, Any]) -> dict[str, Any] | None:
     current = session.get("use_case_current_question")
     if isinstance(current, dict) and current.get("question"):
@@ -897,9 +919,10 @@ def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
     filtered_questions = _filter_new_questions(result["questions"], session)
     if open_language_questions:
         follow_up_questions = filtered_questions or _fallback_open_language_questions(open_language_questions)
+        follow_up_questions = follow_up_questions[:3]
         session["requirements_gate_passed"] = False
         session["current_question"] = follow_up_questions[0]
-        session["current_questions"] = [follow_up_questions[0]]
+        session["current_questions"] = follow_up_questions
         session["pending_questions"] = []
         session["runtime_error"] = ""
         return
@@ -915,9 +938,10 @@ def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
             session["current_questions"] = []
             session["pending_questions"] = []
         else:
+            filtered_questions = filtered_questions[:3]
             session["requirements_gate_passed"] = False
             session["current_question"] = filtered_questions[0]
-            session["current_questions"] = [filtered_questions[0]]
+            session["current_questions"] = filtered_questions
             session["pending_questions"] = []
     session["runtime_error"] = ""
 

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -176,7 +176,11 @@ def resume_changeset(repo_root: Path | str, change_set_id: str) -> dict[str, Any
     return {"change_set_id": change_set_id, "harvest": result.as_dict()}
 
 
-def answer_requirements_changeset(repo_root: Path | str, change_set_id: str, answer: str) -> dict[str, Any]:
+def answer_requirements_changeset(
+    repo_root: Path | str,
+    change_set_id: str,
+    answer: str | list[str],
+) -> dict[str, Any]:
     root = Path(repo_root).resolve()
     activate_changeset_harvest_ui(root, change_set_id)
     result = answer_requirements(root, answer)
@@ -402,14 +406,17 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
                     answer_requirements_changeset(
                         self.repo_root,
                         _required_change_set_id(body),
-                        str(body.get("answer", "")),
+                        body.get("answers", body.get("answer", "")),
                     ),
                 )
                 return
             if path == "/api/requirements/start":
                 result = start_requirements(self.repo_root, str(body.get("prompt", "")))
             elif path == "/api/requirements/answer":
-                result = answer_requirements(self.repo_root, str(body.get("answer", "")))
+                result = answer_requirements(
+                    self.repo_root,
+                    body.get("answers", body.get("answer", "")),
+                )
             elif path == "/api/use-cases/start":
                 payload = start_use_cases_changeset(
                     self.repo_root,

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -868,6 +868,9 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "Resume Workflow" in javascript
         assert "/resume" in javascript
         assert "Continue to Use Case Definition" in javascript
+        assert "Submit all answers" in javascript
+        assert 'document.querySelectorAll("[data-grill-answer]")' in javascript
+        assert "JSON.stringify({ change_set_id: app.requirementsChangeSet, answers })" in javascript
         assert "Retry Use Case Definition" in javascript
         assert "Continue to Event Storming" in javascript
         assert "Continue Event Storming" in javascript
@@ -981,6 +984,35 @@ def test_start_requirements_changeset_serializes_harvest_result(tmp_path: Path, 
     assert payload["harvest"]["status"] == "requirements_running"
     assert payload["change_set_id"] == "CHG-20260526-099"
     assert (tmp_path / "docs/changes/active/CHG-20260526-099.md").exists()
+
+
+def test_answer_requirements_changeset_forwards_batched_answers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    answers = ["Customer", "Request accepted", "Invalid request rejected"]
+    received: list[list[str]] = []
+    result = type(
+        "HarvestResult",
+        (),
+        {"as_dict": lambda self: {"status": "requirements_passed"}},
+    )()
+    monkeypatch.setattr(ui_server, "activate_changeset_harvest_ui", lambda *_args: None)
+    monkeypatch.setattr(
+        ui_server,
+        "answer_requirements",
+        lambda _root, submitted: received.append(submitted) or result,
+    )
+    monkeypatch.setattr(ui_server, "save_changeset_harvest_ui", lambda *_args: None)
+
+    payload = ui_server.answer_requirements_changeset(
+        tmp_path,
+        "CHG-20260611-001",
+        answers,
+    )
+
+    assert received == [answers]
+    assert payload["harvest"]["status"] == "requirements_passed"
 
 
 def test_ui_server_loads_scoped_changeset_resume_without_starting_workflow(

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -274,6 +274,54 @@ def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
     assert (tmp_path / USE_CASES_PATH).is_file()
 
 
+def test_harvest_ui_presents_and_answers_three_requirements_questions_together(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def batched_grill_me(_root: Path, session: dict) -> dict:
+        complete = len(session["clarifications"]) == 3
+        return {
+            "complete": complete,
+            "questions": [] if complete else [
+                {"question": "Who is the actor?", "recommended": "Customer"},
+                {"question": "What is success?", "recommended": "Request accepted"},
+                {"question": "What failure matters?", "recommended": "Invalid request rejected"},
+            ],
+            "requirements_markdown": "# Requirements Specification\n",
+            "context_markdown": "# Project Context\n\n## 3. Open Language Questions\n\n- None.\n",
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_grill_me", batched_grill_me)
+
+    result = start_requirements(tmp_path, "build a queue system")
+
+    assert [item["question"] for item in result.current_questions] == [
+        "Who is the actor?",
+        "What is success?",
+        "What failure matters?",
+    ]
+
+    with pytest.raises(ValueError, match="one answer is required"):
+        answer_requirements(tmp_path, ["Customer"])
+
+    result = answer_requirements(
+        tmp_path,
+        ["Customer", "Request accepted", "Invalid request rejected"],
+    )
+
+    assert result.requirements_gate_passed is True
+    assert [item["answer"] for item in result.clarifications] == [
+        "Customer",
+        "Request accepted",
+        "Invalid request rejected",
+    ]
+    assert [item["questions"][0]["question"] for item in result.clarifications] == [
+        "Who is the actor?",
+        "What is success?",
+        "What failure matters?",
+    ]
+
+
 def test_changeset_resume_restores_pending_question_without_advancing_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## 구현 의도
요구사항 정의 단계에서 Grill-Me가 최대 3개 질문을 반환해도 대시보드가 첫 질문만 표시하던 문제를 수정합니다. 사용자가 한 화면에서 모든 질문을 확인하고 한 번에 답변하도록 합니다.

## 구현 접근
- 요구사항 세션의 `current_questions`에 최대 3개 질문을 보존합니다.
- 질문별 답변 수가 일치하는지 검증하고 각 답변을 기존 clarification 형식으로 기록합니다.
- API가 기존 단일 `answer`와 신규 `answers` 배열을 모두 처리하도록 호환성을 유지합니다.
- 대시보드에 번호가 있는 질문 카드와 질문별 입력란을 렌더링하고 한 번의 요청으로 제출합니다.
- 런타임, API 전달, 대시보드 자산 회귀 테스트를 추가했습니다.

## 검증 방법
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `python3 -m py_compile harness_codex/runtime/harvest_ui.py harness_codex/runtime/ui_server.py`
- 요구사항/UI 집중 테스트: 65 passed
- 전체 테스트: 491 passed
- Playwright Chromium 검증: 입력란 3개 렌더링, 답변 3개 단일 POST 제출, 완료 상태 표시 확인
- `git fetch origin` 후 `HEAD...origin/main` 차이 0/0 확인

## 위험 및 롤백
- 위험: 다중 질문 세션에서 답변 개수가 질문 개수와 다르면 요청이 거부됩니다. 이는 답변-질문 오매핑 방지를 위한 의도된 검증입니다.
- 호환성: 단일 질문 세션과 기존 `answer` 필드는 계속 지원합니다.
- 롤백: 이 PR의 단일 커밋 `4a29e36`을 revert하면 기존 단일 질문 UI와 처리 방식으로 복원됩니다.