### PR TITLE
refactor(prompt): scope runtime context by workflow stage

### DIFF
--- a/harness_codex/runtime/prompt.py
+++ b/harness_codex/runtime/prompt.py
@@ -20,6 +20,7 @@ _AGENT_CONTEXT = Path("AGENTS.md")
 _CONTEXT_MAP = Path("docs/agent/context.md")
 _COMMANDS = Path("docs/agent/commands.md")
 _SESSION_STATE = Path("docs/agent/session-state.md")
+PROMPT_CONTEXT_PROFILE_KEY = "prompt_context_profile"
 
 CONTEXT_PROFILE_FILES: dict[str, tuple[Path, ...]] = {
     "plan": (_AGENT_CONTEXT, _CONTEXT_MAP, _COMMANDS),
@@ -38,6 +39,7 @@ REPOSITORY_SETTINGS_FILES = (
 STEP_METADATA_ALLOWLIST = frozenset(
     {
         "stage",
+        PROMPT_CONTEXT_PROFILE_KEY,
         "scope",
         "condition",
         "fail_closed",
@@ -124,15 +126,24 @@ def _stage(step: Step) -> str:
     return str(step.metadata.get("stage") or "").strip()
 
 
+def _context_profile(step: Step) -> str:
+    value = step.metadata.get(PROMPT_CONTEXT_PROFILE_KEY)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return _stage(step)
+
+
 def _source_of_truth(step: Step, context: RunContext) -> str:
     stage = _stage(step)
-    paths = list(CONTEXT_PROFILE_FILES.get(stage, (_AGENT_CONTEXT,)))
+    profile = _context_profile(step)
+    paths = list(CONTEXT_PROFILE_FILES.get(profile, (_AGENT_CONTEXT,)))
     if bool(context.metadata.get("include_session_state")):
         paths.append(_SESSION_STATE)
 
     references = _existing_context_references(context.repo_root, tuple(dict.fromkeys(paths)))
     lines = [
         f"Stage: `{stage or 'unspecified'}`.",
+        f"Context profile: `{profile or 'default'}`.",
         "Use only the referenced source files needed to complete this step; do not broad-dump repository context.",
     ]
     if references:
@@ -236,6 +247,7 @@ def _workflow_definition(step: Step, context: RunContext) -> str:
                     "workflow_name": context.workflow_name,
                     "workflow_path": str(workflow_path),
                     "stage": _stage(step),
+                    "prompt_context_profile": _context_profile(step),
                     "scope": step.metadata.get("scope"),
                 }
             ),

--- a/harness_codex/runtime/prompt.py
+++ b/harness_codex/runtime/prompt.py
@@ -1,9 +1,9 @@
-"""Deterministic prompt assembly for runtime agent invocations."""
+"""Deterministic, stage-scoped prompt assembly for runtime agent invocations."""
 
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -12,22 +12,64 @@ from harness_codex.runtime.models import RunContext, Step
 STABLE_PREFIX_END_MARKER = "## 6. ChangeSet Summary"
 
 RUNTIME_INSTRUCTION = """You are running as a harness-codex specialist agent.
-Follow the repository source-of-truth files, the selected agent instruction, and the selected skill.
-Keep edits inside the active ChangeSet and selected work item boundary.
+Read `AGENTS.md` first, then load only the stage-profile and runtime-declared files needed for this task.
+Follow the selected agent instruction and skill. Keep edits inside the active ChangeSet and selected work-item boundary.
 Report changed files, verification commands, and blockers clearly."""
 
-SOURCE_OF_TRUTH_FILES = (
-    Path("AGENTS.md"),
-    Path("docs/agent/context.md"),
-    Path("docs/agent/commands.md"),
-    Path("docs/agent/session-state.md"),
-    Path("docs/agent/codebase-artifacts.md"),
-    Path("docs/agent/design-conformance-report.md"),
-)
+_AGENT_CONTEXT = Path("AGENTS.md")
+_CONTEXT_MAP = Path("docs/agent/context.md")
+_COMMANDS = Path("docs/agent/commands.md")
+_SESSION_STATE = Path("docs/agent/session-state.md")
+
+CONTEXT_PROFILE_FILES: dict[str, tuple[Path, ...]] = {
+    "plan": (_AGENT_CONTEXT, _CONTEXT_MAP, _COMMANDS),
+    "security-review": (_AGENT_CONTEXT, _CONTEXT_MAP),
+    "review": (_AGENT_CONTEXT,),
+    "execution": (_AGENT_CONTEXT, _COMMANDS),
+    "security-verification": (_AGENT_CONTEXT, _CONTEXT_MAP),
+    "documentation": (_AGENT_CONTEXT, _CONTEXT_MAP, _COMMANDS),
+}
 
 REPOSITORY_SETTINGS_FILES = (
     Path(".codex/repository-settings.md"),
     Path(".codex/stack-profile.yaml"),
+)
+
+STEP_METADATA_ALLOWLIST = frozenset(
+    {
+        "stage",
+        "scope",
+        "condition",
+        "fail_closed",
+        "baseline",
+        "artifact_type",
+        "review_gate",
+        "test_gate",
+        "run_on_final_work_item_only",
+        "loop_target",
+        "max_retry_count",
+        "classifier",
+    }
+)
+
+RUNTIME_METADATA_ALLOWLIST = frozenset(
+    {
+        "is_final_work_item",
+        "skip_precompleted_work_item_steps",
+        "force_verification",
+        "resume_target",
+        "resume_from_step",
+        "include_session_state",
+    }
+)
+
+WORK_ITEM_METADATA_ALLOWLIST = (
+    "id",
+    "type",
+    "name",
+    "slice_path",
+    "verification_goal_path",
+    "status",
 )
 
 
@@ -40,16 +82,16 @@ def build_agent_prompt(
     skill_path: Path | None = None,
     skill_body: str | None = None,
 ) -> str:
-    """Build one deterministic agent prompt.
+    """Build one deterministic prompt with stage-scoped references only.
 
     Stable sections are emitted first so repeated calls can reuse provider prefix
-    caches. Volatile run IDs, ChangeSet data, selected work item data, logs, and
-    current payload are intentionally appended after the stable prefix marker.
+    caches. Volatile run IDs, ChangeSet data, selected work-item data, and
+    execution controls are appended after the stable prefix marker.
     """
-
+    del skill_body  # The agent loads the selected skill from its repository path.
     sections = [
         _section("1. Runtime Instruction", RUNTIME_INSTRUCTION),
-        _section("2. Repository Source of Truth", _source_of_truth(context.repo_root)),
+        _section("2. Repository Source of Truth", _source_of_truth(step, context)),
         _section(
             "3. Delegation Contract",
             _delegation_contract(
@@ -60,8 +102,8 @@ def build_agent_prompt(
                 context.repo_root,
             ),
         ),
-        _section("4. Workflow Definition", _workflow_definition(context)),
-        _section("5. Repository Settings", _repository_settings(context.repo_root)),
+        _section("4. Workflow Definition", _workflow_definition(step, context)),
+        _section("5. Repository Settings", _repository_settings(step, context.repo_root)),
         _section("6. ChangeSet Summary", _changeset_summary(context)),
         _section("7. Work Item Slice", _work_item_slice(context)),
         _section("8. Current Execution Payload", _current_execution_payload(step, context)),
@@ -71,7 +113,6 @@ def build_agent_prompt(
 
 def stable_prefix(prompt: str) -> str:
     """Return the stable prefix before volatile ChangeSet/work-item sections."""
-
     return prompt.split(STABLE_PREFIX_END_MARKER, maxsplit=1)[0]
 
 
@@ -79,27 +120,67 @@ def _section(title: str, body: str) -> str:
     return f"## {title}\n\n{body.strip()}"
 
 
-def _source_of_truth(repo_root: Path) -> str:
-    return _fixed_file_block(repo_root, SOURCE_OF_TRUTH_FILES)
+def _stage(step: Step) -> str:
+    return str(step.metadata.get("stage") or "").strip()
 
 
-def _repository_settings(repo_root: Path) -> str:
-    return _fixed_file_block(repo_root, REPOSITORY_SETTINGS_FILES)
+def _source_of_truth(step: Step, context: RunContext) -> str:
+    stage = _stage(step)
+    paths = list(CONTEXT_PROFILE_FILES.get(stage, (_AGENT_CONTEXT,)))
+    if bool(context.metadata.get("include_session_state")):
+        paths.append(_SESSION_STATE)
+
+    references = _existing_context_references(context.repo_root, tuple(dict.fromkeys(paths)))
+    lines = [
+        f"Stage: `{stage or 'unspecified'}`.",
+        "Use only the referenced source files needed to complete this step; do not broad-dump repository context.",
+    ]
+    if references:
+        lines.extend(["", "Available source references:", references])
+    else:
+        lines.append("\nNo optional profile files are present.")
+    return "\n".join(lines)
 
 
-def _fixed_file_block(repo_root: Path, paths: tuple[Path, ...]) -> str:
+def _repository_settings(step: Step, repo_root: Path) -> str:
+    declared = tuple(path for path in REPOSITORY_SETTINGS_FILES if path in step.inputs)
+    references = _existing_context_references(repo_root, declared)
+    return references or "No declared repository settings file is present."
+
+
+def _existing_context_references(repo_root: Path, paths: tuple[Path, ...]) -> str:
     blocks: list[str] = []
-    for path in sorted(paths, key=lambda value: str(value)):
+    for path in sorted(set(paths), key=str):
         absolute = repo_root / path
-        if absolute.exists():
-            blocks.append(_file_block(path, absolute.read_text(encoding="utf-8"), repo_root))
-        else:
-            blocks.append(_file_block(path, "<not found>", repo_root))
-    return "\n\n".join(blocks)
+        if absolute.is_file():
+            blocks.append(_context_reference(path, absolute.read_text(encoding="utf-8"), repo_root))
+    return "\n".join(blocks)
 
 
-def _file_block(path: Path, content: str, repo_root: Path) -> str:
-    return _cached_context_block(path, content, "text", repo_root=repo_root)
+def _context_reference(source_path: Path, content: str, repo_root: Path) -> str:
+    normalized = content.strip()
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    cache_path = Path(".harness/cache/prompt-context") / f"{digest}.md"
+    absolute_cache_path = repo_root / cache_path
+    absolute_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    if not absolute_cache_path.exists():
+        absolute_cache_path.write_text(
+            "\n".join(
+                [
+                    f"# Prompt Context Cache {digest}",
+                    "",
+                    f"- Source: `{source_path}`",
+                    f"- Bytes: {len(normalized.encode('utf-8'))}",
+                    "",
+                    "```text",
+                    normalized,
+                    "```",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+    return f"- `{source_path}` (Cache: `{cache_path}`, bytes: {len(normalized.encode('utf-8'))})"
 
 
 def _delegation_contract(
@@ -144,63 +225,63 @@ def _display_path(path: Path, repo_root: Path) -> str:
         return str(path)
 
 
-def _workflow_definition(context: RunContext) -> str:
-    workflow_path = context.repo_root / ".harness/workflows" / f"{context.workflow_name}.yaml"
-    if workflow_path.exists():
-        return _file_block(
-            Path(".harness/workflows") / f"{context.workflow_name}.yaml",
-            workflow_path.read_text(encoding="utf-8"),
-            context.repo_root,
-        )
-    return _file_block(
-        Path(".harness/workflows") / f"{context.workflow_name}.yaml",
-        "<not found>",
-        context.repo_root,
+def _workflow_definition(step: Step, context: RunContext) -> str:
+    workflow_path = Path(".harness/workflows") / f"{context.workflow_name}.yaml"
+    return "\n".join(
+        [
+            "Use the workflow file only when this stage definition is insufficient.",
+            "```json",
+            _stable_json(
+                {
+                    "workflow_name": context.workflow_name,
+                    "workflow_path": str(workflow_path),
+                    "stage": _stage(step),
+                    "scope": step.metadata.get("scope"),
+                }
+            ),
+            "```",
+        ]
     )
+
+
+def _step_contract(step: Step) -> dict[str, Any]:
+    return {
+        "id": step.id,
+        "kind": step.kind.value,
+        "name": step.name,
+        "agent_id": step.agent_id,
+        "skill_id": _prompt_skill_id(step),
+        "command": step.command,
+        "inputs": [str(path) for path in step.inputs],
+        "outputs": [str(path) for path in step.outputs],
+        "metadata": {
+            key: _jsonable(step.metadata[key])
+            for key in sorted(STEP_METADATA_ALLOWLIST)
+            if key in step.metadata
+        },
+    }
 
 
 def _changeset_summary(context: RunContext) -> str:
     change_set_path_value = context.metadata.get("change_set_path")
     change_set_path = Path(str(change_set_path_value)) if change_set_path_value else None
-    blocks = [
-        "```json",
-        _stable_json(
-            {
-                "change_set_id": context.metadata.get("change_set_id"),
-                "change_set_path": str(change_set_path) if change_set_path else None,
-            }
-        ),
-        "```",
-    ]
-    if change_set_path is not None:
-        absolute = context.repo_root / change_set_path
-        blocks.extend(
-            [
-                "",
-                _file_block(
-                    change_set_path,
-                    absolute.read_text(encoding="utf-8") if absolute.exists() else "<not found>",
-                    context.repo_root,
-                ),
-            ]
+    summary: dict[str, Any] = {
+        "change_set_id": context.metadata.get("change_set_id"),
+        "change_set_path": str(change_set_path) if change_set_path else None,
+    }
+    if change_set_path is not None and (context.repo_root / change_set_path).is_file():
+        summary["change_set_reference"] = _context_reference(
+            change_set_path,
+            (context.repo_root / change_set_path).read_text(encoding="utf-8"),
+            context.repo_root,
         )
-    return "\n".join(blocks)
+    return "\n".join(["```json", _stable_json(summary), "```"])
 
 
 def _work_item_slice(context: RunContext) -> str:
     active_id = context.metadata.get("active_work_item_id")
     active_type = context.metadata.get("active_work_item_type")
-    affected_items = context.metadata.get("affected_work_items", ())
-    active_item = None
-    if isinstance(affected_items, list):
-        active_item = next(
-            (
-                item
-                for item in affected_items
-                if isinstance(item, dict) and item.get("id") == active_id
-            ),
-            None,
-        )
+    active_item = _active_work_item(context.metadata.get("affected_work_items"), active_id)
     return "\n".join(
         [
             "```json",
@@ -216,6 +297,19 @@ def _work_item_slice(context: RunContext) -> str:
     )
 
 
+def _active_work_item(affected_items: Any, active_id: Any) -> dict[str, Any] | None:
+    if not isinstance(affected_items, list):
+        return None
+    for item in affected_items:
+        if isinstance(item, dict) and item.get("id") == active_id:
+            return {
+                key: _jsonable(item[key])
+                for key in WORK_ITEM_METADATA_ALLOWLIST
+                if key in item
+            }
+    return None
+
+
 def _current_execution_payload(step: Step, context: RunContext) -> str:
     payload = {
         "run_id": context.run_id,
@@ -224,18 +318,12 @@ def _current_execution_payload(step: Step, context: RunContext) -> str:
         "repo_root": str(context.repo_root),
         "workdir": str(context.workdir),
         "run_dir": str(context.run_dir),
-        "step": {
-            "id": step.id,
-            "kind": step.kind.value,
-            "name": step.name,
-            "agent_id": step.agent_id,
-            "skill_id": _prompt_skill_id(step),
-            "command": step.command,
-            "inputs": [str(path) for path in step.inputs],
-            "outputs": [str(path) for path in step.outputs],
-            "metadata": _jsonable(step.metadata),
+        "step": _step_contract(step),
+        "runtime_controls": {
+            key: _jsonable(context.metadata[key])
+            for key in sorted(RUNTIME_METADATA_ALLOWLIST)
+            if key in context.metadata
         },
-        "runtime_metadata": _jsonable(context.metadata),
     }
     return "\n".join(["```json", _stable_json(payload), "```"])
 
@@ -251,59 +339,6 @@ def _prompt_skill_id(step: Step) -> str | None:
     if isinstance(value, str) and value.strip():
         return value
     return None
-
-
-def _cached_context_block(
-    source_path: Path,
-    content: str,
-    language: str,
-    *,
-    repo_root: Path | None = None,
-) -> str:
-    normalized = content.strip()
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-    cache_path = Path(".harness/cache/prompt-context") / f"{digest}.md"
-    if repo_root is not None:
-        absolute_cache_path = repo_root / cache_path
-        absolute_cache_path.parent.mkdir(parents=True, exist_ok=True)
-        if not absolute_cache_path.exists():
-            absolute_cache_path.write_text(
-                "\n".join(
-                    [
-                        f"# Prompt Context Cache {digest}",
-                        "",
-                        f"- Source: `{source_path}`",
-                        f"- Language: `{language}`",
-                        f"- Bytes: {len(normalized.encode('utf-8'))}",
-                        "",
-                        f"```{language}",
-                        normalized,
-                        "```",
-                        "",
-                    ]
-                ),
-                encoding="utf-8",
-            )
-    return "\n".join(
-        [
-            f"### `{source_path}`",
-            f"- Cache: `{cache_path}`",
-            f"- SHA-256: `{digest}`",
-            f"- Bytes: {len(normalized.encode('utf-8'))}",
-            "- Instruction: read the cache file if this context is needed.",
-            "",
-            "Preview:",
-            "```text",
-            _preview(normalized),
-            "```",
-        ]
-    )
-
-
-def _preview(content: str, max_chars: int = 1000) -> str:
-    if len(content) <= max_chars:
-        return content
-    return content[:max_chars].rstrip() + "\n..."
 
 
 def _jsonable(value: Any) -> Any:

--- a/tests/runtime/test_prompt_builder.py
+++ b/tests/runtime/test_prompt_builder.py
@@ -137,7 +137,7 @@ def test_volatile_context_does_not_change_stable_prefix(tmp_path: Path) -> None:
     assert first != second
 
 
-def test_missing_optional_context_keeps_stable_section_order(tmp_path: Path) -> None:
+def test_missing_optional_context_is_omitted_from_prompt(tmp_path: Path) -> None:
     write_stable_context(tmp_path)
     (tmp_path / ".codex/repository-settings.md").unlink()
 
@@ -150,12 +150,8 @@ def test_missing_optional_context_keeps_stable_section_order(tmp_path: Path) -> 
         skill_body="# Skill\nexecute plan\n",
     )
 
-    assert "### `.codex/repository-settings.md`" in prompt
-    assert ".harness/cache/prompt-context/" in prompt
-    assert any(
-        "<not found>" in path.read_text(encoding="utf-8")
-        for path in (tmp_path / ".harness/cache/prompt-context").glob("*.md")
-    )
+    assert ".codex/repository-settings.md" not in prompt
+    assert "<not found>" not in prompt
     assert prompt.index("## 5. Repository Settings") < prompt.index("## 6. ChangeSet Summary")
 
 

--- a/tests/runtime/test_prompt_input_profiles.py
+++ b/tests/runtime/test_prompt_input_profiles.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind
+from harness_codex.runtime.prompt import build_agent_prompt
+
+
+def _write_context(repo: Path) -> None:
+    (repo / "AGENTS.md").write_text("# AGENTS\nROOT_MARKER\n", encoding="utf-8")
+    agent_docs = repo / "docs/agent"
+    agent_docs.mkdir(parents=True)
+    (agent_docs / "context.md").write_text("CONTEXT_MARKER\n", encoding="utf-8")
+    (agent_docs / "commands.md").write_text("COMMAND_MARKER\n", encoding="utf-8")
+    (agent_docs / "session-state.md").write_text("SESSION_MARKER\n", encoding="utf-8")
+    (agent_docs / "codebase-artifacts.md").write_text("UNRELATED_ARTIFACT_MARKER\n", encoding="utf-8")
+    (agent_docs / "design-conformance-report.md").write_text("UNRELATED_DESIGN_MARKER\n", encoding="utf-8")
+
+    codex_dir = repo / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "repository-settings.md").write_text("SETTINGS_MARKER\n", encoding="utf-8")
+
+    workflow_dir = repo / ".harness/workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "changeset-use-case-workflow.yaml").write_text(
+        "WORKFLOW_BODY_MARKER " * 500,
+        encoding="utf-8",
+    )
+    change_dir = repo / "docs/changes/active"
+    change_dir.mkdir(parents=True)
+    (change_dir / "CHG-001.md").write_text(
+        "CHANGESET_BODY_MARKER " * 500,
+        encoding="utf-8",
+    )
+
+
+def _context(repo: Path, *, include_session_state: bool = False) -> RunContext:
+    return RunContext(
+        run_id="run-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo,
+        workdir=repo,
+        run_dir=repo / ".harness/runs/run-001",
+        metadata={
+            "change_set_id": "CHG-001",
+            "change_set_path": "docs/changes/active/CHG-001.md",
+            "active_work_item_id": "UC-001",
+            "active_work_item_type": "use_case",
+            "affected_work_items": [
+                {
+                    "id": "UC-001",
+                    "type": "use_case",
+                    "slice_path": "docs/use-cases/UC-001",
+                    "secret_metadata": "MUST_NOT_APPEAR",
+                }
+            ],
+            "include_session_state": include_session_state,
+            "is_final_work_item": True,
+            "unbounded_runtime_metadata": "MUST_NOT_APPEAR",
+        },
+    )
+
+
+def _step(stage: str) -> Step:
+    return Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute work item",
+        agent_id="implementation_executor",
+        skill_id="harness-plan-executor",
+        inputs=(
+            Path("docs/plans/active/UC-001/plan.md"),
+            Path(".codex/repository-settings.md"),
+        ),
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        metadata={
+            "stage": stage,
+            "scope": "work_item",
+            "review_gate": {"approved_status": "approved"},
+            "opaque_metadata": "MUST_NOT_APPEAR",
+        },
+    )
+
+
+def _prompt(repo: Path, *, stage: str, include_session_state: bool = False) -> str:
+    return build_agent_prompt(
+        step=_step(stage),
+        context=_context(repo, include_session_state=include_session_state),
+        agent_config={"name": "implementation_executor", "description": "executor"},
+        agent_config_path=Path(".codex/agents/implementation_executor.toml"),
+        skill_path=repo / ".codex/skills/harness-plan-executor/SKILL.md",
+    )
+
+
+def test_execution_profile_is_small_and_excludes_unrelated_context(tmp_path: Path) -> None:
+    _write_context(tmp_path)
+
+    prompt = _prompt(tmp_path, stage="execution")
+
+    assert "AGENTS.md" in prompt
+    assert "docs/agent/commands.md" in prompt
+    assert "docs/agent/context.md" not in prompt
+    assert "docs/agent/session-state.md" not in prompt
+    assert "codebase-artifacts.md" not in prompt
+    assert "design-conformance-report.md" not in prompt
+    assert "ROOT_MARKER" not in prompt
+    assert "COMMAND_MARKER" not in prompt
+    assert "SESSION_MARKER" not in prompt
+
+
+def test_plan_profile_can_opt_in_to_session_state(tmp_path: Path) -> None:
+    _write_context(tmp_path)
+
+    prompt = _prompt(tmp_path, stage="plan", include_session_state=True)
+
+    assert "docs/agent/context.md" in prompt
+    assert "docs/agent/commands.md" in prompt
+    assert "docs/agent/session-state.md" in prompt
+    assert "SESSION_MARKER" not in prompt
+
+
+def test_prompt_uses_references_not_full_workflow_or_unbounded_metadata(tmp_path: Path) -> None:
+    _write_context(tmp_path)
+
+    prompt = _prompt(tmp_path, stage="security-verification")
+
+    assert "WORKFLOW_BODY_MARKER" not in prompt
+    assert "CHANGESET_BODY_MARKER" not in prompt
+    assert "MUST_NOT_APPEAR" not in prompt
+    assert '"is_final_work_item": true' in prompt
+    assert '"stage": "security-verification"' in prompt
+    assert '"opaque_metadata"' not in prompt
+    assert "docs/changes/active/CHG-001.md" in prompt
+
+
+def test_missing_optional_profile_file_is_omitted(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
+
+    prompt = _prompt(tmp_path, stage="execution")
+
+    assert "<not found>" not in prompt
+    assert "docs/agent/commands.md" not in prompt
+
+
+def test_context_cache_retains_audit_content_without_prompt_preview(tmp_path: Path) -> None:
+    _write_context(tmp_path)
+
+    prompt = _prompt(tmp_path, stage="plan")
+
+    cache_files = tuple((tmp_path / ".harness/cache/prompt-context").glob("*.md"))
+    assert cache_files
+    assert any("CONTEXT_MARKER" in path.read_text(encoding="utf-8") for path in cache_files)
+    assert "CONTEXT_MARKER" not in prompt
+    assert "Preview:" not in prompt

--- a/tests/runtime/test_prompt_input_profiles.py
+++ b/tests/runtime/test_prompt_input_profiles.py
@@ -60,7 +60,15 @@ def _context(repo: Path, *, include_session_state: bool = False) -> RunContext:
     )
 
 
-def _step(stage: str) -> Step:
+def _step(stage: str, *, prompt_context_profile: str | None = None) -> Step:
+    metadata = {
+        "stage": stage,
+        "scope": "work_item",
+        "review_gate": {"approved_status": "approved"},
+        "opaque_metadata": "MUST_NOT_APPEAR",
+    }
+    if prompt_context_profile is not None:
+        metadata["prompt_context_profile"] = prompt_context_profile
     return Step(
         id="execute-work-item",
         kind=StepKind.AGENT,
@@ -72,18 +80,19 @@ def _step(stage: str) -> Step:
             Path(".codex/repository-settings.md"),
         ),
         outputs=(Path("docs/plans/active/UC-001/plan.md"),),
-        metadata={
-            "stage": stage,
-            "scope": "work_item",
-            "review_gate": {"approved_status": "approved"},
-            "opaque_metadata": "MUST_NOT_APPEAR",
-        },
+        metadata=metadata,
     )
 
 
-def _prompt(repo: Path, *, stage: str, include_session_state: bool = False) -> str:
+def _prompt(
+    repo: Path,
+    *,
+    stage: str,
+    include_session_state: bool = False,
+    prompt_context_profile: str | None = None,
+) -> str:
     return build_agent_prompt(
-        step=_step(stage),
+        step=_step(stage, prompt_context_profile=prompt_context_profile),
         context=_context(repo, include_session_state=include_session_state),
         agent_config={"name": "implementation_executor", "description": "executor"},
         agent_config_path=Path(".codex/agents/implementation_executor.toml"),
@@ -116,6 +125,37 @@ def test_plan_profile_can_opt_in_to_session_state(tmp_path: Path) -> None:
     assert "docs/agent/commands.md" in prompt
     assert "docs/agent/session-state.md" in prompt
     assert "SESSION_MARKER" not in prompt
+
+
+def test_public_stage_can_use_internal_prompt_context_profile(tmp_path: Path) -> None:
+    _write_context(tmp_path)
+
+    prompt = _prompt(
+        tmp_path,
+        stage="plan-writing",
+        prompt_context_profile="plan",
+    )
+
+    assert "Stage: `plan-writing`." in prompt
+    assert "Context profile: `plan`." in prompt
+    assert "docs/agent/context.md" in prompt
+    assert "docs/agent/commands.md" in prompt
+    assert '"prompt_context_profile": "plan"' in prompt
+
+
+def test_public_implementation_stage_can_use_security_profile(tmp_path: Path) -> None:
+    _write_context(tmp_path)
+
+    prompt = _prompt(
+        tmp_path,
+        stage="implementation",
+        prompt_context_profile="security-verification",
+    )
+
+    assert "Stage: `implementation`." in prompt
+    assert "Context profile: `security-verification`." in prompt
+    assert "docs/agent/context.md" in prompt
+    assert "docs/agent/commands.md" not in prompt
 
 
 def test_prompt_uses_references_not_full_workflow_or_unbounded_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## 구현 의도

런타임 agent prompt가 모든 단계에 동일한 source-of-truth preview, workflow 전체 preview, repository settings, 전체 runtime metadata를 넣는 구조를 줄입니다. 이 PR은 스킬 간 위임·순서 불일치 문제는 별도 이슈 범위로 남기고, prompt input 경계만 다룹니다.

## 구현 접근

### Stage별 context profile

| Context profile | 자동 reference |
| --- | --- |
| `plan` | `AGENTS.md`, context map, commands |
| `security-review` | `AGENTS.md`, context map |
| `review` | `AGENTS.md` |
| `execution` | `AGENTS.md`, commands |
| `security-verification` | `AGENTS.md`, context map |
| `documentation` | `AGENTS.md`, context map, commands |

공개 workflow stage와 prompt context profile은 분리합니다. workflow가 `plan-writing`·`implementation`처럼 사용자-facing stage 이름을 바꾸더라도, 각 agent step은 `prompt_context_profile` metadata로 필요한 최소 context profile을 명시합니다. 해당 metadata가 없으면 기존처럼 `stage`를 fallback으로 사용합니다.

Prompt에는 파일 본문 preview 대신 원본 경로, cache path, byte size만 넣습니다. agent는 필요한 파일만 직접 읽습니다.

### 입력 축소 규칙

- 존재하지 않는 optional context는 `<not found>` block을 만들지 않습니다.
- `docs/agent/session-state.md`는 기본 입력에서 제외하고 `include_session_state`가 명시된 run에서만 reference합니다.
- workflow 전체는 넣지 않고 workflow name/path/stage/scope/prompt context profile만 전달합니다.
- ChangeSet은 본문 preview 대신 ID/path/cache reference만 전달합니다.
- work item과 runtime metadata는 allowlist만 payload에 포함합니다.
- step input/output 및 gate metadata는 ChangeSet 이후 payload에 두어 stable prefix에서 work-item별 변동을 제거했습니다.

## 변경 파일

- `harness_codex/runtime/prompt.py`
  - stage-scoped context profile, public stage와 prompt profile 분리, optional context omission, metadata allowlist, compact workflow/ChangeSet contract
- `tests/runtime/test_prompt_builder.py`
  - optional context가 prompt에 남지 않는 정책 반영
- `tests/runtime/test_prompt_input_profiles.py`
  - profile, session opt-in, preview 제거, cache audit, public stage/profile 분리 검증

## 검증 방법

```text
PYTHONPATH=/mnt/data/prompt-reduction-work \
  python3 -m pytest -q tests/runtime/test_prompt_builder.py
python3 -m py_compile harness_codex/runtime/prompt.py
```

## 위험 및 롤백

- 위험: 이전에는 자동 preview로 보이던 cold-path 문서를 agent가 필요할 때 직접 읽지 않을 수 있습니다.
- 완화: `AGENTS.md` 우선 읽기, stage profile, ChangeSet/step input/output path를 계속 제공합니다.
- 롤백: `prompt.py`와 두 test 변경을 되돌리면 기존 full-preview assembly로 복구됩니다.

## 제한

로컬 환경에 Codex CLI 인증/실행 파일이 없어 live Codex model invocation은 실행하지 못했습니다. 대신 generated prompt를 실제 subprocess fixture reviewer에 전달해 prompt input boundary와 review artifact contract를 검증했습니다.