### PR TITLE
파일 기반 장기 메모리 MVP 추가

### DIFF
--- a/.harness/memory/eval-history/README.md
+++ b/.harness/memory/eval-history/README.md
@@ -1,0 +1,5 @@
+# Eval History Memory
+
+Store before/after evaluation summaries as JSON files when a harness evolution candidate is accepted or rejected.
+
+Do not store raw logs here. Link to sanitized eval result paths, decisions, score changes, regression notes, and reviewed memory entries.

--- a/.harness/memory/failure-patterns/incomplete-plan-contract.md
+++ b/.harness/memory/failure-patterns/incomplete-plan-contract.md
@@ -1,0 +1,60 @@
+---
+id: incomplete-plan-contract
+type: failure-pattern
+scope: harness
+status: active
+confidence: high
+created_at: 2026-06-18
+last_validated: 2026-06-18
+summary: >
+  Plan-writing can produce a plan.md that exists but lacks executable verification criteria.
+decision_impact: >
+  Before implementation, validate that plan.md contains concrete verification commands or an explicitly accepted alternative for docs-only or investigation-only work.
+applies_to:
+  stages:
+    - plan-writing
+    - implementation
+  work_item_types:
+    - use-case
+    - maintenance
+  change_types:
+    - runtime-code
+    - test-hardening
+does_not_apply_to:
+  - docs-only work with explicit document validation
+  - investigation-only work with accepted evidence output
+evidence:
+  - issue:#359
+known_fixes:
+  - add-stage-boundary-validator
+  - strengthen-output-contract
+regression_risks:
+  - strict-validator-blocks-doc-only-change
+---
+# Failure Pattern: incomplete-plan-contract
+
+## Symptom
+
+`plan-writing` appears to succeed, but `implementation` later blocks because `plan.md` lacks executable verification steps or explicit accepted alternatives.
+
+## Typical Causes
+
+- Planner instructions allow vague checklist items.
+- Template checks verify file presence instead of semantic completion.
+- Downstream implementation assumes upstream plan artifacts are complete.
+
+## Detection
+
+- `docs/plans/active/<WORK-ITEM-ID>/plan.md` exists.
+- Verification criteria are missing, vague, or only reference documents without rationale.
+- Implementation stage reports an incomplete plan contract.
+
+## Known Fixes
+
+- Add a stage-boundary validator before implementation.
+- Strengthen planner output contract.
+- Update plan templates to require executable verification or explicit alternative evidence.
+
+## Regression Risks
+
+Strict validation can block docs-only or investigation-only work unless the validator understands those scopes.

--- a/.harness/memory/index.yaml
+++ b/.harness/memory/index.yaml
@@ -1,0 +1,46 @@
+version: 1
+patterns:
+  - id: incomplete-plan-contract
+    type: failure-pattern
+    keywords:
+      - plan.md
+      - verification missing
+      - implementation blocked
+      - plan contract
+    path: failure-patterns/incomplete-plan-contract.md
+    status: active
+    last_validated: 2026-06-18
+    summary: Plan-writing can produce a plan file that exists but lacks executable verification criteria.
+  - id: add-stage-boundary-validator
+    type: patch-pattern
+    keywords:
+      - schema
+      - required sections
+      - validator
+      - stage boundary
+    path: patch-patterns/add-stage-boundary-validator.md
+    status: active
+    last_validated: 2026-06-18
+    summary: Add explicit validation before downstream stages consume generated artifacts.
+  - id: strict-validator-blocks-doc-only-change
+    type: regression
+    keywords:
+      - strict validator
+      - docs-only
+      - plan validation
+      - regression
+    path: regressions/strict-validator-blocks-doc-only-change.md
+    status: candidate
+    last_validated: 2026-06-18
+    summary: Overly strict validation may block documentation-only or investigation-only work.
+  - id: harness-memory-selection-policy
+    type: project-rule
+    keywords:
+      - memory promotion
+      - decision impact
+      - evidence
+      - safety
+    path: project/harness-memory-selection-policy.md
+    status: active
+    last_validated: 2026-06-18
+    summary: Promote only reusable, evidence-backed, scoped, safe lessons into long-term memory.

