### PR TITLE
[codex] 설계 단계 재실행 UI 통합

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -41,6 +41,14 @@ h1 { margin-bottom: 0; font-size: 31px; }
 .stage { background: #f1f2ec; border-radius: 9px; min-height: 84px; padding: 10px; }
 .stage.stale { background: var(--stale); }
 .stage strong { display: block; font-size: 12px; }
+.stage-rerun-button { margin-top: 9px; padding: 4px 8px; }
+.stage-rerun-form { border-top: 1px solid var(--line); display: grid; gap: 9px; margin-top: 16px; padding-top: 16px; }
+.stage-rerun-form h4 { margin: 0; }
+.stage-rerun-form label { color: var(--muted); font-size: 12px; font-weight: 600; text-transform: uppercase; }
+.stage-rerun-form select { border: 1px solid var(--line); border-radius: 7px; max-width: 420px; padding: 8px 10px; }
+.stage-rerun-form textarea { min-height: 96px; }
+.stage-rerun-actions { display: flex; gap: 8px; }
+.stage-rerun-result { margin: 16px 0 0; white-space: pre-wrap; }
 .small { color: var(--muted); font-size: 12px; }
 .artifact { color: var(--accent); display: block; margin: 4px 0; }
 .flow-lane { display: flex; gap: 10px; margin: 14px 0 22px; overflow-x: auto; padding-bottom: 8px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -10,6 +10,8 @@ const app = {
   eventSelectedUc: null,
   dddSelectedUc: null,
   dddSelectedStep: "entity_vo",
+  rerunStageId: "",
+  rerunResult: "",
   workflowRecovered: false,
   busy: false,
   busyLabel: "",
@@ -193,6 +195,8 @@ function render() {
     if (advanceEventStorming) advanceEventStorming.onclick = continueEventStormingDefinition;
     const eventForm = document.querySelector("#event-storming-form");
     if (eventForm) eventForm.onsubmit = submitEventStormingAnswer;
+    const eventRerunForm = document.querySelector("#event-storming-rerun-form");
+    if (eventRerunForm) eventRerunForm.onsubmit = submitEventStormingRerun;
     const startDdd = document.querySelector("#start-ddd-architecture");
     if (startDdd) startDdd.onclick = startDddArchitecture;
     const restartDdd = document.querySelector("#restart-ddd-architecture");
@@ -403,6 +407,15 @@ function renderEventStormingWorkspace() {
   const progress = state.uc_ids.length
     ? `<p class="small">Completed ${escapeHtml(state.completed_count || 0)} / ${escapeHtml(state.total_count || state.uc_ids.length)}</p><div class="event-progress">${statusItems}</div>`
     : '<p class="small">Start Event Storming to process generated use cases.</p>';
+  const rerun = item?.status === "complete"
+    ? `<form id="event-storming-rerun-form" class="stage-rerun-form">
+        <h4>Rerun ${escapeHtml(currentId)} Event Storming</h4>
+        <p class="small">Reruns selected use case with <code>--force</code>, verifies output, and marks downstream design stale.</p>
+        <label for="event-storming-rerun-prompt">Correction prompt</label>
+        <textarea id="event-storming-rerun-prompt" placeholder="Describe corrections or additional event-storming decisions..." required ${app.busy ? "disabled" : ""}></textarea>
+        <button class="primary" type="submit" ${app.busy ? "disabled" : ""}>${app.busy ? "Rerunning..." : "Rerun selected use case"}</button>
+      </form>`
+    : "";
   let interaction = "";
   if (item?.status === "needs_input" && item.current_question) {
     interaction = `<form id="event-storming-form" class="grill-form">
@@ -428,6 +441,7 @@ function renderEventStormingWorkspace() {
     <section class="panel event-progress-panel"><h3>Event Storming Progress</h3>${progress}</section>
     <section class="panel event-document"><h3>${escapeHtml(currentId || "Event Storming")} Document</h3><div id="event-document-editor"></div></section>
     <section class="panel event-live-preview"><h3>Sticky Notes Preview</h3><div id="event-live-board"></div></section>
+    ${rerun ? `<section class="panel">${rerun}</section>` : ""}
     <section class="panel grill-panel"><h3>Oracle Questions</h3>${interaction}</section>`;
 }
 
@@ -642,6 +656,42 @@ async function submitEventStormingAnswer(event) {
   });
 }
 
+async function submitEventStormingRerun(event) {
+  event.preventDefault();
+  const prompt = document.querySelector("#event-storming-rerun-prompt")?.value.trim() || "";
+  const ucId = app.eventSelectedUc
+    || app.harvest?.event_storming?.current_uc
+    || app.harvest?.event_storming?.uc_ids?.find((id) => app.harvest.event_storming.items[id]?.status === "complete");
+  if (!prompt || !ucId) return;
+  app.busy = true;
+  app.busyLabel = `Rerunning ${ucId} Event Storming`;
+  app.error = "";
+  render();
+  try {
+    const response = await fetch(`/api/dashboard/change-sets/${encodeURIComponent(app.requirementsChangeSet)}/rerun-stage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stage_id: "event-storming",
+        uc_id: ucId,
+        user_prompt: prompt,
+      }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Unable to rerun event storming.");
+    app.harvest = result.harvest;
+    app.state = result.dashboard;
+    app.eventSelectedUc = ucId;
+    await openCurrentEventDocument();
+  } catch (error) {
+    app.error = error.message;
+  } finally {
+    app.busy = false;
+    app.busyLabel = "";
+    render();
+  }
+}
+
 async function runEventStormingTurn(endpoint, label, extra = {}) {
   app.busy = true;
   app.busyLabel = label;
@@ -803,6 +853,9 @@ function renderDetail(change) {
       <strong>${escapeHtml(stage.procedure)}</strong>
       <span class="pill ${stage.status}">${escapeHtml(stage.status)}</span>
       <div class="small">${escapeHtml(stage.verified_at)}</div>
+      ${change.lifecycle === "active" && ["verified", "stale"].includes(stage.status) && rerunnableDesignStage(stage.id)
+        ? `<button type="button" class="stage-rerun-button" data-rerun-stage="${escapeHtml(stage.id)}">Rerun</button>`
+        : ""}
     </div>`).join("");
   const hasAggregateBoard = Boolean(change.event_storming_board?.slices?.length);
   const workItems = change.work_items.map((item) => `
@@ -825,7 +878,9 @@ function renderDetail(change) {
     ${change.lifecycle === "active" ? `<div class="stage-tabs dashboard-tabs">
       <button data-resume-workflow class="stage-tab"><span class="progress-dot"></span>Resume Workflow</button>
     </div>` : ""}
-    <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div></section>
+    <section class="panel"><h3>Workflow Stages</h3><div class="timeline">${stages}</div>
+      ${renderStageRerunForm(change)}
+    </section>
     ${documents ? `<section class="panel"><h3>Documents</h3><div class="doc-actions">${documents}</div><div id="editor"></div></section>` : ""}
     ${renderCanvasBoard(change.event_storming_board)}
     ${renderDddCanvasBoard(change.ddd_architecture_board)}
@@ -890,12 +945,106 @@ function bindDetail(change) {
   if (deleteButton) deleteButton.onclick = () => deleteActiveChangeSet(change);
   const resumeWorkflow = document.querySelector("[data-resume-workflow]");
   if (resumeWorkflow) resumeWorkflow.onclick = () => loadWorkflowResults(change.id);
+  document.querySelectorAll("[data-rerun-stage]").forEach((node) => {
+    node.onclick = () => {
+      app.rerunStageId = node.dataset.rerunStage;
+      app.rerunResult = "";
+      app.error = "";
+      render();
+    };
+  });
+  const rerunForm = document.querySelector("#stage-rerun-form");
+  if (rerunForm) rerunForm.onsubmit = (event) => submitStageRerun(event, change);
+  const cancelRerun = document.querySelector("#cancel-stage-rerun");
+  if (cancelRerun) cancelRerun.onclick = () => {
+    app.rerunStageId = "";
+    app.rerunResult = "";
+    render();
+  };
   if (app.openDocument && change.documents.some((item) => item.id === app.openDocument.id)) {
     renderEditor();
   }
   bindCanvas();
   bindDddCanvas();
   requestAnimationFrame(drawDddVoLinks);
+}
+
+function rerunnableDesignStage(stageId) {
+  return [
+    "requirements-definition",
+    "ubiquitous-language-definition",
+    "use-case-definition",
+    "event-storming",
+    "ddd-architecture-definition",
+    "technical-decisions",
+  ].includes(stageId);
+}
+
+function stageRequiresUseCase(stageId) {
+  return [
+    "event-storming",
+    "ddd-architecture-definition",
+    "technical-decisions",
+  ].includes(stageId);
+}
+
+function renderStageRerunForm(change) {
+  if (!app.rerunStageId) {
+    return app.rerunResult ? `<p class="completion stage-rerun-result">${escapeHtml(app.rerunResult)}</p>` : "";
+  }
+  const stage = change.stages.find((item) => item.id === app.rerunStageId);
+  if (!stage) return "";
+  const requiresUc = stageRequiresUseCase(stage.id);
+  const workItems = change.work_items.filter((item) => item.id.startsWith("UC-"));
+  const ucField = requiresUc
+    ? `<label for="stage-rerun-uc">Use case</label>
+       <select id="stage-rerun-uc" required>
+         <option value="">Select use case</option>
+         ${workItems.map((item) => `<option value="${escapeHtml(item.id)}">${escapeHtml(item.id)}: ${escapeHtml(item.name)}</option>`).join("")}
+       </select>`
+    : "";
+  return `<form id="stage-rerun-form" class="stage-rerun-form">
+    <h4>Rerun ${escapeHtml(stage.procedure)}</h4>
+    <p class="small">Stage agent runs again with <code>--force</code>, updates artifacts, then runs normal stage verification.</p>
+    ${ucField}
+    <label for="stage-rerun-prompt">Correction prompt</label>
+    <textarea id="stage-rerun-prompt" placeholder="Describe corrections or additional decisions..." required ${app.busy ? "disabled" : ""}></textarea>
+    <div class="stage-rerun-actions">
+      <button class="primary" type="submit" ${app.busy ? "disabled" : ""}>${app.busy ? "Rerunning..." : "Rerun and verify"}</button>
+      <button id="cancel-stage-rerun" type="button" ${app.busy ? "disabled" : ""}>Cancel</button>
+    </div>
+  </form>`;
+}
+
+async function submitStageRerun(event, change) {
+  event.preventDefault();
+  const prompt = document.querySelector("#stage-rerun-prompt")?.value.trim() || "";
+  const ucId = document.querySelector("#stage-rerun-uc")?.value || "";
+  if (!prompt) return;
+  app.busy = true;
+  app.error = "";
+  render();
+  try {
+    const response = await fetch(`/api/dashboard/change-sets/${encodeURIComponent(change.id)}/rerun-stage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        stage_id: app.rerunStageId,
+        uc_id: ucId,
+        user_prompt: prompt,
+      }),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Unable to rerun design stage.");
+    app.state = result.dashboard;
+    app.rerunResult = result.output || "Stage rerun and verification completed.";
+    app.rerunStageId = "";
+  } catch (error) {
+    app.error = error.message;
+  } finally {
+    app.busy = false;
+    render();
+  }
 }
 
 async function loadWorkflowResults(changeSetId) {

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -8,6 +8,8 @@ import json
 import os
 import signal
 import shutil
+import subprocess
+import sys
 import threading
 import time
 from datetime import datetime
@@ -48,7 +50,22 @@ from harness_codex.runtime.harvest_ui import (
     start_use_case_generation,
     start_use_cases,
 )
-from harness_codex.runtime.procedure_stages import render_initial_changeset
+from harness_codex.runtime.procedure_stages import (
+    PROCEDURE_STAGES,
+    procedure_stage,
+    render_initial_changeset,
+    update_changeset_stage_status,
+)
+
+
+_RERUNNABLE_DESIGN_STAGE_IDS = {
+    "requirements-definition",
+    "ubiquitous-language-definition",
+    "use-case-definition",
+    "event-storming",
+    "ddd-architecture-definition",
+    "technical-decisions",
+}
 
 
 _SERVER_ENDPOINTS: tuple[tuple[str, str, str], ...] = (
@@ -78,6 +95,7 @@ _SERVER_ENDPOINTS: tuple[tuple[str, str, str], ...] = (
     ("POST", "/api/ddd-architecture/advance", "advance DDD architecture"),
     ("POST", "/api/ddd-architecture/rerun-step", "rerun DDD architecture step"),
     ("POST", "/api/ddd-architecture/answer", "answer DDD architecture question"),
+    ("POST", "/api/dashboard/change-sets/{change_set_id}/rerun-stage", "rerun design stage"),
     ("PUT", "/api/dashboard/documents/{document_id}", "save dashboard document"),
     ("DELETE", "/api/dashboard/change-sets/{change_set_id}", "delete active ChangeSet"),
 )
@@ -375,6 +393,81 @@ def rerun_ddd_architecture_step_changeset(
     return {"change_set_id": change_set_id, "harvest": result.as_dict()}
 
 
+def rerun_design_stage(
+    repo_root: Path | str,
+    change_set_id: str,
+    stage_id: str,
+    user_prompt: str,
+    *,
+    uc_id: str = "",
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    if stage_id not in _RERUNNABLE_DESIGN_STAGE_IDS:
+        raise ValueError("stage_id must identify a rerunnable design stage")
+    prompt = user_prompt.strip()
+    if not prompt:
+        raise ValueError("user_prompt is required")
+    change_set_path = root / "docs/changes/active" / f"{change_set_id}.md"
+    if not change_set_path.exists():
+        raise ValueError("active ChangeSet does not exist")
+    if stage_id in {
+        "event-storming",
+        "ddd-architecture-definition",
+        "technical-decisions",
+    } and not uc_id.strip():
+        raise ValueError("uc_id is required for this design stage")
+
+    activate_changeset_harvest_ui(root, change_set_id)
+    command = [
+        sys.executable,
+        "-m",
+        "harness_codex",
+        stage_id,
+        change_set_id,
+        "--idea",
+        prompt,
+        "--force",
+    ]
+    if uc_id.strip():
+        command.extend(["--uc", uc_id.strip()])
+    result = subprocess.run(
+        command,
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    output = result.stdout.strip()
+    error = result.stderr.strip()
+    if result.returncode != 0:
+        detail = error or output or f"stage rerun exited with status {result.returncode}"
+        raise ValueError(detail)
+    _mark_downstream_stages_stale(change_set_path, stage_id)
+    save_changeset_harvest_ui(root, change_set_id)
+    return {
+        "change_set_id": change_set_id,
+        "stage_id": stage_id,
+        "uc_id": uc_id.strip(),
+        "output": output,
+        "harvest": load_changeset_harvest_ui(root, change_set_id).as_dict(),
+        "dashboard": document_dashboard_state(root),
+    }
+
+
+def _mark_downstream_stages_stale(change_set_path: Path, stage_id: str) -> None:
+    stage_ids = [stage.stage_id for stage in PROCEDURE_STAGES]
+    start = stage_ids.index(stage_id) + 1
+    text = change_set_path.read_text(encoding="utf-8")
+    for downstream_id in stage_ids[start:]:
+        text = update_changeset_stage_status(
+            text,
+            stage=procedure_stage(downstream_id),
+            status="stale",
+            notes=f"stale after forced rerun of {stage_id}",
+        )
+    change_set_path.write_text(text, encoding="utf-8")
+
+
 def answer_ddd_architecture_changeset(
     repo_root: Path | str,
     change_set_id: str,
@@ -611,6 +704,19 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
                     str(body.get("uc_id", "")).strip(),
                     str(body.get("step_id", "")).strip(),
                     str(body.get("answer", "")),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path.startswith("/api/dashboard/change-sets/") and path.endswith("/rerun-stage"):
+                change_set_id = unquote(
+                    path.removeprefix("/api/dashboard/change-sets/").removesuffix("/rerun-stage")
+                )
+                payload = rerun_design_stage(
+                    self.repo_root,
+                    change_set_id,
+                    str(body.get("stage_id", "")).strip(),
+                    str(body.get("user_prompt", "")),
+                    uc_id=str(body.get("uc_id", "")).strip(),
                 )
                 self._write_json(HTTPStatus.OK, payload)
                 return

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import threading
 from http.server import ThreadingHTTPServer
 from pathlib import Path
@@ -794,6 +795,86 @@ def test_ui_server_serves_dashboard_and_edit_api(tmp_path: Path) -> None:
         server.server_close()
 
 
+def test_rerun_design_stage_forces_stage_and_returns_refreshed_dashboard(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_run(command, *, cwd, text, capture_output, check):
+        calls.append((command, cwd))
+        assert text is True
+        assert capture_output is True
+        assert check is False
+        return subprocess.CompletedProcess(command, 0, "Verification: passed\n", "")
+
+    monkeypatch.setattr(ui_server.subprocess, "run", fake_run)
+    monkeypatch.setattr(ui_server, "activate_changeset_harvest_ui", lambda *_args: None)
+    monkeypatch.setattr(ui_server, "save_changeset_harvest_ui", lambda *_args: None)
+    monkeypatch.setattr(
+        ui_server,
+        "load_changeset_harvest_ui",
+        lambda *_args: type("Result", (), {"as_dict": lambda self: {"status": "event_storming_ready"}})(),
+    )
+
+    payload = ui_server.rerun_design_stage(
+        tmp_path,
+        "CHG-001",
+        "event-storming",
+        "Add cancellation invariant.",
+        uc_id="UC-001",
+    )
+
+    assert calls == [
+        (
+            [
+                ui_server.sys.executable,
+                "-m",
+                "harness_codex",
+                "event-storming",
+                "CHG-001",
+                "--idea",
+                "Add cancellation invariant.",
+                "--force",
+                "--uc",
+                "UC-001",
+            ],
+            tmp_path.resolve(),
+        )
+    ]
+    assert payload["output"] == "Verification: passed"
+    assert payload["harvest"]["status"] == "event_storming_ready"
+    assert payload["dashboard"]["change_sets"][0]["id"] == "CHG-001"
+    statuses = {
+        stage["id"]: stage["status"]
+        for stage in payload["dashboard"]["change_sets"][0]["stages"]
+    }
+    assert statuses["event-storming"] == "pending"
+    assert statuses["ddd-architecture-definition"] == "stale"
+    assert statuses["implementation"] == "stale"
+
+
+def test_rerun_design_stage_requires_prompt_and_scoped_uc(tmp_path: Path) -> None:
+    _write_change_set(tmp_path)
+
+    with pytest.raises(ValueError, match="user_prompt is required"):
+        ui_server.rerun_design_stage(
+            tmp_path,
+            "CHG-001",
+            "requirements-definition",
+            "",
+        )
+    with pytest.raises(ValueError, match="uc_id is required"):
+        ui_server.rerun_design_stage(
+            tmp_path,
+            "CHG-001",
+            "technical-decisions",
+            "Use transactional outbox.",
+        )
+
+
 def test_run_ui_server_prints_bind_url_and_endpoint_list(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -886,6 +967,11 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert '"/api/ddd-architecture/restart"' in javascript
         assert '"/api/ddd-architecture/advance"' in javascript
         assert '"/api/ddd-architecture/rerun-step"' in javascript
+        assert "/rerun-stage" in javascript
+        assert "Rerun and verify" in javascript
+        assert "Correction prompt" in javascript
+        assert "Rerun selected use case" in javascript
+        assert "submitEventStormingRerun" in javascript
         assert '"/api/ddd-architecture/answer"' in javascript
         assert "Restart DDD Architecture" in javascript
         assert "Additional rerun prompt" in javascript


### PR DESCRIPTION
## 구현 의도

완료된 설계 단계의 질문·승인 컴포넌트를 동일 위치의 재실행 컴포넌트로 전환한다. 사용자는 각 설계 화면을 벗어나지 않고 보정 프롬프트를 입력해 해당 단계를 강제 재실행하고 검증할 수 있어야 한다.

## 구현 접근

- Requirements, Ubiquitous Language, Use Cases, Event Storming, DDD Architecture, Technical Decisions에 공통 재실행 컴포넌트를 적용했다.
- 미완료 단계는 기존 질문·게이트 컴포넌트를 유지하고, 완료 단계에서는 sticky 질문 영역을 재실행 폼으로 교체한다.
- Event Storming 완료 화면에서 `Oracle Questions` 컴포넌트를 제거하고 선택된 UC의 재실행 컴포넌트로 교체했다.
- DDD Architecture 완료 화면에서 전체 단계 재실행을 제공하며 기존 하위 단계별 재실행 기능은 유지했다.
- 기존에 없던 Technical Decisions 워크플로 탭과 문서 미리보기·UC 선택·재실행 UI를 추가했다.
- 대시보드 API가 기존 CLI 설계 단계 명령을 `--force`와 `--idea`로 실행하도록 연결했다.
- UC 범위 단계는 UC ID를 필수 검증한다.
- 재실행 완료 후 대시보드 세션 아티팩트를 동기화하고 후속 단계를 `stale`로 표시한다.
- Technical Decisions 문서를 대시보드 문서 모델에서 조회·편집할 수 있도록 노출했다.

## 검증 방법

- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `PYTHONDONTWRITEBYTECODE=1 /home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -p no:cacheprovider -q`
- 전체 테스트 508개 통과
- Playwright로 6개 설계 탭 모두에서 완료 상태의 공통 재실행 폼과 보정 프롬프트 입력을 확인했다.
- Event Storming 완료 화면에서 `Oracle Questions` 제목이 사라지고 `Rerun Event Storming` 컴포넌트가 표시되는 것을 확인했다.
- 실제 활성 대시보드 상태에서 Technical Decisions 탭과 문서 미리보기를 확인했다.

## 위험 및 롤백

- 재실행 API는 동기식 하위 프로세스로 동작하므로 긴 에이전트 실행 동안 해당 HTTP 요청이 유지된다.
- 이전 설계 단계 재실행은 후속 단계 상태를 의도적으로 `stale`로 변경하므로 사용자가 후속 워크플로를 다시 적용해야 한다.
- Technical Decisions 탭은 DDD Architecture 대상 UC를 기준으로 노출되며 문서가 아직 없으면 재실행을 통해 생성한다.
- 문제 발생 시 이 PR 커밋을 되돌리면 기존 질문·게이트 중심 UI와 DDD 하위 단계 재실행 동작으로 복구된다.