### PR TITLE
[codex] 대시보드 sticky 패널 접기 기능 추가

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -93,6 +93,11 @@ details { margin-top: 10px; }
 .workspace-heading { align-items: end; display: flex; justify-content: space-between; margin-bottom: 18px; }
 .requirements-document .markdown-preview { max-height: 460px; overflow-y: auto; }
 .grill-panel { margin-top: 24px; position: sticky; bottom: 14px; box-shadow: 0 -4px 18px rgba(25,34,28,.06); z-index: 20; }
+.grill-panel.collapsed { padding-bottom: 12px; }
+.grill-panel-header { align-items: center; display: flex; gap: 12px; justify-content: space-between; }
+.grill-panel-header h3 { margin: 0; }
+.grill-panel-body { margin-top: 14px; }
+.grill-panel-toggle { background: #eef1e8; flex: 0 0 auto; }
 .question { font-size: 17px; font-weight: 600; margin-bottom: 0; }
 .grill-question { border-top: 1px solid var(--line); display: grid; gap: 10px; padding-top: 14px; }
 .grill-question:first-of-type { border-top: 0; padding-top: 0; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -17,6 +17,7 @@ const app = {
   busy: false,
   busyLabel: "",
   error: "",
+  grillPanelCollapsed: false,
   canvas: { scale: 1, x: 0, y: 0 },
   dddCanvas: { scale: 1, x: 0, y: 0 },
 };
@@ -216,6 +217,7 @@ function render() {
     if (app.stageTab === "eventStorming") renderEventDocumentEditor();
     if (app.stageTab === "dddArchitecture") renderDddDocumentEditor();
     if (app.stageTab === "technicalDecisions") renderEditor();
+    bindGrillPanel();
     const requirementForm = document.querySelector("#grill-form");
     if (requirementForm) requirementForm.onsubmit = submitRequirementAnswer;
     const startLanguage = document.querySelector("#start-ubiquitous-language");
@@ -345,6 +347,26 @@ function renderRequirementsWorkspace() {
   </section>`;
 }
 
+function renderGrillPanel(title, body) {
+  const collapsed = app.grillPanelCollapsed;
+  return `<section class="panel grill-panel ${collapsed ? "collapsed" : ""}">
+    <div class="grill-panel-header">
+      <h3>${escapeHtml(title)}</h3>
+      <button type="button" class="grill-panel-toggle" data-grill-panel-toggle aria-expanded="${collapsed ? "false" : "true"}">${collapsed ? "Expand" : "Collapse"}</button>
+    </div>
+    <div class="grill-panel-body" ${collapsed ? "hidden" : ""}>${body}</div>
+  </section>`;
+}
+
+function bindGrillPanel() {
+  const toggle = document.querySelector("[data-grill-panel-toggle]");
+  if (!toggle) return;
+  toggle.onclick = () => {
+    app.grillPanelCollapsed = !app.grillPanelCollapsed;
+    render();
+  };
+}
+
 function renderStageTabs() {
   const requirementsDone = app.harvest?.requirements_gate_passed;
   const languageDone = app.harvest?.language_gate_passed;
@@ -406,7 +428,7 @@ function renderRequirementsTab() {
       : "<p>No current question.</p>";
   return `
     <section class="panel requirements-document"><h3>Requirements</h3><div id="editor"></div></section>
-    <section class="panel grill-panel"><h3>${app.harvest?.requirements_gate_passed ? "Rerun Requirements" : "Grill-Me Questions"}</h3>${questionPanel}</section>
+    ${renderGrillPanel(app.harvest?.requirements_gate_passed ? "Rerun Requirements" : "Grill-Me Questions", questionPanel)}
   `;
 }
 
@@ -425,7 +447,7 @@ function renderUbiquitousLanguageWorkspace() {
        <button class="primary next-stage" id="complete-ubiquitous-language" type="button" ${app.busy ? "disabled" : ""}>Confirm Ubiquitous Language</button>`;
   return `
     <section class="panel requirements-document"><h3>Ubiquitous Language</h3>${document}</section>
-    <section class="panel grill-panel"><h3>${app.harvest?.language_gate_passed ? "Rerun Ubiquitous Language" : "Language Gate"}</h3>${action}</section>
+    ${renderGrillPanel(app.harvest?.language_gate_passed ? "Rerun Ubiquitous Language" : "Language Gate", action)}
   `;
 }
 
@@ -453,7 +475,7 @@ function renderUseCaseWorkspace() {
     : '<p class="small">Generated use-case document appears here when runtime completes.</p>';
   return `
     <section class="panel requirements-document"><h3>Use Case Document</h3>${document}</section>
-    <section class="panel grill-panel"><h3>${app.harvest?.use_cases_ready ? "Rerun Use Case Definition" : "Use Case Questions"}</h3>${questionPanel}</section>
+    ${renderGrillPanel(app.harvest?.use_cases_ready ? "Rerun Use Case Definition" : "Use Case Questions", questionPanel)}
   `;
 }
 
@@ -494,7 +516,7 @@ function renderEventStormingWorkspace() {
     <section class="panel event-progress-panel"><h3>Event Storming Progress</h3>${progress}</section>
     <section class="panel event-document"><h3>${escapeHtml(currentId || "Event Storming")} Document</h3><div id="event-document-editor"></div></section>
     <section class="panel event-live-preview"><h3>Sticky Notes Preview</h3><div id="event-live-board"></div></section>
-    <section class="panel grill-panel"><h3>${state.complete ? "Rerun Event Storming" : "Oracle Questions"}</h3>${interaction}</section>`;
+    ${renderGrillPanel(state.complete ? "Rerun Event Storming" : "Oracle Questions", interaction)}`;
 }
 
 function renderDddArchitectureWorkspace() {
@@ -551,7 +573,7 @@ function renderDddArchitectureWorkspace() {
   return `<section class="panel"><h3>DDD Architecture Progress</h3><p class="small">Completed ${escapeHtml(state.completed_count || 0)} / ${escapeHtml(state.total_count || 0)} substeps</p>${restartAction}<div class="event-progress">${ucProgress}</div><nav class="ddd-steps">${stepTabs}</nav></section>
     <section class="panel"><h3>${escapeHtml(currentId || "DDD")} Design Document</h3><div id="ddd-document-editor"></div></section>
     <section class="panel ddd-live-preview"><h3>Design Visualization</h3><div id="ddd-live-board"></div></section>
-    <section class="panel grill-panel"><h3>${state.complete ? "Rerun DDD Architecture" : "DDD Architect Questions"}</h3>${rerunControls}${interaction}</section>`;
+    ${renderGrillPanel(state.complete ? "Rerun DDD Architecture" : "DDD Architect Questions", `${rerunControls}${interaction}`)}`;
 }
 
 function technicalDecisionUseCases() {
@@ -585,7 +607,7 @@ function renderTechnicalDecisionsWorkspace() {
     : '<p class="small">No completed Technical Decisions document.</p>';
   return `<section class="panel"><h3>Technical Decisions</h3><div class="event-progress">${tabs}</div></section>
     <section class="panel requirements-document"><h3>${escapeHtml(currentId || "Technical Decisions")} Document</h3><div id="editor"></div></section>
-    <section class="panel grill-panel"><h3>Rerun Technical Decisions</h3>${rerun}</section>`;
+    ${renderGrillPanel("Rerun Technical Decisions", rerun)}`;
 }
 
 function renderWorkflowRerunPanel(stageId, label, ucId = "", nextAction = "") {

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -1057,6 +1057,10 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "dddFlowTouchesMembers(row, members, displayAggregateName)" in javascript
         assert "entity method" not in javascript
         assert "bindCanvas" in javascript
+        assert "function renderGrillPanel" in javascript
+        assert "function bindGrillPanel" in javascript
+        assert "data-grill-panel-toggle" in javascript
+        assert "grillPanelCollapsed" in javascript
         assert "function stickyText" in javascript
         assert "function eventFlowKind" in javascript
         assert "function applyDomainElementLabels" in javascript
@@ -1075,6 +1079,8 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert ".event-canvas" in stylesheet
         assert ".ddd-aggregate-panel" in stylesheet
         assert ".grill-panel { margin-top: 24px; position: sticky; bottom: 14px;" in stylesheet
+        assert ".grill-panel-header" in stylesheet
+        assert ".grill-panel-toggle" in stylesheet
         assert "z-index: 20" in stylesheet
         assert ".ddd-model-card" in stylesheet
         assert ".ddd-entity-vo-row" in stylesheet


### PR DESCRIPTION
## 구현 의도

런타임 대시보드의 하단 sticky 질의/재실행 패널이 화면 공간을 계속 차지하는 문제를 줄이기 위해 접기/펼치기 기능을 추가합니다.

## 구현 접근

- `renderGrillPanel` 공통 렌더러를 추가해 Requirements, Ubiquitous Language, Use Cases, Event Storming, DDD Architecture, Technical Decisions 패널에 동일한 토글 UI를 적용했습니다.
- `grillPanelCollapsed` 클라이언트 상태와 `bindGrillPanel` 이벤트 바인딩을 추가해 렌더링 이후에도 접힘 상태가 유지되도록 했습니다.
- collapsed/header/body/toggle 스타일을 추가해 접힌 상태에서 제목과 Expand 버튼만 남도록 했습니다.
- 대시보드 asset 테스트에 토글 렌더링과 CSS 훅 검증을 추가했습니다.

## 검증 방법

- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `/home/jiwoo/workspace/harness/venv/bin/python -m pytest tests/runtime/test_document_dashboard.py`
- Playwright로 로컬 대시보드를 열고 `Collapse` → body hidden/`Expand` 버튼 → 재펼침을 검증했습니다.

## 리스크 및 롤백

- 리스크: 패널 상태가 전역 클라이언트 상태라 워크플로우 탭 간에도 같은 접힘 상태가 유지됩니다. 현재 의도한 동작이지만 탭별 상태가 필요하면 확장해야 합니다.
- 롤백: 이 커밋을 되돌리면 기존 sticky 패널 렌더링 구조로 복원됩니다.