--- a/.harness/memory/patch-patterns/add-stage-boundary-validator.md
+++ b/.harness/memory/patch-patterns/add-stage-boundary-validator.md
@@ -1,0 +1,47 @@
+---
+id: add-stage-boundary-validator
+type: patch-pattern
+scope: harness
+status: active
+confidence: high
+created_at: 2026-06-18
+last_validated: 2026-06-18
+summary: >
+  Add explicit validation before downstream stages consume generated artifacts.
+decision_impact: >
+  When a downstream stage fails because an upstream artifact exists but is incomplete, add an explicit artifact contract and validate it at the boundary before continuing.
+applies_to:
+  stages:
+    - plan-writing
+    - implementation
+    - verification
+  work_item_types:
+    - use-case
+    - maintenance
+does_not_apply_to:
+  - raw log archival
+  - hidden LLM-only memory
+evidence:
+  - issue:#359
+known_fixes:
+  - define-artifact-contract
+  - add-contract-validator
+regression_risks:
+  - strict-validator-blocks-doc-only-change
+---
+# Patch Pattern: add-stage-boundary-validator
+
+## Use When
+
+A downstream stage fails because an upstream artifact exists but is incomplete, stale, or too vague to execute.
+
+## Patch Shape
+
+1. Define explicit required fields or sections for the artifact.
+2. Add a validator at the stage boundary.
+3. Block downstream execution with an actionable error.
+4. Add tests for valid artifacts, invalid artifacts, and scoped exceptions.
+
+## Verification
+
+Run focused validator tests and one downstream-flow test that proves invalid artifacts stop before execution.

--- a/.harness/memory/project/harness-memory-selection-policy.md
+++ b/.harness/memory/project/harness-memory-selection-policy.md
@@ -1,0 +1,53 @@
+---
+id: harness-memory-selection-policy
+type: project-rule
+scope: harness
+status: active
+confidence: high
+created_at: 2026-06-18
+last_validated: 2026-06-18
+summary: >
+  Promote only reusable, evidence-backed, scoped, safe lessons into long-term memory.
+decision_impact: >
+  Memory candidates must explain how future planning, implementation, verification, or evolution behavior changes before they become active memory.
+applies_to:
+  stages:
+    - requirements-definition
+    - use-case-definition
+    - event-storming
+    - ddd-architecture-definition
+    - technical-decisions
+    - plan-writing
+    - implementation
+    - verification
+  work_item_types:
+    - use-case
+    - maintenance
+does_not_apply_to:
+  - raw traces without evidence summaries
+  - secrets or sensitive data
+evidence:
+  - issue:#360
+known_fixes: []
+regression_risks: []
+---
+# Project Rule: harness-memory-selection-policy
+
+## Rule
+
+Store long-term memory only when it is likely to recur, changes future behavior, is expensive to rediscover, is stable enough to reuse, has evidence, has clear scope, and is safe to store.
+
+## Required Active Fields
+
+- `decision_impact`
+- `applies_to`
+- `evidence`
+
+## Do Not Store
+
+- Raw trace logs as active memory.
+- Current run state.
+- One-off command output.
+- Easily searchable file paths or constants.
+- Unvalidated guesses.
+- Secrets, tokens, credentials, or personal data.

--- a/.harness/memory/regressions/strict-validator-blocks-doc-only-change.md
+++ b/.harness/memory/regressions/strict-validator-blocks-doc-only-change.md
@@ -1,0 +1,37 @@
+---
+id: strict-validator-blocks-doc-only-change
+type: regression
+scope: harness
+status: candidate
+confidence: medium
+created_at: 2026-06-18
+last_validated: 2026-06-18
+summary: >
+  Overly strict validation may block documentation-only or investigation-only work.
+decision_impact: >
+  Plan validation must distinguish runtime code, docs-only, refactoring, and investigation scopes before requiring executable runtime commands.
+applies_to:
+  stages:
+    - plan-writing
+    - implementation
+  work_item_types:
+    - maintenance
+does_not_apply_to:
+  - runtime-code changes that require executable tests
+evidence:
+  - issue:#359
+regression_risks: []
+---
+# Regression: strict-validator-blocks-doc-only-change
+
+## What Improved
+
+Stricter validation can prevent incomplete plans from reaching implementation.
+
+## What Can Break
+
+Documentation-only or investigation-only maintenance work may not need runtime test commands, but it still needs concrete evidence.
+
+## Lesson
+
+Validators should require executable commands for runtime code changes and allow scoped evidence checks for documentation or investigation work.

