### PR TITLE
[codex] 인스톨러 모드 선택과 런타임 스킬 추가

### DIFF
--- a/.codex/skills/harness-agent-context/SKILL.md
+++ b/.codex/skills/harness-agent-context/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: harness-agent-context
+description: Initialize or refresh repo-local harness agent context files through the runtime CLI. Use when the user asks for `harness init`, `harness agent-context init`, agent context bootstrap, repo description detection, AGENTS.md/docs/agent generation, or validation of generated agent context.
+---
+
+# Harness Agent Context
+
+## Command Map
+
+- Use `./harness init [--description TEXT] [--force] [--no-llm]` for the top-level convenience command.
+- Use `./harness agent-context init [--description TEXT] [--force] [--llm|--no-llm]` when the user names the nested command.
+
+## Procedure
+
+1. Inspect existing `AGENTS.md`, nested `AGENTS.md`, and `docs/agent/` before running with `--force`.
+2. Prefer dry inspection and status first: `git status --porcelain=v1` and targeted diffs.
+3. Run the command from the repository root.
+4. Verify generated context with:
+
+```bash
+find . -name AGENTS.md -print | sort | xargs -r wc -w
+wc -w docs/agent/*.md
+rg -n -P "\p{Hangul}" AGENTS.md docs/agent || true
+git diff --stat
+```
+
+Documents under `docs/` must stay English. Do not overwrite unrelated worktree changes.

--- a/.codex/skills/harness-agent-context/agents/openai.yaml
+++ b/.codex/skills/harness-agent-context/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Agent Context"
+  short_description: "Initialize repo agent context"
+  default_prompt: "Use $harness-agent-context to initialize repo-local harness agent context."

--- a/.codex/skills/harness-changes/SKILL.md
+++ b/.codex/skills/harness-changes/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: harness-changes
+description: Operate harness ChangeSets through the runtime CLI. Use when the user asks to list, inspect, show contents, delete, continue, or document deltas for ChangeSets with `harness changes`.
+---
+
+# Harness Changes
+
+## Command Map
+
+- `./harness changes list`
+- `./harness changes active`
+- `./harness changes show <CHG-ID>`
+- `./harness changes contents <CHG-ID>`
+- `./harness changes continue <CHG-ID>`
+- `./harness changes delete <CHG-ID>`
+- `./harness changes document-delta <CHG-ID> --uc <UC-ID> --summary TEXT --plan|--preview|--apply`
+
+## Procedure
+
+1. Use `list` or `active` before ID-specific commands when the target is unclear.
+2. For destructive deletion, show exact ChangeSet ID and affected path first, then require explicit user confirmation.
+3. For `document-delta`, prefer `--preview` or `--plan` before `--apply` unless the user explicitly requested apply.
+4. Summarize command output; do not paste long artifacts.
+5. Preserve ChangeSet/use-case/work-item boundaries.

--- a/.codex/skills/harness-changes/agents/openai.yaml
+++ b/.codex/skills/harness-changes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Changes"
+  short_description: "Operate harness ChangeSets"
+  default_prompt: "Use $harness-changes to inspect or update harness ChangeSets."

--- a/.codex/skills/harness-code-planner/SKILL.md
+++ b/.codex/skills/harness-code-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-code-planner
-description: Create or maintain an executor-ready implementation plan for one active ChangeSet work item. Use after a ChangeSet and one work-item slice exist and before coding starts, or when updating/completing that work-item plan. The skill keeps planning scoped to the active ChangeSet, writes only docs/plans/active/<WORK-ITEM-ID>/plan.md, and moves it to docs/plans/completed/<WORK-ITEM-ID>/plan.md only after all checkbox tasks and build/test/e2e/runtime-server/static-analysis verification are complete.
+description: Create or maintain an executor-ready implementation plan for one active ChangeSet work item. Use after a ChangeSet and one work-item slice exist and before coding starts, or when updating/completing that work-item plan. Also use for the harness plan-writing runtime command. The skill keeps planning scoped to the active ChangeSet and moves plans to completed only after all checkbox tasks and build/test/e2e/runtime-server/static-analysis verification are complete.
 ---
 
 # Harness Code Planner

--- a/.codex/skills/harness-completion/SKILL.md
+++ b/.codex/skills/harness-completion/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: harness-completion
+description: Install or inspect harness shell completion through the runtime CLI. Use when the user asks for tab completion, shell completion setup, completion troubleshooting, or `harness completion install`.
+---
+
+# Harness Completion
+
+## Command Map
+
+- `./harness completion install [--shell auto|zsh|bash|all]`
+
+## Procedure
+
+1. Detect shell from `$SHELL` when user did not specify one.
+2. Run install command from repo root.
+3. If troubleshooting, inspect `scripts/harness-completion.bash`, `scripts/harness-completion.zsh`, and `docs/runtime-shell-completion.md`.
+4. Verify with `bash scripts/test-harness-completion.bash` when behavior changed.

--- a/.codex/skills/harness-completion/agents/openai.yaml
+++ b/.codex/skills/harness-completion/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Completion"
+  short_description: "Install shell completion"
+  default_prompt: "Use $harness-completion to install or inspect harness shell completion."

--- a/.codex/skills/harness-contracts/SKILL.md
+++ b/.codex/skills/harness-contracts/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: harness-contracts
+description: Validate harness document handoff contracts through the runtime CLI. Use when the user asks to check ChangeSet or work-item document contracts, dashboard contract data, artifact handoff validity, or `harness contracts validate`.
+---
+
+# Harness Contracts
+
+## Command Map
+
+- `./harness contracts validate <CHG-ID> [--work-item ID] [--json]`
+
+## Procedure
+
+1. Identify ChangeSet and optional work item from user input or `./harness changes list`.
+2. Run validation from repo root.
+3. If output is long, rerun with `--json` only when machine-readable detail helps.
+4. Report failing contract, expected artifact, missing/invalid field, and next owner stage.
+5. Do not edit artifacts unless user also asks for remediation.

--- a/.codex/skills/harness-contracts/agents/openai.yaml
+++ b/.codex/skills/harness-contracts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Contracts"
+  short_description: "Validate document contracts"
+  default_prompt: "Use $harness-contracts to validate harness document handoff contracts."

