### PR TITLE
feat: typed work-item document contracts

### DIFF
--- a/.github/workflows/runtime-contracts.yml
+++ b/.github/workflows/runtime-contracts.yml
@@ -23,3 +23,4 @@ jobs:
           tests/runtime/test_affected_use_case_resolver.py
           tests/runtime/test_workflow_materializer.py
           tests/runtime/test_typed_work_item_documents.py
+          tests/runtime/test_typed_work_item_document_cli.py

--- a/.github/workflows/runtime-contracts.yml
+++ b/.github/workflows/runtime-contracts.yml
@@ -1,0 +1,25 @@
+name: Runtime document contracts
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - feat/**
+
+jobs:
+  runtime-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest pyyaml
+      - name: Run resolver and materializer contract tests
+        run: >-
+          python -m pytest -q
+          tests/runtime/test_affected_use_case_resolver.py
+          tests/runtime/test_workflow_materializer.py
+          tests/runtime/test_typed_work_item_documents.py

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -26,15 +26,13 @@ steps:
     skill_id: harness-code-planner
     inputs:
       - docs/changes/active/<CHG-ID>.md
-      - docs/use-cases/<UC-ID>
-      - docs/maintenance/<MAINT-ID>
-      - ARCHITECTURE.md
       - .codex/repository-settings.md
     outputs:
       - docs/plans/active/<WORK-ITEM-ID>/plan.md
     metadata:
       stage: plan
       scope: work_item
+      inputs_resolved_by: work_item_document_contract
 
   - id: secure-work-item-plan
     kind: agent
@@ -45,9 +43,6 @@ steps:
     inputs:
       - docs/changes/active/<CHG-ID>.md
       - docs/plans/active/<WORK-ITEM-ID>/plan.md
-      - docs/use-cases/<UC-ID>
-      - docs/maintenance/<MAINT-ID>
-      - ARCHITECTURE.md
       - .codex/repository-settings.md
     outputs:
       - docs/plans/active/<WORK-ITEM-ID>/plan.md
@@ -55,6 +50,7 @@ steps:
       stage: security-review
       scope: work_item
       baseline: OWASP ASVS 5.0.0
+      inputs_resolved_by: work_item_document_contract
 
   - id: review-work-item-plan
     kind: agent
@@ -65,8 +61,6 @@ steps:
     inputs:
       - docs/changes/active/<CHG-ID>.md
       - docs/plans/active/<WORK-ITEM-ID>/plan.md
-      - docs/use-cases/<UC-ID>
-      - docs/maintenance/<MAINT-ID>
       - .codex/test-gate.yaml
     outputs:
       - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/reviews/plan-review.md
@@ -74,6 +68,7 @@ steps:
       stage: review
       scope: work_item
       artifact_type: plan
+      inputs_resolved_by: work_item_document_contract
       review_gate:
         output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/reviews/plan-review.md
         status_label: Review Status
@@ -93,17 +88,16 @@ steps:
     metadata:
       stage: execution
       scope: work_item
+      inputs_resolved_by: work_item_document_contract
 
   - id: verify-work-item
     kind: validator
-    name: Verify work item against E2E or maintenance verification goal
+    name: Verify work item against its type-specific verification goal
     needs: [execute-work-item]
     command: python3 -m harness_codex.runtime.verify_work_item --change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>
     timeout_sec: 600
     inputs:
       - docs/plans/active/<WORK-ITEM-ID>/plan.md
-      - docs/use-cases/<UC-ID>/e2e-goal.md
-      - docs/maintenance/<MAINT-ID>/verification-goal.md
       - .codex/test-gate.yaml
     outputs:
       - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json
@@ -111,6 +105,7 @@ steps:
     metadata:
       stage: verification
       scope: work_item
+      inputs_resolved_by: work_item_document_contract
       test_gate: .codex/test-gate.yaml required stages must PASS
 
   - id: classify-verification-result

--- a/harness_codex/runtime/changes/models.py
+++ b/harness_codex/runtime/changes/models.py
@@ -11,7 +11,10 @@ class WorkItemType(str, Enum):
     """Execution unit type inside one ChangeSet."""
 
     USE_CASE = "use_case"
+    BUG_FIX = "bug_fix"
     MAINTENANCE = "maintenance"
+    REFACTORING = "refactoring"
+    FEATURE_EXTENSION = "feature_extension"
 
 
 @dataclass(frozen=True)

--- a/harness_codex/runtime/changes/resolver.py
+++ b/harness_codex/runtime/changes/resolver.py
@@ -1,4 +1,4 @@
-"""Resolve active ChangeSets into per-use-case planning scopes."""
+"""Resolve active ChangeSets into per-work-item planning scopes."""
 
 from __future__ import annotations
 
@@ -6,17 +6,23 @@ from pathlib import Path
 
 from harness_codex.runtime.changes.models import (
     AffectedUseCase,
+    AffectedWorkItem,
     ChangeSet,
     PlanningBlocked,
     PlanningInputScope,
     WorkItemType,
 )
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.changes.work_item_documents import (
+    executor_input_paths,
+    missing_required_documents,
+    planner_input_paths,
+    verification_goal_path,
+)
 from harness_codex.runtime.document_metadata import (
     approval_status_from_markdown,
     approval_status_from_metadata_or_markdown,
 )
-
 
 APPROVED_STATUS = "approved"
 
@@ -26,7 +32,7 @@ class NoActiveChangeSetsError(FileNotFoundError):
 
 
 class ChangeSetResolver:
-    """Load active ChangeSets and derive planner/executor inputs."""
+    """Load active ChangeSets and derive type-aware planner/executor inputs."""
 
     def __init__(self, repo_root: Path | str) -> None:
         self.repo_root = Path(repo_root)
@@ -34,27 +40,23 @@ class ChangeSetResolver:
     def list_active(self) -> tuple[ChangeSet, ...]:
         active_dir = self.repo_root / "docs/changes/active"
         paths = sorted(active_dir.glob("*.md"))
-
         if not paths:
             raise NoActiveChangeSetsError(
                 f"No active ChangeSet markdown files found in {active_dir}"
             )
-
         return tuple(self.load(path) for path in paths)
 
     def load(self, path: Path | str) -> ChangeSet:
         change_set_path = Path(path)
         if not change_set_path.is_absolute():
             change_set_path = self.repo_root / change_set_path
-
         text = change_set_path.read_text(encoding="utf-8")
-        relative_path = change_set_path.relative_to(self.repo_root)
-        return parse_changeset_markdown(text, path=relative_path)
+        return parse_changeset_markdown(
+            text,
+            path=change_set_path.relative_to(self.repo_root),
+        )
 
-    def validate_active_change_set(
-        self,
-        change_set: ChangeSet,
-    ) -> PlanningBlocked | None:
+    def validate_active_change_set(self, change_set: ChangeSet) -> PlanningBlocked | None:
         """Validate the ChangeSet-first runtime contract before execution."""
 
         change_set_path = change_set.path or Path(
@@ -93,67 +95,11 @@ class ChangeSetResolver:
                 )
 
             if work_item.work_item_type == WorkItemType.USE_CASE:
-                use_case = _find_use_case(change_set, work_item.work_item_id)
-                if use_case is None:
-                    return PlanningBlocked(
-                        change_set_id=change_set.change_set_id,
-                        reason=(
-                            f"Use case work item {work_item.work_item_id} "
-                            "has no affected use-case row"
-                        ),
-                    )
-                missing = _missing_use_case_documents(
-                    self.repo_root,
-                    use_case.slice_path,
-                )
-                if missing:
-                    return PlanningBlocked(
-                        change_set_id=change_set.change_set_id,
-                        reason=(
-                            f"Use case work item {work_item.work_item_id} "
-                            "is missing required documents: "
-                            + ", ".join(str(path) for path in missing)
-                        ),
-                    )
-                approval_found, approval_status, approval_path = _approval_status_for_use_case(
-                    self.repo_root,
-                    change_set,
-                    use_case,
-                )
-                if approval_found and approval_status.lower() != APPROVED_STATUS:
-                    return PlanningBlocked(
-                        change_set_id=change_set.change_set_id,
-                        reason=(
-                            f"Use case work item {work_item.work_item_id} "
-                            "is waiting for E2E goal approval: "
-                            f"status={approval_status or '<blank>'} "
-                            f"path={approval_path}. "
-                            "Approve or refine the E2E goal before planning."
-                        ),
-                    )
-                technical_blocked = _technical_decision_blocker(
-                    self.repo_root,
-                    work_item.work_item_id,
-                    use_case.slice_path / "technical-decisions.md",
-                )
-                if technical_blocked:
-                    return PlanningBlocked(
-                        change_set_id=change_set.change_set_id,
-                        reason=technical_blocked,
-                    )
-                continue
-
-            missing = _missing_maintenance_documents(self.repo_root, work_item.slice_path)
-            if missing:
-                return PlanningBlocked(
-                    change_set_id=change_set.change_set_id,
-                    reason=(
-                        f"Maintenance work item {work_item.work_item_id} "
-                        "is missing required documents: "
-                        + ", ".join(str(path) for path in missing)
-                    ),
-                )
-
+                blocked = self._validate_use_case_work_item(change_set, work_item)
+            else:
+                blocked = self._validate_typed_work_item(change_set, work_item)
+            if blocked is not None:
+                return blocked
         return None
 
     def resolve_planning_scopes(
@@ -164,13 +110,11 @@ class ChangeSetResolver:
         if blocked is not None:
             return blocked
 
-        work_items = change_set.ordered_work_items()
         change_set_path = change_set.path or Path(
             f"docs/changes/active/{change_set.change_set_id}.md"
         )
         scopes: list[PlanningInputScope] = []
-
-        for work_item in work_items:
+        for work_item in change_set.ordered_work_items():
             if work_item.work_item_type == WorkItemType.USE_CASE:
                 use_case = _find_use_case(change_set, work_item.work_item_id)
                 if use_case is None:
@@ -181,20 +125,15 @@ class ChangeSetResolver:
                             "has no affected use-case row"
                         ),
                     )
+                scopes.append(_use_case_scope(change_set, change_set_path, use_case))
+            else:
                 scopes.append(
-                    _use_case_scope(change_set, change_set_path, use_case)
+                    _typed_work_item_scope(
+                        repo_root=self.repo_root,
+                        change_set_path=change_set_path,
+                        work_item=work_item,
+                    )
                 )
-                continue
-
-            scopes.append(
-                _maintenance_scope(
-                    repo_root=self.repo_root,
-                    change_set_path=change_set_path,
-                    work_item_id=work_item.work_item_id,
-                    slice_path=work_item.slice_path,
-                )
-            )
-
         return tuple(scopes)
 
     def resolve_work_item_scopes(
@@ -203,11 +142,76 @@ class ChangeSetResolver:
     ) -> tuple[PlanningInputScope, ...] | PlanningBlocked:
         return self.resolve_planning_scopes(change_set)
 
+    def _validate_use_case_work_item(
+        self,
+        change_set: ChangeSet,
+        work_item: AffectedWorkItem,
+    ) -> PlanningBlocked | None:
+        use_case = _find_use_case(change_set, work_item.work_item_id)
+        if use_case is None:
+            return PlanningBlocked(
+                change_set_id=change_set.change_set_id,
+                reason=(
+                    f"Use case work item {work_item.work_item_id} "
+                    "has no affected use-case row"
+                ),
+            )
+        missing = _missing_use_case_documents(self.repo_root, use_case.slice_path)
+        if missing:
+            return PlanningBlocked(
+                change_set_id=change_set.change_set_id,
+                reason=(
+                    f"Use case work item {work_item.work_item_id} "
+                    "is missing required documents: "
+                    + ", ".join(str(path) for path in missing)
+                ),
+            )
+        approval_found, approval_status, approval_path = _approval_status_for_use_case(
+            self.repo_root,
+            change_set,
+            use_case,
+        )
+        if approval_found and approval_status.lower() != APPROVED_STATUS:
+            return PlanningBlocked(
+                change_set_id=change_set.change_set_id,
+                reason=(
+                    f"Use case work item {work_item.work_item_id} "
+                    "is waiting for E2E goal approval: "
+                    f"status={approval_status or '<blank>'} path={approval_path}. "
+                    "Approve or refine the E2E goal before planning."
+                ),
+            )
+        technical_blocked = _technical_decision_blocker(
+            self.repo_root,
+            work_item.work_item_id,
+            use_case.slice_path / "technical-decisions.md",
+        )
+        if technical_blocked:
+            return PlanningBlocked(
+                change_set_id=change_set.change_set_id,
+                reason=technical_blocked,
+            )
+        return None
 
-def _find_use_case(
-    change_set: ChangeSet,
-    uc_id: str,
-) -> AffectedUseCase | None:
+    def _validate_typed_work_item(
+        self,
+        change_set: ChangeSet,
+        work_item: AffectedWorkItem,
+    ) -> PlanningBlocked | None:
+        missing = missing_required_documents(self.repo_root, work_item)
+        if not missing:
+            return None
+        label = "Maintenance" if work_item.work_item_type == WorkItemType.MAINTENANCE else work_item.work_item_type.value
+        return PlanningBlocked(
+            change_set_id=change_set.change_set_id,
+            reason=(
+                f"{label} work item {work_item.work_item_id} is missing required documents: "
+                + ", ".join(str(path) for path in missing)
+            ),
+        )
+
+
+def _find_use_case(change_set: ChangeSet, uc_id: str) -> AffectedUseCase | None:
     for use_case in change_set.affected_use_cases:
         if use_case.uc_id == uc_id:
             return use_case
@@ -255,7 +259,6 @@ def _use_case_scope(
             )
         )
     )
-
     return PlanningInputScope(
         change_set_path=change_set_path,
         use_case=use_case,
@@ -269,72 +272,42 @@ def _use_case_scope(
     )
 
 
-def _maintenance_scope(
+def _typed_work_item_scope(
     *,
     repo_root: Path,
     change_set_path: Path,
-    work_item_id: str,
-    slice_path: Path,
+    work_item: AffectedWorkItem,
 ) -> PlanningInputScope:
-    plan_path = Path(f"docs/plans/active/{work_item_id}/plan.md")
-    technical_decisions = slice_path / "technical-decisions.md"
-    planner_inputs = tuple(
-        path
-        for path in (
-            change_set_path,
-            slice_path / "change-intent.md",
-            slice_path / "affected-files.md",
-            technical_decisions,
-            slice_path / "verification-goal.md",
-            Path("ARCHITECTURE.md"),
-            Path(".codex/repository-settings.md"),
-        )
-        if path != technical_decisions or (repo_root / technical_decisions).exists()
-    )
-    executor_inputs = (
-        plan_path,
-        slice_path / "change-intent.md",
-        slice_path / "affected-files.md",
-        slice_path / "verification-goal.md",
-        change_set_path,
-        Path("ARCHITECTURE.md"),
-        Path(".codex/repository-settings.md"),
-    )
+    plan_path = Path(f"docs/plans/active/{work_item.work_item_id}/plan.md")
     return PlanningInputScope(
         change_set_path=change_set_path,
         use_case=None,
-        planner_inputs=planner_inputs,
-        executor_inputs=executor_inputs,
+        planner_inputs=planner_input_paths(
+            repo_root,
+            change_set_path=change_set_path,
+            work_item=work_item,
+        ),
+        executor_inputs=executor_input_paths(
+            repo_root,
+            change_set_path=change_set_path,
+            work_item=work_item,
+            plan_path=plan_path,
+        ),
         e2e_goal_path=None,
-        work_item_id=work_item_id,
-        work_item_type=WorkItemType.MAINTENANCE,
+        work_item_id=work_item.work_item_id,
+        work_item_type=work_item.work_item_type,
         plan_path=plan_path,
-        verification_goal_path=slice_path / "verification-goal.md",
+        verification_goal_path=verification_goal_path(work_item),
     )
 
 
-def _missing_use_case_documents(
-    repo_root: Path,
-    slice_path: Path,
-) -> tuple[Path, ...]:
+def _missing_use_case_documents(repo_root: Path, slice_path: Path) -> tuple[Path, ...]:
     required = (
         slice_path / "use-case.md",
         slice_path / "event-storming.md",
         slice_path / "ddd-design.md",
         slice_path / "technical-decisions.md",
         slice_path / "e2e-goal.md",
-    )
-    return tuple(path for path in required if not (repo_root / path).exists())
-
-
-def _missing_maintenance_documents(
-    repo_root: Path,
-    slice_path: Path,
-) -> tuple[Path, ...]:
-    required = (
-        slice_path / "change-intent.md",
-        slice_path / "affected-files.md",
-        slice_path / "verification-goal.md",
     )
     return tuple(path for path in required if not (repo_root / path).exists())
 
@@ -348,7 +321,6 @@ def _approval_status_for_use_case(
     for approval in change_set.goal_approvals:
         if approval.work_item_id == use_case.uc_id:
             return True, approval.approval_status, approval.path
-
     found, status = _use_case_approval_status(repo_root, e2e_goal_path)
     return found, status, e2e_goal_path
 
@@ -357,17 +329,11 @@ def _use_case_approval_status(repo_root: Path, e2e_goal_path: Path) -> tuple[boo
     absolute_path = repo_root / e2e_goal_path
     if not absolute_path.exists():
         return False, ""
-
     return approval_status_from_metadata_or_markdown(absolute_path.read_text(encoding="utf-8"))
 
 
-def _technical_decision_blocker(
-    repo_root: Path,
-    uc_id: str,
-    technical_path: Path,
-) -> str | None:
-    absolute_path = repo_root / technical_path
-    text = absolute_path.read_text(encoding="utf-8")
+def _technical_decision_blocker(repo_root: Path, uc_id: str, technical_path: Path) -> str | None:
+    text = (repo_root / technical_path).read_text(encoding="utf-8")
     approval_found, approval_status = approval_status_from_metadata_or_markdown(text)
     normalized_status = approval_status.lower()
     if not approval_found or normalized_status != APPROVED_STATUS:
@@ -377,16 +343,13 @@ def _technical_decision_blocker(
             f"status={status} path={technical_path}. "
             "Approve technical decisions before planning."
         )
-
     pending_items = _pending_decision_items_from_markdown(text)
     if pending_items:
-        preview = "; ".join(pending_items[:3])
         return (
             f"Use case work item {uc_id} has pending technical decisions: "
-            f"path={technical_path} pending={preview}. "
+            f"path={technical_path} pending={'; '.join(pending_items[:3])}. "
             "Resolve implementation-impacting decisions before planning."
         )
-
     return None
 
 
@@ -407,9 +370,7 @@ def _pending_decision_items_from_markdown(text: str) -> tuple[str, ...]:
                 or "미결정" in heading
             )
             continue
-        if not in_section:
-            continue
-        if not stripped or stripped.startswith("|") or stripped.startswith("---"):
+        if not in_section or not stripped or stripped.startswith("|") or stripped.startswith("---"):
             continue
         item = stripped.lstrip("-*0123456789. ").strip()
         if not item or item.lower() in {"none", "n/a", "no pending decisions"}:

--- a/harness_codex/runtime/changes/work_item_documents.py
+++ b/harness_codex/runtime/changes/work_item_documents.py
@@ -1,0 +1,308 @@
+"""Typed work-item document contracts and non-destructive scaffolding.
+
+Use-case slices are created by the README design stages.  Non-UC work items use
+this module to create a small, type-specific slice without inventing a use case.
+The generator only creates missing files; it never replaces authored content.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from harness_codex.runtime.changes.models import AffectedWorkItem, ChangeSet, WorkItemType
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+
+
+_COMMON_DOCUMENTS = (
+    "brief.md",
+    "architecture-impact.md",
+    "verification-goal.md",
+    "links.md",
+)
+
+_TYPE_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
+    WorkItemType.USE_CASE: (),
+    WorkItemType.MAINTENANCE: (
+        "change-intent.md",
+        "affected-files.md",
+        "maintenance-spec.md",
+    ),
+    WorkItemType.BUG_FIX: ("reproduction.md", "regression-goal.md"),
+    WorkItemType.REFACTORING: ("refactoring-contract.md",),
+    WorkItemType.FEATURE_EXTENSION: ("acceptance-delta.md",),
+}
+
+# Existing maintenance slices are intentionally kept compatible during migration.
+_REQUIRED_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
+    WorkItemType.USE_CASE: (
+        "use-case.md",
+        "event-storming.md",
+        "ddd-design.md",
+        "technical-decisions.md",
+        "e2e-goal.md",
+    ),
+    WorkItemType.MAINTENANCE: (
+        "change-intent.md",
+        "affected-files.md",
+        "verification-goal.md",
+    ),
+    WorkItemType.BUG_FIX: _COMMON_DOCUMENTS + ("reproduction.md", "regression-goal.md"),
+    WorkItemType.REFACTORING: _COMMON_DOCUMENTS + ("refactoring-contract.md",),
+    WorkItemType.FEATURE_EXTENSION: _COMMON_DOCUMENTS + ("acceptance-delta.md",),
+}
+
+
+def required_document_paths(work_item: AffectedWorkItem) -> tuple[Path, ...]:
+    """Return the documents that must exist before the work item can be planned."""
+
+    return tuple(work_item.slice_path / name for name in _REQUIRED_DOCUMENTS[work_item.work_item_type])
+
+
+def scaffold_document_paths(work_item: AffectedWorkItem) -> tuple[Path, ...]:
+    """Return all documents created for a non-UC work item."""
+
+    if work_item.work_item_type == WorkItemType.USE_CASE:
+        return ()
+    names = (*_COMMON_DOCUMENTS, *_TYPE_DOCUMENTS[work_item.work_item_type])
+    return tuple(dict.fromkeys(work_item.slice_path / name for name in names))
+
+
+def verification_goal_path(work_item: AffectedWorkItem) -> Path:
+    """Return the verification contract used by the work-item verifier."""
+
+    if work_item.work_item_type == WorkItemType.USE_CASE:
+        return work_item.slice_path / "e2e-goal.md"
+    return work_item.slice_path / "verification-goal.md"
+
+
+def missing_required_documents(repo_root: Path | str, work_item: AffectedWorkItem) -> tuple[Path, ...]:
+    """Return required contract documents absent from the repository."""
+
+    root = Path(repo_root)
+    return tuple(path for path in required_document_paths(work_item) if not (root / path).is_file())
+
+
+def planner_input_paths(
+    repo_root: Path | str,
+    *,
+    change_set_path: Path,
+    work_item: AffectedWorkItem,
+) -> tuple[Path, ...]:
+    """Resolve type-aware planner inputs without UC/maintenance path guessing."""
+
+    root = Path(repo_root)
+    candidates = (
+        change_set_path,
+        *required_document_paths(work_item),
+        *scaffold_document_paths(work_item),
+        Path("ARCHITECTURE.md"),
+        Path(".codex/repository-settings.md"),
+    )
+    return _existing_or_required(root, candidates, required=(change_set_path, *required_document_paths(work_item)))
+
+
+def executor_input_paths(
+    repo_root: Path | str,
+    *,
+    change_set_path: Path,
+    work_item: AffectedWorkItem,
+    plan_path: Path,
+) -> tuple[Path, ...]:
+    """Resolve type-aware executor inputs, retaining the active plan even before it exists."""
+
+    return tuple(
+        dict.fromkeys(
+            (
+                plan_path,
+                *planner_input_paths(
+                    repo_root,
+                    change_set_path=change_set_path,
+                    work_item=work_item,
+                ),
+            )
+        )
+    )
+
+
+def scaffold_work_item_documents(
+    repo_root: Path | str,
+    work_item: AffectedWorkItem,
+) -> tuple[Path, ...]:
+    """Create missing non-UC document templates and return created relative paths.
+
+    The function deliberately does not scaffold use-case design artifacts.  Those
+    files are owned by the README stages from use-case-definition through
+    technical-decisions and must not be replaced with empty templates.
+    """
+
+    if work_item.work_item_type == WorkItemType.USE_CASE:
+        return ()
+
+    root = Path(repo_root)
+    created: list[Path] = []
+    for relative_path in scaffold_document_paths(work_item):
+        absolute_path = root / relative_path
+        if absolute_path.exists():
+            continue
+        absolute_path.parent.mkdir(parents=True, exist_ok=True)
+        absolute_path.write_text(_render_document(work_item, relative_path.name), encoding="utf-8")
+        created.append(relative_path)
+    return tuple(created)
+
+
+def scaffold_change_set_work_items(
+    repo_root: Path | str,
+    change_set: ChangeSet,
+    *,
+    work_item_id: str | None = None,
+) -> tuple[Path, ...]:
+    """Scaffold one or all non-UC work items in a ChangeSet."""
+
+    created: list[Path] = []
+    for work_item in change_set.ordered_work_items():
+        if work_item_id and work_item.work_item_id != work_item_id:
+            continue
+        created.extend(scaffold_work_item_documents(repo_root, work_item))
+    if work_item_id and not any(item.work_item_id == work_item_id for item in change_set.ordered_work_items()):
+        raise ValueError(f"Work item {work_item_id} is not affected by {change_set.change_set_id}")
+    return tuple(created)
+
+
+def _existing_or_required(
+    root: Path,
+    candidates: Iterable[Path],
+    *,
+    required: Iterable[Path],
+) -> tuple[Path, ...]:
+    required_paths = set(required)
+    paths: list[Path] = []
+    for path in candidates:
+        if path in required_paths or (root / path).exists():
+            paths.append(path)
+    return tuple(dict.fromkeys(paths))
+
+
+def _render_document(work_item: AffectedWorkItem, filename: str) -> str:
+    frontmatter = (
+        "---\n"
+        f"work_item_id: {work_item.work_item_id}\n"
+        f"work_item_type: {work_item.work_item_type.value}\n"
+        "status: draft\n"
+        "---\n\n"
+    )
+    title = f"# {work_item.work_item_id}. {work_item.name or work_item.work_item_type.value}\n\n"
+    bodies = {
+        "brief.md": (
+            "## Goal\n\n- TODO: describe the intended outcome.\n\n"
+            "## Scope\n\n- Bounded context: TODO\n- Aggregate, component, module, or adapter: TODO\n\n"
+            "## Non-goals\n\n- TODO\n\n## Dependencies\n\n- TODO\n"
+        ),
+        "architecture-impact.md": (
+            "## Architecture Impact\n\n"
+            "- Decision: `none` (`none` | `update` | `create` | `adr`)\n"
+            "- Reason: TODO\n"
+            "- Canonical architecture references: TODO or `none`\n"
+        ),
+        "verification-goal.md": (
+            "## Verification Goal\n\n"
+            "- Observable success condition: TODO\n"
+            "- Required command evidence: TODO\n"
+            "- Regression or compatibility condition: TODO\n"
+        ),
+        "links.md": (
+            "## Links\n\n"
+            "- ChangeSet: TODO\n"
+            "- Related issue: TODO\n"
+            "- Related UC, ADR, or architecture document: TODO\n"
+        ),
+        "change-intent.md": (
+            "## Change Intent\n\n"
+            "- Problem or operational goal: TODO\n"
+            "- Expected improvement: TODO\n"
+        ),
+        "affected-files.md": (
+            "## Affected Files and Boundaries\n\n"
+            "- Included modules or files: TODO\n"
+            "- Excluded modules or files: TODO\n"
+        ),
+        "maintenance-spec.md": (
+            "## Maintenance Specification\n\n"
+            "- Current condition: TODO\n"
+            "- Target metric or operational property: TODO\n"
+            "- Rollback: TODO\n"
+        ),
+        "reproduction.md": (
+            "## Reproduction\n\n"
+            "- Preconditions: TODO\n"
+            "- Steps: TODO\n"
+            "- Expected result: TODO\n"
+            "- Actual result: TODO\n"
+        ),
+        "regression-goal.md": (
+            "## Regression Goal\n\n"
+            "- Failure that must not recur: TODO\n"
+            "- Test level and scenario: TODO\n"
+        ),
+        "refactoring-contract.md": (
+            "## Refactoring Contract\n\n"
+            "- Structural intent: TODO\n"
+            "- Preserved public behavior and invariants: TODO\n"
+            "- Forbidden behavior changes: TODO\n"
+        ),
+        "acceptance-delta.md": (
+            "## Acceptance Delta\n\n"
+            "- Parent UC or new-UC decision: TODO\n"
+            "- Changed acceptance conditions: TODO\n"
+            "- Compatibility and migration impact: TODO\n"
+        ),
+    }
+    return frontmatter + title + bodies[filename]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Scaffold typed non-UC work-item documents without overwriting authored text."""
+
+    parser = argparse.ArgumentParser(description="Scaffold typed ChangeSet work-item documents.")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--change-set", required=True)
+    parser.add_argument("--work-item", default="")
+    parser.add_argument("--check", action="store_true", help="Fail when required documents are missing.")
+    args = parser.parse_args(argv)
+
+    root = Path(args.repo_root)
+    change_set_path = root / "docs/changes/active" / f"{args.change_set}.md"
+    if not change_set_path.is_file():
+        raise ValueError(f"Active ChangeSet file not found: {change_set_path.relative_to(root)}")
+    change_set = parse_changeset_markdown(
+        change_set_path.read_text(encoding="utf-8"),
+        path=change_set_path.relative_to(root),
+    )
+    selected = tuple(
+        item
+        for item in change_set.ordered_work_items()
+        if not args.work_item or item.work_item_id == args.work_item
+    )
+    if not selected:
+        raise ValueError(f"Work item {args.work_item} is not affected by {change_set.change_set_id}")
+
+    if args.check:
+        missing = tuple(
+            path
+            for item in selected
+            for path in missing_required_documents(root, item)
+        )
+        if missing:
+            print("MISSING: " + ", ".join(str(path) for path in missing))
+            return 1
+        print("PASS: typed work-item document contracts are complete")
+        return 0
+
+    created = tuple(path for item in selected for path in scaffold_work_item_documents(root, item))
+    print("CREATED: " + (", ".join(str(path) for path in created) if created else "none"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness_codex/runtime/workflows/materializer.py
+++ b/harness_codex/runtime/workflows/materializer.py
@@ -8,11 +8,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from harness_codex.runtime.changes.models import (
-    ChangeSet,
-    PlanningInputScope,
-    WorkItemType,
-)
+from harness_codex.runtime.changes.models import ChangeSet, PlanningInputScope, WorkItemType
 from harness_codex.runtime.models import Step, Workflow
 
 _PLACEHOLDER_PATTERN = re.compile(r"<[A-Z][A-Z0-9_-]*>")
@@ -29,13 +25,7 @@ def materialize_workflow_for_scope(
     *,
     run_id: str = "",
 ) -> Workflow:
-    """Return a workflow whose placeholders are bound to one ChangeSet work item.
-
-    Workflows may retain readable legacy UC/maintenance paths in YAML, but runtime
-    inputs are always replaced with the resolver's type-aware document contract.
-    This prevents a bug-fix or refactoring work item from preflighting an empty
-    `docs/use-cases/` or `docs/maintenance/` placeholder path.
-    """
+    """Return one workflow bound to the selected work-item document contract."""
 
     replacements = materialization_replacements(change_set, scope, run_id=run_id)
     steps = tuple(_materialize_step(step, replacements, scope) for step in workflow.steps)
@@ -106,10 +96,7 @@ def unresolved_placeholders(workflow: Workflow) -> frozenset[str]:
     )
 
 
-def write_materialized_workflow_manifest(
-    workflow: Workflow,
-    path: Path,
-) -> None:
+def write_materialized_workflow_manifest(workflow: Workflow, path: Path) -> None:
     """Write a compact materialized workflow manifest for run auditing."""
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -124,8 +111,11 @@ def _materialize_step(
     replacements: dict[str, str],
     scope: PlanningInputScope,
 ) -> Step:
-    materialized_inputs = tuple(_replace_path(path, replacements) for path in step.inputs)
-    scoped_inputs = _scoped_inputs_for_step(step, scope)
+    materialized_inputs = tuple(
+        _replace_path(path, replacements)
+        for path in step.inputs
+        if _input_is_applicable(path, replacements)
+    )
     return replace(
         step,
         id=_replace_text(step.id, replacements),
@@ -134,24 +124,35 @@ def _materialize_step(
         agent_id=_replace_optional_text(step.agent_id, replacements),
         skill_id=_replace_optional_text(step.skill_id, replacements),
         command=_replace_optional_text(step.command, replacements),
-        inputs=scoped_inputs if scoped_inputs is not None else materialized_inputs,
+        inputs=_scoped_inputs_for_step(materialized_inputs, step, scope),
         outputs=tuple(_replace_path(path, replacements) for path in step.outputs),
         metadata=_replace_metadata(step.metadata, replacements),
     )
 
 
+def _input_is_applicable(path: Path, replacements: dict[str, str]) -> bool:
+    raw_path = str(path)
+    return not (
+        ("<UC-ID>" in raw_path and not replacements["<UC-ID>"])
+        or ("<MAINT-ID>" in raw_path and not replacements["<MAINT-ID>"])
+    )
+
+
 def _scoped_inputs_for_step(
+    materialized_inputs: tuple[Path, ...],
     step: Step,
     scope: PlanningInputScope,
-) -> tuple[Path, ...] | None:
-    """Select resolver-owned inputs for work-item execution stages."""
+) -> tuple[Path, ...]:
+    """Combine stable step inputs with the selected type-specific documents."""
 
     stage = str(step.metadata.get("stage") or "")
     if stage in {"plan", "security-review", "review"}:
-        return scope.planner_inputs
-    if stage in {"execution", "verification"}:
-        return scope.executor_inputs
-    return None
+        contract_inputs = scope.planner_inputs
+    elif stage in {"execution", "verification"}:
+        contract_inputs = scope.executor_inputs
+    else:
+        contract_inputs = ()
+    return tuple(dict.fromkeys((*materialized_inputs, *contract_inputs)))
 
 
 def _replace_optional_text(value: str | None, replacements: dict[str, str]) -> str | None:

--- a/harness_codex/runtime/workflows/materializer.py
+++ b/harness_codex/runtime/workflows/materializer.py
@@ -29,10 +29,16 @@ def materialize_workflow_for_scope(
     *,
     run_id: str = "",
 ) -> Workflow:
-    """Return a workflow whose placeholders are bound to one ChangeSet work item."""
+    """Return a workflow whose placeholders are bound to one ChangeSet work item.
+
+    Workflows may retain readable legacy UC/maintenance paths in YAML, but runtime
+    inputs are always replaced with the resolver's type-aware document contract.
+    This prevents a bug-fix or refactoring work item from preflighting an empty
+    `docs/use-cases/` or `docs/maintenance/` placeholder path.
+    """
 
     replacements = materialization_replacements(change_set, scope, run_id=run_id)
-    steps = tuple(_materialize_step(step, replacements) for step in workflow.steps)
+    steps = tuple(_materialize_step(step, replacements, scope) for step in workflow.steps)
     materialized = replace(
         workflow,
         steps=steps,
@@ -113,7 +119,13 @@ def write_materialized_workflow_manifest(
     )
 
 
-def _materialize_step(step: Step, replacements: dict[str, str]) -> Step:
+def _materialize_step(
+    step: Step,
+    replacements: dict[str, str],
+    scope: PlanningInputScope,
+) -> Step:
+    materialized_inputs = tuple(_replace_path(path, replacements) for path in step.inputs)
+    scoped_inputs = _scoped_inputs_for_step(step, scope)
     return replace(
         step,
         id=_replace_text(step.id, replacements),
@@ -122,10 +134,24 @@ def _materialize_step(step: Step, replacements: dict[str, str]) -> Step:
         agent_id=_replace_optional_text(step.agent_id, replacements),
         skill_id=_replace_optional_text(step.skill_id, replacements),
         command=_replace_optional_text(step.command, replacements),
-        inputs=tuple(_replace_path(path, replacements) for path in step.inputs),
+        inputs=scoped_inputs if scoped_inputs is not None else materialized_inputs,
         outputs=tuple(_replace_path(path, replacements) for path in step.outputs),
         metadata=_replace_metadata(step.metadata, replacements),
     )
+
+
+def _scoped_inputs_for_step(
+    step: Step,
+    scope: PlanningInputScope,
+) -> tuple[Path, ...] | None:
+    """Select resolver-owned inputs for work-item execution stages."""
+
+    stage = str(step.metadata.get("stage") or "")
+    if stage in {"plan", "security-review", "review"}:
+        return scope.planner_inputs
+    if stage in {"execution", "verification"}:
+        return scope.executor_inputs
+    return None
 
 
 def _replace_optional_text(value: str | None, replacements: dict[str, str]) -> str | None:

--- a/tests/runtime/test_typed_work_item_document_cli.py
+++ b/tests/runtime/test_typed_work_item_document_cli.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from harness_codex.runtime.changes.work_item_documents import main
+
+
+def test_scaffold_command_generates_and_checks_bug_fix_documents(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    change_set_path.parent.mkdir(parents=True)
+    change_set_path.write_text(
+        """# ChangeSet CHG-001
+
+## 1. Metadata
+|Item|Value|
+|---|---|
+|ChangeSet ID|`CHG-001`|
+|Status|active|
+
+## 5. Affected Work Items
+|Work Item ID|Type|Name|Impact Type|Slice Path|Status|
+|---|---|---|---|---|---|
+|`BUG-042`|bug_fix|Duplicate queue admission after reconnect|fix|`docs/maintenance/BUG-042/`|planned|
+""",
+        encoding="utf-8",
+    )
+
+    assert main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--change-set",
+            "CHG-001",
+            "--work-item",
+            "BUG-042",
+        ]
+    ) == 0
+    assert "reproduction.md" in capsys.readouterr().out
+
+    expected = (
+        "brief.md",
+        "architecture-impact.md",
+        "verification-goal.md",
+        "links.md",
+        "reproduction.md",
+        "regression-goal.md",
+    )
+    for filename in expected:
+        assert (tmp_path / "docs/maintenance/BUG-042" / filename).is_file()
+
+    assert main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--change-set",
+            "CHG-001",
+            "--work-item",
+            "BUG-042",
+            "--check",
+        ]
+    ) == 0
+    assert "PASS: typed work-item document contracts are complete" in capsys.readouterr().out

--- a/tests/runtime/test_typed_work_item_documents.py
+++ b/tests/runtime/test_typed_work_item_documents.py
@@ -1,0 +1,161 @@
+from pathlib import Path
+
+from harness_codex.runtime.changes import ChangeSetResolver
+from harness_codex.runtime.changes.models import (
+    AffectedWorkItem,
+    ChangeSet,
+    PlanningInputScope,
+    WorkItemType,
+)
+from harness_codex.runtime.changes.work_item_documents import (
+    missing_required_documents,
+    scaffold_work_item_documents,
+)
+from harness_codex.runtime.models import RunMode, Step, StepKind, Workflow
+from harness_codex.runtime.workflows import materialize_workflow_for_scope
+
+
+def test_scaffold_bug_fix_documents_are_type_specific_and_non_destructive(
+    tmp_path: Path,
+) -> None:
+    work_item = AffectedWorkItem(
+        work_item_id="BUG-042",
+        work_item_type=WorkItemType.BUG_FIX,
+        name="Duplicate queue admission after reconnect",
+        impact_type="fix",
+        slice_path=Path("docs/maintenance/BUG-042"),
+    )
+
+    created = scaffold_work_item_documents(tmp_path, work_item)
+
+    expected = {
+        Path("docs/maintenance/BUG-042/brief.md"),
+        Path("docs/maintenance/BUG-042/architecture-impact.md"),
+        Path("docs/maintenance/BUG-042/verification-goal.md"),
+        Path("docs/maintenance/BUG-042/links.md"),
+        Path("docs/maintenance/BUG-042/reproduction.md"),
+        Path("docs/maintenance/BUG-042/regression-goal.md"),
+    }
+    assert set(created) == expected
+    assert not missing_required_documents(tmp_path, work_item)
+
+    reproduction = tmp_path / "docs/maintenance/BUG-042/reproduction.md"
+    reproduction.write_text("# Authored reproduction\n", encoding="utf-8")
+    assert scaffold_work_item_documents(tmp_path, work_item) == ()
+    assert reproduction.read_text(encoding="utf-8") == "# Authored reproduction\n"
+
+
+def test_resolver_uses_bug_fix_contract_without_use_case_paths(tmp_path: Path) -> None:
+    change_set_path = tmp_path / "docs/changes/active/CHG-001.md"
+    change_set_path.parent.mkdir(parents=True)
+    change_set_path.write_text(
+        """# ChangeSet CHG-001
+
+## 1. Metadata
+|Item|Value|
+|---|---|
+|ChangeSet ID|`CHG-001`|
+|Status|active|
+
+## 5. Affected Work Items
+|Work Item ID|Type|Name|Impact Type|Slice Path|Status|
+|---|---|---|---|---|---|
+|`BUG-042`|bug_fix|Duplicate queue admission after reconnect|fix|`docs/maintenance/BUG-042/`|planned|
+""",
+        encoding="utf-8",
+    )
+    work_item = AffectedWorkItem(
+        work_item_id="BUG-042",
+        work_item_type=WorkItemType.BUG_FIX,
+        name="Duplicate queue admission after reconnect",
+        impact_type="fix",
+        slice_path=Path("docs/maintenance/BUG-042"),
+    )
+    scaffold_work_item_documents(tmp_path, work_item)
+
+    resolver = ChangeSetResolver(tmp_path)
+    scopes = resolver.resolve_work_item_scopes(resolver.load(change_set_path))
+
+    assert isinstance(scopes, tuple)
+    scope = scopes[0]
+    assert scope.work_item_type == WorkItemType.BUG_FIX
+    assert scope.verification_goal_path == Path("docs/maintenance/BUG-042/verification-goal.md")
+    assert Path("docs/maintenance/BUG-042/reproduction.md") in scope.planner_inputs
+    assert Path("docs/maintenance/BUG-042/regression-goal.md") in scope.planner_inputs
+    assert not any("docs/use-cases" in str(path) for path in scope.planner_inputs)
+
+
+def test_materializer_uses_scope_owned_inputs_for_non_uc_work_item() -> None:
+    workflow = Workflow(
+        name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="plan-work-item",
+                kind=StepKind.AGENT,
+                name="Plan <WORK-ITEM-ID>",
+                agent_id="implementation_planner",
+                inputs=(
+                    Path("docs/use-cases/<UC-ID>"),
+                    Path("docs/maintenance/<MAINT-ID>"),
+                ),
+                metadata={"stage": "plan", "scope": "work_item"},
+            ),
+            Step(
+                id="verify-work-item",
+                kind=StepKind.VALIDATOR,
+                name="Verify <WORK-ITEM-ID>",
+                command="echo verify",
+                inputs=(
+                    Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
+                    Path("docs/maintenance/<MAINT-ID>/verification-goal.md"),
+                ),
+                metadata={"stage": "verification", "scope": "work_item"},
+            ),
+        ),
+    )
+    change_set = ChangeSet(
+        change_set_id="CHG-001",
+        title="Typed work-item documents",
+        path=Path("docs/changes/active/CHG-001.md"),
+    )
+    scope = PlanningInputScope(
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        use_case=None,
+        planner_inputs=(
+            Path("docs/changes/active/CHG-001.md"),
+            Path("docs/maintenance/BUG-042/reproduction.md"),
+            Path("docs/maintenance/BUG-042/regression-goal.md"),
+        ),
+        executor_inputs=(
+            Path("docs/plans/active/BUG-042/plan.md"),
+            Path("docs/maintenance/BUG-042/verification-goal.md"),
+        ),
+        e2e_goal_path=None,
+        work_item_id="BUG-042",
+        work_item_type=WorkItemType.BUG_FIX,
+        plan_path=Path("docs/plans/active/BUG-042/plan.md"),
+        verification_goal_path=Path("docs/maintenance/BUG-042/verification-goal.md"),
+    )
+
+    materialized = materialize_workflow_for_scope(workflow, change_set, scope)
+
+    assert materialized.steps[0].inputs == scope.planner_inputs
+    assert materialized.steps[1].inputs == scope.executor_inputs
+    assert not any(str(path) in {"docs/use-cases", "docs/maintenance"} for step in materialized.steps for path in step.inputs)
+
+
+def test_refactoring_contract_uses_preservation_document(tmp_path: Path) -> None:
+    work_item = AffectedWorkItem(
+        work_item_id="REF-007",
+        work_item_type=WorkItemType.REFACTORING,
+        name="Split dispatcher and broker responsibilities",
+        impact_type="refactor",
+        slice_path=Path("docs/maintenance/REF-007"),
+    )
+
+    scaffold_work_item_documents(tmp_path, work_item)
+
+    contract = tmp_path / "docs/maintenance/REF-007/refactoring-contract.md"
+    assert contract.is_file()
+    assert "Preserved public behavior and invariants" in contract.read_text(encoding="utf-8")

--- a/tests/runtime/test_typed_work_item_documents.py
+++ b/tests/runtime/test_typed_work_item_documents.py
@@ -145,6 +145,47 @@ def test_materializer_uses_scope_owned_inputs_for_non_uc_work_item() -> None:
     assert not any(str(path) in {"docs/use-cases", "docs/maintenance"} for step in materialized.steps for path in step.inputs)
 
 
+def test_materializer_preserves_shared_plan_and_gate_inputs() -> None:
+    workflow = Workflow(
+        name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="review-work-item-plan",
+                kind=StepKind.AGENT,
+                name="Review <WORK-ITEM-ID>",
+                agent_id="artifact_reviewer",
+                inputs=(
+                    Path("docs/changes/active/<CHG-ID>.md"),
+                    Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),
+                    Path(".codex/test-gate.yaml"),
+                ),
+                metadata={"stage": "review", "scope": "work_item"},
+            ),
+        ),
+    )
+    change_set = ChangeSet(change_set_id="CHG-001", title="Typed work-item documents")
+    scope = PlanningInputScope(
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        use_case=None,
+        planner_inputs=(Path("docs/maintenance/BUG-042/reproduction.md"),),
+        executor_inputs=(),
+        e2e_goal_path=None,
+        work_item_id="BUG-042",
+        work_item_type=WorkItemType.BUG_FIX,
+        plan_path=Path("docs/plans/active/BUG-042/plan.md"),
+    )
+
+    materialized = materialize_workflow_for_scope(workflow, change_set, scope)
+
+    assert materialized.steps[0].inputs == (
+        Path("docs/changes/active/CHG-001.md"),
+        Path("docs/plans/active/BUG-042/plan.md"),
+        Path(".codex/test-gate.yaml"),
+        Path("docs/maintenance/BUG-042/reproduction.md"),
+    )
+
+
 def test_refactoring_contract_uses_preservation_document(tmp_path: Path) -> None:
     work_item = AffectedWorkItem(
         work_item_id="REF-007",


### PR DESCRIPTION
Implements typed work-item document contracts for #374.

Included:
- `bug_fix`, `refactoring`, `feature_extension` work-item types
- non-destructive non-UC document scaffolding
- type-aware planner and executor input resolution
- shared plan and test-gate inputs retained during materialization
- contract test workflow

Latest validation: `Runtime document contracts` passed.

Covered scenarios:
- bug-fix document command and contract check
- existing document preservation
- resolver avoids unrelated UC paths
- refactoring contract creation
- materializer keeps plan/test-gate inputs

Limits:
- the scaffolder is currently a module command, not a first-class `./harness` command
- generated non-UC docs are draft templates
- hierarchical canonical architecture documents and ChangeSet finalization are outside this PR