--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -1,0 +1,163 @@
+# File-Backed Long-Term Memory
+
+Harness long-term memory is explicit repository state under `.harness/memory/`. It stores reusable operational knowledge for planning, implementation, verification, and self-evolution. It is not raw logs, hidden model memory, or run state.
+
+## Structure
+
+```text
+.harness/memory/
+  index.yaml
+  failure-patterns/
+  patch-patterns/
+  regressions/
+  eval-history/
+  project/
+```
+
+`index.yaml` is the lookup surface. Each entry points to a Markdown file with YAML front matter and reviewable explanation.
+
+## Memory Types
+
+- `failure-pattern`: repeated symptoms, causes, detection signals, known fixes, and risks.
+- `patch-pattern`: reusable implementation shape that has worked before.
+- `regression`: accepted change that improved one path but damaged another.
+- `project-rule`: project-specific or harness-wide rule that should affect future decisions.
+- `eval-history`: before/after evaluation summary for harness evolution candidates.
+
+## Promotion Criteria
+
+Promote a memory only when it satisfies these checks:
+
+- Recurrence likelihood: likely to matter again.
+- Decision impact: changes what a future planner, executor, verifier, or evolution proposer does.
+- Rediscovery cost: expensive enough that storing the lesson is useful.
+- Stability: stable or explicitly conditional.
+- Evidence: backed by run IDs, evals, ChangeSets, PRs, issues, or approved design documents.
+- Scope clarity: states where it applies and where it does not.
+- Safety: contains no secrets, credentials, tokens, or personal data.
+
+The most important field is `decision_impact`. A memory that cannot explain future behavior change should not become active memory.
+
+## Scoring
+
+Score each criterion from 0 to 2:
+
+| Criterion | 0 | 1 | 2 |
+| --- | --- | --- | --- |
+| Recurrence likelihood | one-off | occasional | repeated/common |
+| Decision impact | no behavior change | weak influence | clearly changes future action |
+| Rediscovery cost | easy to search | moderate | expensive to rediscover |
+| Stability | likely temporary | conditional | stable principle/pattern |
+| Evidence | none | single source | multiple run/eval/design sources |
+| Scope clarity | vague | partly scoped | clear applies/does-not-apply scope |
+| Safety | unsafe | needs sanitization | safe |
+
+Suggested decisions:
+
+- `0-5`: do not store.
+- `6-8`: keep as run evidence or candidate memory.
+- `9-11`: long-term memory candidate.
+- `12+`: active long-term memory, after review and required fields pass.
+
+Active memories require:
+
+- `decision_impact`
+- `applies_to`
+- `evidence`
+
+## Lifecycle
+
+Allowed status values:
+
+- `candidate`: captured but not generalized or reviewed.
+- `active`: eligible for future memory lookup.
+- `stale`: may still be useful but needs revalidation.
+- `deprecated`: superseded by newer knowledge.
+- `rejected`: reviewed and intentionally not promoted.
+
+Promotion flow:
+
+```text
+raw trace or observation
+  -> evidence summary
+  -> memory candidate
+  -> scoring and review
+  -> active, rejected, stale, or deprecated memory
+```
+
+## What Not To Store
+
+Do not promote:
+
+- Raw trace logs as active memory.
+- Current run state.
+- Active ChangeSet status.
+- One-off command outputs.
+- Easily searchable file paths or constants.
+- Unvalidated guesses.
+- Generic advice.
+- Secrets, credentials, tokens, `.env` values, or personal data.
+
+Raw execution data should become memory only through:
+
+```text
+raw trace -> evidence summary -> pattern -> reusable lesson
+```
+
+## Runtime Commands
+
+```bash
+python3 -m harness_codex memory list
+python3 -m harness_codex memory search "plan contract"
+python3 -m harness_codex memory score candidate.yaml
+```
+
+`memory score` expects scoring criteria under a `scores` mapping so semantic fields such as `decision_impact` can keep their explanatory text:
+
+```yaml
+status: active
+decision_impact: Validate plan artifacts before implementation.
+applies_to:
+  stages:
+    - plan-writing
+evidence:
+  - issue:#360
+scores:
+  recurrence_likelihood: 2
+  decision_impact: 2
+  rediscovery_cost: 2
+  stability: 2
+  evidence: 2
+  scope_clarity: 2
+  safety: 2
+```
+
+Memory lookup is advisory. It does not mutate run state, ChangeSets, plans, or source files.
+
+## Evolution Change Manifest References
+
+Harness evolution candidates should reference memory entries in `change-manifest.yaml` so reviewers can see which prior lessons shaped the proposal.
+
+Example:
+
+```yaml
+change:
+  id: EVL-001
+  title: Strengthen plan boundary validation
+
+memory_references:
+  - id: incomplete-plan-contract
+    type: failure-pattern
+    path: .harness/memory/failure-patterns/incomplete-plan-contract.md
+    influence: validates plan artifacts before implementation
+  - id: add-stage-boundary-validator
+    type: patch-pattern
+    path: .harness/memory/patch-patterns/add-stage-boundary-validator.md
+    influence: uses known boundary-validator patch shape
+  - id: strict-validator-blocks-doc-only-change
+    type: regression
+    path: .harness/memory/regressions/strict-validator-blocks-doc-only-change.md
+    influence: keeps docs-only work from being blocked by runtime-only checks
+```
+
+The manifest should not copy raw memory bodies. It should link memory IDs and summarize how each entry affected the change.