--- a/.codex/skills/harness-dashboard/SKILL.md
+++ b/.codex/skills/harness-dashboard/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: harness-dashboard
+description: Use harness dashboard runtime commands. Use when the user asks for dashboard JSON, contract dashboard projection, local dashboard server, UI server, or `harness dashboard` / `harness ui-server`.
+---
+
+# Harness Dashboard
+
+## Command Map
+
+- `./harness dashboard [contracts --change-set <CHG-ID> --format json]`
+- `./harness ui-server [--host HOST] [--port PORT]`
+
+## Procedure
+
+1. Use `dashboard` for state JSON and `ui-server` for browser UI.
+2. For contract views, pass explicit `--change-set`.
+3. If starting `ui-server`, keep session running only when user needs live UI; report URL.
+4. For dashboard code changes, verify with:
+
+```bash
+node --check harness_codex/runtime/dashboard_assets/dashboard.js
+python3 -m py_compile harness_codex/runtime/ui_server.py harness_codex/runtime/document_dashboard.py
+```

--- a/.codex/skills/harness-dashboard/agents/openai.yaml
+++ b/.codex/skills/harness-dashboard/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Dashboard"
+  short_description: "Use dashboard commands"
+  default_prompt: "Use $harness-dashboard to inspect dashboard JSON or run the local UI server."

--- a/.codex/skills/harness-ddd-design/SKILL.md
+++ b/.codex/skills/harness-ddd-design/SKILL.md
@@ -6,7 +6,8 @@ description: >
   aggregates, bounded contexts, application services, domain services, and
   communication maps from the selected use-case slice. The selected slice
   event-storming document is the primary source; outside/canonical documents are
-  fallback only for information missing from the slice.
+  fallback only for information missing from the slice. Also use for the harness
+  ddd-architecture-definition runtime command.
 ---
 
 # Harness DDD Design

--- a/.codex/skills/harness-event-storming/SKILL.md
+++ b/.codex/skills/harness-event-storming/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Use after requirements and use cases exist to run ticketon-ddd style event
   storming through the oracle agent. The skill derives commands, events,
   policies, systems, external systems, and invariants from use cases, and
-  writes docs/use-cases/<UC-ID>/event-storming.md for each affected use-case
-  slice.
+  writes use-case event-storming docs for each affected use-case slice. Also use
+  for the harness event-storming runtime command.
 ---
 
 # Harness Event Storming

--- a/.codex/skills/harness-evolution/SKILL.md
+++ b/.codex/skills/harness-evolution/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: harness-evolution
+description: Manage harness evolution proposals through the runtime CLI. Use when the user asks to propose, accept, reject, inspect, or decide repo workflow evolution changes with `harness evolution`.
+---
+
+# Harness Evolution
+
+## Command Map
+
+- `./harness evolution propose ...`
+- `./harness evolution accept ...`
+- `./harness evolution reject ...`
+
+## Procedure
+
+1. Run `./harness help evolution` to confirm exact required arguments for current runtime.
+2. Treat accept/reject as workflow-governance decisions; confirm target proposal before applying.
+3. Record proposal IDs and affected files in the response.
+4. Do not mix proposal decisions with unrelated implementation edits.

--- a/.codex/skills/harness-evolution/agents/openai.yaml
+++ b/.codex/skills/harness-evolution/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Evolution"
+  short_description: "Manage evolution proposals"
+  default_prompt: "Use $harness-evolution to propose, accept, or reject harness evolution changes."

--- a/.codex/skills/harness-plan-executor/SKILL.md
+++ b/.codex/skills/harness-plan-executor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-plan-executor
-description: Orchestrate use-case scoped execution of docs/plans/active/<UC-ID>/plan.md for harness engineering by delegating implementation to the implementation_executor agent, verifying against the use-case E2E goal and test gate, adding remediation tasks only for implementation failures, and moving completed use-case plans to docs/plans/completed/<UC-ID>/plan.md.
+description: Orchestrate use-case scoped execution of active implementation plans for harness engineering by delegating implementation to the implementation_executor agent, verifying against the use-case E2E goal and test gate, adding remediation tasks only for implementation failures, and moving completed use-case plans to completed plans. Also use for the harness implementation runtime command.
 ---
 
 # Harness Plan Executor

--- a/.codex/skills/harness-requirements/SKILL.md
+++ b/.codex/skills/harness-requirements/SKILL.md
@@ -4,6 +4,7 @@ description:
   Use when a user wants to turn an early product or feature idea into a
   requirements specification. This skill clarifies unresolved requirements
   decisions through a time-boxed grill-me flow and writes docs/design/요구사항.md.
+  Also use for the harness requirements-definition runtime command.
 ---
 
 # Harness Requirements

--- a/.codex/skills/harness-runtime-artifacts/SKILL.md
+++ b/.codex/skills/harness-runtime-artifacts/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: harness-runtime-artifacts
+description: Show or accept generated harness runtime stage artifacts. Use when the user asks to inspect generated stage output, accept a stage artifact, approve runtime artifacts, or run `harness artifacts show|accept`.
+---
+
+# Harness Runtime Artifacts
+
+## Command Map
+
+- `./harness artifacts show <CHG-ID> <stage>`
+- `./harness artifacts accept <CHG-ID> <stage>`
+
+## Procedure
+
+1. Use `show` before `accept` unless the user already reviewed the artifact.
+2. For `accept`, state exact ChangeSet and stage, then require explicit approval if the user did not already ask to accept.
+3. After acceptance, run `./harness stages list <CHG-ID>` to show updated state.
+4. Do not edit artifact content inside this skill.

--- a/.codex/skills/harness-runtime-artifacts/agents/openai.yaml
+++ b/.codex/skills/harness-runtime-artifacts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Runtime Artifacts"
+  short_description: "Show or accept artifacts"
+  default_prompt: "Use $harness-runtime-artifacts to show or accept generated stage artifacts."

--- a/.codex/skills/harness-runtime-help/SKILL.md
+++ b/.codex/skills/harness-runtime-help/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: harness-runtime-help
+description: Show harness runtime command help. Use when the user asks for available harness commands, command usage, CLI help, or `harness help` output.
+---
+
+# Harness Runtime Help
+
+## Command Map
+
+- `./harness help`
+- `./harness help <command>`
+
+## Procedure
+
+1. Run general help when command is unknown.
+2. Run command-specific help before using uncommon or recently changed runtime commands.
+3. Summarize usage and important options; do not paste full help unless requested.

