### PR TITLE
이벤트 스토밍 콘텐츠 검증 루프 추가

### DIFF
--- a/harness_codex/runtime/harvest_ui.py
+++ b/harness_codex/runtime/harvest_ui.py
@@ -33,6 +33,9 @@ USE_CASE_DEFINITION_TIMEOUT_SEC = 3600
 EVENT_STORMING_AGENT_CONFIG_PATH = Path(".codex/agents/oracle.toml")
 EVENT_STORMING_SKILL_PATH = Path(".codex/skills/harness-event-storming/SKILL.md")
 EVENT_STORMING_TIMEOUT_SEC = 3600
+ARTIFACT_REVIEWER_AGENT_CONFIG_PATH = Path(".codex/agents/artifact_reviewer.toml")
+ARTIFACT_REVIEWER_SKILL_PATH = Path(".codex/skills/harness-artifact-reviewer/SKILL.md")
+EVENT_STORMING_REVIEW_ATTEMPTS = 3
 DDD_AGENT_CONFIG_PATH = Path(".codex/agents/ddd_architect.toml")
 DDD_SKILL_PATH = Path(".codex/skills/harness-ddd-design/SKILL.md")
 DDD_TIMEOUT_SEC = 3600
@@ -1033,6 +1036,8 @@ def _new_event_storming_state(uc_ids: list[str]) -> dict[str, Any]:
                 "status": "pending",
                 "current_question": None,
                 "clarifications": [],
+                "review_feedback": [],
+                "reviews": [],
                 "error": "",
             }
             for uc_id in uc_ids
