### PR TITLE
[codex] 구현 진행 상황 및 에디터형 diff UI 추가

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.css
+++ b/harness_codex/runtime/dashboard_assets/dashboard.css
@@ -120,6 +120,37 @@ details { margin-top: 10px; }
 .event-progress-item.complete { background: var(--active); color: var(--accent); }
 .event-progress-item.needs_input { background: var(--stale); }
 .event-progress-item.error { background: #fff3f0; color: #8d291c; }
+.implementation-actions { display: grid; gap: 10px; justify-items: start; }
+.implementation-job { width: 100%; }
+.implementation-job pre { background: #eef1e8; border-radius: 7px; max-height: 260px; overflow: auto; padding: 10px; white-space: pre-wrap; }
+.implementation-grid { display: grid; gap: 18px; grid-template-columns: minmax(320px, 430px) minmax(0, 1fr); }
+.plan-card { border-top: 1px solid var(--line); padding: 14px 0; }
+.plan-card:first-child { border-top: 0; padding-top: 0; }
+.plan-card-heading { align-items: center; display: flex; gap: 10px; justify-content: space-between; }
+.plan-meter { background: #e5e8df; border-radius: 999px; height: 8px; overflow: hidden; }
+.plan-meter span { background: var(--accent); display: block; height: 100%; }
+.plan-tasks { display: grid; gap: 7px; list-style: none; margin: 12px 0 0; max-height: 460px; overflow: auto; padding: 0; }
+.plan-tasks li { align-items: start; display: grid; gap: 8px; grid-template-columns: 18px minmax(0, 1fr) auto; }
+.plan-tasks li.done { color: var(--muted); }
+.checkbox { border: 1px solid #9fac9f; border-radius: 3px; color: var(--accent); display: inline-grid; font: 11px "SFMono-Regular", Consolas, monospace; height: 16px; line-height: 1; place-items: center; width: 16px; }
+.diff-layout { display: grid; gap: 12px; grid-template-columns: minmax(220px, 320px) minmax(0, 1fr); min-height: 520px; }
+.diff-files { border-right: 1px solid var(--line); display: grid; gap: 5px; max-height: 680px; overflow: auto; padding-right: 10px; }
+.diff-file { align-items: start; background: transparent; display: grid; gap: 7px; grid-template-columns: 34px minmax(0, 1fr); text-align: left; overflow-wrap: anywhere; }
+.diff-file.selected { background: var(--active); border-color: #acc4b0; }
+.diff-status { color: var(--accent); font: 12px "SFMono-Regular", Consolas, monospace; }
+.diff-view { min-width: 0; }
+.diff-editor { background: #fbfbf7; border: 1px solid var(--line); border-radius: 8px; font: 12px/1.5 "SFMono-Regular", Consolas, monospace; max-height: 680px; overflow: auto; }
+.diff-row { display: grid; grid-template-columns: 48px 48px 28px minmax(0, 1fr); min-width: 760px; }
+.diff-row pre { font: inherit; margin: 0; overflow: visible; padding: 2px 10px; white-space: pre; }
+.diff-line-no { background: #eef1e8; border-right: 1px solid var(--line); color: var(--muted); padding: 2px 8px; text-align: right; user-select: none; }
+.diff-marker { border-right: 1px solid var(--line); color: var(--muted); padding: 2px 0; text-align: center; user-select: none; }
+.diff-row.added { background: #e3f4e7; }
+.diff-row.added .diff-line-no, .diff-row.added .diff-marker { background: #ccebd3; color: #1f5d35; }
+.diff-row.deleted { background: #fde9e5; }
+.diff-row.deleted .diff-line-no, .diff-row.deleted .diff-marker { background: #f7d1ca; color: #8d291c; }
+.diff-row.hunk { background: #e8edf3; color: #35506a; }
+.diff-row.hunk .diff-line-no, .diff-row.hunk .diff-marker { background: #d7e0ea; }
+.diff-row.meta { color: var(--muted); }
 .event-live-preview .flow-lane { flex-wrap: wrap; overflow: visible; }
 .canvas-header { align-items: center; display: flex; justify-content: space-between; }
 .canvas-header div { align-items: center; display: flex; gap: 10px; }

--- a/harness_codex/runtime/dashboard_assets/dashboard.js
+++ b/harness_codex/runtime/dashboard_assets/dashboard.js
@@ -10,6 +10,9 @@ const app = {
   eventSelectedUc: null,
   dddSelectedUc: null,
   technicalSelectedUc: null,
+  implementation: null,
+  implementationSelectedDiffPath: "",
+  implementationPollTimer: null,
   dddSelectedStep: "entity_vo",
   rerunStageId: "",
   rerunResult: "",
@@ -201,6 +204,10 @@ function render() {
     app.eventSelectedUc = null;
     app.dddSelectedUc = null;
     app.technicalSelectedUc = null;
+    app.implementation = null;
+    app.implementationSelectedDiffPath = "";
+    if (app.implementationPollTimer) clearTimeout(app.implementationPollTimer);
+    app.implementationPollTimer = null;
     app.canvas = { scale: 1, x: 0, y: 0 };
     app.dddCanvas = { scale: 1, x: 0, y: 0 };
     app.view = "dashboard";
@@ -253,6 +260,13 @@ function render() {
     });
     document.querySelectorAll("[data-technical-uc]").forEach((node) => {
       node.onclick = () => selectTechnicalUseCase(node.dataset.technicalUc);
+    });
+    const startImplementation = document.querySelector("#start-implementation");
+    if (startImplementation) startImplementation.onclick = startImplementationRun;
+    const refreshImplementation = document.querySelector("#refresh-implementation");
+    if (refreshImplementation) refreshImplementation.onclick = () => loadImplementationState({ renderAfter: true });
+    document.querySelectorAll("[data-diff-path]").forEach((node) => {
+      node.onclick = () => selectImplementationDiff(node.dataset.diffPath);
     });
     document.querySelectorAll("[data-ddd-step]").forEach((node) => {
       node.onclick = () => { app.dddSelectedStep = node.dataset.dddStep; render(); };
@@ -330,6 +344,8 @@ function renderRequirementsWorkspace() {
   const tabs = renderStageTabs();
   const body = app.stageTab === "dddArchitecture"
     ? renderDddArchitectureWorkspace()
+    : app.stageTab === "implementation"
+    ? renderImplementationWorkspace()
     : app.stageTab === "technicalDecisions"
     ? renderTechnicalDecisionsWorkspace()
     : app.stageTab === "eventStorming"
@@ -375,6 +391,7 @@ function renderStageTabs() {
   const eventsDone = app.harvest?.event_storming?.complete;
   const dddDone = app.harvest?.ddd_architecture?.complete;
   const technicalAvailable = Boolean(technicalDecisionUseCases().length);
+  const implementationAvailable = technicalAvailable;
   return `<nav class="stage-tabs" aria-label="Workflow stages">
     <button class="stage-tab ${app.stageTab === "requirements" ? "selected" : ""}" data-stage-tab="requirements">
       <span class="progress-dot ${requirementsDone ? "complete" : "active"}"></span>Requirements
@@ -393,6 +410,9 @@ function renderStageTabs() {
     </button>
     <button class="stage-tab ${app.stageTab === "technicalDecisions" ? "selected" : ""}" data-stage-tab="technicalDecisions" ${!dddDone || !technicalAvailable ? "disabled" : ""}>
       <span class="progress-dot ${technicalAvailable ? "complete" : dddDone ? "active" : ""}"></span>Technical Decisions
+    </button>
+    <button class="stage-tab ${app.stageTab === "implementation" ? "selected" : ""}" data-stage-tab="implementation" ${!implementationAvailable ? "disabled" : ""}>
+      <span class="progress-dot ${implementationAvailable ? "active" : ""}"></span>Implementation
     </button>
   </nav>`;
 }
@@ -604,11 +624,109 @@ function renderTechnicalDecisionsWorkspace() {
   const currentId = app.technicalSelectedUc || useCases[0]?.id || "";
   const tabs = useCases.map((item) => `<button type="button" data-technical-uc="${escapeHtml(item.id)}" class="event-progress-item ${item.id === currentId ? "complete" : ""}">${escapeHtml(item.id)}</button>`).join("");
   const rerun = currentId
-    ? renderWorkflowRerunPanel("technical-decisions", `${currentId} Technical Decisions`, currentId)
+    ? renderWorkflowRerunPanel(
+        "technical-decisions",
+        `${currentId} Technical Decisions`,
+        currentId,
+        '<button class="primary next-stage" type="button" data-stage-tab="implementation">Open Implementation</button>',
+      )
     : '<p class="small">No completed Technical Decisions document.</p>';
   return `<section class="panel"><h3>Technical Decisions</h3><div class="event-progress">${tabs}</div></section>
     <section class="panel"><h3>${escapeHtml(currentId || "Technical Decisions")} Document</h3><div id="editor"></div></section>
     ${renderGrillPanel("Rerun Technical Decisions", rerun)}`;
+}
+
+function renderImplementationWorkspace() {
+  const state = app.implementation;
+  const job = state?.job;
+  const running = job?.status === "running";
+  const plans = (state?.plans || []).map(renderImplementationPlan).join("");
+  const files = state?.diff?.files || [];
+  const selectedPath = app.implementationSelectedDiffPath || files[0]?.path || "";
+  const diffButtons = files.map((file) => `<button type="button" data-diff-path="${escapeHtml(file.path)}" class="diff-file ${file.path === selectedPath ? "selected" : ""}">
+      <span class="diff-status">${escapeHtml(file.status)}</span>${escapeHtml(file.path)}
+    </button>`).join("");
+  const diffBody = state?.selectedDiff?.patch
+    ? renderDiffEditor(state.selectedDiff.patch)
+    : files.length ? '<p class="small">Select a changed file to inspect its diff.</p>' : '<p class="small">No working tree diff yet.</p>';
+  const jobOutput = job
+    ? `<details class="implementation-job" ${job.status !== "running" ? "open" : ""}><summary>Implementation job: ${escapeHtml(job.status)}</summary>
+        <p class="small">Started ${escapeHtml(job.started_at || "")}${job.finished_at ? `, finished ${escapeHtml(job.finished_at)}` : ""}</p>
+        ${job.output ? `<pre>${escapeHtml(job.output)}</pre>` : ""}
+        ${job.error ? `<pre class="error">${escapeHtml(job.error)}</pre>` : ""}
+      </details>`
+    : "";
+  return `<section class="panel implementation-actions">
+      <h3>Implementation</h3>
+      <p class="small">Runs <code>harness implementation ${escapeHtml(app.requirementsChangeSet)} --apply</code>. Diff and plan progress refresh while it runs.</p>
+      <button class="primary" id="start-implementation" type="button" ${running ? "disabled" : ""}>${running ? "Implementation running" : "Start Implementation"}</button>
+      <button id="refresh-implementation" type="button">Refresh progress</button>
+      ${jobOutput}
+    </section>
+    <section class="implementation-grid">
+      <div class="panel"><h3>Plan Checklist</h3>${plans || '<p class="small">No active or completed plan found.</p>'}</div>
+      <div class="panel diff-explorer"><h3>Diff Explorer</h3><div class="diff-layout"><nav class="diff-files">${diffButtons}</nav><div class="diff-view">${diffBody}</div></div></div>
+    </section>`;
+}
+
+function renderDiffEditor(patch) {
+  const rows = parseUnifiedDiff(patch);
+  if (!rows.length) return '<p class="small">No textual diff for this file.</p>';
+  return `<div class="diff-editor" role="table" aria-label="File diff">
+    ${rows.map((row) => {
+      if (row.kind === "hunk") {
+        return `<div class="diff-row hunk" role="row">
+          <div class="diff-line-no"></div><div class="diff-line-no"></div><div class="diff-marker"></div><pre>${escapeHtml(row.text)}</pre>
+        </div>`;
+      }
+      return `<div class="diff-row ${escapeHtml(row.kind)}" role="row">
+        <div class="diff-line-no">${escapeHtml(row.oldLine || "")}</div>
+        <div class="diff-line-no">${escapeHtml(row.newLine || "")}</div>
+        <div class="diff-marker">${escapeHtml(row.marker)}</div>
+        <pre>${escapeHtml(row.text)}</pre>
+      </div>`;
+    }).join("")}
+  </div>`;
+}
+
+function parseUnifiedDiff(patch) {
+  const rows = [];
+  let oldLine = 0;
+  let newLine = 0;
+  for (const line of String(patch || "").split(/\r?\n/)) {
+    const hunk = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)$/);
+    if (hunk) {
+      oldLine = Number(hunk[1]);
+      newLine = Number(hunk[2]);
+      rows.push({ kind: "hunk", text: line });
+      continue;
+    }
+    if (!rows.length || /^diff --git |^index |^--- |^\+\+\+ /.test(line)) continue;
+    if (line.startsWith("-")) {
+      rows.push({ kind: "deleted", oldLine: oldLine++, newLine: "", marker: "-", text: line.slice(1) });
+    } else if (line.startsWith("+")) {
+      rows.push({ kind: "added", oldLine: "", newLine: newLine++, marker: "+", text: line.slice(1) });
+    } else if (line.startsWith(" ")) {
+      rows.push({ kind: "context", oldLine: oldLine++, newLine: newLine++, marker: "", text: line.slice(1) });
+    } else if (line.startsWith("\\ No newline")) {
+      rows.push({ kind: "meta", oldLine: "", newLine: "", marker: "", text: line });
+    }
+  }
+  return rows;
+}
+
+function renderImplementationPlan(plan) {
+  const tasks = (plan.tasks || []).map((task) => `<li class="${task.checked ? "done" : ""}">
+    <span class="checkbox">${task.checked ? "x" : ""}</span>
+    <span>${escapeHtml(task.text)}</span>
+    <span class="small">L${escapeHtml(task.line)}</span>
+  </li>`).join("");
+  return `<article class="plan-card">
+    <div class="plan-card-heading"><strong>${escapeHtml(plan.work_item_id)} ${escapeHtml(plan.name || "")}</strong><span class="pill ${escapeHtml(plan.lifecycle || "missing")}">${escapeHtml(plan.lifecycle || "missing")}</span></div>
+    <p class="small">${escapeHtml(plan.path || "missing plan")} · ${escapeHtml(plan.completed_count || 0)} / ${escapeHtml(plan.total_count || 0)} (${escapeHtml(plan.percent || 0)}%)</p>
+    <div class="plan-meter"><span style="width: ${Math.max(0, Math.min(100, Number(plan.percent || 0)))}%"></span></div>
+    ${tasks ? `<ul class="plan-tasks">${tasks}</ul>` : '<p class="small">No checkbox tasks found.</p>'}
+  </article>`;
 }
 
 function renderWorkflowRerunPanel(stageId, label, ucId = "", nextAction = "") {
@@ -666,6 +784,7 @@ async function selectStageTab(tab) {
   if (tab === "eventStorming" && !app.harvest?.use_cases_ready) return;
   if (tab === "dddArchitecture" && !app.harvest?.event_storming?.complete) return;
   if (tab === "technicalDecisions" && (!app.harvest?.ddd_architecture?.complete || !technicalDecisionUseCases().length)) return;
+  if (tab === "implementation" && !technicalDecisionUseCases().length) return;
   app.stageTab = tab;
   if (tab === "requirements") {
     if (app.workflowRecovered) setRecoveredRequirementsDocument();
@@ -674,6 +793,7 @@ async function selectStageTab(tab) {
   if (tab === "eventStorming") await openCurrentEventDocument();
   if (tab === "dddArchitecture") await openCurrentDddDocument();
   if (tab === "technicalDecisions") await openCurrentTechnicalDecisionsDocument();
+  if (tab === "implementation") await loadImplementationState();
   render();
 }
 
@@ -853,6 +973,68 @@ async function selectTechnicalUseCase(ucId) {
   app.technicalSelectedUc = ucId;
   await openCurrentTechnicalDecisionsDocument();
   render();
+}
+
+async function loadImplementationState({ renderAfter = false } = {}) {
+  if (!app.requirementsChangeSet) return;
+  const response = await fetch(`/api/dashboard/change-sets/${encodeURIComponent(app.requirementsChangeSet)}/implementation`);
+  const result = await response.json();
+  if (!response.ok) {
+    app.error = result.error || "Unable to load implementation state.";
+    if (renderAfter) render();
+    return;
+  }
+  app.implementation = result;
+  const files = result.diff?.files || [];
+  if (!app.implementationSelectedDiffPath && files.length) app.implementationSelectedDiffPath = files[0].path;
+  if (app.implementationSelectedDiffPath && files.some((file) => file.path === app.implementationSelectedDiffPath)) {
+    await loadImplementationDiff(app.implementationSelectedDiffPath);
+  }
+  scheduleImplementationPoll();
+  if (renderAfter) render();
+}
+
+async function loadImplementationDiff(path) {
+  const response = await fetch(`/api/dashboard/change-sets/${encodeURIComponent(app.requirementsChangeSet)}/implementation/diff?path=${encodeURIComponent(path)}`);
+  const result = await response.json();
+  if (!response.ok) {
+    app.error = result.error || "Unable to load diff.";
+    return;
+  }
+  app.implementationSelectedDiffPath = path;
+  app.implementation = { ...(app.implementation || {}), selectedDiff: result };
+}
+
+async function selectImplementationDiff(path) {
+  await loadImplementationDiff(path);
+  render();
+}
+
+async function startImplementationRun() {
+  app.error = "";
+  await fetch(`/api/dashboard/change-sets/${encodeURIComponent(app.requirementsChangeSet)}/implementation/start`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  }).then(async (response) => {
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || "Unable to start implementation.");
+    app.implementation = { ...(app.implementation || {}), job: result.job };
+  }).catch((error) => {
+    app.error = error.message;
+  });
+  await loadImplementationState({ renderAfter: true });
+}
+
+function scheduleImplementationPoll() {
+  if (app.implementationPollTimer) {
+    clearTimeout(app.implementationPollTimer);
+    app.implementationPollTimer = null;
+  }
+  if (app.stageTab !== "implementation" || app.implementation?.job?.status !== "running") return;
+  app.implementationPollTimer = setTimeout(async () => {
+    await loadImplementationState({ renderAfter: true });
+  }, 2500);
 }
 
 async function runEventStormingTurn(endpoint, label, extra = {}) {

--- a/harness_codex/runtime/document_dashboard.py
+++ b/harness_codex/runtime/document_dashboard.py
@@ -190,6 +190,7 @@ def _work_item_payload(
         "status": item.status,
         "artifacts": [],
     }
+    payload["plan"] = _plan_summary(root, item.work_item_id)
     if item.work_item_type is not WorkItemType.USE_CASE:
         return payload
 
@@ -217,6 +218,48 @@ def _work_item_payload(
     if lifecycle == "active":
         payload["editable_document_id"] = f"use-case:{change_set_id}:{item.work_item_id}"
     return payload
+
+
+def _plan_summary(root: Path, work_item_id: str) -> dict[str, Any]:
+    active = root / "docs/plans/active" / work_item_id / "plan.md"
+    completed = root / "docs/plans/completed" / work_item_id / "plan.md"
+    path = active if active.exists() else completed
+    if not path.exists():
+        return {
+            "path": "",
+            "lifecycle": "missing",
+            "tasks": [],
+            "completed_count": 0,
+            "total_count": 0,
+            "percent": 0,
+        }
+    tasks = _parse_plan_tasks(path.read_text(encoding="utf-8"))
+    completed_count = sum(1 for task in tasks if task["checked"])
+    total_count = len(tasks)
+    return {
+        "path": _relative_path(root, path),
+        "lifecycle": "active" if path == active else "completed",
+        "tasks": tasks,
+        "completed_count": completed_count,
+        "total_count": total_count,
+        "percent": round((completed_count / total_count) * 100) if total_count else 0,
+    }
+
+
+def _parse_plan_tasks(content: str) -> list[dict[str, Any]]:
+    tasks: list[dict[str, Any]] = []
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        match = re.match(r"^\s*[-*]\s+\[([ xX])\]\s+(.+?)\s*$", line)
+        if not match:
+            continue
+        tasks.append(
+            {
+                "line": line_number,
+                "checked": match.group(1).lower() == "x",
+                "text": _sticky_text(match.group(2)),
+            }
+        )
+    return tasks
 
 
 def _document_summaries(

--- a/harness_codex/runtime/ui_server.py
+++ b/harness_codex/runtime/ui_server.py
@@ -6,6 +6,7 @@ import argparse
 import errno
 import json
 import os
+import re
 import signal
 import shutil
 import subprocess
@@ -17,7 +18,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from harness_codex.runtime.document_dashboard import (
     DashboardChangeSetNotFound,
@@ -77,6 +78,12 @@ _SERVER_ENDPOINTS: tuple[tuple[str, str, str], ...] = (
     ("GET", "/api/harvest", "harvest session state"),
     ("GET", "/api/dashboard", "dashboard document state"),
     ("GET", "/api/dashboard/change-sets/{change_set_id}/resume", "resume scoped ChangeSet"),
+    ("GET", "/api/dashboard/change-sets/{change_set_id}/implementation", "implementation progress"),
+    (
+        "GET",
+        "/api/dashboard/change-sets/{change_set_id}/implementation/diff?path={path}",
+        "implementation diff file",
+    ),
     ("GET", "/api/dashboard/documents/{document_id}", "read dashboard document"),
     ("POST", "/api/change-sets/requirements/start", "start requirements ChangeSet"),
     ("POST", "/api/change-sets/requirements/answer", "answer requirements question"),
@@ -96,9 +103,14 @@ _SERVER_ENDPOINTS: tuple[tuple[str, str, str], ...] = (
     ("POST", "/api/ddd-architecture/rerun-step", "rerun DDD architecture step"),
     ("POST", "/api/ddd-architecture/answer", "answer DDD architecture question"),
     ("POST", "/api/dashboard/change-sets/{change_set_id}/rerun-stage", "rerun design stage"),
+    ("POST", "/api/dashboard/change-sets/{change_set_id}/implementation/start", "start implementation"),
     ("PUT", "/api/dashboard/documents/{document_id}", "save dashboard document"),
     ("DELETE", "/api/dashboard/change-sets/{change_set_id}", "delete active ChangeSet"),
 )
+
+_IMPLEMENTATION_JOBS: dict[str, dict[str, Any]] = {}
+_IMPLEMENTATION_JOBS_LOCK = threading.Lock()
+_DIFF_PATCH_LIMIT = 200_000
 
 
 def _ui_server_pid_path(repo_root: Path) -> Path:
@@ -511,6 +523,133 @@ def _required_change_set_id(body: dict[str, Any]) -> str:
     return change_set_id
 
 
+def implementation_progress_state(repo_root: Path | str, change_set_id: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    change_set = _active_dashboard_change_set(root, change_set_id)
+    return {
+        "change_set_id": change_set_id,
+        "plans": [
+            item.get("plan", {}) | {"work_item_id": item["id"], "name": item["name"]}
+            for item in change_set["work_items"]
+        ],
+        "diff": {"files": _git_diff_files(root)},
+        "job": _implementation_job(change_set_id),
+    }
+
+
+def implementation_diff_file(repo_root: Path | str, change_set_id: str, path: str) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    _active_dashboard_change_set(root, change_set_id)
+    normalized = _normalize_diff_path(path)
+    files = _git_diff_files(root)
+    status_by_path = {item["path"]: item["status"] for item in files}
+    if normalized not in status_by_path:
+        raise ValueError("diff path is not part of current implementation diff")
+    patch = _git_file_patch(root, normalized, status_by_path[normalized])
+    truncated = len(patch) > _DIFF_PATCH_LIMIT
+    if truncated:
+        patch = patch[:_DIFF_PATCH_LIMIT] + "\n\n[diff truncated]\n"
+    return {"path": normalized, "patch": patch, "truncated": truncated}
+
+
+def start_implementation_changeset(repo_root: Path | str, change_set_id: str, *, force_verification: bool = False) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    _active_dashboard_change_set(root, change_set_id)
+    with _IMPLEMENTATION_JOBS_LOCK:
+        current = _IMPLEMENTATION_JOBS.get(change_set_id)
+        if current and current.get("status") == "running":
+            return {"change_set_id": change_set_id, "job": dict(current)}
+        job = {
+            "change_set_id": change_set_id,
+            "status": "running",
+            "started_at": datetime.now().isoformat(timespec="seconds"),
+            "finished_at": "",
+            "returncode": None,
+            "output": "",
+            "error": "",
+        }
+        _IMPLEMENTATION_JOBS[change_set_id] = job
+    thread = threading.Thread(
+        target=_run_implementation_job,
+        args=(root, change_set_id, force_verification),
+        daemon=True,
+    )
+    thread.start()
+    return {"change_set_id": change_set_id, "job": dict(job)}
+
+
+def _run_implementation_job(root: Path, change_set_id: str, force_verification: bool) -> None:
+    command = [sys.executable, "-m", "harness_codex", "implementation", change_set_id, "--apply"]
+    if force_verification:
+        command.append("--force-verification")
+    result = subprocess.run(command, cwd=root, text=True, capture_output=True, check=False)
+    with _IMPLEMENTATION_JOBS_LOCK:
+        job = _IMPLEMENTATION_JOBS[change_set_id]
+        job["status"] = "succeeded" if result.returncode == 0 else "failed"
+        job["finished_at"] = datetime.now().isoformat(timespec="seconds")
+        job["returncode"] = result.returncode
+        job["output"] = result.stdout.strip()
+        job["error"] = result.stderr.strip()
+
+
+def _implementation_job(change_set_id: str) -> dict[str, Any] | None:
+    with _IMPLEMENTATION_JOBS_LOCK:
+        job = _IMPLEMENTATION_JOBS.get(change_set_id)
+        return dict(job) if job else None
+
+
+def _active_dashboard_change_set(root: Path, change_set_id: str) -> dict[str, Any]:
+    if not re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id):
+        raise ValueError("active ChangeSet does not exist")
+    for change_set in document_dashboard_state(root)["change_sets"]:
+        if change_set["id"] == change_set_id and change_set["lifecycle"] == "active":
+            return change_set
+    raise ValueError("active ChangeSet does not exist")
+
+
+def _git_diff_files(root: Path) -> list[dict[str, str]]:
+    output = _run_git(root, ["status", "--porcelain=v1", "--untracked-files=all"])
+    files: list[dict[str, str]] = []
+    for line in output.splitlines():
+        if len(line) < 4:
+            continue
+        status = line[:2].strip() or "M"
+        path = line[3:]
+        if " -> " in path:
+            path = path.rsplit(" -> ", maxsplit=1)[1]
+        files.append({"path": path, "status": status})
+    return files
+
+
+def _git_file_patch(root: Path, path: str, status: str) -> str:
+    if status == "??":
+        result = subprocess.run(
+            ["git", "diff", "--no-index", "--", "/dev/null", path],
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode not in (0, 1):
+            raise ValueError(result.stderr.strip() or "git diff failed")
+        return result.stdout
+    return _run_git(root, ["diff", "HEAD", "--", path])
+
+
+def _normalize_diff_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    if not normalized or normalized.startswith("/") or ".." in Path(normalized).parts:
+        raise ValueError("invalid diff path")
+    return normalized
+
+
+def _run_git(root: Path, args: list[str]) -> str:
+    result = subprocess.run(["git", *args], cwd=root, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise ValueError(result.stderr.strip() or "git command failed")
+    return result.stdout
+
+
 def run_ui_server(
     repo_root: Path | str,
     *,
@@ -572,6 +711,30 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
             change_set_id = unquote(path.removeprefix("/api/dashboard/change-sets/").removesuffix("/resume"))
             try:
                 self._write_json(HTTPStatus.OK, resume_changeset(self.repo_root, change_set_id))
+            except ValueError as exc:
+                self._write_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        if path.startswith("/api/dashboard/change-sets/") and path.endswith("/implementation"):
+            change_set_id = unquote(path.removeprefix("/api/dashboard/change-sets/").removesuffix("/implementation"))
+            try:
+                self._write_json(HTTPStatus.OK, implementation_progress_state(self.repo_root, change_set_id))
+            except ValueError as exc:
+                self._write_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        if path.startswith("/api/dashboard/change-sets/") and path.endswith("/implementation/diff"):
+            change_set_id = unquote(
+                path.removeprefix("/api/dashboard/change-sets/").removesuffix("/implementation/diff")
+            )
+            query = parse_qs(urlparse(self.path).query)
+            try:
+                self._write_json(
+                    HTTPStatus.OK,
+                    implementation_diff_file(
+                        self.repo_root,
+                        change_set_id,
+                        unquote(query.get("path", [""])[0]),
+                    ),
+                )
             except ValueError as exc:
                 self._write_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
             return
@@ -725,6 +888,17 @@ class HarvestUiRequestHandler(BaseHTTPRequestHandler):
                     str(body.get("stage_id", "")).strip(),
                     str(body.get("user_prompt", "")),
                     uc_id=str(body.get("uc_id", "")).strip(),
+                )
+                self._write_json(HTTPStatus.OK, payload)
+                return
+            elif path.startswith("/api/dashboard/change-sets/") and path.endswith("/implementation/start"):
+                change_set_id = unquote(
+                    path.removeprefix("/api/dashboard/change-sets/").removesuffix("/implementation/start")
+                )
+                payload = start_implementation_changeset(
+                    self.repo_root,
+                    change_set_id,
+                    force_verification=bool(body.get("force_verification", False)),
                 )
                 self._write_json(HTTPStatus.OK, payload)
                 return

--- a/tests/runtime/test_document_dashboard.py
+++ b/tests/runtime/test_document_dashboard.py
@@ -315,6 +315,50 @@ def test_document_dashboard_exposes_technical_decisions_for_active_use_case(
     assert loaded["editable"] is True
 
 
+def test_document_dashboard_projects_plan_checklist_progress(tmp_path: Path) -> None:
+    _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True, exist_ok=True)
+    plan.write_text(
+        "# Plan\n\n- [x] Build implementation endpoint\n- [ ] Add dashboard diff explorer\n",
+        encoding="utf-8",
+    )
+
+    work_item = document_dashboard_state(tmp_path)["change_sets"][0]["work_items"][0]
+
+    assert work_item["plan"]["path"] == "docs/plans/active/UC-001/plan.md"
+    assert work_item["plan"]["completed_count"] == 1
+    assert work_item["plan"]["total_count"] == 2
+    assert work_item["plan"]["percent"] == 50
+    assert work_item["plan"]["tasks"][1] == {
+        "line": 4,
+        "checked": False,
+        "text": "Add dashboard diff explorer",
+    }
+
+
+def test_implementation_progress_state_exposes_git_diff_files(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True)
+    _write_change_set(tmp_path)
+    _write_documents(tmp_path)
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_text("before\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    tracked.write_text("after\n", encoding="utf-8")
+
+    state = ui_server.implementation_progress_state(tmp_path, "CHG-001")
+    diff = ui_server.implementation_diff_file(tmp_path, "CHG-001", "tracked.txt")
+
+    assert state["plans"][0]["work_item_id"] == "UC-001"
+    assert state["diff"]["files"] == [{"path": "tracked.txt", "status": "M"}]
+    assert "-before" in diff["patch"]
+    assert "+after" in diff["patch"]
+
+
 def test_dashboard_projects_completed_ui_workflow_and_generated_use_cases_document(tmp_path: Path) -> None:
     _write_change_set(tmp_path)
     _write_documents(tmp_path)
@@ -923,7 +967,7 @@ def test_run_ui_server_prints_bind_url_and_endpoint_list(
         def server_close(self) -> None:
             return
 
-    monkeypatch.setattr(ui_server, "_terminate_previous_ui_server", lambda _root: True)
+    monkeypatch.setattr(ui_server, "_terminate_previous_ui_server", lambda _root, _host, _port: True)
     monkeypatch.setattr(
         ui_server,
         "_create_http_server",
@@ -939,6 +983,7 @@ def test_run_ui_server_prints_bind_url_and_endpoint_list(
     assert "Exposed endpoints:" in output
     assert "http://127.0.0.1:43210/api/endpoints - endpoint discovery" in output
     assert "http://127.0.0.1:43210/api/dashboard - dashboard document state" in output
+    assert "http://127.0.0.1:43210/api/dashboard/change-sets/{change_set_id}/implementation" in output
     assert "http://127.0.0.1:43210/api/ddd-architecture/answer" in output
 
 


### PR DESCRIPTION
## 구현 의도

Technical Decisions 이후 실제 구현 단계를 대시보드에서 시작하고, 실행 중 계획 체크리스트와 코드 변경 내용을 확인할 수 있도록 합니다.

## 구현 접근

- ChangeSet별 구현 작업을 백그라운드에서 실행하는 API를 추가했습니다.
- active/completed plan의 체크박스를 파싱해 완료 개수와 진행률을 투영합니다.
- Git working tree의 변경 파일 목록과 파일별 patch API를 추가했습니다.
- raw patch 텍스트 대신 에디터형 diff 화면으로 렌더링합니다.
- 기존 workflow 화면에 Implementation 탭과 자동 polling을 연결했습니다.
- diff 경로 검증과 출력 크기 제한을 적용했습니다.

## 검증 방법

- `node --check harness_codex/runtime/dashboard_assets/dashboard.js`
- `python3 -m py_compile harness_codex/runtime/ui_server.py harness_codex/runtime/document_dashboard.py`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime/test_document_dashboard.py` (`34 passed`)
- Playwright Chromium headless로 Technical Decisions → Implementation 이동, plan 진행률, 파일 목록, 에디터형 added/deleted row 렌더링을 검증했습니다.

## 위험 및 롤백

- 구현 작업 상태는 UI 서버 프로세스 메모리에 있으므로 서버 재시작 시 실행 이력 표시가 초기화됩니다. 실제 runtime 산출물과 Git 변경 내용은 유지됩니다.
- 큰 diff는 200,000자로 제한되어 일부 내용이 잘릴 수 있습니다.
- 문제 발생 시 이 커밋을 revert하면 기존 dashboard workflow로 복원됩니다.