### PR TITLE
계획 차단 시 계획 단계 재시작

### DIFF
--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -3406,6 +3406,8 @@ def _run_failure_kind(failure_kind: FailureKind | None) -> RunFailureKind | None
         return RunFailureKind.DOCUMENT_DELTA_CONFLICT
     if failure_kind == FailureKind.SCOPE_CONFLICT:
         return RunFailureKind.SCOPE_CONFLICT
+    if failure_kind == FailureKind.PLAN_REVIEW_REJECTED:
+        return RunFailureKind.PLAN_REVIEW_REJECTED
     if failure_kind == FailureKind.VERIFICATION_GOAL_UNCLEAR:
         return RunFailureKind.VERIFICATION_GOAL_UNCLEAR
     if failure_kind == FailureKind.UNKNOWN:

--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -84,6 +84,7 @@ class RunnerEngine:
         previous_failure_signature: tuple[str, str, str] | None = None
         next_index = 0
         skipped_runtime_steps: set[str] = set()
+        active_context = context
         step_index = {
             step.id: index for index, step in enumerate(execution_plan.steps)
         }
@@ -98,7 +99,7 @@ class RunnerEngine:
             if self._is_runtime_remediation_step(step):
                 continue
 
-            decision = self._evaluate_command_policy(step, context)
+            decision = self._evaluate_command_policy(step, active_context)
             if decision is not None and not decision.allowed:
                 result = StepResult(
                     step_id=step.id,
@@ -112,18 +113,18 @@ class RunnerEngine:
                     run_id=context.run_id,
                     status=RunStatus.BLOCKED,
                     step_results=tuple(results),
-                    mode=context.mode,
+                    mode=active_context.mode,
                     failed_step_id=step.id,
                     blocker=decision.reason,
                     retry_count=retry_count,
                     metadata=self._result_metadata(
                         execution_plan,
-                        context,
+                        active_context,
                         tuple(results),
                     ),
                 )
 