@@ -1098,38 +1103,67 @@ def _advance_event_storming(
     item["status"] = "running"
     item["error"] = ""
     output_path = root / USE_CASE_SLICE_ROOT / target_id / "event-storming.md"
-    if output_path.exists():
-        output_path.unlink()
     try:
-        result = _run_event_storming(root, session, change_set_id, target_id)
-        status = str(result.get("status", "")).strip().lower()
-        if status == "complete":
-            ready, error = _validate_event_storming_slice(output_path)
-            if not ready:
-                raise ValueError(f"event storming reported complete but {error}")
-            item["status"] = "complete"
-            item["current_question"] = None
-            item["error"] = ""
-            state["completed_count"] = sum(
-                1 for value in state["items"].values() if value.get("status") == "complete"
-            )
-            state["complete"] = state["completed_count"] == len(state["uc_ids"])
-            state["status"] = "complete" if state["complete"] else "running"
+        for _attempt in range(EVENT_STORMING_REVIEW_ATTEMPTS):
+            if output_path.exists():
+                output_path.unlink()
+            result = _run_event_storming(root, session, change_set_id, target_id)
+            status = str(result.get("status", "")).strip().lower()
+            if status == "complete":
+                ready, error = _validate_event_storming_slice(output_path)
+                if not ready:
+                    raise ValueError(f"event storming reported complete but {error}")
+                review = _run_event_storming_content_review(
+                    root,
+                    session,
+                    change_set_id,
+                    target_id,
+                    output_path,
+                )
+                item.setdefault("reviews", []).append(review)
+                review_status = str(review.get("status", "")).strip().lower()
+                if review_status == "complete":
+                    item["status"] = "complete"
+                    item["current_question"] = None
+                    item["error"] = ""
+                    state["completed_count"] = sum(
+                        1 for value in state["items"].values() if value.get("status") == "complete"
+                    )
+                    state["complete"] = state["completed_count"] == len(state["uc_ids"])
+                    state["status"] = "complete" if state["complete"] else "running"
+                    session["runtime_error"] = ""
+                    return
+                if review_status == "needs_input":
+                    questions = review.get("questions", [])
+                    if not isinstance(questions, list) or not questions:
+                        raise ValueError("event storming content review needs input but returned no question")
+                    question = questions[0]
+                    item.setdefault("review_feedback", []).append(_event_storming_review_feedback(review))
+                    item["status"] = "needs_input"
+                    item["current_question"] = {
+                        "question": str(question.get("question", "")).strip(),
+                        "recommended": str(question.get("recommended", "") or "").strip(),
+                    }
+                    state["status"] = "needs_input"
+                    session["runtime_error"] = ""
+                    return
+                item.setdefault("review_feedback", []).append(_event_storming_review_feedback(review))
+                continue
+            if status == "blocked":
+                raise ValueError(str(result.get("blocker", "") or "event storming blocked"))
+            questions = result.get("questions", [])
+            if not isinstance(questions, list) or not questions:
+                raise ValueError("event storming needs input but returned no question")
+            question = questions[0]
+            item["status"] = "needs_input"
+            item["current_question"] = {
+                "question": str(question.get("question", "")).strip(),
+                "recommended": str(question.get("recommended", "") or "").strip(),
+            }
+            state["status"] = "needs_input"
             session["runtime_error"] = ""
             return
-        if status == "blocked":
-            raise ValueError(str(result.get("blocker", "") or "event storming blocked"))
-        questions = result.get("questions", [])
-        if not isinstance(questions, list) or not questions:
-            raise ValueError("event storming needs input but returned no question")
-        question = questions[0]
-        item["status"] = "needs_input"
-        item["current_question"] = {
-            "question": str(question.get("question", "")).strip(),
-            "recommended": str(question.get("recommended", "") or "").strip(),
-        }
-        state["status"] = "needs_input"
-        session["runtime_error"] = ""
+        raise ValueError("event storming content review rejected corrected artifacts")
     except ValueError as exc:
         item["status"] = "error"
         item["error"] = str(exc)
@@ -1707,6 +1741,9 @@ Return only JSON with keys: status, questions, changed_files, blocker.
 
 Event-storming answer history:
 {json.dumps(item.get("clarifications", []), ensure_ascii=False, indent=2)}
+
+Content review feedback:
+{json.dumps(item.get("review_feedback", []), ensure_ascii=False, indent=2)}
 """
 
 
@@ -1730,6 +1767,148 @@ def _parse_event_storming_json(text: str) -> dict[str, Any]:
         "questions": questions,
         "changed_files": [str(item) for item in data.get("changed_files", [])],
         "blocker": str(data.get("blocker", "") or ""),
+    }
+
+
+def _run_event_storming_content_review(
+    root: Path,
+    session: dict[str, Any],
+    change_set_id: str,
+    uc_id: str,
+    output_path: Path,
+) -> dict[str, Any]:
+    agent_config_path = root / ARTIFACT_REVIEWER_AGENT_CONFIG_PATH
+    skill_path = root / ARTIFACT_REVIEWER_SKILL_PATH
+    if not agent_config_path.exists():
+        raise ValueError(f"missing artifact reviewer agent config: {ARTIFACT_REVIEWER_AGENT_CONFIG_PATH}")
+    if not skill_path.exists():
+        raise ValueError(f"missing artifact reviewer skill config: {ARTIFACT_REVIEWER_SKILL_PATH}")
+
+    run_id = f"interactive-event-storming-review-{uuid4().hex[:12]}"
+    run_dir = root / ".harness/ui/event-storming-review-runs" / run_id
+    step_dir = run_dir / "step"
+    step_dir.mkdir(parents=True, exist_ok=True)
+    review_output = Path(".harness/ui/event-storming-review-runs") / run_id / "review.md"
+    step = Step(
+        id=f"event-storming-content-review-{uc_id}",
+        kind=StepKind.AGENT,
+        name=f"Review event storming content for {uc_id}",
+        agent_id="artifact_reviewer",
+        skill_id="harness-artifact-reviewer",
+        inputs=(
+            Path("docs/changes/active") / f"{change_set_id}.md",
+            USE_CASE_SLICE_ROOT / uc_id / "use-case.md",
+            USE_CASE_SLICE_ROOT / uc_id / "e2e-goal.md",
+            output_path.relative_to(root) if output_path.is_absolute() else output_path,
+        ),
+        outputs=(review_output,),
+        timeout_sec=EVENT_STORMING_TIMEOUT_SEC,
+        metadata={"stage": "event-storming-content-review", "scope": uc_id, "interactive": True},
+    )
+    context = RunContext(
+        run_id=run_id,
+        workflow_name="event-storming-content-review-workflow",
+        mode=RunMode.APPLY,
+        repo_root=root,
+        workdir=root,
+        run_dir=run_dir,
+        metadata={"stage": "event_storming_content_review", "change_set_id": change_set_id, "uc_id": uc_id},
+    )
+    final_message = _run_interactive_agent(
+        root=root,
+        step=step,
+        context=context,
+        step_dir=step_dir,
+        agent_config_path=agent_config_path,
+        skill_path=skill_path,
+        prompt_suffix=_event_storming_content_review_contract(
+            change_set_id,
+            uc_id,
+            review_output,
+            session.get("event_storming", {}).get("items", {}).get(uc_id, {}),
+        ),
+        label="event-storming content review",
+        timeout_error=(
+            f"event storming content review timed out after {EVENT_STORMING_TIMEOUT_SEC} seconds. "
+            "Retry to continue from this use case."
+        ),
+    )
+    return _parse_event_storming_review_json(final_message)
+
+
+def _event_storming_content_review_contract(
+    change_set_id: str,
+    uc_id: str,
+    review_output: Path,
+    item: dict[str, Any],
+) -> str:
+    return f"""## Interactive Event Storming Content Review
+
+Target ChangeSet: {change_set_id}
+Target Use Case: {uc_id}
+
+Use `artifact_reviewer` and $harness-artifact-reviewer.
+Review content correctness, completeness, contradictions, and stage-boundary fit. Do not only check Markdown shape. Do not edit event-storming artifacts.
+Write one review report to `{review_output}`.
+
+Return only JSON with keys: status, questions, review_file, findings, blocker.
+- Return `complete` only when commands, events, policies, systems, external systems, and invariants match the ChangeSet, use-case slice, and E2E goal without contradictions.
+- Return `needs_input` only when a content issue requires a user answer inside the event-storming boundary.
+- Return `blocked` when content is wrong, contradictory, missing required event-storming elements, or violates stage boundaries and can be corrected by rerunning event storming with findings.
+- Findings must name exact wrong or missing content so the next event-storming turn can fix it.
+
+Previous review feedback:
+{json.dumps(item.get("review_feedback", []), ensure_ascii=False, indent=2)}
+"""
+
+
+def _parse_event_storming_review_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", stripped, flags=re.DOTALL)
+        if match is None:
+            raise ValueError(f"event storming content review returned non-JSON output: {stripped}")
+        data = json.loads(match.group(0))
+    if not isinstance(data, dict):
+        raise ValueError("event storming content review returned invalid JSON object")
+
+    status = str(data.get("status", "") or "").strip().lower()
+    if status not in {"needs_input", "complete", "blocked"}:
+        raise ValueError(f"event storming content review returned invalid status: {status or '<empty>'}")
+    raw_questions = data.get("questions", [])
+    if not isinstance(raw_questions, list):
+        raise ValueError("event storming content review returned invalid questions")
+    questions: list[dict[str, str]] = []
+    for item in raw_questions[:3]:
+        if not isinstance(item, dict):
+            continue
+        question = str(item.get("question", "") or "").strip()
+        recommended = str(item.get("recommended", "") or "").strip()
+        if question:
+            questions.append({"question": question, "recommended": recommended})
+    if status == "needs_input" and not questions:
+        raise ValueError("event storming content review needs_input requires at least one question")
+
+    raw_findings = data.get("findings", [])
+    if not isinstance(raw_findings, list):
+        raise ValueError("event storming content review returned invalid findings")
+    return {
+        "status": status,
+        "questions": questions,
+        "review_file": str(data.get("review_file", "") or "").strip(),
+        "findings": [str(item) for item in raw_findings],
+        "blocker": str(data.get("blocker", "") or "").strip(),
+    }
+
+
+def _event_storming_review_feedback(review: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": str(review.get("status", "") or ""),
+        "review_file": str(review.get("review_file", "") or ""),
+        "findings": [str(item) for item in review.get("findings", [])],
+        "blocker": str(review.get("blocker", "") or ""),
     }
 
 

--- a/tests/runtime/test_harvest_ui.py
+++ b/tests/runtime/test_harvest_ui.py
@@ -922,6 +922,16 @@ def test_event_storming_processes_use_case_queue_and_resumes_question(
         return {"status": "complete", "questions": [], "changed_files": [], "blocker": ""}
 
     monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_event_storming", fake_event_storming)
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_event_storming_content_review",
+        lambda *_args: {
+            "status": "complete",
+            "questions": [],
+            "review_file": ".harness/ui/event-storming-review-runs/run/review.md",
+            "findings": [],
+            "blocker": "",
+        },
+    )
 
     first = start_event_storming(tmp_path, "CHG-001")
     paused = advance_event_storming(tmp_path, "CHG-001")
@@ -932,6 +942,127 @@ def test_event_storming_processes_use_case_queue_and_resumes_question(
     assert completed.event_storming["complete"] is True
     assert completed.active_stage == "eventStorming"
     assert calls == [("UC-001", 0), ("UC-002", 0), ("UC-002", 1)]
+
+
+def test_event_storming_content_review_reruns_oracle_with_feedback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_passed_requirements(tmp_path)
+    write_runtime_ready_use_cases(tmp_path)
+    start_use_cases(tmp_path)
+    event_calls: list[int] = []
+    review_calls = 0
+
+    def fake_event_storming(_root: Path, session: dict, _change_set_id: str, uc_id: str) -> dict:
+        item = session["event_storming"]["items"][uc_id]
+        event_calls.append(len(item["review_feedback"]))
+        write_event_storming_slice(tmp_path, uc_id)
+        return {"status": "complete", "questions": [], "changed_files": [], "blocker": ""}
+
+    def fake_review(
+        _root: Path,
+        _session: dict,
+        _change_set_id: str,
+        _uc_id: str,
+        _output_path: Path,
+    ) -> dict:
+        nonlocal review_calls
+        review_calls += 1
+        if review_calls == 1:
+            return {
+                "status": "blocked",
+                "questions": [],
+                "review_file": ".harness/ui/event-storming-review-runs/run/review.md",
+                "findings": ["Command contradicts the use-case actor action."],
+                "blocker": "Fix command and event names.",
+            }
+        return {
+            "status": "complete",
+            "questions": [],
+            "review_file": ".harness/ui/event-storming-review-runs/run/review.md",
+            "findings": [],
+            "blocker": "",
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_event_storming", fake_event_storming)
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_event_storming_content_review",
+        fake_review,
+    )
+
+    result = start_event_storming(tmp_path, "CHG-001")
+
+    item = result.event_storming["items"]["UC-001"]
+    assert result.event_storming["complete"] is True
+    assert item["status"] == "complete"
+    assert event_calls == [0, 1]
+    assert review_calls == 2
+    assert item["review_feedback"][0]["findings"] == [
+        "Command contradicts the use-case actor action."
+    ]
+
+
+def test_event_storming_content_review_question_resumes_after_answer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_passed_requirements(tmp_path)
+    write_runtime_ready_use_cases(tmp_path)
+    start_use_cases(tmp_path)
+    event_calls: list[int] = []
+    review_calls = 0
+
+    def fake_event_storming(_root: Path, session: dict, _change_set_id: str, uc_id: str) -> dict:
+        item = session["event_storming"]["items"][uc_id]
+        event_calls.append(len(item["clarifications"]))
+        write_event_storming_slice(tmp_path, uc_id)
+        return {"status": "complete", "questions": [], "changed_files": [], "blocker": ""}
+
+    def fake_review(
+        _root: Path,
+        _session: dict,
+        _change_set_id: str,
+        _uc_id: str,
+        _output_path: Path,
+    ) -> dict:
+        nonlocal review_calls
+        review_calls += 1
+        if review_calls == 1:
+            return {
+                "status": "needs_input",
+                "questions": [
+                    {
+                        "question": "Which actor-visible failure event should be modeled?",
+                        "recommended": "Use Open Failed.",
+                    }
+                ],
+                "review_file": ".harness/ui/event-storming-review-runs/run/review.md",
+                "findings": ["Failure event is ambiguous."],
+                "blocker": "",
+            }
+        return {
+            "status": "complete",
+            "questions": [],
+            "review_file": ".harness/ui/event-storming-review-runs/run/review.md",
+            "findings": [],
+            "blocker": "",
+        }
+
+    monkeypatch.setattr("harness_codex.runtime.harvest_ui._run_event_storming", fake_event_storming)
+    monkeypatch.setattr(
+        "harness_codex.runtime.harvest_ui._run_event_storming_content_review",
+        fake_review,
+    )
+
+    paused = start_event_storming(tmp_path, "CHG-001")
+    completed = answer_event_storming(tmp_path, "CHG-001", "UC-001", "Use Open Failed.")
+
+    assert paused.event_storming["status"] == "needs_input"
+    assert paused.current_question["question"] == "Which actor-visible failure event should be modeled?"
+    assert completed.event_storming["complete"] is True
+    assert event_calls == [0, 1]
+    assert review_calls == 2
 
 
 def test_changeset_snapshot_excludes_stale_event_output_until_stage_completes(tmp_path: Path) -> None:


### PR DESCRIPTION
## 구현 의도
이벤트 스토밍 UI 흐름에서 마크다운 형태만 검증하던 한계를 줄이고, 생성된 내용의 모순이나 누락을 별도 콘텐츠 리뷰로 검증한 뒤 실패 시 같은 유스케이스의 이벤트 스토밍을 다시 실행하도록 했습니다.

## 구현 방식
- 이벤트 스토밍 완료 직후 artifact_reviewer 기반 콘텐츠 리뷰 단계를 실행합니다.
- 리뷰가 blocked를 반환하면 findings/blocker를 다음 이벤트 스토밍 프롬프트에 전달하고 최대 3회까지 재생성합니다.
- 리뷰가 needs_input을 반환하면 UI 질문 상태로 멈추고, 답변 후 동일 유스케이스를 다시 진행합니다.
- 리뷰 결과와 피드백을 이벤트 스토밍 세션 상태에 저장합니다.

## 검증 방법
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_harvest_ui.py::test_event_storming_processes_use_case_queue_and_resumes_question tests/runtime/test_harvest_ui.py::test_event_storming_content_review_reruns_oracle_with_feedback tests/runtime/test_harvest_ui.py::test_event_storming_content_review_question_resumes_after_answer`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/runtime/test_harvest_ui.py`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s tests/test_cli_commands.py::test_interactive_grill_me_stages_use_shared_runner tests/test_cli_commands.py::test_interactive_content_review_questions_rerun_stage_agent tests/test_cli_commands.py::test_interactive_content_review_blocked_reruns_stage_agent`
- `/home/jiwoo/workspace/harness/venv/bin/python3 -m py_compile harness_codex/runtime/harvest_ui.py`
- `git diff --check`
- 전체 테스트 `/home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q -s`는 변경과 무관한 기존 skill 계약 테스트 12개 실패를 확인했습니다. 실패 항목은 planner/executor skill 문구 누락 관련입니다.

## 위험 및 롤백
이벤트 스토밍 UI 단계에서 리뷰 에이전트 실행이 추가되어 단계 시간이 늘어날 수 있습니다. 문제가 있으면 이 커밋을 되돌리면 기존 구조 검증만 수행하는 흐름으로 복구됩니다.

## 스크린샷
UI 렌더링 변경이 없어 해당 없음.