### PR TITLE
기술 결정 단계 사용자 질문 흐름 복구

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -103,6 +103,7 @@ INTERACTIVE_GRILL_ME_STAGE_IDS = frozenset(
         "ubiquitous-language-definition",
         "use-case-definition",
         "event-storming",
+        "technical-decisions",
     }
 )
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1474,6 +1474,68 @@ def test_interactive_grill_me_answers_are_saved_and_passed_to_next_turn(
     ]
 
 
+def test_technical_decisions_requests_user_input_before_verification(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    monkeypatch.setenv("HARNESS_NONINTERACTIVE", "1")
+    monkeypatch.setattr(
+        cli,
+        "_exec_stage_grill_me_prompt",
+        lambda *_args: json.dumps(
+            {
+                "status": "needs_input",
+                "questions": [
+                    {
+                        "question": "Where should accepted image bytes be stored?",
+                        "recommended": "Use local filesystem storage for the MVP.",
+                    }
+                ],
+                "changed_files": [
+                    "docs/use-cases/UC-001/technical-decisions.md"
+                ],
+                "blocker": "",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "verify_procedure_stage",
+        lambda *_, **__: pytest.fail("verification must wait for user input"),
+    )
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "technical-decisions",
+            "CHG-001",
+            "--uc",
+            "UC-001",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Interactive status: needs_input" in output
+    assert "Verification: skipped" in output
+    assert "Pending questions:" in output
+    assert "Where should accepted image bytes be stored?" in output
+    assert "Recommended: Use local filesystem storage for the MVP." in output
+
+    session_path = next((tmp_path / ".harness/runs").glob("*/grill-me-session.json"))
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    assert session["status"] == "needs_input"
+    assert session["pending_questions"] == [
+        {
+            "question": "Where should accepted image bytes be stored?",
+            "recommended": "Use local filesystem storage for the MVP.",
+        }
+    ]
+
+
 def test_interactive_content_review_questions_rerun_stage_agent(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## 구현 의도

기술 결정 문서에 구현 차단 결정이 남으면 검증 실패로 종료하지 않고 사용자 질문을 노출해 답변 후 재개할 수 있게 한다.

## 구현 접근

- `technical-decisions`를 기존 대화형 Grill-Me 단계 집합에 추가했다.
- 비대화형 대시보드 실행에서 `needs_input` 질문과 추천 답변을 세션에 보존하는 회귀 테스트를 추가했다.
- 사용자 입력 전에는 산출물 검증을 실행하지 않도록 기존 대화형 흐름을 재사용했다.

## 검증 방법

- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/test_cli_commands.py -k "technical_decisions or interactive_grill_me"`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime/test_procedure_stage_runtime.py tests/runtime/test_document_dashboard.py -k "technical or pending_questions or rerun_design_stage"`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` (`523 passed`)

## 위험 및 롤백

위험은 기술 결정 단계가 대화형 실행 경로를 사용하면서 실행 결과 형식이 변경되는 점이다. 기존 대시보드의 `needs_input` 처리 계약을 그대로 사용해 범위를 제한했다. 문제 발생 시 커밋 `0484c4b`를 되돌리면 이전 단발성 에이전트 실행 경로로 복원된다.

## 스크린샷

기술 결정 재실행 및 사용자 질문 응답 화면:

![기술 결정 재실행](https://raw.githubusercontent.com/omegafrog/harness-codex/fix/plan-writing-ui-rerun-no-mode/.github/pr-assets/06-technical-decisions.png)

![사용자 질문 응답](https://raw.githubusercontent.com/omegafrog/harness-codex/fix/plan-writing-ui-rerun-no-mode/.github/pr-assets/rerun-pending-questions.png)