### PR TITLE
[codex] DDD 시각화 레이어 겹침 수정

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -89,8 +89,7 @@ details { margin-top: 10px; }
 .prompt-form button, .grill-form button { justify-self: start; }
 .workspace-heading { align-items: end; display: flex; justify-content: space-between; margin-bottom: 18px; }
 .requirements-document .markdown-preview { max-height: 460px; overflow-y: auto; }
-.grill-panel { margin-top: 24px; position: sticky; bottom: 14px; box-shadow: 0 -4px 18px rgba(25,34,28,.06); }
-.ddd-grill-panel { position: static; }
+.grill-panel { margin-top: 24px; position: sticky; bottom: 14px; box-shadow: 0 -4px 18px rgba(25,34,28,.06); z-index: 20; }
 .question { font-size: 17px; font-weight: 600; margin-bottom: 0; }
 .grill-question { border-top: 1px solid var(--line); display: grid; gap: 10px; padding-top: 14px; }
 .grill-question:first-of-type { border-top: 0; padding-top: 0; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -517,7 +517,7 @@ function renderDddArchitectureWorkspace() {
   return `<section class="panel"><h3>DDD Architecture Progress</h3><p class="small">Completed ${escapeHtml(state.completed_count || 0)} / ${escapeHtml(state.total_count || 0)} substeps</p>${restartAction}<div class="event-progress">${ucProgress}</div><nav class="ddd-steps">${stepTabs}</nav></section>
     <section class="panel"><h3>${escapeHtml(currentId || "DDD")} Design Document</h3><div id="ddd-document-editor"></div></section>
     <section class="panel ddd-live-preview"><h3>Design Visualization</h3><div id="ddd-live-board"></div></section>
-    <section class="panel grill-panel ddd-grill-panel"><h3>${state.complete ? "Rerun DDD Architecture" : "DDD Architect Questions"}</h3>${rerunControls}${interaction}</section>`;
+    <section class="panel grill-panel"><h3>${state.complete ? "Rerun DDD Architecture" : "DDD Architect Questions"}</h3>${rerunControls}${interaction}</section>`;
 }
 
 function technicalDecisionUseCases() {

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -1021,7 +1021,6 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "renderDddCanvasBoard" in javascript
         assert "ddd-evolved-design" in javascript
         assert "ddd-aggregate-panel" in javascript
-        assert "grill-panel ddd-grill-panel" in javascript
         assert "ddd-aggregate-name" in javascript
         assert "ddd-model-card" in javascript
         assert "ddd-root-badge" in javascript
@@ -1072,7 +1071,8 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "max-width: min(1720px, calc(100vw - 48px))" in stylesheet
         assert ".event-canvas" in stylesheet
         assert ".ddd-aggregate-panel" in stylesheet
-        assert ".ddd-grill-panel { position: static; }" in stylesheet
+        assert ".grill-panel { margin-top: 24px; position: sticky; bottom: 14px;" in stylesheet
+        assert "z-index: 20" in stylesheet
         assert ".ddd-model-card" in stylesheet
         assert ".ddd-entity-vo-row" in stylesheet
         assert ".ddd-vo-link-layer" in stylesheet


### PR DESCRIPTION
## 구현 의도
DDD 아키텍처 화면에서 Design Visualization의 카드/링크 레이어가 sticky Grill 패널 위로 튀어나와 보이는 문제를 수정합니다.

## 구현 방식
기존 PR에서 추가된 DDD 전용 non-sticky 패널 처리를 제거하여 sticky 동작을 유지했습니다. 대신 공통 `grill-panel`에 `z-index: 20`을 부여해 DDD 시각화 내부 레이어보다 위에서 그려지도록 했습니다. 대시보드 자산 테스트는 sticky 유지와 z-index 적용을 검증하도록 갱신했습니다.

## 검증 방법
- `/home/jiwoo/workspace/harness/venv/bin/python -m pytest tests/runtime/test_document_dashboard.py`
- 결과: 32 passed
- Playwright UI 검증: `http://127.0.0.1:8765/dashboard`에서 ChangeSet 재개 후 DDD Architecture 화면을 열고 sticky 패널 겹침 지점을 검사했습니다.
- Playwright 판정: `.grill-panel`은 `position: sticky`, `z-index: 20`; DDD 내부 링크/속성 레이어는 각각 `z-index: 2/3`; 겹침 지점의 최상단 element는 `.grill-panel` 내부였습니다.
- 스크린샷: `.harness/verification/ddd-grill-panel-layer-fix.png`

## 위험 및 롤백
공통 Grill 패널의 stacking order가 올라갑니다. 다른 단계에서 예기치 않은 레이어 문제가 생기면 `z-index: 20` 추가와 이전 PR의 DDD 전용 클래스 제거 변경을 되돌리면 됩니다.