### PR TITLE
[codex] 대시보드 Mermaid 렌더링 지원

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -69,6 +69,9 @@ textarea { border: 1px solid var(--line); border-radius: 7px; font: 13px/1.48 "S
 .markdown-preview ul, .markdown-preview ol { margin: 8px 0 16px; padding-left: 25px; white-space: normal; }
 .markdown-preview li { margin: 4px 0; }
 .markdown-preview code { background: #eef1e8; border-radius: 4px; font: 12px "SFMono-Regular", Consolas, monospace; padding: 1px 4px; }
+.markdown-preview pre { background: #eef1e8; border-radius: 7px; overflow-x: auto; padding: 12px; white-space: pre; }
+.markdown-preview pre.mermaid { background: #fff; border: 1px solid var(--line); text-align: center; white-space: normal; }
+.markdown-preview pre.mermaid-error { color: #9c2d20; text-align: left; white-space: pre; }
 .markdown-table { margin: 12px 0; max-width: 100%; overflow-x: auto; white-space: normal; }
 .markdown-table table { border-collapse: collapse; min-width: 1280px; width: max-content; }
 .markdown-table th, .markdown-table td { border: 1px solid var(--line); min-width: 170px; padding: 7px 10px; text-align: left; vertical-align: top; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -27,6 +27,24 @@ const escapeHtml = (value) => String(value ?? "")
   .replaceAll(">", "&gt;")
   .replaceAll('"', "&quot;");
 
+let mermaidLoadPromise = null;
+
+function renderMermaidDiagrams(root = document) {
+  const nodes = [...root.querySelectorAll(".mermaid:not([data-mermaid-rendered])")];
+  if (!nodes.length) return;
+  if (!mermaidLoadPromise) {
+    mermaidLoadPromise = import("https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs")
+      .then((module) => {
+        module.default.initialize({ startOnLoad: false, securityLevel: "strict" });
+        return module.default;
+      });
+  }
+  mermaidLoadPromise
+    .then((mermaid) => mermaid.run({ nodes }))
+    .then(() => nodes.forEach((node) => { node.dataset.mermaidRendered = "true"; }))
+    .catch(() => nodes.forEach((node) => { node.classList.add("mermaid-error"); }));
+}
+
 function markdownPreview(content) {
   const lines = String(content ?? "").split(/\r?\n/);
   const html = [];
@@ -39,6 +57,22 @@ function markdownPreview(content) {
     listItems = [];
   };
   for (let index = 0; index < lines.length; index += 1) {
+    const fence = lines[index].match(/^```([A-Za-z0-9_-]*)\s*$/);
+    if (fence) {
+      flushList();
+      const language = fence[1].toLowerCase();
+      const block = [];
+      index += 1;
+      while (index < lines.length && !/^```\s*$/.test(lines[index])) {
+        block.push(lines[index]);
+        index += 1;
+      }
+      const code = escapeHtml(block.join("\n"));
+      html.push(language === "mermaid"
+        ? `<pre class="mermaid">${code}</pre>`
+        : `<pre><code class="language-${escapeHtml(language)}">${code}</code></pre>`);
+      continue;
+    }
     const heading = renderHeading(lines[index]);
     if (heading) {
       flushList();
@@ -1232,6 +1266,7 @@ function renderEditor(message = "") {
   document.querySelector("#preview-mode").onclick = () => { app.editorMode = "preview"; renderEditor(); };
   if (editable) document.querySelector("#edit-mode").onclick = () => { app.editorMode = "edit"; renderEditor(); };
   if (editing) document.querySelector("#save-doc").onclick = saveDocument;
+  if (!editing) renderMermaidDiagrams(target);
 }
 
 function isEditingDashboardDocument() {
@@ -1346,6 +1381,7 @@ function renderEventDocumentEditor(message = "") {
   updatePreview(app.openDocument.content);
   document.querySelector("#event-preview-mode").onclick = () => { app.editorMode = "preview"; renderEventDocumentEditor(); };
   document.querySelector("#event-edit-mode").onclick = () => { app.editorMode = "edit"; renderEventDocumentEditor(); };
+  if (!editing) renderMermaidDiagrams(target);
   if (editing) {
     document.querySelector("#event-doc-content").oninput = (event) => updatePreview(event.target.value);
     document.querySelector("#event-save-doc").onclick = async () => {
@@ -1763,6 +1799,7 @@ function renderDddDocumentEditor(message = "") {
   update(app.openDocument.content);
   document.querySelector("#ddd-preview-mode").onclick = () => { app.editorMode = "preview"; renderDddDocumentEditor(); };
   document.querySelector("#ddd-edit-mode").onclick = () => { app.editorMode = "edit"; renderDddDocumentEditor(); };
+  if (!editing) renderMermaidDiagrams(target);
   if (editing) {
     document.querySelector("#ddd-doc-content").oninput = (event) => update(event.target.value);
     document.querySelector("#ddd-save-doc").onclick = async () => {

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -1015,6 +1015,9 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "Additional rerun prompt" in javascript
         assert "Rerun ${escapeHtml(step.label)}" in javascript
         assert "renderDddVisualization" in javascript
+        assert "renderMermaidDiagrams" in javascript
+        assert "cdn.jsdelivr.net/npm/mermaid" in javascript
+        assert '<pre class="mermaid">' in javascript
         assert "function richTextHtml" in javascript
         assert "function tableColumnClass" in javascript
         assert "function normalizeDddEntityVoRows" in javascript


### PR DESCRIPTION
## 구현 의도
DDD 아키텍처 문서에 포함된 Mermaid 코드 블록이 대시보드 Markdown 미리보기에서 원문 코드로만 보이는 문제를 해결합니다.

## 구현 접근
Markdown 미리보기 파서가 fenced code block을 인식하도록 확장하고, `mermaid` 언어 블록은 Mermaid 렌더 대상 `<pre class="mermaid">`로 변환했습니다. 대시보드는 Mermaid ESM 번들을 지연 로드한 뒤 미리보기 DOM에서 SVG 렌더링을 실행합니다. 일반 코드 블록과 Mermaid 렌더 실패 상태를 위한 스타일도 추가했습니다.

## 검증 방법
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `/home/jiwoo/workspace/harness/venv/bin/python -m pytest tests/runtime/test_document_dashboard.py`
- `/home/jiwoo/workspace/harness/venv/bin/python -m pytest tests/runtime/test_harvest_ui.py tests/runtime/test_harvest_ui_grill_me_command.py`
- Playwright로 로컬 대시보드를 열어 DDD 문서의 Mermaid 블록이 SVG로 렌더링되고 원문 `flowchart TD`가 사라지는지 확인했습니다. 스크린샷: `/tmp/harness-mermaid-rendered.png`

## 위험 및 롤백
Mermaid 라이브러리는 현재 CDN에서 지연 로드하므로 오프라인 환경에서는 다이어그램 렌더링이 실패하고 스타일상 오류 상태로 표시될 수 있습니다. 문제가 있으면 이 커밋을 되돌리면 기존 Markdown 미리보기 동작으로 복구됩니다.