### PR TITLE
[codex] DDD 질문 패널 겹침 수정

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -90,6 +90,7 @@ details { margin-top: 10px; }
 .workspace-heading { align-items: end; display: flex; justify-content: space-between; margin-bottom: 18px; }
 .requirements-document .markdown-preview { max-height: 460px; overflow-y: auto; }
 .grill-panel { margin-top: 24px; position: sticky; bottom: 14px; box-shadow: 0 -4px 18px rgba(25,34,28,.06); }
+.ddd-grill-panel { position: static; }
 .question { font-size: 17px; font-weight: 600; margin-bottom: 0; }
 .grill-question { border-top: 1px solid var(--line); display: grid; gap: 10px; padding-top: 14px; }
 .grill-question:first-of-type { border-top: 0; padding-top: 0; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -517,7 +517,7 @@ function renderDddArchitectureWorkspace() {
   return `<section class="panel"><h3>DDD Architecture Progress</h3><p class="small">Completed ${escapeHtml(state.completed_count || 0)} / ${escapeHtml(state.total_count || 0)} substeps</p>${restartAction}<div class="event-progress">${ucProgress}</div><nav class="ddd-steps">${stepTabs}</nav></section>
     <section class="panel"><h3>${escapeHtml(currentId || "DDD")} Design Document</h3><div id="ddd-document-editor"></div></section>
     <section class="panel ddd-live-preview"><h3>Design Visualization</h3><div id="ddd-live-board"></div></section>
-    <section class="panel grill-panel"><h3>${state.complete ? "Rerun DDD Architecture" : "DDD Architect Questions"}</h3>${rerunControls}${interaction}</section>`;
+    <section class="panel grill-panel ddd-grill-panel"><h3>${state.complete ? "Rerun DDD Architecture" : "DDD Architect Questions"}</h3>${rerunControls}${interaction}</section>`;
 }
 
 function technicalDecisionUseCases() {

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -1021,6 +1021,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "renderDddCanvasBoard" in javascript
         assert "ddd-evolved-design" in javascript
         assert "ddd-aggregate-panel" in javascript
+        assert "grill-panel ddd-grill-panel" in javascript
         assert "ddd-aggregate-name" in javascript
         assert "ddd-model-card" in javascript
         assert "ddd-root-badge" in javascript
@@ -1071,6 +1072,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "max-width: min(1720px, calc(100vw - 48px))" in stylesheet
         assert ".event-canvas" in stylesheet
         assert ".ddd-aggregate-panel" in stylesheet
+        assert ".ddd-grill-panel { position: static; }" in stylesheet
         assert ".ddd-model-card" in stylesheet
         assert ".ddd-entity-vo-row" in stylesheet
         assert ".ddd-vo-link-layer" in stylesheet


### PR DESCRIPTION
## 구현 의도
DDD 아키텍처 화면에서 Design Visualization 위로 DDD Architect Questions 패널이 sticky 상태로 겹쳐 보이는 문제를 수정합니다.

## 구현 방식
DDD 아키텍처 질문 패널에 `ddd-grill-panel` 클래스를 추가하고, 해당 패널만 `position: static`으로 지정했습니다. 기존 공통 `grill-panel` sticky 동작은 다른 단계에서 유지됩니다. 대시보드 자산 테스트에 클래스와 스타일 검증을 추가했습니다.

## 검증 방법
- `/home/jiwoo/workspace/harness/venv/bin/python -m pytest tests/runtime/test_document_dashboard.py`
- 결과: 32 passed

## 위험 및 롤백
영향 범위는 DDD 아키텍처 질문 패널 배치로 제한됩니다. 문제가 생기면 `ddd-grill-panel` 클래스 추가와 CSS 규칙을 되돌리면 됩니다.