### PR TITLE
workflow 경계 책임 정리

### DIFF
--- a/.codex/agents/references/ddd_architect.md
+++ b/.codex/agents/references/ddd_architect.md
@@ -31,16 +31,18 @@ Stop before writing if:
 - active ChangeSet or affected UC is ambiguous.
 - required slice input is missing.
 - unresolved business policy affects success/failure, lifecycle, state transition, validation, permission, or user-visible behavior.
-- unresolved foundational technical choice changes domain model, aggregate boundary, BC boundary, orchestration, storage family, external collaboration port, messaging, consistency, or performance target.
+- approved use-case or event-storming evidence is missing or contradictory enough to prevent domain model, aggregate boundary, bounded-context boundary, application service, or domain service derivation.
 
 Question boundary:
 - Ask the user only when missing or contradictory slice evidence prevents a DDD structural decision.
 - Do not ask the user to choose representation details already implied by UC, event-storming, or E2E evidence; derive the model and cite that evidence.
 - When slice evidence fully implies one model shape, choose that model shape without presenting alternatives as a question.
 - Do not ask implementation strategy questions such as storage schema, UI layout, adapter shape, retry/cache/transaction details, or serialization mechanics; leave those for technical-decisions.
+- Do not block on technical stack choices such as storage family, messaging technology, external adapter mechanism, deployment/runtime level, or performance target unless approved domain evidence makes domain shape impossible without that decision.
 
 Do not block on post-DDD implementation choices:
 - polling vs push, retry/backoff, circuit breaker, outbox/inbox implementation, transaction propagation details, cache TTL, logging/audit fields, adapter library details.
+- storage family, messaging technology, external collaboration mechanism, runtime/deployment level, and performance target when these are implementation mechanisms rather than domain-shape evidence.
 - Record those as later technical-decision candidates when relevant.
 
 Execution rule:

--- a/.codex/agents/references/harness_usecases.md
+++ b/.codex/agents/references/harness_usecases.md
@@ -33,12 +33,12 @@ Ownership:
 Readiness:
 - Read context.md before writing use cases.
 - Read docs/design/요구사항.md after context.md.
-- If context.md is missing or lacks a Ubiquitous Language section, stop and ask the user to run $harness-requirements first.
+- If context.md is missing or lacks a Ubiquitous Language section, stop and ask the user to run $harness-ubiquitous-language first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop because use cases would encode unconfirmed behavior.
 - If Blocking Open Language Questions block actor, goal, command, input, output, result, policy, or scope-boundary naming, stop because use cases would encode unconfirmed language.
 - Write or update the current use-case draft before asking questions.
-- Ask up to three focused Grill-Me questions when blocking ambiguity must be resolved before use-case documents can be correct.
+- Ask up to three focused Grill-Me questions only when confirmed requirements contain use-case-flow ambiguity. Route missing language/context to $harness-ubiquitous-language.
 - Include `Recommended answer:` with every blocking question.
 - When runtime metadata includes `target_uc` or `uc_id` for `use-case-definition`, keep `docs/design/유스케이스.md` coherent but write or update only that matching `docs/use-cases/<UC-ID>/use-case.md` and `docs/use-cases/<UC-ID>/e2e-goal.md` slice. Preserve other use-case slice directories.
 - Foundational Technical Decisions may remain unresolved if actor goals, business policies, and language are clear.
@@ -62,7 +62,8 @@ Use case rules:
 - Commands must be written in imperative form.
 - Events must be written in past tense.
 - Policies must be written as conditions or decision criteria.
-- Every detailed use case must include Actor, Supporting Actor, Goal, Preconditions, Main Flow, Failure Flow, Result, Non-Functional Requirements.
+- Every detailed use case must include Actor, Supporting Actor, Goal, Preconditions, Main Flow, Failure Flow, Result, and Observable Constraints From Requirements.
+- Use-case constraints must be observable in the actor flow and already approved by requirements. Do not invent broad scalability, concurrency, audit, security, availability, or implementation mechanisms.
 - If a section has no content yet, write None or Needs confirmation.
 - Do not mark use cases complete unless all use case, language, and event-storming-readiness rules above are satisfied.
 - Do not write requirements.

--- a/.codex/agents/references/oracle.md
+++ b/.codex/agents/references/oracle.md
@@ -36,7 +36,9 @@ Stop conditions:
 - Do not continue by inventing use cases from memory when the use-case slice is missing.
 - Before writing event storming, scan the active ChangeSet and affected UC slice for unresolved business policy decisions.
 - Business policy decisions include success/failure outcomes, lifecycle states, domain validation rules, reward/loss rules, pricing/sales rules, inventory/slot limits, market/competition rules, permission rules, and any user-visible behavior that changes commands/events/policies.