--- a/harness_codex/cli.py
+++ b/harness_codex/cli.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Mapping
 from uuid import uuid4
 
+import yaml
+
 from harness_codex.runtime import (
     AgentContextBootstrapResult,
     BasicStepRunner,
@@ -62,6 +64,12 @@ from harness_codex.runtime.evolution import (
     accept_evolution,
     propose_evolution,
     reject_evolution,
+)
+from harness_codex.runtime.memory import (
+    MemoryError,
+    load_memory_entries,
+    score_memory_candidate,
+    search_memory,
 )
 from harness_codex.runtime.procedure_stages import (
     PROCEDURE_STAGES,
@@ -151,6 +159,7 @@ COMMAND_HELP: tuple[tuple[str, str], ...] = (
     ("implementation", "Run one ChangeSet through UC-scoped implementation loops."),
     ("ultrawork", "Create a ChangeSet and run affected workflows."),
     ("evolution", "Manage evolution proposals."),
+    ("memory", "List, search, and score file-backed long-term memory."),
     ("stages", "Inspect runtime procedure stage artifacts."),
     ("artifacts", "Show or accept generated stage artifacts."),
     ("resume", "Inspect next resume target for one run."),
@@ -195,6 +204,11 @@ TOPIC_HELP: Mapping[str, str] = {
         "[--uc UC-ID] [--force] [--plan|--preview|--apply]"
     ),
     "evolution": "Usage: harness evolution propose|accept|reject ...",
+    "memory": (
+        "Usage: harness memory list [--all]\n"
+        "       harness memory search QUERY [--all]\n"
+        "       harness memory score CANDIDATE.yaml"
+    ),
     "stages": "Usage: harness stages list <CHG-ID>",
     "artifacts": "Usage: harness artifacts show|accept <CHG-ID> <stage>",
     "resume": "Usage: harness resume <RUN-ID>",
@@ -217,6 +231,7 @@ def main(argv: list[str] | None = None) -> int:
         NoActiveChangeSetsError,
         DesignBridgeError,
         WorkflowMaterializationError,
+        MemoryError,
         ValueError,
     ) as exc:
         print(str(exc), file=sys.stderr)
@@ -421,6 +436,19 @@ def build_parser() -> argparse.ArgumentParser:
     evolution_reject = evolution_subparsers.add_parser("reject")
     evolution_reject.add_argument("proposal_id")
     evolution_reject.set_defaults(func=evolution_reject_command)
+
+    memory = subparsers.add_parser("memory")
+    memory_subparsers = memory.add_subparsers(required=True)
+    memory_list = memory_subparsers.add_parser("list")
+    memory_list.add_argument("--all", action="store_true")
+    memory_list.set_defaults(func=memory_list_command)
+    memory_search = memory_subparsers.add_parser("search")
+    memory_search.add_argument("query")
+    memory_search.add_argument("--all", action="store_true")
+    memory_search.set_defaults(func=memory_search_command)
+    memory_score = memory_subparsers.add_parser("score")
+    memory_score.add_argument("candidate_path")
+    memory_score.set_defaults(func=memory_score_command)
 
     stages = subparsers.add_parser("stages")
     stages_subparsers = stages.add_subparsers(required=True)
@@ -2872,6 +2900,57 @@ def evolution_reject_command(args: argparse.Namespace, repo_root: Path) -> str:
     except EvolutionError as error:
         return f"Evolution reject blocked: {error}"
     return f"Evolution proposal rejected: {proposal_path}"
+
+
+def memory_list_command(args: argparse.Namespace, repo_root: Path) -> str:
+    entries = [
+        entry
+        for entry in load_memory_entries(repo_root)
+        if args.all or entry.status == "active"
+    ]
+    if not entries:
+        return "No memory entries found"
+    return "\n".join(
+        f"{entry.id}\t{entry.type}\t{entry.status}\t.harness/memory/{entry.path}"
+        for entry in entries
+    )
+
+
+def memory_search_command(args: argparse.Namespace, repo_root: Path) -> str:
+    results = search_memory(repo_root, args.query, include_inactive=args.all)
+    if not results:
+        return "No matching memory entries found"
+    return "\n".join(
+        "\t".join(
+            [
+                result.entry.id,
+                result.entry.type,
+                result.entry.status,
+                f"score={result.score}",
+                f"matched={','.join(result.matched_terms)}",
+                f".harness/memory/{result.entry.path}",
+            ]
+        )
+        for result in results
+    )
+
+
+def memory_score_command(args: argparse.Namespace, repo_root: Path) -> str:
+    path = Path(args.candidate_path)
+    absolute_path = path if path.is_absolute() else repo_root / path
+    candidate = yaml.safe_load(absolute_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(candidate, dict):
+        raise MemoryError("memory candidate score input must be a mapping")
+    score = score_memory_candidate(candidate)
+    missing = ",".join(score.required_fields_missing) or "none"
+    return "\n".join(
+        [
+            f"score={score.total}",
+            f"decision={score.decision}",
+            f"missing_required_fields={missing}",
+            f"active_ready={str(score.active_ready).lower()}",
+        ]
+    )
 
 
 def stages_list_command(args: argparse.Namespace, repo_root: Path) -> str:

--- a/harness_codex/runtime/memory.py
+++ b/harness_codex/runtime/memory.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+
+MEMORY_ROOT = Path(".harness/memory")
+MEMORY_INDEX = MEMORY_ROOT / "index.yaml"
+ACTIVE_REQUIRED_FIELDS = (
+    "decision_impact",
+    "applies_to",
+    "evidence",
+)
+MEMORY_STATUSES = ("candidate", "active", "stale", "deprecated", "rejected")
+SCORE_FIELDS = (
+    "recurrence_likelihood",
+    "decision_impact",
+    "rediscovery_cost",
+    "stability",
+    "evidence",
+    "scope_clarity",
+    "safety",
+)
+
+
+class MemoryError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class MemoryIndexEntry:
+    id: str
+    type: str
+    keywords: tuple[str, ...]
+    path: Path
+    status: str
+    last_validated: str
+    summary: str = ""
+
+
+@dataclass(frozen=True)
+class MemoryEntry:
+    index: MemoryIndexEntry
+    metadata: Mapping[str, Any]
+    body: str
+
+    @property
+    def id(self) -> str:
+        return self.index.id
+
+    @property
+    def type(self) -> str:
+        return self.index.type
+
+    @property
+    def path(self) -> Path:
+        return self.index.path
+
+    @property
+    def status(self) -> str:
+        return self.index.status
+
+    @property
+    def decision_impact(self) -> str:
+        value = self.metadata.get("decision_impact", "")
+        return str(value).strip()
+
+
+@dataclass(frozen=True)
+class MemorySearchResult:
+    entry: MemoryEntry
+    score: int
+    matched_terms: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MemoryScore:
+    total: int
+    decision: str
+    required_fields_missing: tuple[str, ...]
+    active_ready: bool
+
+
+def load_memory_index(repo_root: Path | str) -> tuple[MemoryIndexEntry, ...]:
+    root = Path(repo_root)
+    index_path = root / MEMORY_INDEX
+    if not index_path.exists():
+        return ()
+    document = yaml.safe_load(index_path.read_text(encoding="utf-8")) or {}
+    patterns = document.get("patterns", [])
+    if not isinstance(patterns, list):
+        raise MemoryError("memory index patterns must be a list")
+    return tuple(_index_entry(item, root) for item in patterns)
+
+
+def load_memory_entries(repo_root: Path | str) -> tuple[MemoryEntry, ...]:
+    root = Path(repo_root)
+    return tuple(load_memory_entry(root, entry) for entry in load_memory_index(root))
+
+
+def load_memory_entry(
+    repo_root: Path | str,
+    index_entry: MemoryIndexEntry | str,
+) -> MemoryEntry:
+    root = Path(repo_root)
+    entry = (
+        _entry_by_id(root, index_entry)
+        if isinstance(index_entry, str)
+        else index_entry
+    )
+    absolute_path = root / MEMORY_ROOT / entry.path
+    if not absolute_path.exists():
+        raise MemoryError(f"missing memory entry: {MEMORY_ROOT / entry.path}")
+    metadata, body = _split_front_matter(absolute_path.read_text(encoding="utf-8"))
+    _validate_entry_metadata(entry, metadata)
+    return MemoryEntry(index=entry, metadata=metadata, body=body)
+
+
+def search_memory(
+    repo_root: Path | str,
+    query: str,
+    *,
+    include_inactive: bool = False,
+) -> tuple[MemorySearchResult, ...]:
+    terms = _terms(query)
+    if not terms:
+        return ()
+    results: list[MemorySearchResult] = []
+    for entry in load_memory_entries(repo_root):
+        if not include_inactive and entry.status != "active":
+            continue
+        haystack = " ".join(
+            [
+                entry.id,
+                entry.type,
+                " ".join(entry.index.keywords),
+                entry.index.summary,
+                entry.decision_impact,
+                entry.body,
+            ]
+        ).lower()
+        matched = tuple(term for term in terms if term in haystack)
+        if matched:
+            score = len(matched) + _keyword_bonus(entry.index.keywords, matched)
+            results.append(MemorySearchResult(entry, score, matched))
+    return tuple(sorted(results, key=lambda result: (-result.score, result.entry.id)))
+
+
+def score_memory_candidate(candidate: Mapping[str, Any]) -> MemoryScore:
+    total = 0
+    for field in SCORE_FIELDS:
+        value = _candidate_score(candidate, field)
+        if not isinstance(value, int) or value < 0 or value > 2:
+            raise MemoryError(f"{field} score must be an integer from 0 to 2")
+        total += value
+
+    decision = _score_decision(total)
+    missing = tuple(
+        field
+        for field in ACTIVE_REQUIRED_FIELDS
+        if not _has_meaningful_value(candidate.get(field))
+    )
+    active_ready = total >= 12 and not missing and candidate.get("status") == "active"
+    return MemoryScore(
+        total=total,
+        decision=decision,
+        required_fields_missing=missing,
+        active_ready=active_ready,
+    )
+
+
+def validate_memory_entry(entry: MemoryEntry) -> None:
+    _validate_entry_metadata(entry.index, entry.metadata)
+
+
+def _index_entry(item: object, root: Path) -> MemoryIndexEntry:
+    if not isinstance(item, dict):
+        raise MemoryError("memory index entry must be a mapping")
+    entry_id = _required_string(item, "id")
+    entry_type = _required_string(item, "type")
+    raw_path = _required_string(item, "path")
+    status = _required_string(item, "status")
+    if status not in MEMORY_STATUSES:
+        raise MemoryError(f"invalid memory status for {entry_id}: {status}")
+    keywords = item.get("keywords", [])
+    if not isinstance(keywords, list) or not all(isinstance(k, str) for k in keywords):
+        raise MemoryError(f"memory keywords must be strings for {entry_id}")
+    path = Path(raw_path)
+    if path.is_absolute() or ".." in path.parts:
+        raise MemoryError(f"memory path must stay under {MEMORY_ROOT}: {raw_path}")
+    last_validated = str(item.get("last_validated", "")).strip()
+    if not last_validated:
+        raise MemoryError(f"memory last_validated is required for {entry_id}")
+    if not (root / MEMORY_ROOT / path).exists():
+        raise MemoryError(f"memory index points to missing path: {path}")
+    return MemoryIndexEntry(
+        id=entry_id,
+        type=entry_type,
+        keywords=tuple(keywords),
+        path=path,
+        status=status,
+        last_validated=last_validated,
+        summary=str(item.get("summary", "")).strip(),
+    )
+
+
+def _entry_by_id(root: Path, entry_id: str) -> MemoryIndexEntry:
+    for entry in load_memory_index(root):
+        if entry.id == entry_id:
+            return entry
+    raise MemoryError(f"unknown memory entry: {entry_id}")
+
+
+def _split_front_matter(text: str) -> tuple[Mapping[str, Any], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    try:
+        _start, raw_metadata, body = text.split("---\n", 2)
+    except ValueError as exc:
+        raise MemoryError("memory front matter is not closed") from exc
+    metadata = yaml.safe_load(raw_metadata) or {}
+    if not isinstance(metadata, dict):
+        raise MemoryError("memory front matter must be a mapping")
+    return metadata, body.lstrip()
+
+
+def _validate_entry_metadata(
+    index_entry: MemoryIndexEntry,
+    metadata: Mapping[str, Any],
+) -> None:
+    if metadata:
+        if str(metadata.get("id", "")).strip() != index_entry.id:
+            raise MemoryError(f"memory id mismatch: {index_entry.id}")
+        if str(metadata.get("type", "")).strip() != index_entry.type:
+            raise MemoryError(f"memory type mismatch: {index_entry.id}")
+        if str(metadata.get("status", "")).strip() != index_entry.status:
+            raise MemoryError(f"memory status mismatch: {index_entry.id}")
+    if index_entry.status == "active":
+        missing = [
+            field
+            for field in ACTIVE_REQUIRED_FIELDS
+            if not _has_meaningful_value(metadata.get(field))
+        ]
+        if missing:
+            joined = ", ".join(missing)
+            raise MemoryError(
+                f"active memory {index_entry.id} missing required fields: {joined}"
+            )
+
+
+def _terms(query: str) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            part.lower()
+            for part in re.findall(r"[A-Za-z0-9_.-]+", query)
+            if len(part) > 1
+        )
+    )
+
+
+def _keyword_bonus(keywords: tuple[str, ...], matched: tuple[str, ...]) -> int:
+    keyword_text = " ".join(keywords).lower()
+    return sum(1 for term in matched if term in keyword_text)
+
+
+def _score_decision(total: int) -> str:
+    if total <= 5:
+        return "do_not_store"
+    if total <= 8:
+        return "keep_as_evidence_or_candidate"
+    if total <= 11:
+        return "long_term_memory_candidate"
+    return "active_long_term_memory"
+
+
+def _candidate_score(candidate: Mapping[str, Any], field: str) -> object:
+    scores = candidate.get("scores", {})
+    if isinstance(scores, dict) and field in scores:
+        return scores[field]
+    score_key = f"{field}_score"
+    if score_key in candidate:
+        return candidate[score_key]
+    value = candidate.get(field, 0)
+    return value if isinstance(value, int) else 0
+
+
+def _has_meaningful_value(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
+def _required_string(item: Mapping[str, Any], key: str) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise MemoryError(f"memory index field is required: {key}")
+    return value.strip()

--- a/tests/runtime/test_memory.py
+++ b/tests/runtime/test_memory.py
@@ -1,0 +1,154 @@
+from pathlib import Path
+
+import yaml
+
+from harness_codex.cli import main
+from harness_codex.runtime.memory import (
+    MemoryError,
+    load_memory_entry,
+    load_memory_entries,
+    score_memory_candidate,
+    search_memory,
+)
+
+
+def test_memory_index_loads_seed_entries() -> None:
+    entries = load_memory_entries(Path("."))
+
+    ids = {entry.id for entry in entries}
+    assert "incomplete-plan-contract" in ids
+    assert "add-stage-boundary-validator" in ids
+    assert "harness-memory-selection-policy" in ids
+    assert all(entry.decision_impact for entry in entries if entry.status == "active")
+
+
+def test_memory_search_returns_active_keyword_matches() -> None:
+    results = search_memory(Path("."), "plan contract verification missing")
+
+    assert results
+    assert results[0].entry.id == "incomplete-plan-contract"
+    assert "plan" in results[0].matched_terms
+
+
+def test_memory_search_skips_candidate_entries_by_default() -> None:
+    assert not search_memory(Path("."), "overly")
+
+    results = search_memory(Path("."), "overly", include_inactive=True)
+
+    assert results[0].entry.id == "strict-validator-blocks-doc-only-change"
+
+
+def test_memory_score_candidate_thresholds_and_required_fields() -> None:
+    candidate = {
+        "status": "active",
+        "scores": {
+            "recurrence_likelihood": 2,
+            "decision_impact": 2,
+            "rediscovery_cost": 2,
+            "stability": 2,
+            "evidence": 2,
+            "scope_clarity": 2,
+            "safety": 2,
+        },
+        "decision_impact": "Run plan contract validation before implementation.",
+        "evidence": ["issue:#360"],
+        "applies_to": {"stages": ["plan-writing"]},
+    }
+
+    score = score_memory_candidate(candidate)
+
+    assert score.total == 14
+    assert score.decision == "active_long_term_memory"
+    assert score.required_fields_missing == ()
+    assert score.active_ready is True
+
+
+def test_memory_score_rejects_invalid_scores() -> None:
+    try:
+        score_memory_candidate({"recurrence_likelihood": 3})
+    except MemoryError as error:
+        assert "recurrence_likelihood" in str(error)
+    else:
+        raise AssertionError("invalid score should fail")
+
+
+def test_active_memory_requires_decision_impact_scope_and_evidence(tmp_path: Path) -> None:
+    memory_dir = tmp_path / ".harness/memory/failure-patterns"
+    memory_dir.mkdir(parents=True)
+    (tmp_path / ".harness/memory/index.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "patterns": [
+                    {
+                        "id": "missing-evidence",
+                        "type": "failure-pattern",
+                        "keywords": ["plan"],
+                        "path": "failure-patterns/missing-evidence.md",
+                        "status": "active",
+                        "last_validated": "2026-06-18",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (memory_dir / "missing-evidence.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "id: missing-evidence",
+                "type: failure-pattern",
+                "status: active",
+                "decision_impact: Validate before implementation.",
+                "applies_to:",
+                "  stages:",
+                "    - plan-writing",
+                "---",
+                "# Missing Evidence",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        load_memory_entry(tmp_path, "missing-evidence")
+    except MemoryError as error:
+        assert "evidence" in str(error)
+    else:
+        raise AssertionError("active memory without evidence should fail")
+
+
+def test_memory_cli_list_search_and_score(tmp_path: Path, capsys) -> None:
+    score_input = tmp_path / "candidate.yaml"
+    score_input.write_text(
+        yaml.safe_dump(
+                {
+                    "status": "active",
+                    "scores": {
+                        "recurrence_likelihood": 2,
+                        "decision_impact": 2,
+                        "rediscovery_cost": 2,
+                        "stability": 2,
+                        "evidence": 2,
+                        "scope_clarity": 2,
+                        "safety": 2,
+                    },
+                    "decision_impact": "Validate the plan before implementation.",
+                    "evidence": ["issue:#360"],
+                    "applies_to": {"stages": ["plan-writing"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert main(["memory", "list"]) == 0
+    output = capsys.readouterr().out
+    assert "incomplete-plan-contract" in output
+
+    assert main(["memory", "search", "stage boundary validator"]) == 0
+    output = capsys.readouterr().out
+    assert "add-stage-boundary-validator" in output
+
+    assert main(["memory", "score", str(score_input)]) == 0
+    output = capsys.readouterr().out
+    assert "active_ready=true" in output


### PR DESCRIPTION
## 구현 의도

- #359, #360의 파일 기반 장기 메모리 MVP를 추가합니다.
- 실행 로그를 그대로 저장하지 않고, 재사용 가능한 실패 패턴, 패치 패턴, 회귀 후보, 프로젝트 규칙을 git에서 검토 가능한 형태로 관리합니다.
- 메모리 승격 기준과 `change-manifest.yaml` 참조 방식을 문서화합니다.

## 구현 방식

- `.harness/memory/` 아래 `index.yaml`과 seed 항목을 추가했습니다.
- `harness_codex/runtime/memory.py`에 인덱스 로더, Markdown front matter 검증, 키워드 검색, 후보 점수 계산을 구현했습니다.
- `harness memory list|search|score` CLI를 추가했습니다.
- 활성 메모리는 `decision_impact`, `applies_to`, `evidence` 필드를 요구합니다.
- `docs/long-term-memory.md`에 승격 기준, 상태 lifecycle, 금지 데이터, `change-manifest.yaml` 메모리 참조 예시를 정리했습니다.

## 검증 방법

- 통과: `/home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/cli.py harness_codex/runtime/memory.py`
- 통과: `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_memory.py`
- 통과: `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_evolution.py tests/test_cli_commands.py`
- 통과: `/home/jiwoo/workspace/harness/venv/bin/python3 -m harness_codex memory search "plan contract"`
- 통과: `/home/jiwoo/workspace/harness/venv/bin/python3 -m harness_codex memory list`
- 실패: `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s`
  - 554개 통과, 12개 실패
  - 실패는 `.codex/skills/harness-code-planner` 및 implementation executor skill 계약 문자열 누락 테스트에서 발생했습니다.
  - 이번 변경 파일 범위에는 해당 skill 파일이 없습니다.

## 위험 및 롤백

- 위험: 메모리 인덱스가 깨진 경로를 가리키면 `memory` CLI가 명시적으로 실패합니다.
- 위험: 검색은 단순 키워드 기반이라 의미 검색이나 자동 승격은 지원하지 않습니다.
- 롤백: 이 커밋을 되돌리면 `.harness/memory/`, `memory` CLI, 관련 문서와 테스트가 제거되며 기존 런타임 실행 경로는 원복됩니다.

Closes #359
Closes #360
