### PR TITLE
[codex] 기술 결정 blocker를 대화형으로 처리

### DIFF
--- a/.codex/agents/references/technical_decisions.md
+++ b/.codex/agents/references/technical_decisions.md
@@ -28,11 +28,10 @@ Slice-first rule:
 - If outside documents conflict with the selected slice, keep the slice authoritative and record the conflict.
 
 Decision scope:
-- backend transport and API shape
+- backend transport mechanism and adapter technology
 - persistence technology and repository adapter strategy
 - build/bootstrap convention
 - runtime/deployment constraint level
-- backend save failure to user-visible response mapping
 - transaction boundary and durable save rule
 - retry/idempotency when it affects the selected use case
 - observability and test strategy required by implementation planning
@@ -41,6 +40,8 @@ Stop conditions:
 - If any required input is missing, stop and explain the missing input.
 - If the selected use case is ambiguous, stop and ask for one UC ID.
 - If a decision changes approved requirements, use case behavior, event storming, DDD boundaries, or architecture constraints, stop and report the upstream stage to revisit.
+- Report a missing upstream policy only when the approved requirements, use-case flow, event-storming, DDD evidence, or E2E goal explicitly requires that behavior and leaves it contradictory or undefined. Cite the exact evidence.
+- Do not invent abandoned-draft, orphan-asset, retention, deletion, expiry, cleanup, or other lifecycle scenarios outside the approved slice. Their absence is not a blocker or pending decision. Exclude them or choose an implementation mechanism that avoids creating that state.
 - If a decision cannot be approved from explicit user input or already approved documents, write the decision as pending and mark the document not approved.
 
 Approval rule:

--- a/.codex/skills/harness-technical-decisions/references/detailed-instructions.md
+++ b/.codex/skills/harness-technical-decisions/references/detailed-instructions.md
@@ -69,7 +69,11 @@ selected use-case slice와 DDD 설계를 입력으로 삼아, 구현자가 바�
 - 요구사항/유스케이스/DDD 경계 자체의 재결정
 
 위 항목이 빠져 구현이 막히면 technical-decisions 질문으로 묻지 말고 upstream requirements/use-case
-blocker로 보고한다. 기술 결정은 승인된 제품/비즈니스 정책을 전제로 구현 mechanism만 결정한다.
+blocker로 보고한다. 단, 승인된 requirements, use case, event storming, DDD evidence, E2E goal이 해당
+동작을 명시적으로 요구하는 경우에만 "빠진 정책"으로 판단한다. 승인된 slice에 없는 abandoned draft,
+orphan asset, retention, deletion, expiry, cleanup lifecycle을 가정해서 blocker나 pending decision을
+만들면 안 된다. 범위 밖 가상 상태는 제외하거나 그 상태를 만들지 않는 구현 mechanism을 선택한다.
+기술 결정은 승인된 제품/비즈니스 정책을 전제로 구현 mechanism만 결정한다.
 
 요구사항 단계에서 이미 확정했어야 하는 큰 기반 기술이 빠져 있으면 pending으로 남기고
 다음 단계 gate를 막는다. 단, 이 스킬은 요구사항/유스케이스 자체를 다시 작성하지 않는다.
@@ -119,4 +123,6 @@ blocker로 보고한다. 기술 결정은 승인된 제품/비즈니스 정책�
 - `Pending Decisions`에 기술 mechanism 선택이 남아 있으면 planner로 넘어가지 않는다.
 - `Pending Decisions`에 draft expiry, retention, cleanup, source metadata policy, user-visible behavior처럼
   upstream product/business policy가 남아 있으면 technical-decisions 질문으로 묻지 않고 blocker로 보고한다.
+- 위 blocker는 승인된 slice가 해당 동작을 명시적으로 요구한다는 정확한 evidence를 포함해야 한다.
+  승인된 slice에 없는 abandoned-draft/orphan-asset lifecycle은 blocker 또는 pending으로 추가하지 않는다.
 - `Approval Status`가 `approved`가 아니면 planner를 실행하지 않는다.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -2090,8 +2090,13 @@ def _interactive_stage_boundary(stage_id: str) -> str:
             "- Do not ask product/business policy questions such as whether a draft must exist, how long user data "
             "is retained, when abandoned/unsaved data is deleted, what source metadata is required, or what user-visible "
             "behavior should happen. Those belong upstream in requirements/use-case definition.\n"
-            "- If a missing business policy blocks a technical choice, return `blocked` with an upstream-policy blocker "
-            "instead of asking the user inside technical-decisions.\n"
+            "- Treat a business policy as missing only when approved requirements, use-case flow, event-storming, DDD "
+            "evidence, or E2E goals explicitly require that behavior and leave its policy contradictory or undefined.\n"
+            "- Do not invent abandoned-draft, orphan-asset, retention, deletion, expiry, cleanup, or other hypothetical "
+            "lifecycle scenarios outside the approved slice. Their absence is not an upstream blocker. Exclude them "
+            "from this slice or choose a technical mechanism that avoids creating the hypothetical state.\n"
+            "- If an explicitly required business policy is genuinely missing and blocks every valid implementation, "
+            "return `blocked` with the exact upstream evidence and stage instead of asking the user here.\n"
             "- Do not reopen requirements, use-case behavior, event-storming semantics, or DDD model boundaries."
         ),
     }
@@ -2261,8 +2266,13 @@ def _interactive_stage_question_policy_prompt(stage_id: str) -> str:
             "- Forbidden questions: product/business policy, user-visible behavior, whether a draft/asset/source must "
             "exist, how long unsaved or abandoned user data is retained, expiry duration, cleanup timing, source "
             "metadata rules, actor goals, success/failure policy, or DDD model boundaries.\n"