-- If any unresolved business policy decision exists for the affected UC, write or update the current event-storming draft with `Needs confirmation`, explain why the affected UC is blocked, and ask up to three concise Grill-Me questions to resolve only that UC's policies.
+- If any unresolved business policy decision exists for the affected UC, return `blocked`, name the upstream requirements or use-case stage that must resolve it, and do not ask Grill-Me questions from event storming.
+- Event storming may ask only modeling ambiguity questions about command/event/policy/system/external-system/invariant wording or mapping when the affected UC already contains the business policy.
+- Do not resolve actor goal, success/failure policy, validation policy, retention/source policy, or user-visible behavior decisions in event storming.
 - Foundational technical decisions may remain unresolved at event storming only if they do not change commands, domain events, policies, external systems, or invariants. Carry them into 확인 필요 as `기반 기술 결정 확인 필요`.
 - Detailed implementation strategies such as polling, circuit breaker, retry/backoff, outbox/inbox, cache TTL, and observability fields are not event-storming blockers. Carry them forward as post-DDD technical-decision candidates when relevant.
 

--- a/.codex/agents/references/technical_decisions.md
+++ b/.codex/agents/references/technical_decisions.md
@@ -28,13 +28,21 @@ Slice-first rule:
 - If outside documents conflict with the selected slice, keep the slice authoritative and record the conflict.
 
 Decision scope:
-- backend transport mechanism and adapter technology
+- framework/library choice, AOP/proxy use, cipher/crypto primitive choice
+- backend transport mechanism and adapter technology only when it does not change the approved use-case API behavior
 - persistence technology and repository adapter strategy
 - build/bootstrap convention
-- runtime/deployment constraint level
-- transaction boundary and durable save rule
+- runtime/deployment mechanism needed for implementation planning
+- transaction boundary and durable save mechanics
 - retry/idempotency when it affects the selected use case
-- observability and test strategy required by implementation planning
+- observability tooling and technical test strategy required by implementation planning
+
+Out of scope:
+- user-visible behavior
+- API behavior that changes the approved use-case contract
+- success/failure policy
+- retention, cleanup, source metadata, or lifecycle policy
+- DDD boundaries or use-case refinement
 
 Stop conditions:
 - If any required input is missing, stop and explain the missing input.

--- a/.codex/skills/harness-ddd-design/references/detailed-instructions.md
+++ b/.codex/skills/harness-ddd-design/references/detailed-instructions.md
@@ -55,12 +55,13 @@ description: >
 - 코드, 테스트, 패키지 구조, 구현 파일을 만들지 않는다.
 - 쓰기 범위는 `docs/use-cases/<UC-ID>/ddd-design.md`와 `ARCHITECTURE.md`로만 제한한다.
 - 각 산출물 파일은 단일하게 유지하고, 이미 있으면 기존 파일을 수정한다.
-- 상세 DDD 설계 전에 비즈니스 정책 미결정과 기반 기술 결정 미결정을 검사한다.
+- 상세 DDD 설계 전에 비즈니스 정책 미결정과 도메인 구조를 막는 증거 누락을 검사한다.
 - 비즈니스 정책 미결정이 남아 있으면 요구사항~이벤트 스토밍 단계로 되돌려야 하므로
   설계를 작성하지 않고 멈춘다.
-- 기반 기술 결정 미결정이 도메인 모델, 어그리거트, BC, 애플리케이션 서비스,
-  저장소 계열, 외부 협력 포트, 메시징 사용 여부처럼 DDD 구조에 영향을 주면 설계를
-  작성하지 않고 멈춘다.
+- 저장소 계열, 메시징 기술, 외부 adapter mechanism, runtime/deployment level,
+  performance target 같은 기술 stack 선택은 DDD 설계를 막지 않는다. 승인된
+  use-case/event-storming 증거가 모순되거나 부족해서 도메인 모델, 어그리거트, BC,
+  애플리케이션 서비스, 도메인 서비스 구조를 도출할 수 없을 때만 멈춘다.
 - 사용자 질문은 selected slice 증거가 누락되었거나 서로 모순되어 DDD 구조 결정을 할
   수 없을 때만 한다.
 - UC, event-storming, E2E 증거가 이미 함의하는 표현 방식은 사용자에게 선택지를 묻지
@@ -71,7 +72,8 @@ description: >
   serialization mechanics 같은 구현 전략 질문은 하지 않고 technical-decisions 단계로
   넘긴다.
 - polling 방식, circuit breaker, retry/backoff, outbox/inbox 구현, cache TTL,
-  세부 transaction propagation 같은 구현 전략은 DDD 설계를 막지 않는다. 필요한
+  세부 transaction propagation, storage family, messaging technology, external
+  collaboration mechanism 같은 구현 전략은 DDD 설계를 막지 않는다. 필요한
   후보와 설계상 제약만 `확인 필요`에 남기고 DDD 이후 `harness-technical-decisions`
   단계에서 확정한다.
 - DDD 설계는 selected UC에 필요한 도메인 모델, 어그리거트, 애플리케이션 서비스,

--- a/.codex/skills/harness-event-storming/references/detailed-instructions.md
+++ b/.codex/skills/harness-event-storming/references/detailed-instructions.md
@@ -53,7 +53,11 @@ planner/executor의 직접 입력은 UC slice 파일이다.
 - oracle이 읽는 md 파일은 active ChangeSet, affected UC의 `use-case.md`,
   `e2e-goal.md`, 그리고 summary/index 목적의 `docs/design/이벤트 스토밍.md`로 제한한다.
 - ChangeSet 또는 affected UC slice에 비즈니스 정책 확인 필요가 남아 있으면 해당 UC의
