### PR TITLE
[codex] Technical Decisions 문서 영역 스크롤 방식 수정

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -91,7 +91,6 @@ details { margin-top: 10px; }
 .prompt-form textarea { min-height: 220px; }
 .prompt-form button, .grill-form button { justify-self: start; }
 .workspace-heading { align-items: end; display: flex; justify-content: space-between; margin-bottom: 18px; }
-.technical-document .markdown-preview { max-height: 460px; overflow-y: auto; }
 .grill-panel { margin-top: 24px; position: sticky; bottom: 14px; box-shadow: 0 -4px 18px rgba(25,34,28,.06); z-index: 20; }
 .grill-panel.collapsed { padding-bottom: 12px; }
 .grill-panel-header { align-items: center; display: flex; gap: 12px; justify-content: space-between; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -607,7 +607,7 @@ function renderTechnicalDecisionsWorkspace() {
     ? renderWorkflowRerunPanel("technical-decisions", `${currentId} Technical Decisions`, currentId)
     : '<p class="small">No completed Technical Decisions document.</p>';
   return `<section class="panel"><h3>Technical Decisions</h3><div class="event-progress">${tabs}</div></section>
-    <section class="panel technical-document"><h3>${escapeHtml(currentId || "Technical Decisions")} Document</h3><div id="editor"></div></section>
+    <section class="panel"><h3>${escapeHtml(currentId || "Technical Decisions")} Document</h3><div id="editor"></div></section>
     ${renderGrillPanel("Rerun Technical Decisions", rerun)}`;
 }
 

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -993,6 +993,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert '<section class="panel"><h3>Requirements</h3><div id="editor"></div></section>' in javascript
         assert '<section class="panel"><h3>Ubiquitous Language</h3>${document}</section>' in javascript
         assert '<section class="panel"><h3>Use Case Document</h3>${document}</section>' in javascript
+        assert '<section class="panel"><h3>${escapeHtml(currentId || "Technical Decisions")} Document</h3><div id="editor"></div></section>' in javascript
         assert "Submit all answers" in javascript
         assert 'document.querySelectorAll("[data-grill-answer]")' in javascript
         assert "JSON.stringify({ change_set_id: app.requirementsChangeSet, answers })" in javascript
@@ -1077,7 +1078,7 @@ def test_ui_server_root_serves_dashboard_with_new_changeset_action(tmp_path: Pat
         assert "stage-tabs" in stylesheet
         assert ".markdown-preview code" in stylesheet
         assert ".requirements-document .markdown-preview" not in stylesheet
-        assert ".technical-document .markdown-preview { max-height: 460px; overflow-y: auto; }" in stylesheet
+        assert ".technical-document .markdown-preview" not in stylesheet
         assert ".markdown-table .column-long" in stylesheet
         assert "max-height: 180px" in stylesheet
         assert "max-width: min(1720px, calc(100vw - 48px))" in stylesheet


### PR DESCRIPTION
## 구현 의도

Technical Decisions 문서 영역도 DDD Architecture처럼 내부 스크롤 컨테이너가 아니라 페이지 전체 스크롤로 길게 표시되도록 수정합니다.

## 구현 방식

- Technical Decisions 문서 패널에서 `technical-document` 클래스를 제거했습니다.
- `.technical-document .markdown-preview`의 `max-height`/`overflow-y` 제한 CSS를 제거했습니다.
- 대시보드 자산 스모크 테스트에 Technical Decisions 일반 패널 마크업과 제거된 CSS 셀렉터 회귀 검증을 추가했습니다.

## 검증 방법

- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime/test_document_dashboard.py::test_ui_server_root_serves_dashboard_with_new_changeset_action`
- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/runtime/ui_server.py harness_codex/runtime/document_dashboard.py`
- Playwright로 Technical Decisions 탭에 긴 문서를 주입해 `overflow-y: visible`, `max-height: none`, 페이지 스크롤 증가를 확인했습니다.

## 위험 및 롤백

- 위험: 긴 Technical Decisions 문서에서 sticky Rerun 패널이 기존처럼 일부 본문 위에 겹쳐 보일 수 있습니다.
- 롤백: 이 커밋을 되돌리면 Technical Decisions 문서 영역만 이전 내부 스크롤 제한 방식으로 복구됩니다.
