### PR TITLE
[codex] Bounded Context 소유 항목 렌더링 수정

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -193,6 +193,8 @@ details { margin-top: 10px; }
 .ddd-boundary.aggregate { background: #f6efe0; }
 .ddd-aggregate-card { display: grid; gap: 6px; }
 .ddd-boundary.context { background: #eef4e8; border-style: solid; }
+.ddd-context-owned { display: grid; gap: 5px; margin-top: 10px; }
+.ddd-context-owned-item { background: rgba(255,255,255,.62); border: 1px solid rgba(89,118,94,.18); border-radius: 6px; font-size: 12px; overflow-wrap: anywhere; padding: 5px 7px; }
 .ddd-boundary .root, .communication { background: var(--active); border-radius: 12px; color: var(--accent); display: inline-block; font-size: 11px; margin-top: 8px; padding: 3px 9px; }
 .ddd-canvas { height: 720px; }
 .ddd-slice { max-width: none; min-width: 1020px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -119,6 +119,7 @@ function renderInline(text) {
   });
   return escaped
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/&lt;br\s*\/?&gt;/gi, "<br>")
     .replace(/\u0000CODE(\d+)\u0000/g, (_match, index) => codeSpans[Number(index)]);
 }
 
@@ -169,7 +170,7 @@ function renderTable(headers, rows) {
 
 function tableColumnClass(header) {
   const normalized = stickyText(header).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-  const tallColumns = ["evidence", "pseudocode", "calls", "baseline-evidence", "event-storming-evidence", "policy-evidence", "attributes-vos", "proposed-definition", "atomic-invariant"];
+  const tallColumns = ["evidence", "pseudocode", "calls", "baseline-evidence", "event-storming-evidence", "policy-evidence", "attributes-vos", "proposed-definition", "atomic-invariant", "owned-aggregates-entities"];
   return tallColumns.includes(normalized) ? `column-${normalized} column-long` : `column-${normalized || "value"}`;
 }
 
@@ -1722,7 +1723,7 @@ function renderDddVisualization(board, stepId) {
     return `<section class="ddd-aggregate-panel"><h5 class="ddd-aggregate-name">${richTextHtml(displayAggregateName)}</h5><div class="ddd-model-board">${entityVoRows}${standaloneVoBoard}</div>${services}</section>`;
   }).join("");
   const contexts = completed("bounded_contexts") && (board.bounded_contexts || []).length
-    ? `<section class="ddd-context-panel"><h5 class="ddd-context-heading">Bounded Contexts</h5><div class="ddd-grid">${board.bounded_contexts.map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong><p>${richTextHtml(row["Owned Aggregates / Entities"] || "")}</p><span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div></section>`
+    ? `<section class="ddd-context-panel"><h5 class="ddd-context-heading">Bounded Contexts</h5><div class="ddd-grid">${board.bounded_contexts.map((row) => `<article class="ddd-boundary context"><strong>${richTextHtml(row["Bounded Context"] || "")}</strong>${renderDddContextOwnedHtml(row["Owned Aggregates / Entities"] || "")}<span class="communication">${richTextHtml(row["Communication Type"] || "")}${row["Target BC"] ? ` -> ${richTextHtml(row["Target BC"])}` : ""}</span></article>`).join("")}</div></section>`
     : "";
   const evidence = [
     renderDddEvidence(board.entity_vo || [], "Evidence"),
@@ -1803,6 +1804,12 @@ function dddFlowDescription(row) {
 function renderDddEvidence(rows, key) {
   if (!rows.length) return "";
   return `<div class="ddd-evidence">${rows.map((row) => `<p><strong>${richTextHtml(row.Entity || row["Owner / Service"] || row.Aggregate || row["Bounded Context"] || row["Application Service"] || "")}</strong>: ${richTextHtml(row[key] || "")}</p>`).join("")}</div>`;
+}
+
+function renderDddContextOwnedHtml(value) {
+  const items = dddSplitNames(value);
+  if (!items.length) return "";
+  return `<div class="ddd-context-owned">${items.map((item) => `<div class="ddd-context-owned-item">${richTextHtml(item)}</div>`).join("")}</div>`;
 }
 
 function renderDddDocumentEditor(message = "") {

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -1319,15 +1319,19 @@ def test_ddd_visualization_splits_br_aggregate_members() -> None:
 {script}
 const board = parseDddMarkdown({json.dumps(markdown)});
 const html = renderDddVisualization(board, "bounded_contexts");
+const preview = markdownPreview({json.dumps(markdown)});
 if (!html.includes("FleetingNoteCapture")) throw new Error("missing aggregate");
 if (!html.includes("FleetingNote")) throw new Error("missing root entity");
 if (!html.includes("InsertedImage")) throw new Error("missing br-split member entity");
 if (!html.includes("ImageSource")) throw new Error("missing br-split value object");
 if (!html.includes("Bounded Contexts")) throw new Error("missing bounded-context heading");
 if ((html.match(/ddd-boundary context/g) || []).length !== 2) throw new Error("missing bounded-context cards");
+if ((html.match(/ddd-context-owned-item/g) || []).length < 4) throw new Error("missing split bounded-context owned entries");
 if (!html.includes("Fleeting Note Capture")) throw new Error("missing primary bounded context");
 if (!html.includes("Image Asset Intake")) throw new Error("missing target bounded context");
 if (!html.includes("internal_http -> Image Asset Intake")) throw new Error("missing bounded-context communication");
+if (!preview.includes("<code>FleetingNoteCapture</code><br><code>FleetingNote</code><br><code>InsertedImage</code>")) throw new Error("bounded-context table br was escaped");
+if (preview.includes("FleetingNoteCapture&lt;br")) throw new Error("bounded-context table still shows literal br");
 """
     subprocess.run(["node", "-e", node_test], check=True)
 


### PR DESCRIPTION
## 구현 의도

Bounded Contexts 테이블의 Owned Aggregates / Entities 값이 <br> 구분자를 그대로 노출하거나 시각화 카드에서 하나의 덩어리처럼 보이는 문제를 수정합니다.

## 구현 접근

- Markdown preview의 inline 렌더링에서 <br> 태그를 실제 줄바꿈으로 변환했습니다.
- Owned Aggregates / Entities 컬럼을 긴 컬럼으로 분류해 테이블에서 안정적으로 표시되도록 했습니다.
- Bounded Context 시각화 카드에서 Owned Aggregates / Entities 값을 개별 항목으로 분리해 렌더링했습니다.
- 기존 DDD 시각화 회귀 테스트에 Bounded Context owned 항목 분리와 문서 테이블 <br> 렌더링 검증을 추가했습니다.

## 검증 방법

- node --check harness_codex/runtime/dashboard_assets/dashboard.js
- /home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime/test_harvest_ui.py -k "ddd_visualization_splits_br_aggregate_members or ddd_aggregate_validation_rejects_placeholder_name"
- Python Playwright로 zeten 대시보드에서 Workflow를 재개하고 DDD Architecture 화면을 열어 Bounded Context 카드 2개, Owned Aggregates / Entities 개별 항목, 문서 테이블 <br> 줄바꿈 렌더링을 확인했습니다.

## 위험 및 롤백

- 위험: Markdown preview에서 <br>를 실제 줄바꿈으로 렌더링합니다. 현재 의도된 문서 테이블 줄바꿈 표현을 바로잡는 변경입니다.
- 롤백: 이 커밋을 되돌리면 기존 Bounded Context 테이블과 카드 렌더링으로 복구됩니다.