-  이벤트 스토밍을 작성하지 않고, 어떤 정책 때문에 해당 UC가 막혔는지 설명하고 멈춘다.
+  이벤트 스토밍을 작성하지 않고, upstream requirements/use-case blocker로 보고한다.
+  이벤트 스토밍 단계에서 actor goal, success/failure policy, validation policy,
+  retention/source policy, user-visible behavior를 질문하거나 확정하지 않는다.
+- Event-storming drafts must be written before asking questions, and questions
+  must stay inside event-storming modeling ambiguity.
 - 기반 기술 결정 확인 필요는 커맨드/이벤트/정책/외부 시스템/불변식에 영향을 주지
   않는 경우에만 이벤트 스토밍의 확인 필요로 이월할 수 있다.
 - polling, circuit breaker, retry/backoff, outbox/inbox, cache TTL 같은 세부 구현
@@ -97,10 +101,11 @@ planner/executor의 직접 입력은 UC slice 파일이다.
 When invoked by runtime, every turn must return only JSON and then exit. Do not
 wait for interactive stdin.
 
-- Write or update the current `docs/use-cases/<UC-ID>/event-storming.md` draft before asking questions.
-- Use `needs_input` only when user answers are required before event storming can be correct.
+- Write or update the current `docs/use-cases/<UC-ID>/event-storming.md` draft before asking event-storming modeling questions.
+- Use `needs_input` only for command, event, policy, system, external system, or invariant wording/mapping ambiguity when the approved use case already contains the business policy.
 - Ask up to three focused Grill-Me questions with `question` and `recommended`.
 - Ask only command, event, policy, system, external system, or invariant ambiguity questions.
+- Return `blocked`, not `needs_input`, for missing actor goal, success/failure policy, validation policy, retention/source policy, user-visible behavior, or other product/business policy. Name the upstream stage.
 - Do not ask aggregate, DDD architecture, or technical strategy questions; report those as downstream handoff notes or blockers.
 
 Use this shape when user input is needed:

--- a/.codex/skills/harness-usecases/references/agent-prompt.md
+++ b/.codex/skills/harness-usecases/references/agent-prompt.md
@@ -17,7 +17,7 @@ Owned files:
 Rules:
 - Do not revert edits made by others.
 - Do not edit code, settings, skill files, agent files, requirements documents, or context.md.
-- If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-requirements first.
+- If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-ubiquitous-language first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop and explain that use cases need confirmed policy.
 - If Blocking Open Language Questions block naming, stop and explain that use cases need confirmed ubiquitous language.
@@ -36,7 +36,7 @@ Rules:
 - `use-case.md` must contain the detailed single-UC flow.
 - `e2e-goal.md` must contain the E2E goal with Given/When/Then sections.
 - Write or update the current use-case draft before asking questions.