--- a/.codex/skills/harness-runtime-help/agents/openai.yaml
+++ b/.codex/skills/harness-runtime-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Runtime Help"
+  short_description: "Show runtime CLI help"
+  default_prompt: "Use $harness-runtime-help to show harness CLI usage for a command."

--- a/.codex/skills/harness-runtime-report/SKILL.md
+++ b/.codex/skills/harness-runtime-report/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: harness-runtime-report
+description: Print and summarize harness runtime run reports. Use when the user asks for a run report, run status details, failure summary, or to execute the harness report command for a run ID.
+---
+
+# Harness Runtime Report
+
+## Command Map
+
+- `./harness report <RUN-ID>`
+
+## Procedure
+
+1. Resolve run ID from `.harness/runs/` if missing.
+2. Run report command from repo root.
+3. Summarize key status, failed step, artifact paths, and next command.
+4. Keep raw logs out of the response unless the user asks for exact output.

--- a/.codex/skills/harness-runtime-report/agents/openai.yaml
+++ b/.codex/skills/harness-runtime-report/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Runtime Report"
+  short_description: "Summarize run reports"
+  default_prompt: "Use $harness-runtime-report to print and summarize a harness run report."

--- a/.codex/skills/harness-runtime-reset/SKILL.md
+++ b/.codex/skills/harness-runtime-reset/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: harness-runtime-reset
+description: Reset local harness runtime artifacts through `harness reset`. Use when the user asks to clear run state, workflow artifacts, sessions, checkpoints, dashboard UI state, or explicitly reset harness runtime data.
+---
+
+# Harness Runtime Reset
+
+## Command Map
+
+- `./harness reset --runs [--apply]`
+- `./harness reset --workflow-artifacts [--apply]`
+- `./harness reset --all [--apply]`
+
+## Procedure
+
+1. Read `docs/runtime-reset-command.md` when scope is unclear.
+2. Run without `--apply` first to preview targets.
+3. Before `--apply`, state exact scope and require explicit confirmation unless user already gave it.
+4. Never use reset as part of update; update must preserve workflow artifacts.
+5. After apply, run concise status checks and report removed target groups.

--- a/.codex/skills/harness-runtime-reset/agents/openai.yaml
+++ b/.codex/skills/harness-runtime-reset/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Runtime Reset"
+  short_description: "Reset runtime artifacts"
+  default_prompt: "Use $harness-runtime-reset to preview or apply a harness runtime reset."

--- a/.codex/skills/harness-runtime-resume/SKILL.md
+++ b/.codex/skills/harness-runtime-resume/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: harness-runtime-resume
+description: Inspect the next resume target for a harness runtime run. Use when the user asks how to resume a run, what run should continue next, or to execute the harness resume command for a run ID.
+---
+
+# Harness Runtime Resume
+
+## Command Map
+
+- `./harness resume <RUN-ID>`
+
+## Procedure
+
+1. If run ID is unknown, list `.harness/runs/` or use dashboard/report commands to identify candidates.
+2. Run resume inspection; do not automatically execute downstream stage work unless user requested continuation.
+3. Report run ID, next stage, suggested command, and blocker if present.

--- a/.codex/skills/harness-runtime-resume/agents/openai.yaml
+++ b/.codex/skills/harness-runtime-resume/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Runtime Resume"
+  short_description: "Inspect resume target"
+  default_prompt: "Use $harness-runtime-resume to inspect the next resume target for a run."

--- a/.codex/skills/harness-runtime-run/SKILL.md
+++ b/.codex/skills/harness-runtime-run/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: harness-runtime-run
+description: Run repository-local application and wiki commands through the harness runtime. Use when the user asks for `harness run app`, app server status/stop/attach, foreground app runs, wiki serve/build/install, or runtime server verification.
+---
+
+# Harness Runtime Run
+
+## Command Map
+
+- `./harness run app [--timeout SECONDS] [-- SERVER_ARG ...]`
+- `./harness run app --foreground [-- APP_ARG ...]`
+- `./harness run app status`
+- `./harness run app stop`
+- `./harness run app attach infra|server`
+- `./harness run wiki [serve|build|install] [--dev-addr HOST:PORT]`
+
+## Procedure
+
+1. Use status before starting or stopping existing app sessions.
+2. Prefer managed `run app` for runtime verification when plan asks for runtime server proof.
+3. Stop servers after verification unless user wants them left running.
+4. For wiki changes, run `./harness run wiki build` before reporting success.
+5. Summarize logs; avoid dumping long server output.

--- a/.codex/skills/harness-runtime-run/agents/openai.yaml
+++ b/.codex/skills/harness-runtime-run/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Runtime Run"
+  short_description: "Run app and wiki commands"
+  default_prompt: "Use $harness-runtime-run to run harness-managed app or wiki commands."

--- a/.codex/skills/harness-runtime-stages/SKILL.md
+++ b/.codex/skills/harness-runtime-stages/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: harness-runtime-stages
+description: Inspect runtime procedure stage artifacts through the harness CLI. Use when the user asks to list stages, see ChangeSet stage state, inspect staged workflow progress, or run `harness stages list`.
+---
+
+# Harness Runtime Stages
+
+## Command Map
+
+- `./harness stages list <CHG-ID>`
+
+## Procedure
+
+1. Resolve the ChangeSet ID with `./harness changes list` if needed.
+2. Run `./harness stages list <CHG-ID>`.
+3. Report stage ID, state, required next action, and artifact pointers.
+4. Use `harness-runtime-artifacts` for artifact body display or acceptance.

--- a/.codex/skills/harness-runtime-stages/agents/openai.yaml
+++ b/.codex/skills/harness-runtime-stages/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Runtime Stages"
+  short_description: "Inspect procedure stages"
+  default_prompt: "Use $harness-runtime-stages to list runtime procedure stages for a ChangeSet."

--- a/.codex/skills/harness-runtime-update/SKILL.md
+++ b/.codex/skills/harness-runtime-update/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: harness-runtime-update
+description: Update installed harness-codex runtime files through `harness update`. Use when the user asks to refresh an installed runtime, update harness runtime from origin/main or another ref, dry-run an update, skip venv refresh, or troubleshoot runtime update behavior.
+---
+
+# Harness Runtime Update
+
+## Command Map
+
+- `./harness update [--repo URL] [--ref REF] [--skip-venv] [--dry-run]`
+
+## Procedure
+
+1. Read `docs/runtime-update-command.md` when exact preservation behavior matters.
+2. Prefer `--dry-run` first unless user explicitly requested execution.
+3. Preserve workflow-generated artifacts and project-local config.
+4. After update, inspect `git diff --stat` and report runtime version transition if shown.
+5. Do not use reset to fix update issues unless user explicitly asks for reset.

