### PR TITLE
[codex] UI 서버 실행 시 기존 프로세스 재시작

### DIFF
--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -89,7 +89,9 @@ def _terminate_previous_ui_server(repo_root: Path) -> bool:
         pid = int(pid_path.read_text(encoding="utf-8").strip())
     except (FileNotFoundError, ValueError):
         return False
-    if pid <= 0 or pid == os.getpid():
+    process_matches = _is_harness_ui_server_process(pid)
+    if pid <= 0 or pid == os.getpid() or process_matches is False:
+        pid_path.unlink(missing_ok=True)
         return False
     try:
         os.kill(pid, signal.SIGTERM)
@@ -97,6 +99,84 @@ def _terminate_previous_ui_server(repo_root: Path) -> bool:
         pid_path.unlink(missing_ok=True)
         return False
     return True
+
+
+def _terminate_ui_server_on_port(host: str, port: int) -> bool:
+    pid = _ui_server_pid_on_port(host, port)
+    if pid is None or pid == os.getpid():
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _ui_server_pid_on_port(host: str, port: int) -> int | None:
+    listen_inodes = _listen_socket_inodes(host, port)
+    if not listen_inodes:
+        return None
+    try:
+        process_dirs = tuple(Path("/proc").iterdir())
+    except FileNotFoundError:
+        return None
+    for process_dir in process_dirs:
+        if not process_dir.name.isdigit():
+            continue
+        pid = int(process_dir.name)
+        if _process_owns_socket(process_dir, listen_inodes) and _is_harness_ui_server_process(pid) is True:
+            return pid
+    return None
+
+
+def _listen_socket_inodes(host: str, port: int) -> set[str]:
+    if host not in {"", "0.0.0.0", "127.0.0.1", "::", "::1", "localhost"}:
+        return set()
+    inodes: set[str] = set()
+    for table in (Path("/proc/net/tcp"), Path("/proc/net/tcp6")):
+        try:
+            lines = table.read_text(encoding="utf-8").splitlines()[1:]
+        except FileNotFoundError:
+            continue
+        for line in lines:
+            fields = line.split()
+            if len(fields) < 10 or fields[3] != "0A":
+                continue
+            try:
+                _address_hex, port_hex = fields[1].rsplit(":", maxsplit=1)
+            except ValueError:
+                continue
+            if int(port_hex, 16) == port:
+                inodes.add(fields[9])
+    return inodes
+
+
+def _process_owns_socket(process_dir: Path, listen_inodes: set[str]) -> bool:
+    try:
+        entries = tuple((process_dir / "fd").iterdir())
+    except (FileNotFoundError, PermissionError):
+        return False
+    for entry in entries:
+        try:
+            target = os.readlink(entry)
+        except (FileNotFoundError, PermissionError, OSError):
+            continue
+        if target.startswith("socket:[") and target.removeprefix("socket:[").removesuffix("]") in listen_inodes:
+            return True
+    return False
+
+
+def _is_harness_ui_server_process(pid: int) -> bool | None:
+    try:
+        command = (Path("/proc") / str(pid) / "cmdline").read_bytes().split(b"\x00")
+    except FileNotFoundError:
+        return False if Path("/proc").exists() else None
+    except PermissionError:
+        return None
+    arguments = {part.decode("utf-8", errors="replace") for part in command if part}
+    return "ui-server" in arguments and (
+        "harness_codex" in arguments or "harness_codex.runtime.ui_server" in arguments
+    )
 
 
 def _create_http_server(
@@ -318,6 +398,8 @@ def run_ui_server(
         repo_root = root
 
     restart_pending = _terminate_previous_ui_server(root)
+    if not restart_pending:
+        restart_pending = _terminate_ui_server_on_port(host, port)
     server = _create_http_server(host, port, Handler, wait_for_restart=restart_pending)
     _print_startup_log(root, host, port, restarted=restart_pending)
     pid_path = _ui_server_pid_path(root)

--- a/tests/runtime/test_ui_server_restart.py
+++ b/tests/runtime/test_ui_server_restart.py
@@ -65,3 +65,52 @@ def test_ui_server_restarts_existing_server_for_repo(tmp_path: Path) -> None:
         if first.poll() is None:
             first.terminate()
             first.wait(timeout=2)
+
+
+def test_ui_server_restarts_server_from_different_repo(tmp_path: Path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    port = _available_port()
+    first_pid_path = first_root / ".harness" / "ui-server.pid"
+    second_pid_path = second_root / ".harness" / "ui-server.pid"
+    first = _start_server(first_root, port)
+    second: subprocess.Popen[bytes] | None = None
+    try:
+        _wait_for_dashboard(port, first_pid_path, first.pid)
+
+        second = _start_server(second_root, port)
+        _wait_for_dashboard(port, second_pid_path, second.pid)
+
+        assert first.wait(timeout=2) == 0
+        assert not first_pid_path.exists()
+    finally:
+        if second is not None and second.poll() is None:
+            second.terminate()
+            second.wait(timeout=2)
+            assert not second_pid_path.exists()
+        if first.poll() is None:
+            first.terminate()
+            first.wait(timeout=2)
+
+
+def test_ui_server_restarts_existing_server_without_pid_file(tmp_path: Path) -> None:
+    port = _available_port()
+    pid_path = tmp_path / ".harness" / "ui-server.pid"
+    first = _start_server(tmp_path, port)
+    second: subprocess.Popen[bytes] | None = None
+    try:
+        _wait_for_dashboard(port, pid_path, first.pid)
+        pid_path.unlink()
+
+        second = _start_server(tmp_path, port)
+        _wait_for_dashboard(port, pid_path, second.pid)
+
+        assert first.wait(timeout=2) == 0
+    finally:
+        if second is not None and second.poll() is None:
+            second.terminate()
+            second.wait(timeout=2)
+            assert not pid_path.exists()
+        if first.poll() is None:
+            first.terminate()
+            first.wait(timeout=2)


### PR DESCRIPTION
## 구현 의도
`harness ui-server` 실행 시 동일 포트를 사용 중인 기존 Harness UI 서버를 자동 종료하고 새 서버를 시작한다. 다른 저장소 또는 워크트리에서 실행된 서버와 PID 파일이 유실된 서버도 재시작 대상으로 처리한다.

## 구현 접근
- 저장소별 PID 파일을 우선 확인하고 기존 Harness UI 서버에 `SIGTERM`을 전송한다.
- PID 파일만 신뢰하지 않고 `/proc/net/tcp*`와 프로세스 파일 디스크립터를 조회해 요청 포트를 점유한 Harness UI 서버를 식별한다.
- Harness UI 서버가 아닌 프로세스는 종료하지 않는다.
- stale PID가 다른 프로세스를 가리키면 PID 파일만 제거한다.
- 기존 서버 종료 후 포트 해제까지 기다린 뒤 새 서버를 바인딩한다.
- 동일 저장소, 다른 저장소, PID 파일 유실 시나리오를 통합 테스트로 검증한다.

## 검증 방법
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q`
- 결과: `491 passed`
- `git diff --check` 통과

## 위험 및 롤백
- 포트 기반 탐지는 Linux `/proc`에 의존한다. `/proc`을 사용할 수 없는 환경에서는 기존 PID 파일 기반 동작으로 폴백한다.
- 프로세스 명령행에 `harness_codex`와 `ui-server`가 모두 확인된 경우만 종료해 오탐 위험을 제한한다.
- 문제 발생 시 커밋 `178755a`를 revert하면 기존 PID 파일 기반 재시작 동작으로 복구된다.