-- Ask up to three focused Grill-Me questions only when requirements or language are ambiguous enough to block correctness.
+- Ask up to three focused Grill-Me questions only when confirmed requirements contain use-case-flow ambiguity; route missing language/context to $harness-ubiquitous-language.
 - Include `Recommended answer:` with every question.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```

--- a/.codex/skills/harness-usecases/references/detailed-instructions.md
+++ b/.codex/skills/harness-usecases/references/detailed-instructions.md
@@ -17,13 +17,15 @@ This skill turns confirmed requirements into both the canonical use case documen
 
 Responsibilities are split as follows.
 
-- `harness-requirements`: writes `docs/design/요구사항.md` and the project-wide language source `context.md`.
+- `harness-requirements`: writes `docs/design/요구사항.md`.
+- `harness-ubiquitous-language`: writes the project-wide language source `context.md`.
 - `harness-usecases`: validates requirements and ubiquitous language readiness, then writes `docs/design/유스케이스.md` plus `docs/use-cases/<UC-ID>/use-case.md` and `docs/use-cases/<UC-ID>/e2e-goal.md` for every harvested use case.
 
 If requirements do not exist, if `context.md` does not exist, if core ubiquitous
 language is unresolved, or if core business policy decisions remain unresolved,
-stop and ask the user to run `$harness-requirements` first. Do not invent missing
-requirements or missing domain terms.
+stop and name the owning upstream stage: `$harness-requirements` for missing
+requirements or business policy, `$harness-ubiquitous-language` for missing
+or unresolved `context.md`. Do not invent missing requirements or missing domain terms.
 
 When this skill is invoked, delegate the work to the dedicated agent defined in
 `.codex/agents/harness_usecases.toml`. If the dedicated agent cannot be found

--- a/.codex/skills/harness-usecases/references/invocation.md
+++ b/.codex/skills/harness-usecases/references/invocation.md
@@ -34,7 +34,7 @@ Rules:
 - Do not revert existing user changes.
 - Read context.md first.
 - Read docs/design/요구사항.md after context.md.
-- If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-requirements first.
+- If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-ubiquitous-language first.
 - If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
 - If unresolved Business Policy Decisions remain, stop because use cases would encode unconfirmed behavior.
 - If Blocking Open Language Questions block actor, goal, command, input, output, result, policy, or scope-boundary naming, stop because use cases would encode unconfirmed language.
@@ -57,7 +57,7 @@ Rules:
    Read `docs/design/요구사항.md` and any explicit user-provided decision record.
 
 3. **Check readiness**
-   Stop if requirements are missing, `context.md` is missing, unresolved business policy decisions remain, or open language questions block use-case naming.
+   Stop if requirements are missing, `context.md` is missing, unresolved business policy decisions remain, or open language questions block use-case naming. Route missing or unresolved `context.md` to `$harness-ubiquitous-language`.
    Foundational technology decisions may remain unresolved if they do not affect actor goals.
 
 4. **Derive actor goals**
@@ -80,4 +80,3 @@ Rules:
 8. **Confirm completion**
    If any use case still has multiple goals, mixed command/policy wording, multi-meaning event-storming candidates, non-canonical language, or Forbidden Terms, mark it as `Needs confirmation`.
    If ambiguity blocks correctness, write or update the current use-case draft before asking questions, then ask up to three focused Grill-Me questions and include `Recommended answer:` for each.
-

--- a/.codex/skills/harness-usecases/references/templates.md
+++ b/.codex/skills/harness-usecases/references/templates.md
@@ -39,35 +39,14 @@
 **Result**
 - ...
 
-**Non-Functional Requirements**
+**Observable Constraints From Requirements**
 - ...
 
 ---
 
-## 4. System-Wide Non-Functional Requirements
-### 4.1 Performance
-- ...
-
-### 4.2 Scalability
-- ...
-
-### 4.3 Availability
-- ...
-
-### 4.4 Data Consistency
-- ...
-
-### 4.5 Concurrency Control
-- ...
-
-### 4.6 Security
-- ...
-
-### 4.7 Failure Handling and Recovery
-- ...
-
-### 4.8 Auditability and Operability
-- ...
+## 4. Confirmed Requirement Constraints Referenced By Use Cases
+- List only process-specific observable constraints already approved in requirements.
+- Reference broad system-wide NFRs from `docs/design/요구사항.md` when relevant; do not invent scalability, concurrency, audit, security, availability, or implementation mechanisms here.
 
 ## 5. Needs Confirmation
 - ...
@@ -101,7 +80,7 @@
 ## Result
 - ...
 
-## Non-Functional Requirements
+## Observable Constraints From Requirements
 - ...
 
 ## Needs Confirmation

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -146,7 +146,8 @@ Primary staged workflow:
 
 | Stage | Scope | Main outputs |
 | --- | --- | --- |
-| `requirements-definition` | Project requirements and language | `docs/design/요구사항.md`, `context.md`, active ChangeSet |
+| `requirements-definition` | Project requirements | `docs/design/요구사항.md`, active ChangeSet |
+| `ubiquitous-language-definition` | Project ubiquitous language | `context.md` |
 | `use-case-definition` | External-actor use cases and UC slices | `docs/design/유스케이스.md`, `docs/use-cases/<UC-ID>/use-case.md`, `e2e-goal.md` |
 | `event-storming` | Commands, events, policies, systems, invariants | `docs/use-cases/<UC-ID>/event-storming.md` |
 | `ddd-architecture-definition` | UC-scoped DDD architecture | `docs/use-cases/<UC-ID>/ddd-design.md` |

--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -75,7 +75,6 @@ def start_requirements(root: Path | str, prompt: str) -> HarvestUiResult:
         raise ValueError("initial prompt is required")
     _write_session(root_path, session)
     _advance_grill_me(root_path, session)
-    _write_context_doc(root_path, session)
     _write_requirements_doc(root_path, session)
     _write_session(root_path, session)
     return _result(root_path, session)
@@ -109,7 +108,6 @@ def answer_requirements(root: Path | str, answer: str | list[str]) -> HarvestUiR
     session["current_question"] = None
     session["pending_questions"] = []
     _advance_grill_me(root_path, session)
-    _write_context_doc(root_path, session)
     _write_requirements_doc(root_path, session)
     _write_session(root_path, session)
     return _result(root_path, session)
@@ -120,6 +118,7 @@ def start_ubiquitous_language(root: Path | str) -> HarvestUiResult:
     session = _load_or_recover_session(root_path)
     if not session["requirements_gate_passed"]:
         raise ValueError("requirements gate has not passed")
+    _write_context_doc(root_path, session)
     context = _read_optional(root_path / CONTEXT_PATH).strip()
     if not context:
         raise ValueError("context.md is missing or empty")
@@ -134,6 +133,7 @@ def complete_ubiquitous_language(root: Path | str) -> HarvestUiResult:
     session = _load_or_recover_session(root_path)
     if not session["requirements_gate_passed"]:
         raise ValueError("requirements gate has not passed")
+    _write_context_doc(root_path, session)
     context = _read_optional(root_path / CONTEXT_PATH).strip()
     if not context:
         raise ValueError("context.md is missing or empty")
@@ -972,23 +972,10 @@ def _activate_next_use_case_pending_question(session: dict[str, Any]) -> None:
 
 def _advance_grill_me(root: Path, session: dict[str, Any]) -> None:
     result = _run_grill_me(root, session)
-    context_markdown = str(result.get("context_markdown", "") or "")
     requirements_markdown = str(result.get("requirements_markdown", "") or "")
-    if context_markdown:
-        session["draft_context_markdown"] = context_markdown
     if requirements_markdown:
         session["draft_requirements_markdown"] = requirements_markdown
-    open_language_questions = _extract_open_language_questions(session["draft_context_markdown"])
     filtered_questions = _filter_new_questions(result["questions"], session)
-    if open_language_questions:
-        follow_up_questions = filtered_questions or _fallback_open_language_questions(open_language_questions)
-        follow_up_questions = follow_up_questions[:3]
-        session["requirements_gate_passed"] = False
-        session["current_question"] = follow_up_questions[0]
-        session["current_questions"] = follow_up_questions
-        session["pending_questions"] = []
-        session["runtime_error"] = ""
-        return
     if result["complete"]:
         session["requirements_gate_passed"] = True
         session["current_question"] = None
@@ -1536,7 +1523,6 @@ def _run_grill_me(root: Path, session: dict[str, Any]) -> dict[str, Any]:
             "complete": False,
             "questions": turn_result["questions"],
             "requirements_markdown": "",
-            "context_markdown": "",
         }
     return _run_grill_me_finalizer(root, session, requirements_skill_path, run_dir)
 
@@ -1713,7 +1699,8 @@ Target ChangeSet: {change_set_id}
 Target Use Case: {uc_id}
 
 Return only JSON with keys: status, questions, changed_files, blocker.
-- Return `needs_input` with exactly one question object when one business-policy answer is required.
+- Return `needs_input` with exactly one question object only for event-storming modeling ambiguity when the approved use-case already contains the business policy.
+- Return `blocked` when actor goal, success/failure policy, validation policy, retention/source policy, user-visible behavior, or any product/business policy is missing or contradictory; name the upstream stage that must resolve it.
 - Return `complete` only after writing `docs/use-cases/{uc_id}/event-storming.md` with validated commands, events, policies, systems, external systems, and invariants.
 - Return `blocked` only when existing inputs cannot be corrected by one user answer in this stage.
 - Model only `{uc_id}`; use its goal or first actor action as initial command.
@@ -1963,10 +1950,10 @@ def _run_grill_me_finalizer(
     step = Step(
         id="grill-me-finalize",
         kind=StepKind.AGENT,
-        name="Draft requirements and language documents from confirmed decisions",
+        name="Draft requirements document from confirmed decisions",
         agent_id="requirements_interviewer",
         skill_id="harness-requirements",
-        outputs=(REQUIREMENTS_PATH, CONTEXT_PATH),
+        outputs=(REQUIREMENTS_PATH,),
         timeout_sec=300,
         metadata={"stage": "harvest", "scope": "requirements_finalization", "interactive": True},
     )
@@ -1991,10 +1978,10 @@ def _run_grill_me_finalizer(
         timeout_error="Grill-Me finalization timed out after 300 seconds. Retry to continue from this stage.",
     )
     result = _parse_grill_me_json(final_message)
-    if not result["requirements_markdown"] or not result["context_markdown"]:
+    if not result["requirements_markdown"]:
         if result["complete"] and not result["questions"] and _is_legacy_grill_me_result(final_message):
             return {"complete": True, "questions": []}
-        raise ValueError("Grill-Me finalization returned incomplete draft documents")
+        raise ValueError("Grill-Me finalization returned incomplete requirements document")
     return result
 
 
@@ -2025,7 +2012,7 @@ Question rules:
 - Ask only the single highest-priority blocker.
 - Do not queue non-blocking follow-up questions.
 - Do not ask detailed canonical naming, alias, forbidden-term, aggregate naming, domain event naming, or state-transition naming questions.
-- Return complete=true once the confirmed decisions are sufficient for separate writer steps to draft docs/design/요구사항.md and context.md.
+- Return complete=true once the confirmed decisions are sufficient to draft docs/design/요구사항.md.
 
 Initial prompt:
 {session["initial_prompt"]}
@@ -2042,18 +2029,16 @@ def _grill_me_finalization_prompt(
 ) -> str:
     return f"""Use the confirmed requirement decisions below to draft the final harvest documents.
 
-Return only JSON with keys: complete, questions, requirements_markdown, context_markdown.
-Always include draft requirements_markdown and context_markdown that reflect the current confirmed state.
+Return only JSON with keys: complete, questions, requirements_markdown.
+Always include draft requirements_markdown that reflects the current confirmed state.
 When incomplete, return exactly 1 question in questions[].
 Each question object must have keys: question, recommended.
 
 Document rules:
 - In requirements_markdown, never use a clarification table column named `Answer`; use `Response`.
-- requirements_markdown must follow harness-requirements and must not own full ubiquitous language confirmation.
-- context_markdown must follow harness-ubiquitous-language and include the Ubiquitous Language table.
-- requirements_markdown must use canonical terms from context_markdown.
-- Return complete=true only when context_markdown has no unresolved entries under `## 3. Open Language Questions`.
-- If context_markdown still has any open language question, return complete=false and ask the focused follow-up question that resolves it.
+- requirements_markdown must follow harness-requirements and must not write or finalize `context.md`.
+- Requirements may include Language Handoff Notes for the ubiquitous-language stage.
+- Do not produce `context_markdown`; `context.md` belongs to harness-ubiquitous-language.
 
 Initial prompt:
 {session["initial_prompt"]}
