### PR TITLE
[codex] 설치된 하네스 파일 gitignore 확대

### DIFF
--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -157,17 +157,15 @@ PRESERVED_PATHS=(
 )
 
 HARNESS_GITIGNORE_ENTRIES=(
-  ".harness/runs/"
-  ".harness/sessions/"
-  ".harness/state/"
-  ".harness/checkpoints/"
-  ".harness/cache/"
-  ".harness/import-backups/"
-  ".harness/skill-evaluations/"
-  ".harness/ui/"
-  ".harness/ui-server.log"
-  ".harness/ui-server.pid"
-  ".codex/harness-bootstrap-state.json"
+  ".harness/"
+  ".codex/"
+  "harness_codex/"
+  "completions/"
+  "harness"
+  "scripts/install-harness-codex.sh"
+  "scripts/bump_runtime_version.py"
+  "tests/runtime/"
+  "venv/"
 )
 
 backup_preserved_paths() {

--- a/tests/runtime/test_install_update_preservation.py
+++ b/tests/runtime/test_install_update_preservation.py
@@ -28,17 +28,15 @@ def test_installer_defines_workflow_artifacts_as_preserved_paths():
 
 def test_installer_defines_harness_operation_gitignore_entries():
     for path in [
-        ".harness/runs/",
-        ".harness/sessions/",
-        ".harness/state/",
-        ".harness/checkpoints/",
-        ".harness/cache/",
-        ".harness/import-backups/",
-        ".harness/skill-evaluations/",
-        ".harness/ui/",
-        ".harness/ui-server.log",
-        ".harness/ui-server.pid",
-        ".codex/harness-bootstrap-state.json",
+        ".harness/",
+        ".codex/",
+        "harness_codex/",
+        "completions/",
+        "harness",
+        "scripts/install-harness-codex.sh",
+        "scripts/bump_runtime_version.py",
+        "tests/runtime/",
+        "venv/",
     ]:
         assert f'"{path}"' in SCRIPT
 
@@ -53,6 +51,9 @@ def test_installer_does_not_gitignore_workflow_artifacts():
         "docs/use-cases/",
         "docs/maintenance/",
         "docs/plans/",
+        "docs/design/",
+        "AGENTS.md",
+        "ARCHITECTURE.md",
         "context.md",
     ]:
         assert f'"{path}"' not in gitignore_entries


### PR DESCRIPTION
## 구현 의도

`install.sh` 실행 후 설치된 하네스 런타임 파일이 대상 저장소의 미추적 파일로 남지 않게 한다. Markdown 산출 문서는 계속 추적 가능하게 유지한다.

## 구현 접근

- `.harness/`, `.codex/`, `harness_codex/`, `completions/`, 런처, 설치 스크립트, 런타임 테스트, `venv/`를 `.gitignore`에 등록한다.
- `docs/**`, `AGENTS.md`, `ARCHITECTURE.md`, `context.md`는 ignore 대상에서 제외한다.
- 중복된 하위 런타임 ignore 규칙은 상위 디렉터리 규칙으로 통합한다.

## 검증 방법

- `bash -n install.sh scripts/install-harness-codex.sh`
- `pytest -q tests/runtime/test_install_update_preservation.py tests/runtime/test_root_install_script.py`: 11개 통과

## 위험 및 롤백

`.codex/` 전체가 ignore되어 대상 저장소에서 로컬 Codex 설정 변경이 추적되지 않는다. 필요하면 이 커밋을 되돌리고 세부 운영 파일 규칙으로 복구한다.