### PR TITLE
하네스 운영 파일 gitignore 등록

### DIFF
--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -156,6 +156,20 @@ PRESERVED_PATHS=(
   "AGENTS.md"
 )
 
+HARNESS_GITIGNORE_ENTRIES=(
+  ".harness/runs/"
+  ".harness/sessions/"
+  ".harness/state/"
+  ".harness/checkpoints/"
+  ".harness/cache/"
+  ".harness/import-backups/"
+  ".harness/skill-evaluations/"
+  ".harness/ui/"
+  ".harness/ui-server.log"
+  ".harness/ui-server.pid"
+  ".codex/harness-bootstrap-state.json"
+)
+
 backup_preserved_paths() {
   local rel src dst
   for rel in "${PRESERVED_PATHS[@]}"; do
@@ -243,6 +257,42 @@ LAUNCHER
   echo "created: harness"
 }
 
+ensure_gitignore_entry() {
+  local gitignore="$1"
+  local entry="$2"
+  if [[ -f "$gitignore" ]] && grep -Fx -- "$entry" "$gitignore" >/dev/null; then
+    return
+  fi
+  printf '%s\n' "$entry" >> "$gitignore"
+}
+
+ensure_harness_gitignore_entries() {
+  local gitignore="$TARGET_DIR/.gitignore"
+  mkdir -p "$(dirname "$gitignore")"
+  touch "$gitignore"
+
+  local entry wrote_header=0
+  for entry in "${HARNESS_GITIGNORE_ENTRIES[@]}"; do
+    if [[ -f "$gitignore" ]] && grep -Fx -- "$entry" "$gitignore" >/dev/null; then
+      continue
+    fi
+    if [[ "$wrote_header" -eq 0 ]]; then
+      if [[ -s "$gitignore" && "$(tail -c 1 "$gitignore")" != "" ]]; then
+        printf '\n' >> "$gitignore"
+      fi
+      printf '# harness-codex 운영 파일\n' >> "$gitignore"
+      wrote_header=1
+    fi
+    ensure_gitignore_entry "$gitignore" "$entry"
+  done
+
+  if [[ "$wrote_header" -eq 1 ]]; then
+    echo "updated: .gitignore"
+  else
+    echo "skip existing: .gitignore harness entries"
+  fi
+}
+
 install_runtime_files() {
 backup_preserved_paths
 
@@ -296,6 +346,8 @@ copy_file_if_missing "$TARGET_DIR/.codex/test-gate.yaml" '# Product verification
 #     command: ./gradlew test
 required: []
 '
+
+ensure_harness_gitignore_entries
 
 restore_preserved_paths() { restore_paths "$@"; }
 restore_preserved_paths

--- a/tests/runtime/test_install_update_preservation.py
+++ b/tests/runtime/test_install_update_preservation.py
@@ -26,6 +26,38 @@ def test_installer_defines_workflow_artifacts_as_preserved_paths():
         assert f'"{path}"' in SCRIPT
 
 
+def test_installer_defines_harness_operation_gitignore_entries():
+    for path in [
+        ".harness/runs/",
+        ".harness/sessions/",
+        ".harness/state/",
+        ".harness/checkpoints/",
+        ".harness/cache/",
+        ".harness/import-backups/",
+        ".harness/skill-evaluations/",
+        ".harness/ui/",
+        ".harness/ui-server.log",
+        ".harness/ui-server.pid",
+        ".codex/harness-bootstrap-state.json",
+    ]:
+        assert f'"{path}"' in SCRIPT
+
+
+def test_installer_does_not_gitignore_workflow_artifacts():
+    gitignore_start = SCRIPT.index("HARNESS_GITIGNORE_ENTRIES=(")
+    gitignore_end = SCRIPT.index(")", gitignore_start)
+    gitignore_entries = SCRIPT[gitignore_start:gitignore_end]
+
+    for path in [
+        "docs/changes/",
+        "docs/use-cases/",
+        "docs/maintenance/",
+        "docs/plans/",
+        "context.md",
+    ]:
+        assert f'"{path}"' not in gitignore_entries
+
+
 def test_installer_restores_preserved_paths_after_forced_runtime_copy():
     backup_index = SCRIPT.index("backup_preserved_paths")
     runtime_copy_index = SCRIPT.index('copy_dir "$SRC_DIR/.harness"')
@@ -36,6 +68,18 @@ def test_installer_restores_preserved_paths_after_forced_runtime_copy():
     assert backup_index < codex_copy_index
     assert runtime_copy_index < restore_index
     assert codex_copy_index < restore_index
+
+
+def test_installer_updates_gitignore_during_runtime_install():
+    runtime_start = SCRIPT.index("install_runtime_files() {")
+    skills_only_start = SCRIPT.index("install_skills_only() {")
+    runtime_body = SCRIPT[runtime_start:skills_only_start]
+
+    mkdir_index = runtime_body.index('mkdir -p \\')
+    gitignore_index = runtime_body.index("ensure_harness_gitignore_entries")
+    restore_index = runtime_body.index("restore_preserved_paths")
+
+    assert mkdir_index < gitignore_index < restore_index
 
 
 def test_installer_copies_shell_completion_sources():
@@ -77,6 +121,7 @@ def test_skills_only_mode_does_not_copy_runtime_files():
     assert 'copy_dir "$SRC_DIR/.harness"' not in skills_only_body
     assert "create_launcher" not in skills_only_body
     assert "python3 -m venv" not in skills_only_body
+    assert "ensure_harness_gitignore_entries" not in skills_only_body
 
 
 def test_default_project_files_are_not_overwritten_by_force_update():


### PR DESCRIPTION
## 구현 의도
하네스 런타임 설치 시 생성되는 런타임 상태와 캐시성 운영 파일만 대상 저장소의 Git 추적 대상에 섞이지 않게 합니다. ChangeSet, use-case, maintenance, plan 같은 워크플로우 산출물은 계속 추적 가능하게 둡니다.

## 구현 접근
런타임 설치 경로에서 `.gitignore`를 생성 또는 갱신하고, `.harness` 런타임 상태/캐시/임시 UI 파일과 `.codex/harness-bootstrap-state.json`만 중복 없이 추가했습니다. `docs/changes/`, `docs/use-cases/`, `docs/maintenance/`, `docs/plans/`, `context.md`는 ignore 목록에서 제외했습니다. `skills-only` 설치는 기존처럼 런타임 운영 파일을 다루지 않도록 유지했습니다.

## 검증 방법
- `bash -n scripts/install-harness-codex.sh`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/runtime/test_install_update_preservation.py`
- 이전 전체 테스트 실행: `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s` 실행 시 기존 `.codex` 스킬 계약 기대값 불일치로 12개 실패, 변경 범위와 무관

## 위험 및 롤백
위험은 기존 `.gitignore`에 하네스 런타임 운영 경로가 자동 추가되는 동작입니다. 문제가 있으면 이번 커밋을 되돌리면 설치 스크립트의 `.gitignore` 갱신 동작이 제거됩니다.

## 스크린샷
UI 변경 없음.