--- a/.codex/skills/harness-runtime-update/agents/openai.yaml
+++ b/.codex/skills/harness-runtime-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Runtime Update"
+  short_description: "Update installed runtime"
+  default_prompt: "Use $harness-runtime-update to dry-run or apply a harness runtime update."

--- a/.codex/skills/harness-technical-decisions/SKILL.md
+++ b/.codex/skills/harness-technical-decisions/SKILL.md
@@ -5,8 +5,8 @@ description: >
   to decide detailed technical strategies such as polling vs push, retry and
   circuit breaker policy, outbox/inbox, idempotency, transaction boundaries,
   cache policy, observability, and adapter-level technology choices. Writes
-  docs/use-cases/<UC-ID>/technical-decisions.md for ChangeSet work and requires
-  approval before planning.
+  use-case technical-decisions docs for ChangeSet work and requires approval
+  before planning. Also use for the harness technical-decisions runtime command.
 ---
 
 # Harness Technical Decisions

--- a/.codex/skills/harness-ubiquitous-language/SKILL.md
+++ b/.codex/skills/harness-ubiquitous-language/SKILL.md
@@ -2,7 +2,8 @@
 name: harness-ubiquitous-language
 description:
   Use after requirements are stable to confirm project ubiquitous language in
-  context.md before use-case generation.
+  context.md before use-case generation. Also use for the harness
+  ubiquitous-language-definition runtime command.
 ---
 
 # Harness Ubiquitous Language

--- a/.codex/skills/harness-ultrawork/SKILL.md
+++ b/.codex/skills/harness-ultrawork/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: harness-ultrawork
+description: Create a ChangeSet and run affected harness workflows through `harness ultrawork`. Use when the user asks to run ultrawork, start an end-to-end ChangeSet workflow from a title or idea, preview affected workflow execution, or apply the runtime orchestration command.
+---
+
+# Harness Ultrawork
+
+## Command Map
+
+- `./harness ultrawork [--title TEXT] [--change-set-id ID] [--uc UC-ID] [--force] [--plan|--preview|--apply]`
+
+## Procedure
+
+1. Use `./harness help ultrawork` when exact current flags matter.
+2. Prefer `--preview` unless the user explicitly requests applying workflow execution.
+3. After execution, report ChangeSet ID, affected use cases, generated artifacts, and resume/report command.
+4. Preserve stage approvals; do not bypass required artifact acceptance.
+
+For fully agent-led orchestration without relying only on the runtime command, use `harness-full-workflow` or `harness-post-harvest-orchestrator`.

--- a/.codex/skills/harness-ultrawork/agents/openai.yaml
+++ b/.codex/skills/harness-ultrawork/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Ultrawork"
+  short_description: "Run ultrawork workflow"
+  default_prompt: "Use $harness-ultrawork to preview or apply a full harness ultrawork run."

--- a/.codex/skills/harness-usecases/SKILL.md
+++ b/.codex/skills/harness-usecases/SKILL.md
@@ -2,7 +2,8 @@
 name: harness-usecases
 description:
   Use after requirements and context.md exist to turn confirmed requirements
-  into external-actor use cases and runtime-ready use-case slice documents.
+  into external-actor use cases and runtime-ready use-case slice documents. Also
+  use for the harness use-case-definition runtime command.
 ---
 
 # Harness Use Cases

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,30 +2,42 @@
 
 ## 0. Quick install for a new repository
 
-새 빈 프로젝트에서는 GitHub의 installer를 내려받아 런타임 파일과 최소 문서 구조를 한 번에 초기화할 수 있다.
+For a new repository, download the GitHub installer and choose whether to install the full runtime or only bundled skills.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash
 ```
 
-기본 동작:
+When an interactive terminal is available, the installer asks for one mode:
 
-- `harness_codex/`, `.harness/`, `.codex/`, `tests/runtime`를 현재 프로젝트에 설치한다.
-- `venv`를 만들고 `pip`, `pytest`, `pyyaml`을 설치한다.
-- 프로젝트 루트에 짧은 실행 래퍼 `./harness`를 생성한다.
-- `ARCHITECTURE.md`, `docs/design/요구사항.md`, `docs/design/유스케이스.md`, `.codex/repository-settings.md`, `.codex/test-gate.yaml`가 없으면 생성한다.
-- `./harness --help` smoke test를 실행한다.
+- `runtime`: installs runtime files, bundled skills, launcher, runtime tests, docs, and venv.
+- `skills-only`: installs only `.codex/skills`.
 
-기존 파일은 기본적으로 덮어쓰지 않는다. 다시 설치하며 덮어쓰려면 다음처럼 실행한다.
+Non-interactive runs default to `runtime`. Pass a mode explicitly for scripted installs:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --force
+curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --runtime
+curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --skills-only
 ```
 
-특정 ref나 대상 디렉터리를 지정할 수도 있다.
+Runtime mode:
+
+- Installs `harness_codex/`, `.harness/`, `.codex/`, `completions/`, and `tests/runtime` into the target project.
+- Creates `venv` and installs `pip`, `pytest`, and `pyyaml`.
+- Creates the root launcher `./harness`.
+- Creates `ARCHITECTURE.md`, `docs/design/요구사항.md`, `docs/design/유스케이스.md`, `.codex/repository-settings.md`, and `.codex/test-gate.yaml` when missing.
+- Runs the `./harness --help` smoke test.
+
+Existing files are not overwritten by default. Use `--force` to refresh managed files:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --ref main --target /path/to/project
+curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --runtime --force
+```
+
+You can also choose a ref or target directory.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --runtime --ref main --target /path/to/project
 ```
 
 After installation, start with repository context and the first runtime stage.