-            "- If a missing upstream product/business policy blocks implementation, return `blocked` and name the "
-            "upstream stage instead of surfacing it as a technical-decisions question.\n"
+            "- Missing-policy blockers require explicit evidence that the approved slice needs that behavior. Do not "
+            "block on invented abandoned-draft, orphan-asset, retention, deletion, expiry, or cleanup scenarios that "
+            "are absent from requirements, use-case flow, event-storming, DDD evidence, and E2E goals.\n"
+            "- For hypothetical lifecycle states outside the approved slice, omit the scenario or choose a mechanism "
+            "that does not create it. Do not add it to Pending Decisions or Planner Requirements.\n"
+            "- If an explicitly required upstream product/business policy blocks every valid implementation, return "
+            "`blocked`, quote the exact upstream evidence, and name the upstream stage.\n"
             "- Do not silently leave `Approval Status` as `pending`; ask focused questions until the document can "
             "be approved, unless upstream inputs are missing, contradictory, or outside the technical-decisions boundary."
         )
@@ -2283,7 +2293,7 @@ def _interactive_stage_json_examples(stage_id: str) -> str:
             [
                 '{"status":"needs_input","questions":[{"question":"Which cipher should encrypt stored image bytes at rest: AES-256-GCM or ChaCha20-Poly1305?","recommended":"Use AES-256-GCM because it is widely supported by the Java runtime and existing security tooling."}],"changed_files":["docs/use-cases/UC-001/technical-decisions.md"],"blocker":""}',
                 '{"status":"complete","questions":[],"changed_files":["docs/use-cases/UC-001/technical-decisions.md"],"blocker":""}',
-                '{"status":"blocked","questions":[],"changed_files":[],"blocker":"Requirements must decide draft retention/expiry policy before technical storage mechanics can be finalized."}',
+                '{"status":"blocked","questions":[],"changed_files":[],"blocker":"Use-case step 8 explicitly requires export delivery, but requirements and E2E goals contradict whether delivery is synchronous or asynchronous."}',
             ]
         )
     if stage_id == "ubiquitous-language-definition":

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1593,6 +1593,58 @@ def test_technical_decisions_business_policy_question_is_blocked_not_asked(
     assert "Pending questions:" not in output
 
 
+def test_technical_decisions_prompt_rejects_hypothetical_lifecycle_blockers(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    write_changeset(tmp_path)
+    prompts: list[str] = []
+    monkeypatch.setenv("HARNESS_NONINTERACTIVE", "1")
+
+    def fake_exec(_root: Path, _step_dir: Path, prompt: str, _label: str) -> str:
+        prompts.append(prompt)
+        return json.dumps(
+            {
+                "status": "complete",
+                "questions": [],
+                "changed_files": ["docs/use-cases/UC-001/technical-decisions.md"],
+                "blocker": "",
+            }
+        )
+
+    monkeypatch.setattr(cli, "_exec_stage_grill_me_prompt", fake_exec)
+    monkeypatch.setattr(cli, "_exec_stage_review_prompt", lambda *_args: json.dumps(
+        {
+            "status": "complete",
+            "questions": [],
+            "review_file": ".harness/review.md",
+            "findings": [],
+            "blocker": "",
+        }
+    ))
+    monkeypatch.setattr(cli, "verify_procedure_stage", lambda *_, **__: (True, []))
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "technical-decisions",
+            "CHG-001",
+            "--uc",
+            "UC-001",
+            "--force",
+        ]
+    )
+
+    assert exit_code == 0
+    assert prompts
+    assert "Do not invent abandoned-draft, orphan-asset" in prompts[0]
+    assert "Their absence is not an upstream blocker" in prompts[0]
+    assert "exact upstream evidence" in prompts[0]
+    assert "Interactive status: complete" in capsys.readouterr().out
+
+
 def test_technical_decisions_pending_business_policy_is_not_converted_to_question(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## 구현 의도

Technical Decisions 에이전트가 승인된 slice에 없는 abandoned draft, orphan asset, retention/deletion lifecycle을 가정하고 upstream requirements/use-case blocker를 생성하는 문제를 방지합니다.

## 구현 접근

- upstream policy blocker는 requirements, use case, event storming, DDD evidence, E2E goal이 해당 동작을 명시적으로 요구할 때만 허용합니다.
- 승인된 slice에 없는 가상 lifecycle은 blocker나 pending decision으로 추가하지 않습니다.
- 범위 밖 상태는 제외하거나 해당 상태를 만들지 않는 구현 mechanism을 선택하도록 prompt를 강화합니다.
- 기존 retention blocker JSON 예시를 실제 upstream contradiction 예시로 교체합니다.
- technical-decisions agent reference에서 user-visible API behavior 결정을 제거합니다.
- 회귀 테스트로 prompt에 explicit evidence 요구와 hypothetical lifecycle 금지가 포함되는지 검증합니다.
- Technical Decisions stage agent 또는 content review가 `blocked`를 반환하면 runtime이 workflow-resolution 질문을 생성해 `needs_input`으로 유지합니다. DDD blocker에는 DDD 재실행/승인을 추천합니다.

## 검증 방법

- `./venv/bin/python3 -m pytest -q`
- 결과: `539 passed`
- `python3 -m py_compile harness_codex/cli.py`
- `git diff --check`

## 위험 및 롤백

- 위험: 실제로 필요한 retention 정책 누락도 무시될 수 있습니다.
- 완화: 승인된 slice가 lifecycle을 명시적으로 요구하는 경우에는 exact evidence를 포함한 upstream blocker를 계속 허용합니다.
- 롤백: 이 PR을 revert하면 기존 missing-policy 판단 규칙과 retention blocker 예시로 복원됩니다.