@@ -2064,8 +2049,7 @@ Compact Q/A history:
 Harness requirements standards:
 - Load `{requirements_skill_path}`.
 - Then read `.codex/skills/harness-requirements/references/detailed-instructions.md`.
-- Load `{language_skill_path}`.
-- Then read `.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md`.
+- Do not load `{language_skill_path}` for requirements finalization.
 - Read additional referenced files only if the current draft needs them.
 """
 
@@ -2141,7 +2125,6 @@ def _parse_grill_me_json(text: str) -> dict[str, Any]:
         data = json.loads(match.group(0))
     complete = bool(data.get("complete"))
     requirements_markdown = str(data.get("requirements_markdown", "") or "").strip()
-    context_markdown = str(data.get("context_markdown", "") or "").strip()
     raw_questions = data.get("questions", [])
     if not isinstance(raw_questions, list):
         raise ValueError("Grill-Me returned invalid questions")
@@ -2162,7 +2145,6 @@ def _parse_grill_me_json(text: str) -> dict[str, Any]:
         "complete": complete,
         "questions": questions,
         "requirements_markdown": requirements_markdown,
-        "context_markdown": context_markdown,
     }
 
 

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -256,7 +256,7 @@ def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
     assert len(result.current_questions) == 1
     assert result.current_question["question"] == "Question 1?"
     assert (tmp_path / REQUIREMENTS_PATH).is_file()
-    assert (tmp_path / CONTEXT_PATH).is_file()
+    assert not (tmp_path / CONTEXT_PATH).exists()
     assert (tmp_path / ".harness/ui/harvest-session.json").is_file()
     assert not (tmp_path / USE_CASES_PATH).exists()
 
@@ -282,9 +282,11 @@ def test_harvest_ui_runs_requirements_then_use_cases_one_question_at_a_time(
     assert result.use_cases_ready is False
     assert result.current_question is None
     assert "Question | Response" in (tmp_path / REQUIREMENTS_PATH).read_text(encoding="utf-8")
+    assert not (tmp_path / CONTEXT_PATH).exists()
 
     result = start_ubiquitous_language(tmp_path)
     assert result.active_stage == "ubiquitousLanguage"
+    assert (tmp_path / CONTEXT_PATH).is_file()
     result = complete_ubiquitous_language(tmp_path)
     assert result.language_gate_passed is True
 
@@ -572,7 +574,7 @@ def test_harvest_ui_filters_duplicate_grill_me_questions(
     assert result.current_question["question"] == "What is the success outcome?"
 
 
-def test_harvest_ui_keeps_grill_me_running_until_context_has_no_open_language_questions(
+def test_harvest_ui_requirements_finalization_ignores_context_markdown(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -598,17 +600,12 @@ def test_harvest_ui_keeps_grill_me_running_until_context_has_no_open_language_qu
 
     result = start_requirements(tmp_path, "build a calculator")
 
-    assert result.requirements_gate_passed is False
-    assert result.current_question is not None
-    assert result.current_question["question"] == "Confirm the canonical term for the arithmetic selector."
-
-    result = answer_requirements(tmp_path, "Use Operator.")
-
     assert result.requirements_gate_passed is True
     assert result.current_question is None
+    assert not (tmp_path / CONTEXT_PATH).exists()
 
 
-def test_harvest_ui_uses_open_language_questions_when_grill_me_returns_no_follow_up(
+def test_harvest_ui_requirements_question_loop_does_not_use_open_language_questions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -624,10 +621,9 @@ def test_harvest_ui_uses_open_language_questions_when_grill_me_returns_no_follow
 
     result = start_requirements(tmp_path, "build a calculator")
 
-    assert result.requirements_gate_passed is False
-    assert result.current_question is not None
-    assert result.current_question["question"] == "Confirm the canonical term for the arithmetic selector."
-    assert "Confirm the canonical term" in result.current_question["recommended"]
+    assert result.requirements_gate_passed is True
+    assert result.current_question is None
+    assert not (tmp_path / CONTEXT_PATH).exists()
 
 
 def test_grill_me_prompt_uses_compact_history_without_skill_bodies_or_drafts() -> None:
@@ -687,13 +683,14 @@ def test_grill_me_finalization_prompt_uses_compact_history_and_writer_contract()
 
     assert "Compact Q/A history" in prompt
     assert "requirements_markdown" in prompt
-    assert "context_markdown" in prompt
+    assert "Return only JSON with keys: complete, questions, requirements_markdown." in prompt
+    assert "Always include draft requirements_markdown" in prompt
     assert "Harness requirements standards" in prompt
     assert ".codex/skills/harness-requirements/SKILL.md" in prompt
     assert ".codex/skills/harness-requirements/references/detailed-instructions.md" in prompt
-    assert ".codex/skills/harness-ubiquitous-language/SKILL.md" in prompt
-    assert ".codex/skills/harness-ubiquitous-language/references/detailed-instructions.md" in prompt
-    assert "Return complete=true only when context_markdown has no unresolved entries" in prompt
+    assert "Load `.codex/skills/harness-ubiquitous-language/SKILL.md`" not in prompt
+    assert ".codex/skills/harness-ubiquitous-language/references/detailed-instructions.md" not in prompt
+    assert "Do not produce `context_markdown`" in prompt
 
 
 def test_harvest_ui_blocks_use_cases_until_requirements_pass(
@@ -725,6 +722,7 @@ def test_harvest_ui_blocks_use_cases_until_ubiquitous_language_is_confirmed(
 
     assert result.requirements_gate_passed is True
     assert result.language_gate_passed is False
+    assert not (tmp_path / CONTEXT_PATH).exists()
     with pytest.raises(ValueError, match="ubiquitous-language gate has not passed"):
         start_use_case_generation(tmp_path, "build a queue system")
 

--- a/tests/test_harvester_skill_instructions.py
+++ b/tests/test_harvester_skill_instructions.py
@@ -10,6 +10,11 @@ def read_contract(path: Path) -> str:
         detailed = path.parent / "references/detailed-instructions.md"
         if detailed.exists():
             text += "\n" + detailed.read_text(encoding="utf-8")
+        if path.parent.name == "harness-usecases":
+            for reference_name in ("agent-prompt.md", "invocation.md", "runtime-contract.md", "templates.md"):
+                reference = path.parent / "references" / reference_name
+                if reference.exists():
+                    text += "\n" + reference.read_text(encoding="utf-8")
     if path.suffix == ".toml":
         detailed = path.parent / "references" / f"{path.stem}.md"
         if detailed.exists():
@@ -177,7 +182,8 @@ def test_main_flow_grill_me_stages_are_draft_first_and_boundary_scoped() -> None
 
     assert "canonical naming" in stage_contracts["requirements"]
     assert "broad requirements" in stage_contracts["language"]
-    assert "requirements" in stage_contracts["usecases"] and "context.md" in stage_contracts["usecases"]
+    assert "harness-ubiquitous-language" in stage_contracts["usecases"]
+    assert "context.md" in stage_contracts["usecases"]
     assert "Do not ask aggregate, DDD architecture, or technical strategy questions" in stage_contracts["eventstorming"]
     assert "Do not ask the user to choose representation details already implied" in ddd_contract
     assert "When slice evidence fully implies one model shape" in ddd_contract
@@ -196,3 +202,54 @@ def test_usecases_consume_context_language_without_editing_it() -> None:
         assert "canonical terms" in text or "canonical" in text
         assert "Forbidden Terms" in text
         assert "Do not edit context.md" in text or "or context.md" in text
+
+
+def test_usecases_route_missing_context_to_ubiquitous_language() -> None:
+    paths = (
+        REPO_ROOT / ".codex/skills/harness-usecases/SKILL.md",
+        REPO_ROOT / ".codex/agents/harness_usecases.toml",
+        REPO_ROOT / ".codex/skills/harness-usecases/references/agent-prompt.md",
+    )
+
+    for path in paths:
+        text = read_contract(path)
+        assert "$harness-ubiquitous-language" in text
+        assert "context.md" in text
+        if "run $harness-requirements first" in text:
+            assert "If docs/design/요구사항.md is missing" in text
+
+
+def test_usecase_nfr_template_is_limited_to_observable_requirement_constraints() -> None:
+    text = read_contract(REPO_ROOT / ".codex/skills/harness-usecases/SKILL.md")
+    agent = read_contract(REPO_ROOT / ".codex/agents/harness_usecases.toml")
+
+    assert "Observable Constraints From Requirements" in text
+    assert "Confirmed Requirement Constraints Referenced By Use Cases" in text
+    assert "do not invent scalability, concurrency, audit, security, availability" in text
+    assert "System-Wide Non-Functional Requirements" not in text
+    assert "Concurrency Control" not in text
+    assert "Observable Constraints From Requirements" in agent
+
+
+def test_technical_decisions_reference_excludes_business_api_behavior_policy() -> None:
+    text = read_contract(REPO_ROOT / ".codex/agents/technical_decisions.toml")
+
+    assert "framework/library choice" in text
+    assert "cipher/crypto primitive" in text
+    assert "API behavior that changes the approved use-case contract" in text
+    assert "user-visible behavior" in text
+    assert "success/failure policy" in text
+    assert "retention, cleanup, source metadata" in text
+    assert "backend save failure to user-visible response" not in text
+
+
+def test_ddd_design_defers_technical_stack_choices() -> None:
+    agent = read_contract(REPO_ROOT / ".codex/agents/references/ddd_architect.md")
+    skill = read_contract(REPO_ROOT / ".codex/skills/harness-ddd-design/SKILL.md")
+
+    assert "Do not block on technical stack choices" in agent
+    assert "storage family" in agent
+    assert "messaging technology" in agent
+    assert "performance target" in agent
+    assert "domain shape impossible" in agent
+    assert "기술 stack 선택은 DDD 설계를 막지 않는다" in skill

--- a/tests/test_oracle_use_case_event_storming.py
+++ b/tests/test_oracle_use_case_event_storming.py
@@ -26,16 +26,13 @@ def test_oracle_writes_affected_use_case_event_storming_slice() -> None:
     assert "docs/use-cases/<UC-ID>/e2e-goal.md" in oracle
     assert "docs/use-cases/<UC-ID>/event-storming.md" in oracle
     assert "Do not create per-use-case event storming files" not in oracle
-    assert "Do not write event-storming content for unaffected use cases" in oracle
+    assert "affected use case" in oracle or "affected UC" in oracle
 
 
 def test_oracle_keeps_canonical_event_storming_as_summary_index() -> None:
     oracle = read_doc(".codex/agents/oracle.toml")
 
-    assert (
-        "Maintain docs/design/이벤트 스토밍.md, when present, as a summary/index"
-        in oracle
-    )
+    assert "summary/index context only" in oracle
     assert "planner/executor의 직접 입력은 UC slice 파일" in read_doc(
         ".codex/skills/harness-event-storming/SKILL.md"
     )
@@ -44,7 +41,18 @@ def test_oracle_keeps_canonical_event_storming_as_summary_index() -> None:
 def test_oracle_blocks_only_the_affected_use_case_on_policy_gaps() -> None:
     oracle = read_doc(".codex/agents/oracle.toml")
 
-    assert "write or update the current event-storming draft" in oracle
-    assert "Needs confirmation" in oracle
-    assert "affected UC is blocked" in oracle
-    assert "resolve only that UC's policies" in oracle
+    assert "return `blocked`" in oracle.lower()
+    assert "upstream requirements or use-case stage" in oracle
+    assert "Do not resolve actor goal" in oracle
+    assert "user-visible behavior decisions in event storming" in oracle
+
+
+def test_event_storming_runtime_contract_blocks_business_policy_questions() -> None:
+    skill = read_doc(".codex/skills/harness-event-storming/SKILL.md")
+
+    assert "Return `blocked`, not `needs_input`" in skill
+    assert "missing actor goal" in skill
+    assert "success/failure policy" in skill
+    assert "validation policy" in skill
+    assert "retention/source policy" in skill
+    assert "user-visible behavior" in skill


### PR DESCRIPTION
## 구현 의도

workflow-boundary 이슈 #346, #347, #348, #349, #350, #351의 단계 소유권을 정리합니다.

Closes #346
Closes #347
Closes #348
Closes #349
Closes #350
Closes #351

## 구현 접근

- requirements 런타임 finalizer가 `context_markdown`을 요구하거나 `context.md`를 쓰지 않도록 변경했습니다.
- `context.md` 생성은 ubiquitous-language 단계 진입/완료 경로에서만 수행되도록 분리했습니다.
- use-case 지침은 누락된 `context.md`를 `$harness-ubiquitous-language`로 라우팅하도록 수정했습니다.
- event-storming은 비즈니스 정책 질문을 `needs_input`으로 묻지 않고 upstream `blocked`로 보고하도록 계약을 수정했습니다.
- technical-decisions, DDD, use-case NFR 템플릿의 과도한 책임 문구를 구현 메커니즘/관찰 가능한 제약 범위로 좁혔습니다.
- 회귀 방지를 위한 런타임/정적 instruction contract 테스트를 추가했습니다.

## 검증 방법

- `PYTHONPATH=. /home/jiwoo/workspace/harness/venv/bin/pytest -q tests/runtime/test_harvest_ui.py tests/test_harvester_skill_instructions.py tests/test_oracle_use_case_event_storming.py tests/test_cli_commands.py::test_technical_decisions_business_policy_question_is_blocked_not_asked tests/test_cli_commands.py::test_technical_decisions_prompt_rejects_hypothetical_lifecycle_blockers tests/test_cli_commands.py::test_technical_decisions_pending_business_policy_is_not_converted_to_question tests/runtime/test_workflow_loader.py tests/runtime/test_models.py`
- `PYTHONPATH=. /home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/runtime/harvest_ui.py`
- 전체 테스트 `PYTHONPATH=. /home/jiwoo/workspace/harness/venv/bin/pytest -q`는 실행했지만, 변경 범위 밖 planner/executor instruction helper 테스트 12개가 실패했습니다.

## 위험 및 롤백

- 위험: 기존 harvest UI에서 requirements 완료 직후 `context.md`가 있다고 가정한 외부 호출자가 있으면 ubiquitous-language 단계 호출이 필요합니다.
- 완화: use-case 시작 전 ubiquitous-language gate는 기존처럼 유지되고, ubiquitous-language 단계에서 fallback `context.md`를 생성합니다.
- 롤백: 이 커밋을 되돌리면 requirements finalizer가 다시 `context_markdown`과 `context.md` 작성을 요구하는 이전 동작으로 복구됩니다.

## UI 변경

해당 없음. 런타임 계약과 instruction 문서 변경이며 브라우저 UI 렌더링 변경은 없습니다.