-            result = self._step_runner.run(step, context)
+            result = self._step_runner.run(step, active_context)
             if decision is not None:
                 result = replace(
                     result,
@@ -172,7 +173,7 @@ class RunnerEngine:
                     retry_count += 1
                     decision_result = self._run_runtime_step(
                         remediation.decision_step,
-                        context,
+                        active_context,
                         results,
                         retry_count=retry_count,
                         failed_step=step,
@@ -181,14 +182,14 @@ class RunnerEngine:
                     if decision_result.status != StepStatus.SUCCEEDED:
                         return self._blocked_result(
                             execution_plan,
-                            context,
+                            active_context,
                             tuple(results),
                             decision_result,
                             retry_count,
                         )
                     remediation_result = self._run_runtime_step(
                         remediation.remediation_step,
-                        context,
+                        active_context,
                         results,
                         retry_count=retry_count,
                         failed_step=step,
@@ -197,7 +198,7 @@ class RunnerEngine:
                     if remediation_result.status != StepStatus.SUCCEEDED:
                         return self._blocked_result(
                             execution_plan,
-                            context,
+                            active_context,
                             tuple(results),
                             remediation_result,
                             retry_count,
@@ -210,7 +211,7 @@ class RunnerEngine:
                 if decision_step is not None:
                     decision_result = self._run_runtime_step(
                         decision_step,
-                        context,
+                        active_context,
                         results,
                         retry_count=retry_count,
                         failed_step=step,
@@ -219,7 +220,7 @@ class RunnerEngine:
                     if decision_result.status != StepStatus.SUCCEEDED:
                         return self._blocked_result(
                             execution_plan,
-                            context,
+                            active_context,
                             tuple(results),
                             decision_result,
                             retry_count,
@@ -235,7 +236,7 @@ class RunnerEngine:
                         retry_count=retry_count,
                         metadata=self._result_metadata(
                             execution_plan,
-                            context,
+                            active_context,
                             tuple(results),
                         ),
                     )
@@ -251,24 +252,50 @@ class RunnerEngine:
                     retry_count=retry_count,
                     metadata=self._result_metadata(
                         execution_plan,
-                        context,
+                        active_context,
                         tuple(results),
                     ),
                 )
 
             if result.status == StepStatus.BLOCKED:
+                if result.failure_kind == FailureKind.SCOPE_CONFLICT:
+                    loop_target = self._scope_conflict_loop_target(
+                        execution_plan,
+                        step_index,
+                    )
+                    signature = (
+                        step.id,
+                        result.failure_kind.value,
+                        result.error or "",
+                    )
+                    if (
+                        loop_target is not None
+                        and previous_failure_signature != signature
+                        and retry_count < max_retries
+                    ):
+                        previous_failure_signature = signature
+                        retry_count += 1
+                        active_context = self._runtime_failure_context(
+                            active_context,
+                            retry_count=retry_count,
+                            failed_step=step,
+                            failed_result=result,
+                        )
+                        next_index = loop_target
+                        continue
+
                 return RunResult(
                     run_id=context.run_id,
                     status=RunStatus.BLOCKED,
                     step_results=tuple(results),
-                    mode=context.mode,
+                    mode=active_context.mode,
                     failed_step_id=step.id,
                     failure_kind=result.failure_kind,
                     blocker=result.error,
                     retry_count=retry_count,
                     metadata=self._result_metadata(
                         execution_plan,
-                        context,
+                        active_context,
                         tuple(results),
                     ),
                 )
@@ -279,7 +306,7 @@ class RunnerEngine:
             step_results=tuple(results),
             mode=context.mode,
             retry_count=retry_count,
-            metadata=self._result_metadata(execution_plan, context, tuple(results)),
+            metadata=self._result_metadata(execution_plan, active_context, tuple(results)),
         )
 
     def _dry_run_result(
@@ -417,6 +444,29 @@ class RunnerEngine:
         results.append(result)
         return result
 
+    def _runtime_failure_context(
+        self,
+        context: RunContext,
+        *,
+        retry_count: int,
+        failed_step: Step,
+        failed_result: StepResult,
+    ) -> RunContext:
+        return replace(
+            context,
+            metadata={
+                **dict(context.metadata),
+                "runtime_retry_count": retry_count,
+                "runtime_failed_step_id": failed_step.id,
+                "runtime_failure_kind": (
+                    failed_result.failure_kind.value
+                    if failed_result.failure_kind is not None
+                    else ""
+                ),
+                "runtime_failure_error": failed_result.error or "",
+            },
+        )
+
     def _blocked_result(
         self,
         execution_plan: ExecutionPlan,
@@ -505,6 +555,18 @@ class RunnerEngine:
 
     def _is_runtime_remediation_step(self, step: Step) -> bool:
         return bool(step.metadata.get("loop_target"))
+
+    def _scope_conflict_loop_target(
+        self,
+        execution_plan: ExecutionPlan,
+        step_index: dict[str, int],
+    ) -> int | None:
+        if "plan-work-item" in step_index:
+            return step_index["plan-work-item"]
+        for index, step in enumerate(execution_plan.steps):
+            if step.agent_id == "implementation_planner":
+                return index
+        return None
 
     def _max_remediation_retries(
         self,

--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -258,8 +258,11 @@ class RunnerEngine:
                 )
 
             if result.status == StepStatus.BLOCKED:
-                if result.failure_kind == FailureKind.SCOPE_CONFLICT:
-                    loop_target = self._scope_conflict_loop_target(
+                if result.failure_kind in {
+                    FailureKind.SCOPE_CONFLICT,
+                    FailureKind.PLAN_REVIEW_REJECTED,
+                }:
+                    loop_target = self._plan_restart_loop_target(
                         execution_plan,
                         step_index,
                     )
@@ -556,7 +559,7 @@ class RunnerEngine:
     def _is_runtime_remediation_step(self, step: Step) -> bool:
         return bool(step.metadata.get("loop_target"))
 
-    def _scope_conflict_loop_target(
+    def _plan_restart_loop_target(
         self,
         execution_plan: ExecutionPlan,
         step_index: dict[str, int],

--- a/harness_codex/runtime/models.py
+++ b/harness_codex/runtime/models.py
@@ -76,6 +76,7 @@ class FailureKind(str, Enum):
     UNCLEAR_E2E_GOAL = "unclear_e2e_goal"
     DOCUMENT_DELTA_CONFLICT = "document_delta_conflict"
     SCOPE_CONFLICT = "scope_conflict"
+    PLAN_REVIEW_REJECTED = "plan_review_rejected"
     VERIFICATION_GOAL_UNCLEAR = "verification_goal_unclear"
     UNKNOWN = "unknown"
 

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -541,7 +541,7 @@ class BasicStepRunner:
             exit_code=result.exit_code,
             output_path=_relative_to_repo(result_path, context),
             error=result.error,
-            failure_kind=_agent_failure_kind(result.status),
+            failure_kind=_agent_failure_kind(result.status, result.metadata),
             metadata=result.metadata,
         )
 
@@ -1864,9 +1864,14 @@ def _jsonable(value: Any) -> Any:
     return value
 
 
-def _agent_failure_kind(status: StepStatus) -> FailureKind | None:
+def _agent_failure_kind(
+    status: StepStatus,
+    metadata: Mapping[str, Any] | None = None,
+) -> FailureKind | None:
     if status == StepStatus.FAILED:
         return FailureKind.IMPLEMENTATION
     if status == StepStatus.BLOCKED:
+        if metadata and metadata.get("scope_diff_blocked_files"):
+            return FailureKind.SCOPE_CONFLICT
         return FailureKind.ENVIRONMENT_BLOCKER
     return None

--- a/harness_codex/runtime/runner.py
+++ b/harness_codex/runtime/runner.py
@@ -1871,6 +1871,8 @@ def _agent_failure_kind(
     if status == StepStatus.FAILED:
         return FailureKind.IMPLEMENTATION
     if status == StepStatus.BLOCKED:
+        if metadata and metadata.get("review_gate_error"):
+            return FailureKind.PLAN_REVIEW_REJECTED
         if metadata and metadata.get("scope_diff_blocked_files"):
             return FailureKind.SCOPE_CONFLICT
         return FailureKind.ENVIRONMENT_BLOCKER

--- a/harness_codex/runtime/state.py
+++ b/harness_codex/runtime/state.py
@@ -67,6 +67,7 @@ class RunFailureKind(str, Enum):
     UPSTREAM_DESIGN_CONFLICT = "UPSTREAM_DESIGN_CONFLICT"
     ENVIRONMENT_BLOCKER = "ENVIRONMENT_BLOCKER"
     SCOPE_CONFLICT = "SCOPE_CONFLICT"
+    PLAN_REVIEW_REJECTED = "PLAN_REVIEW_REJECTED"
     VERIFICATION_GOAL_UNCLEAR = "VERIFICATION_GOAL_UNCLEAR"
 
 
@@ -358,6 +359,16 @@ def decide_resume_target(state: RunState) -> ResumeTarget:
             work_item_id=state.current_work_item_id or state.current_use_case_id,
             work_item_type=_current_work_item_type(state),
             reason="environment blocker must be resolved before resume",
+        )
+
+    if state.failure_kind == RunFailureKind.PLAN_REVIEW_REJECTED:
+        return ResumeTarget(
+            disposition=ResumeDisposition.RETRY_REMEDIATION,
+            uc_id=state.current_use_case_id,
+            work_item_id=state.current_work_item_id or state.current_use_case_id,
+            work_item_type=_current_work_item_type(state),
+            step_id=UseCaseStep.PLAN,
+            reason="plan review rejection can resume from planning",
         )
 
     next_work_item = _first_incomplete_work_item(state)

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -766,6 +766,7 @@ def test_basic_step_runner_blocks_rejected_review_gate(tmp_path: Path) -> None:
     result = runner.run(step, context(tmp_path))
 
     assert result.status == StepStatus.BLOCKED
+    assert result.failure_kind == FailureKind.PLAN_REVIEW_REJECTED
     assert result.error == "review gate status is `rejected`, expected `approved`"
     assert result.metadata["review_gate_status"] == "blocked"
 

--- a/tests/runtime/test_agent_runner.py
+++ b/tests/runtime/test_agent_runner.py
@@ -506,6 +506,7 @@ def test_implementation_executor_scope_diff_blocks_unexpected_file(
     result = runner.run(executor_step(), executor_context(tmp_path))
 
     assert result.status == StepStatus.BLOCKED
+    assert result.failure_kind == FailureKind.SCOPE_CONFLICT
     assert "build.gradle" in (result.error or "")
     assert "PaymentService.java" in (result.error or "")
     result_json = json.loads((tmp_path / result.output_path).read_text(encoding="utf-8"))

--- a/tests/runtime/test_engine.py
+++ b/tests/runtime/test_engine.py
@@ -361,6 +361,68 @@ def test_engine_restarts_scope_conflict_from_plan_work_item() -> None:
     assert "scope diff blocked" in retry_context.metadata["runtime_failure_error"]
 
 
+def test_engine_restarts_rejected_plan_review_from_plan_work_item() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="plan-work-item", kind=StepKind.AGENT, name="Plan"),
+            Step(
+                id="secure-work-item-plan",
+                kind=StepKind.AGENT,
+                name="Secure",
+                needs=("plan-work-item",),
+            ),
+            Step(
+                id="review-work-item-plan",
+                kind=StepKind.AGENT,
+                name="Review",
+                needs=("secure-work-item-plan",),
+            ),
+            Step(
+                id="execute-work-item",
+                kind=StepKind.AGENT,
+                name="Execute",
+                needs=("review-work-item-plan",),
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner(
+        results_by_step_id={
+            "review-work-item-plan": [
+                StepResult(
+                    step_id="review-work-item-plan",
+                    status=StepStatus.BLOCKED,
+                    error="review gate status is `rejected`, expected `approved`",
+                    failure_kind=FailureKind.PLAN_REVIEW_REJECTED,
+                ),
+                StepResult(
+                    step_id="review-work-item-plan",
+                    status=StepStatus.SUCCEEDED,
+                ),
+            ],
+        }
+    )
+
+    result = RunnerEngine(fake_runner).run(workflow, context())
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.retry_count == 1
+    assert fake_runner.executed_step_ids == [
+        "plan-work-item",
+        "secure-work-item-plan",
+        "review-work-item-plan",
+        "plan-work-item",
+        "secure-work-item-plan",
+        "review-work-item-plan",
+        "execute-work-item",
+    ]
+    retry_context = fake_runner.contexts_by_step_id["plan-work-item"][1]
+    assert retry_context.metadata["runtime_failed_step_id"] == "review-work-item-plan"
+    assert retry_context.metadata["runtime_failure_kind"] == "plan_review_rejected"
+    assert "review gate status" in retry_context.metadata["runtime_failure_error"]
+
+
 def test_engine_blocks_non_implementation_failure_without_remediation() -> None:
     workflow = Workflow(
         name="example",

--- a/tests/runtime/test_engine.py
+++ b/tests/runtime/test_engine.py
@@ -24,9 +24,11 @@ class FakeStepRunner:
     ) -> None:
         self.results_by_step_id = results_by_step_id or {}
         self.executed_step_ids: list[str] = []
+        self.contexts_by_step_id: dict[str, list[RunContext]] = {}
 
     def run(self, step: Step, context: RunContext) -> StepResult:
         self.executed_step_ids.append(step.id)
+        self.contexts_by_step_id.setdefault(step.id, []).append(context)
 
         if step.id in self.results_by_step_id:
             result = self.results_by_step_id[step.id]
@@ -290,6 +292,73 @@ def test_engine_loops_implementation_failure_through_remediation() -> None:
         "classify",
         "complete",
     ]
+
+
+def test_engine_restarts_scope_conflict_from_plan_work_item() -> None:
+    workflow = Workflow(
+        name="example",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="plan-work-item", kind=StepKind.AGENT, name="Plan"),
+            Step(
+                id="secure-work-item-plan",
+                kind=StepKind.AGENT,
+                name="Secure",
+                needs=("plan-work-item",),
+            ),
+            Step(
+                id="review-work-item-plan",
+                kind=StepKind.AGENT,
+                name="Review",
+                needs=("secure-work-item-plan",),
+            ),
+            Step(
+                id="execute-work-item",
+                kind=StepKind.AGENT,
+                name="Execute",
+                needs=("review-work-item-plan",),
+            ),
+            Step(
+                id="verify-work-item",
+                kind=StepKind.VALIDATOR,
+                name="Verify",
+                needs=("execute-work-item",),
+            ),
+        ),
+    )
+    fake_runner = FakeStepRunner(
+        results_by_step_id={
+            "execute-work-item": [
+                StepResult(
+                    step_id="execute-work-item",
+                    status=StepStatus.BLOCKED,
+                    error="scope diff blocked unexpected files: src/app.py",
+                    failure_kind=FailureKind.SCOPE_CONFLICT,
+                ),
+                StepResult(step_id="execute-work-item", status=StepStatus.SUCCEEDED),
+            ],
+        }
+    )
+
+    result = RunnerEngine(fake_runner).run(workflow, context())
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.retry_count == 1
+    assert fake_runner.executed_step_ids == [
+        "plan-work-item",
+        "secure-work-item-plan",
+        "review-work-item-plan",
+        "execute-work-item",
+        "plan-work-item",
+        "secure-work-item-plan",
+        "review-work-item-plan",
+        "execute-work-item",
+        "verify-work-item",
+    ]
+    retry_context = fake_runner.contexts_by_step_id["plan-work-item"][1]
+    assert retry_context.metadata["runtime_failed_step_id"] == "execute-work-item"
+    assert retry_context.metadata["runtime_failure_kind"] == "scope_conflict"
+    assert "scope diff blocked" in retry_context.metadata["runtime_failure_error"]
 
 
 def test_engine_blocks_non_implementation_failure_without_remediation() -> None:

--- a/tests/runtime/test_run_state_resume.py
+++ b/tests/runtime/test_run_state_resume.py
@@ -129,6 +129,25 @@ def test_non_implementation_failures_wait_for_upstream_resolution() -> None:
         assert decide_resume_target(state).disposition == expected
 
 
+def test_plan_review_rejection_resumes_from_planning() -> None:
+    state = RunState(
+        run_id="run-001",
+        change_set_id="CHG-001",
+        workflow_name="workflow",
+        mode=RunMode.APPLY,
+        affected_use_cases=("UC-001",),
+        current_use_case_id="UC-001",
+        failure_kind=RunFailureKind.PLAN_REVIEW_REJECTED,
+        status=RunStatus.BLOCKED,
+    )
+
+    target = decide_resume_target(state)
+
+    assert target.disposition == ResumeDisposition.RETRY_REMEDIATION
+    assert target.uc_id == "UC-001"
+    assert target.step_id == UseCaseStep.PLAN
+
+
 def test_completed_run_has_no_resume_target() -> None:
     state = RunState(
         run_id="run-001",


### PR DESCRIPTION
## 구현 의도

구현 실행 중 계획으로 되돌려야 하는 차단이 발생하면, 차단 결과를 플래너 입력으로 전달하고 `plan-work-item`부터 다시 실행되도록 처리합니다. 게이트를 완화하거나 차단을 통과 처리하지 않고, 실제 차단 사유를 다음 계획 산출물이 반영하게 합니다.

## 구현 접근

- `implementation_executor`의 scope-diff 차단을 `scope_conflict` 실패 종류로 분류했습니다.
- `review-work-item-plan`의 거절 게이트를 `plan_review_rejected` 실패 종류로 분류했습니다.
- 실행 엔진이 `scope_conflict` 또는 `plan_review_rejected` 차단을 만나면 `runtime_failed_step_id`, `runtime_failure_kind`, `runtime_failure_error`를 포함한 컨텍스트로 `plan-work-item`부터 재시작하게 했습니다.
- 동일한 차단이 반복되거나 재시도 한도를 넘으면 기존처럼 blocked 상태로 멈춥니다.
- 일반 구현 실패의 기존 remediation 루프는 유지했습니다.

## 검증 방법

- 통과: `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime/test_engine.py tests/runtime/test_agent_runner.py tests/runtime/test_run_state_resume.py tests/test_cli_commands.py tests/runtime/test_contract_dashboard_projection.py`
- 통과: `git diff --check`
- 참고: 이전 전체 `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime` 실행은 기존/별도 실패로 보이는 `test_ddd_stage_and_agent_use_sliced_event_storming_first`의 `Impact Assessment` 문자열 기대에서 1건 실패했습니다. 이번 변경 파일과 직접 관련된 runner/engine/resume 테스트는 통과했습니다.

## 위험 및 롤백

- 위험: 플래너가 차단 정보를 반영하지 못하면 동일 차단이 반복될 수 있어 재시도 한도를 적용했습니다.
- 위험: 리뷰 거절 사유가 계획 입력에 포함되므로, 리뷰 산출물의 차단 설명 품질이 다음 계획 품질에 직접 영향을 줍니다.
- 롤백: 이 PR의 커밋들을 되돌리면 해당 차단 시 기존처럼 즉시 blocked로 종료됩니다.

## 스크린샷

UI 변경이 없어 해당 없음.