@@ -56,14 +68,14 @@ bootstrap preserves it and records that decision in `docs/agent/session-state.md
 `harness requirements-definition` runs this bootstrap when it creates the initial
 ChangeSet state.
 
-## 2. 목적
+## 2. Purpose
 
-이 문서는 ChangeSet과 유스케이스 slice 기반 실행 구조를 정의한다.
-목표는 구현 요청마다 변경 의도와 영향을 명시하고, planner/executor가 전체
-`docs/design/**`를 매번 다시 분석하지 않고 승인된 유스케이스 범위만 읽도록
-입력 경계를 고정하는 것이다.
+This document defines the ChangeSet and use-case slice based execution structure.
+The goal is to make each implementation request state its change intent and impact,
+and to keep planner/executor inputs bounded to approved use-case scope instead of
+re-analyzing all of `docs/design/**` every time.
 
-## 3. 표준 구조
+## 3. Standard Structure
 
 ```text
 docs/
@@ -116,119 +128,121 @@ docs/
       verification.md
 ```
 
-`docs/templates/**`는 새 문서를 만들 때 복사해서 사용하는 기준이다.
+`docs/templates/**` contains the source templates copied for new documents.
 `docs/changes/active`, `docs/changes/completed`, `docs/plans/active`,
-`docs/plans/completed`는 실제 실행 상태를 표현한다.
+and `docs/plans/completed` represent real execution state.
 
-## 4. ChangeSet 규칙
+## 4. ChangeSet Rules
 
-ChangeSet은 하나의 구현 요청 또는 문서 변경 요청을 나타낸다.
-각 ChangeSet은 다음 내용을 반드시 포함한다.
+Each ChangeSet represents one implementation request or documentation change request.
+Every ChangeSet must include:
 
-- 변경 전 의도와 변경 후 의도 (`Before` / `After`)
-- 변경되는 문서 목록
-- 영향받는 work item 목록 (`use_case`, `maintenance`)
-- 유스케이스별 E2E 목표 변경 여부
-- maintenance별 verification goal 변경 여부
-- planner/executor가 읽을 입력 범위
-- 명시적으로 제외되는 범위
+- Intent before and after the change (`Before` / `After`)
+- Changed document list
+- Affected work item list (`use_case`, `maintenance`)
+- Whether each use case changes its E2E goal
+- Whether each maintenance item changes its verification goal
+- Input scope for planner/executor
+- Explicitly excluded scope
 
-새 변경은 `docs/changes/active/<CHG-ID>.md`에 생성한다.
-모든 영향 유스케이스의 plan이 완료되고 검증이 통과하면 같은 파일을
-`docs/changes/completed/<CHG-ID>.md`로 이동한다.
+Create new changes under `docs/changes/active/<CHG-ID>.md`.
+After all affected use-case plans are complete and verification passes, move the same
+file to `docs/changes/completed/<CHG-ID>.md`.
 
-## 5. 유스케이스 Slice 규칙
+## 5. Use-Case Slice Rules
 
-`docs/use-cases/<UC-ID>/`는 특정 유스케이스를 구현 가능한 단위로 좁힌
-executor-facing 문서 집합이다.
+`docs/use-cases/<UC-ID>/` is an executor-facing document set that narrows a specific
+use case into an implementable unit.
 
-- `index.md`: slice 문서의 상태, 승인 여부, 추적 링크
-- `use-case.md`: 액터 목표, 사전조건, 기본/예외 흐름, 결과
-- `event-storming.md`: 해당 UC에 필요한 command/event/policy/system slice
-- `ddd-design.md`: 해당 UC 구현에 필요한 도메인/aggregate/service/BC 결정
-- `technical-decisions.md`: 해당 UC 구현에 필요한 세부 기술 결정
+- `index.md`: slice document state, approval state, and trace links
+- `use-case.md`: actor goal, preconditions, main/exception flows, and outcomes
+- `event-storming.md`: command/event/policy/system slice required by the UC
+- `ddd-design.md`: domain, aggregate, service, and bounded-context decisions required by the UC
+- `technical-decisions.md`: detailed technical decisions required by the UC
 - `docs/use-cases/<UC-ID>/e2e-goal.md`: pre-implementation business acceptance contract,
   including observable success/failure criteria and Given/When/Then
-- `docs/use-cases/<UC-ID>/affected-files.md`: 예상 변경 파일과 금지 파일
+- `docs/use-cases/<UC-ID>/affected-files.md`: expected changed files and forbidden files
 
-유스케이스 slice가 존재하면 planner와 executor는 우선 이 디렉터리의 문서를
-입력으로 사용한다. 공통 설계가 필요할 때만 `docs/design/**`를 보조 입력으로
-참조한다.
+When a use-case slice exists, planner and executor use documents from that directory
+first. They reference `docs/design/**` only as supporting input when shared design is
+needed.
 
-## 6. Maintenance Slice 규칙
+## 6. Maintenance Slice Rules
 
-`docs/maintenance/<MAINT-ID>/`는 특정 유스케이스로 표현하기 어려운
-리팩토링, 버그 수정, 테스트 보강, 인프라 변경, 문서 정리 같은 유지보수성
-작업을 실행 가능한 단위로 좁힌 executor-facing 문서 집합이다.
+`docs/maintenance/<MAINT-ID>/` is an executor-facing document set that narrows
+maintenance work into an executable unit when the work does not fit a specific use
+case, such as refactoring, bug fixes, test hardening, infrastructure changes, or docs
+cleanup.
 
-Maintenance ID는 `MAINT-001`처럼 `MAINT-` 접두사와 3자리 숫자를 사용한다.
-하나의 ChangeSet 안에서 유스케이스 slice와 maintenance slice는 함께 나열될 수
-있고, planner/executor는 ChangeSet의 work item 순서를 따른다.
+Maintenance IDs use the `MAINT-` prefix and three digits, such as `MAINT-001`.
+One ChangeSet can list use-case slices and maintenance slices together; planner and
+executor follow the work item order in the ChangeSet.
 
-- `index.md`: maintenance slice 문서의 상태, 관련 ChangeSet, 문서 목록
-- `change-intent.md`: 변경 의도, 배경, Before/After, 포함/제외 범위
-- `affected-files.md`: 예상 변경 파일, 테스트 파일, 금지 파일
-- `technical-decisions.md`: 필요한 경우의 구현 결정과 보류 결정
-- `verification-goal.md`: 완료 판정 기준과 검증 명령
+- `index.md`: maintenance slice state, related ChangeSet, and document list
+- `change-intent.md`: change intent, background, Before/After, included/excluded scope
+- `affected-files.md`: expected changed files, test files, and forbidden files
+- `technical-decisions.md`: implementation decisions and deferred decisions when needed
+- `verification-goal.md`: completion criteria and verification commands
 
-새 maintenance slice는 `docs/maintenance/<MAINT-ID>/` 아래에 생성하며,
-필수 문서는 `docs/maintenance/<MAINT-ID>/change-intent.md`,
+Create new maintenance slices under `docs/maintenance/<MAINT-ID>/`.
+Required documents are `docs/maintenance/<MAINT-ID>/change-intent.md`,
 `docs/maintenance/<MAINT-ID>/affected-files.md`,
-`docs/maintenance/<MAINT-ID>/verification-goal.md`다.
-`docs/maintenance/<MAINT-ID>/technical-decisions.md`는 구현 결정이 필요한
-경우에 사용한다.
+and `docs/maintenance/<MAINT-ID>/verification-goal.md`.
+Use `docs/maintenance/<MAINT-ID>/technical-decisions.md` only when implementation
+decisions are needed.
 
-Maintenance slice는 이벤트 스토밍이나 UC E2E goal을 요구하지 않는다.
-대신 `verification-goal.md`가 구현 완료와 병합 가능 여부의 기준이 된다.
-계획 파일은 `docs/plans/active/<MAINT-ID>/plan.md`에 생성하고, 완료 후
-`docs/plans/completed/<MAINT-ID>/plan.md`로 이동한다.
+Maintenance slices do not require event storming or a UC E2E goal.
+Instead, `verification-goal.md` is the standard for implementation completion and
+merge readiness. Create the plan at `docs/plans/active/<MAINT-ID>/plan.md`, then move
+it to `docs/plans/completed/<MAINT-ID>/plan.md` after completion.
 
-## 7. Canonical Design 관계
+## 7. Canonical Design Relationship
 
-`docs/design/**`는 전체 제품/도메인 수준의 canonical 문서다.
-`docs/use-cases/<UC-ID>/**`는 특정 유스케이스 실행을 위한 slice 문서다.
-`docs/maintenance/<MAINT-ID>/**`는 canonical 문서를 직접 대체하지 않고,
-특정 유지보수성 변경에 필요한 실행 범위와 검증 기준만 기록한다.
+`docs/design/**` is the product/domain-level canonical document set.
+`docs/use-cases/<UC-ID>/**` is the slice document set for a specific use-case
+execution. `docs/maintenance/<MAINT-ID>/**` does not directly replace canonical docs;
+it records only the execution scope and verification criteria required for a specific
+maintenance change.
 
-- canonical 문서가 전체 진실의 원천이다.
-- UC slice는 canonical 문서에서 해당 UC에 필요한 부분과 ChangeSet의 delta를
-  실행 가능한 형태로 좁힌다.
-- maintenance slice는 canonical 변경이 필요한 경우 ChangeSet에 그 필요성을
-  명시하고, 승인되지 않은 canonical 문서 변경을 임의로 수행하지 않는다.
-- slice와 canonical 문서가 충돌하면 executor loop에서 임의로 해결하지 않는다.
-  `DOCUMENT_DELTA_CONFLICT` 또는 `UPSTREAM_DESIGN_CONFLICT`로 분류하고 상위
-  문서 수정 단계로 되돌린다.
-- 전체 `docs/design/이벤트 스토밍.md`는 summary/index로 유지할 수 있지만,
-  UC 구현 계획의 직접 입력은 `docs/use-cases/<UC-ID>/event-storming.md`다.
+- Canonical documents are the source of truth for the whole product.
+- UC slices narrow the relevant canonical content and ChangeSet delta into an
+  executable form.
+- Maintenance slices state the need in the ChangeSet when canonical changes are
+  required; they do not make unapproved canonical document changes.
+- If slice and canonical documents conflict, the executor loop must not resolve that
+  conflict ad hoc. Classify it as `DOCUMENT_DELTA_CONFLICT` or
+  `UPSTREAM_DESIGN_CONFLICT` and return to the upstream document revision stage.
+- The full `docs/design/이벤트 스토밍.md` can remain as a summary/index, but direct
+  input for UC implementation planning is `docs/use-cases/<UC-ID>/event-storming.md`.
 
-## 8. Plan 이동 규칙
+## 8. Plan Movement Rules
 
-유스케이스별 plan은 `docs/plans/active/<UC-ID>/plan.md`에 생성한다.
-Maintenance별 plan은 `docs/plans/active/<MAINT-ID>/plan.md`에 생성한다.
+Create use-case plans at `docs/plans/active/<UC-ID>/plan.md`.
+Create maintenance plans at `docs/plans/active/<MAINT-ID>/plan.md`.
 Verification evidence can be recorded in the same directory as `verification.md`.
 For use-case work, keep `e2e-goal.md` stable after approval and record implementation-specific
 test suite details, fixtures, request/response examples, UI steps, commands, and actual pass/fail
 evidence in `docs/plans/active/<UC-ID>/verification.md` or the plan verification result.
 
-다음 조건을 모두 만족할 때만 plan을 completed로 이동한다.
+Move plans to completed only when all of these conditions are met:
 
-- `plan.md`의 모든 체크박스가 완료됨
-- `docs/use-cases/<UC-ID>/e2e-goal.md` 또는
-  `docs/maintenance/<MAINT-ID>/verification-goal.md`의 성공 기준 충족
-- repository test gate의 required stage가 모두 PASS
-- 검증 결과가 `plan.md` 또는 `verification.md`에 기록됨
+- Every checkbox in `plan.md` is complete
+- Success criteria in `docs/use-cases/<UC-ID>/e2e-goal.md` or
+  `docs/maintenance/<MAINT-ID>/verification-goal.md` are satisfied
+- Every required repository test-gate stage passes
+- Verification results are recorded in `plan.md` or `verification.md`
 
-완료된 plan은 `docs/plans/completed/<UC-ID>/plan.md`로 이동한다.
-Maintenance plan은 `docs/plans/completed/<MAINT-ID>/plan.md`로 이동한다.
-미완료, 실패, 차단 상태의 plan은 active에 남긴다.
+Move completed UC plans to `docs/plans/completed/<UC-ID>/plan.md`.
+Move completed maintenance plans to `docs/plans/completed/<MAINT-ID>/plan.md`.
+Keep incomplete, failed, or blocked plans under active.
 
-검증 실패는 work item 유형에 맞춰 `implementation failure`, `scope conflict`,
-`environment blocker`, `verification goal unclear`로 분류한다.
+Classify verification failures by work item type as `implementation failure`,
+`scope conflict`, `environment blocker`, or `verification goal unclear`.
 
-## 9. 런타임 CLI
+## 9. Runtime CLI
 
-로컬 런타임은 ChangeSet 아래 work item을 조회하고 실행 상태를
-`.harness/runs/<run-id>/`에 저장한다.
+The local runtime reads work items under a ChangeSet and stores execution state under
+`.harness/runs/<run-id>/`.
 
 ```bash
 ./harness changes list
@@ -253,10 +267,10 @@ Maintenance plan은 `docs/plans/completed/<MAINT-ID>/plan.md`로 이동한다.
 commands. `--apply` runs the selected stage and writes state/report/dashboard
 projections.
 
-## 10. Codex Prompt Prefix와 런타임 아티팩트
+## 10. Codex Prompt Prefix And Runtime Artifacts
 
-OpenAI/Codex 호출 비용 최적화는 응답 캐시가 아니라 **prompt prefix 재사용**에
-맞춘다. 런타임은 에이전트 prompt를 항상 같은 섹션 순서로 조립한다.
+OpenAI/Codex call cost optimization is based on **prompt prefix reuse**, not response
+caching. The runtime always assembles agent prompts in the same section order.
 
 ```text
 [stable] Runtime Instruction
@@ -270,14 +284,14 @@ OpenAI/Codex 호출 비용 최적화는 응답 캐시가 아니라 **prompt pref
 [volatile] Current Execution Payload
 ```
 
-규칙은 다음과 같다.
+Rules:
 
-- stable 섹션은 ChangeSet, work item, run id, 로그보다 항상 앞에 둔다.
-- optional 문서가 없어도 섹션 헤더는 유지하고 `<not found>`로 기록한다.
-- file traversal은 정렬된 고정 순서를 사용한다.
-- run id, temporary path, verifier output, diff, 로그는 stable prefix 앞에 두지 않는다.
+- Stable sections always come before ChangeSet, work item, run ID, and logs.
+- Keep section headers even when optional documents are missing, and record `<not found>`.
+- File traversal uses a sorted fixed order.
+- Do not place run ID, temporary paths, verifier output, diffs, or logs before the stable prefix.
 
-에이전트 호출 시 런타임은 step-local 파일과 run-root snapshot을 함께 남긴다.
+For agent calls, the runtime records both step-local files and run-root snapshots.
 
 ```text
 .harness/runs/<RUN-ID>/
@@ -295,7 +309,7 @@ OpenAI/Codex 호출 비용 최적화는 응답 캐시가 아니라 **prompt pref
     result.json
 ```
 
-`usage-<STEP-ID>.json`은 provider가 usage metadata를 제공하면 token 값을 저장한다.
-노출되지 않는 값, 예를 들어 `cached_prompt_tokens`, 는 값을 추정하지 않고 `null`로
-남긴다. 이 런타임 아티팩트는 source of truth가 아니라 재현, resume, audit, 디버깅을
-위한 실행 증거다.
+`usage-<STEP-ID>.json` stores token values when the provider returns usage metadata.
+For values that are not exposed, such as `cached_prompt_tokens`, leave them as `null`
+instead of estimating. These runtime artifacts are execution evidence for reproduction,
+resume, audit, and debugging; they are not the source of truth.

--- a/harness_codex/runtime/self_update.py
+++ b/harness_codex/runtime/self_update.py
@@ -144,6 +144,7 @@ def build_update_command(
         "bash",
         "-s",
         "--",
+        "--runtime",
         "--force",
         "--target",
         shlex.quote(str(repo_root)),

--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -6,27 +6,42 @@ HARNESS_REF="${HARNESS_CODEX_REF:-main}"
 TARGET_DIR="${HARNESS_CODEX_TARGET:-$PWD}"
 FORCE=0
 SKIP_VENV=0
+INSTALL_MODE="${HARNESS_CODEX_INSTALL_MODE:-}"
 
 usage() {
   cat <<'USAGE'
 Install harness-codex runtime files into the current project.
 
 Usage:
-  bash scripts/install-harness-codex.sh [--force] [--skip-venv] [--ref <git-ref>] [--target <dir>]
+  bash scripts/install-harness-codex.sh [--runtime|--skills-only] [--force] [--skip-venv] [--ref <git-ref>] [--target <dir>]
+
+Modes:
+  --runtime      Install harness runtime, bundled skills, launcher, tests, docs, and venv. Default for non-interactive runs.
+  --skills-only  Install only .codex/skills into the target repository.
 
 Environment:
   HARNESS_CODEX_REPO    GitHub repository URL. Default: https://github.com/omegafrog/harness-codex
   HARNESS_CODEX_REF     Branch, tag, or commit to download. Default: main
   HARNESS_CODEX_TARGET  Target project directory. Default: current directory
+  HARNESS_CODEX_INSTALL_MODE  runtime or skills-only
 
 Examples:
   curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash
-  curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --force
+  curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --runtime --force
+  curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh | bash -s -- --skills-only
 USAGE
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --runtime)
+      INSTALL_MODE="runtime"
+      shift
+      ;;
+    --skills-only)
+      INSTALL_MODE="skills-only"
+      shift
+      ;;
     --force)
       FORCE=1
       shift
@@ -55,6 +70,52 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+select_install_mode() {
+  if [[ -n "$INSTALL_MODE" ]]; then
+    case "$INSTALL_MODE" in
+      runtime|skills-only)
+        return
+        ;;
+      *)
+        echo "Invalid install mode: $INSTALL_MODE" >&2
+        echo "Use --runtime or --skills-only." >&2
+        exit 2
+        ;;
+    esac
+  fi
+
+  if [[ -r /dev/tty && -w /dev/tty ]]; then
+    local choice
+    while true; do
+      {
+        echo "Select harness-codex install mode:"
+        echo "  1) runtime      Install runtime, bundled skills, launcher, tests, docs, and venv"
+        echo "  2) skills-only  Install only .codex/skills"
+        printf "Choice [1/2]: "
+      } > /dev/tty
+      IFS= read -r choice < /dev/tty || choice=""
+      case "$choice" in
+        1|runtime|"")
+          INSTALL_MODE="runtime"
+          break
+          ;;
+        2|skills-only)
+          INSTALL_MODE="skills-only"
+          break
+          ;;
+        *)
+          echo "Enter 1 or 2." > /dev/tty
+          ;;
+      esac
+    done
+  else
+    INSTALL_MODE="runtime"
+    echo "No interactive terminal detected; defaulting to runtime install."
+  fi
+}
+
+select_install_mode
+
 need_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "Missing required command: $1" >&2
@@ -64,7 +125,9 @@ need_command() {
 
 need_command curl
 need_command tar
-need_command python3
+if [[ "$INSTALL_MODE" == "runtime" ]]; then
+  need_command python3
+fi
 
 mkdir -p "$TARGET_DIR"
 TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
@@ -131,8 +194,6 @@ if [[ -z "${SRC_DIR:-}" || ! -d "$SRC_DIR" ]]; then
   exit 1
 fi
 
-backup_preserved_paths
-
 copy_dir() {
   local src="$1"
   local dst="$2"
@@ -181,6 +242,9 @@ LAUNCHER
   chmod +x "$dst"
   echo "created: harness"
 }
+
+install_runtime_files() {
+backup_preserved_paths
 
 copy_dir "$SRC_DIR/harness_codex" "$TARGET_DIR/harness_codex"
 copy_dir "$SRC_DIR/.harness" "$TARGET_DIR/.harness"
@@ -256,7 +320,7 @@ echo "Running harness CLI smoke test"
 
 cat <<EOF
 
-harness-codex installed successfully.
+harness-codex runtime installed successfully.
 
 Next commands:
   cd "$TARGET_DIR"
@@ -264,3 +328,28 @@ Next commands:
   ./harness requirements-definition CHG-$(date +%Y%m%d)-001 --title "initial runtime setup" --idea "initial runtime setup" --plan
 
 EOF
+}
+
+install_skills_only() {
+copy_dir "$SRC_DIR/.codex/skills" "$TARGET_DIR/.codex/skills"
+
+cat <<EOF
+
+harness-codex skills installed successfully.
+
+Installed:
+  $TARGET_DIR/.codex/skills
+
+Runtime files were not installed. Run this installer again with --runtime to install the harness CLI.
+
+EOF
+}
+
+case "$INSTALL_MODE" in
+  runtime)
+    install_runtime_files
+    ;;
+  skills-only)
+    install_skills_only
+    ;;
+esac

--- a/tests/runtime/test_install_update_preservation.py
+++ b/tests/runtime/test_install_update_preservation.py
@@ -60,6 +60,25 @@ def test_installer_copies_shell_completion_sources():
     )
 
 
+def test_installer_exposes_runtime_and_skills_only_modes():
+    assert "--runtime" in SCRIPT
+    assert "--skills-only" in SCRIPT
+    assert 'HARNESS_CODEX_INSTALL_MODE  runtime or skills-only' in SCRIPT
+    assert 'copy_dir "$SRC_DIR/.codex/skills" "$TARGET_DIR/.codex/skills"' in SCRIPT
+
+
+def test_skills_only_mode_does_not_copy_runtime_files():
+    skills_only_start = SCRIPT.index("install_skills_only() {")
+    skills_only_end = SCRIPT.rindex('case "$INSTALL_MODE" in')
+    skills_only_body = SCRIPT[skills_only_start:skills_only_end]
+
+    assert 'copy_dir "$SRC_DIR/.codex/skills" "$TARGET_DIR/.codex/skills"' in skills_only_body
+    assert 'copy_dir "$SRC_DIR/harness_codex"' not in skills_only_body
+    assert 'copy_dir "$SRC_DIR/.harness"' not in skills_only_body
+    assert "create_launcher" not in skills_only_body
+    assert "python3 -m venv" not in skills_only_body
+
+
 def test_default_project_files_are_not_overwritten_by_force_update():
     function_start = SCRIPT.index("copy_file_if_missing() {")
     function_end = SCRIPT.index("create_launcher() {")

--- a/tests/runtime/test_self_update.py
+++ b/tests/runtime/test_self_update.py
@@ -11,7 +11,7 @@ def test_build_update_command_defaults_to_origin_main_download_ref(tmp_path: Pat
     command = build_update_command(tmp_path, repo="https://github.com/omegafrog/harness-codex")
 
     assert "curl -fsSL https://raw.githubusercontent.com/omegafrog/harness-codex/main/scripts/install-harness-codex.sh" in command
-    assert "bash -s -- --force" in command
+    assert "bash -s -- --runtime --force" in command
     assert f"--target {tmp_path}" in command
     assert "--ref main" in command
 
@@ -91,6 +91,7 @@ def test_run_self_update_executes_installer_command(tmp_path: Path) -> None:
     assert calls
     assert completion_calls == [tmp_path]
     command = calls[0][0][0]
+    assert "--runtime" in command
     assert "--force" in command
     assert f"--target {tmp_path}" in command
     assert "--ref main" in command


### PR DESCRIPTION
## 구현 의도

- 다른 리포지토리에서 harness-codex를 설치할 때 전체 런타임 설치와 스킬만 설치 중 선택할 수 있게 합니다.
- 런타임 CLI에만 있던 주요 명령을 스킬로도 호출할 수 있게 보강합니다.

## 구현 방식

- `scripts/install-harness-codex.sh`에 `--runtime`, `--skills-only`, `HARNESS_CODEX_INSTALL_MODE`를 추가하고, 대화형 터미널에서는 설치 모드를 묻도록 했습니다.
- 비대화형 설치와 `harness update`는 기존 동작을 유지하도록 `runtime` 모드를 기본값 또는 명시 플래그로 사용합니다.
- `skills-only` 모드는 `.codex/skills`만 복사하고 런처, venv, 런타임 패키지, 테스트 복사는 수행하지 않습니다.
- 런타임 명령 대응 스킬을 추가하고 기존 워크플로 스킬 설명에 런타임 명령 트리거를 보강했습니다.
- `docs/README.md`의 설치 안내를 새 모드 기준으로 갱신하고 문서를 영어로 정리했습니다.

## 검증 방법

- `bash -n scripts/install-harness-codex.sh`
- `./venv/bin/python3 -m pytest -q tests/runtime/test_install_update_preservation.py tests/runtime/test_self_update.py`
- 신규/수정 스킬 대상 `quick_validate.py` 실행

## 위험 및 롤백

- 설치 스크립트 변경으로 외부 리포지토리 bootstrap 경로에 영향이 있을 수 있습니다. 비대화형 기본값을 `runtime`으로 유지해 기존 curl 설치 경로의 호환성을 보존했습니다.
- 문제가 있으면 이 커밋을 되돌리면 기존 단일 런타임 설치 동작으로 복구됩니다.
