### PR TITLE
[codex] DDD 시각화 줄바꿈과 UI 서버 재시작 수정

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -146,6 +146,8 @@ details { margin-top: 10px; }
 .ddd-evolved-design { display: grid; gap: 18px; min-width: 1020px; }
 .ddd-aggregate-panel { background: #f6efe0; border: 1px solid #d8cdb8; border-radius: 8px; display: grid; gap: 22px; min-height: 500px; padding: 14px 28px 20px; }
 .ddd-aggregate-name { color: var(--text); font-size: 14px; font-weight: 700; margin: 0; text-align: center; }
+.ddd-context-panel { background: #f3f8ef; border: 1px solid #cbdcc6; border-radius: 8px; padding: 14px 18px; }
+.ddd-context-heading { color: var(--text); font-size: 14px; font-weight: 700; margin: 0 0 10px; }
 .ddd-model-board { align-items: start; display: grid; gap: 18px; }
 .ddd-entity-vo-row { align-items: flex-start; display: flex; flex-wrap: wrap; gap: 20px 34px; padding-top: 70px; position: relative; }
 .ddd-vo-link-layer { left: 0; overflow: visible; pointer-events: none; position: absolute; top: 0; z-index: 2; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -1585,6 +1585,7 @@ function dddIsValueObject(board, row) {
 
 function dddSplitNames(text) {
   return stickyText(text)
+    .replace(/<br\s*\/?>/gi, "\n")
     .split(/[,;\n]/g)
     .map((part) => part.trim().replace(/^`|`$/g, ""))
     .filter(Boolean);
@@ -1720,7 +1721,9 @@ function renderDddVisualization(board, stepId) {
     const services = appServices ? `<div class="ddd-aggregate-services ddd-app-service-list">${appServices}</div>` : "";
     return `<section class="ddd-aggregate-panel"><h5 class="ddd-aggregate-name">${richTextHtml(displayAggregateName)}</h5><div class="ddd-model-board">${entityVoRows}${standaloneVoBoard}</div>${services}</section>`;
   }).join("");
-  const contexts = completed("bounded_contexts") ? `<div class="ddd-grid">${(board.bounded_contexts || []).map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong><p>${richTextHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div>` : "";
+  const contexts = completed("bounded_contexts") && (board.bounded_contexts || []).length
+    ? `<section class="ddd-context-panel"><h5 class="ddd-context-heading">Bounded Contexts</h5><div class="ddd-grid">${board.bounded_contexts.map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong><p>${richTextHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div></section>`
+    : "";
   const evidence = [
     renderDddEvidence(board.entity_vo || [], "Evidence"),
     completed("behaviors") ? renderDddEvidence(board.behaviors || [], "Policy Evidence") : "",

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -105,14 +105,15 @@ def _ui_server_pid_path(repo_root: Path) -> Path:
     return repo_root / ".harness" / "ui-server.pid"
 
 
-def _terminate_previous_ui_server(repo_root: Path) -> bool:
+def _terminate_previous_ui_server(repo_root: Path, host: str, port: int) -> bool:
     pid_path = _ui_server_pid_path(repo_root)
     try:
         pid = int(pid_path.read_text(encoding="utf-8").strip())
     except (FileNotFoundError, ValueError):
         return False
     process_matches = _is_harness_ui_server_process(pid)
-    if pid <= 0 or pid == os.getpid() or process_matches is False:
+    owns_port = _process_owns_listen_port(pid, host, port) if process_matches is False else False
+    if pid <= 0 or pid == os.getpid() or (process_matches is False and not owns_port):
         pid_path.unlink(missing_ok=True)
         return False
     try:
@@ -186,6 +187,13 @@ def _process_owns_socket(process_dir: Path, listen_inodes: set[str]) -> bool:
         if target.startswith("socket:[") and target.removeprefix("socket:[").removesuffix("]") in listen_inodes:
             return True
     return False
+
+
+def _process_owns_listen_port(pid: int, host: str, port: int) -> bool:
+    listen_inodes = _listen_socket_inodes(host, port)
+    if not listen_inodes:
+        return False
+    return _process_owns_socket(Path("/proc") / str(pid), listen_inodes)
 
 
 def _is_harness_ui_server_process(pid: int) -> bool | None:
@@ -514,7 +522,7 @@ def run_ui_server(
     class Handler(HarvestUiRequestHandler):
         repo_root = root
 
-    restart_pending = _terminate_previous_ui_server(root)
+    restart_pending = _terminate_previous_ui_server(root, host, port)
     if not restart_pending:
         restart_pending = _terminate_ui_server_on_port(host, port)
     server = _create_http_server(host, port, Handler, wait_for_restart=restart_pending)

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import json
 import re
+import subprocess
 import pytest
 
 from harness_codex.runtime.harvest_ui import (
@@ -1272,6 +1273,63 @@ def test_ddd_aggregate_validation_rejects_placeholder_name(tmp_path: Path) -> No
 
     assert ready is False
     assert "explicit aggregate name" in error
+
+
+def test_ddd_visualization_splits_br_aggregate_members() -> None:
+    script = Path("harness_codex/runtime/dashboard_assets/dashboard.js").read_text(encoding="utf-8")
+    script = script.split("loadDashboard().catch", 1)[0]
+    markdown = """# UC-001 DDD Design
+
+## Impact Assessment
+|Element Type|Element|Status|Baseline Evidence|Event Storming Evidence|
+|---|---|---|---|---|
+|Entity|`FleetingNote`|modify|Existing note.|Stored note keeps images.|
+|Entity|`InsertedImage`|new|No image entity.|Each image has source.|
+|Value Object|`ImageSource`|new|No source VO.|Each image has source.|
+
+## Entity / Value Objects
+|Entity|Attributes / VOs|Status|Previous Definition|Proposed Definition|Evidence|
+|---|---|---|---|---|---|
+|`FleetingNote`|`insertedImages: List<InsertedImage>`|modify|None.|Images kept.|Save note with images.|
+|`InsertedImage`|`source: ImageSource`|new|None.|Source required.|Record source.|
+|`ImageSource`|`value: String`|new|None.|Non-empty source.|Source required.|
+
+## Behaviors
+|Owner / Service|Signature|Participants|Placement|Policy Evidence|
+|---|---|---|---|---|
+|`FleetingNote`|`assertSaveable(): void`|`InsertedImage`|`entity`|Every image needs source.|
+
+## Application Flow
+|Application Service|Signature|Description|Calls|Evidence|
+|---|---|---|---|---|
+|`SaveFleetingNoteApplicationService`|`saveNewFleetingNote(): SaveFleetingNoteResult`|Persist completed note.|`FleetingNote.assertSaveable()`|Save note.|
+
+## Aggregates
+|Aggregate|Aggregate Root|Members|Atomic Invariant|Evidence|
+|---|---|---|---|---|
+|`FleetingNoteCapture`|`FleetingNote`|`InsertedImage`<br>`ImageSource`|Note and images saved together.|Save note.|
+
+## Bounded Contexts
+|Bounded Context|Owned Aggregates / Entities|Boundary Reason|Communication Type|Target BC|Evidence|
+|---|---|---|---|---|---|
+|`Fleeting Note Capture`|`FleetingNoteCapture`<br>`FleetingNote`<br>`InsertedImage`|Owns save flow.|`internal_http`|`Image Asset Intake`|Same user action needs accepted image result.|
+|`Image Asset Intake`|None in this slice.|Owns file acceptance.|`internal_http`|`Fleeting Note Capture`|Invalid file rejected synchronously.|
+"""
+    node_test = f"""
+{script}
+const board = parseDddMarkdown({json.dumps(markdown)});
+const html = renderDddVisualization(board, "bounded_contexts");
+if (!html.includes("FleetingNoteCapture")) throw new Error("missing aggregate");
+if (!html.includes("FleetingNote")) throw new Error("missing root entity");
+if (!html.includes("InsertedImage")) throw new Error("missing br-split member entity");
+if (!html.includes("ImageSource")) throw new Error("missing br-split value object");
+if (!html.includes("Bounded Contexts")) throw new Error("missing bounded-context heading");
+if ((html.match(/ddd-boundary context/g) || []).length !== 2) throw new Error("missing bounded-context cards");
+if (!html.includes("Fleeting Note Capture")) throw new Error("missing primary bounded context");
+if (!html.includes("Image Asset Intake")) throw new Error("missing target bounded context");
+if (!html.includes("internal_http -> Image Asset Intake")) throw new Error("missing bounded-context communication");
+"""
+    subprocess.run(["node", "-e", node_test], check=True)
 
 
 def test_ddd_instruction_mentions_aggregate_name_and_bottom_app_service_methods() -> None:

--- a/tests/runtime/test_ui_server_restart.py
+++ b/tests/runtime/test_ui_server_restart.py
@@ -45,6 +45,18 @@ def _start_server(repo_root: Path, port: int) -> subprocess.Popen[bytes]:
     )
 
 
+def _start_direct_server(repo_root: Path, port: int) -> subprocess.Popen[bytes]:
+    script = (
+        "from harness_codex.runtime.ui_server import run_ui_server;"
+        f"run_ui_server({str(repo_root)!r}, port={port!r})"
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
 def test_ui_server_restarts_existing_server_for_repo(tmp_path: Path) -> None:
     port = _available_port()
     pid_path = tmp_path / ".harness" / "ui-server.pid"
@@ -88,6 +100,28 @@ def test_ui_server_restarts_server_from_different_repo(tmp_path: Path) -> None:
             second.terminate()
             second.wait(timeout=2)
             assert not second_pid_path.exists()
+        if first.poll() is None:
+            first.terminate()
+            first.wait(timeout=2)
+
+
+def test_ui_server_restarts_direct_run_server_for_repo(tmp_path: Path) -> None:
+    port = _available_port()
+    pid_path = tmp_path / ".harness" / "ui-server.pid"
+    first = _start_direct_server(tmp_path, port)
+    second: subprocess.Popen[bytes] | None = None
+    try:
+        _wait_for_dashboard(port, pid_path, first.pid)
+
+        second = _start_server(tmp_path, port)
+        _wait_for_dashboard(port, pid_path, second.pid)
+
+        assert first.wait(timeout=2) == 0
+    finally:
+        if second is not None and second.poll() is None:
+            second.terminate()
+            second.wait(timeout=2)
+            assert not pid_path.exists()
         if first.poll() is None:
             first.terminate()
             first.wait(timeout=2)


### PR DESCRIPTION
## 구현 의도

DDD Architecture 시각화에서 설계 문서의 줄바꿈 기반 목록이 올바르게 표시되지 않는 문제를 수정합니다. 특히 Aggregates의 Members와 Bounded Contexts의 Owned Aggregates / Entities 값이 <br>로 구분될 때, UI에서 빈 패널처럼 보이거나 리터럴 <br> 문자열로 보이는 문제를 해결합니다.

또한 ui-server를 다시 실행했을 때 기존 서버 프로세스를 안전하게 재시작하지 못하는 경우를 보강합니다.

## 구현 접근

- DDD 모델 이름 분리 로직에서 <br> 태그를 줄바꿈으로 정규화해 Aggregates Members와 Bounded Context owned 항목을 동일하게 파싱하도록 변경했습니다.
- Markdown preview의 inline 렌더링에서 <br>가 이스케이프된 텍스트가 아니라 실제 줄바꿈으로 렌더링되도록 수정했습니다.
- Bounded Context 시각화를 전용 패널로 분리하고 Owned Aggregates / Entities 값을 개별 항목으로 표시하도록 변경했습니다.
- ui-server PID 파일이 가리키는 프로세스가 같은 포트를 점유 중이면, 직접 실행된 run_ui_server 프로세스도 재시작 대상으로 인정하도록 보강했습니다.
- DDD 시각화와 ui-server 재시작 동작에 대한 회귀 테스트를 추가했습니다.

## 검증 방법

- node --check harness_codex/runtime/dashboard_assets/dashboard.js
- /home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/runtime/ui_server.py harness_codex/runtime/document_dashboard.py
- /home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime/test_harvest_ui.py -k "ddd_visualization_splits_br_aggregate_members or ddd_aggregate_validation_rejects_placeholder_name"
- /home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime/test_ui_server_restart.py
- Python Playwright로 zeten 대시보드에서 Workflow를 재개하고 DDD Architecture 화면을 열어 다음을 확인했습니다: 집계 패널, 모델 카드, Bounded Context 카드 2개, Owned Aggregates / Entities 개별 항목, 문서 테이블의 <br> 줄바꿈 렌더링, internal_http 연결 표시.

## 위험 및 롤백

- 위험: Markdown preview에서 <br> 렌더링을 허용하므로 해당 태그는 실제 줄바꿈으로 표시됩니다. 현재 변경 범위는 기존 문서 테이블의 줄바꿈 표현을 의도대로 보이게 하는 데 한정됩니다.
- 위험: ui-server 재시작 판정이 직접 실행 프로세스까지 확장되지만, PID 파일과 동일 포트 점유 조건을 함께 요구해 임의 프로세스 종료 가능성을 줄였습니다.
- 롤백: 이 PR의 커밋을 되돌리면 기존 시각화 렌더링과 ui-server 재시작 동작으로 복구됩니다.
