### PR TITLE
fix(전달): ChangeSet PR 커밋 범위 안전화

### DIFF
--- a/.github/workflows/runtime-contracts.yml
+++ b/.github/workflows/runtime-contracts.yml
@@ -19,3 +19,23 @@ jobs:
         run: python -m pip install --upgrade pip pytest pyyaml
       - name: Run full runtime and workflow test suite
         run: python -m pytest -q
+
+  failed-test-summary:
+    needs: runtime-contracts
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print compact pytest failure summary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git clone -q --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" repo
+          cd repo
+          git fetch -q --depth 1 origin "${GITHUB_SHA}"
+          git checkout -q FETCH_HEAD
+          python3 -m pip install -q --upgrade pip pytest pyyaml
+          set +e
+          python3 -m pytest -q > /tmp/pytest.log 2>&1
+          status=$?
+          tail -n 70 /tmp/pytest.log
+          exit $status

--- a/.github/workflows/runtime-contracts.yml
+++ b/.github/workflows/runtime-contracts.yml
@@ -17,10 +17,11 @@ jobs:
           python-version: "3.11"
       - name: Install test dependencies
         run: python -m pip install --upgrade pip pytest pyyaml
-      - name: Run resolver and materializer contract tests
+      - name: Run resolver, materializer, and delivery contract tests
         run: >-
           python -m pytest -q
           tests/runtime/test_affected_use_case_resolver.py
           tests/runtime/test_workflow_materializer.py
           tests/runtime/test_typed_work_item_documents.py
           tests/runtime/test_typed_work_item_document_cli.py
+          tests/runtime/test_change_set_delivery.py

--- a/.github/workflows/runtime-contracts.yml
+++ b/.github/workflows/runtime-contracts.yml
@@ -17,11 +17,5 @@ jobs:
           python-version: "3.11"
       - name: Install test dependencies
         run: python -m pip install --upgrade pip pytest pyyaml
-      - name: Run resolver, materializer, and delivery contract tests
-        run: >-
-          python -m pytest -q
-          tests/runtime/test_affected_use_case_resolver.py
-          tests/runtime/test_workflow_materializer.py
-          tests/runtime/test_typed_work_item_documents.py
-          tests/runtime/test_typed_work_item_document_cli.py
-          tests/runtime/test_change_set_delivery.py
+      - name: Run full runtime and workflow test suite
+        run: python -m pytest -q

--- a/.github/workflows/runtime-contracts.yml
+++ b/.github/workflows/runtime-contracts.yml
@@ -19,23 +19,3 @@ jobs:
         run: python -m pip install --upgrade pip pytest pyyaml
       - name: Run full runtime and workflow test suite
         run: python -m pytest -q
-
-  failed-test-summary:
-    needs: runtime-contracts
-    if: ${{ failure() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print compact pytest failure summary
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          git clone -q --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" repo
-          cd repo
-          git fetch -q --depth 1 origin "${GITHUB_SHA}"
-          git checkout -q FETCH_HEAD
-          python3 -m pip install -q --upgrade pip pytest pyyaml
-          set +e
-          python3 -m pytest -q > /tmp/pytest.log 2>&1
-          status=$?
-          tail -n 70 /tmp/pytest.log
-          exit $status

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -224,7 +224,7 @@ steps:
   kind: git
   name: Commit, push, and create or reuse the ChangeSet pull request
   skill_id: harness-change-set-pr
-  command: python3 -m harness_codex.runtime.change_set_delivery pull-request --change-set <CHG-ID> --run-id <RUN-ID>
+  command: python3 -m harness_codex.runtime.change_set_pr_delivery --change-set <CHG-ID> --run-id <RUN-ID>
   needs:
   - validate-project-wiki
   outputs:

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -224,6 +224,7 @@ steps:
   kind: git
   name: Commit, push, and create or reuse the ChangeSet pull request
   skill_id: harness-change-set-pr
+  command: python3 -m harness_codex.runtime.change_set_delivery pull-request --change-set <CHG-ID> --run-id <RUN-ID>
   needs:
   - validate-project-wiki
   outputs:
@@ -232,11 +233,13 @@ steps:
     stage: delivery
     scope: change_set
     condition: verified_changeset_output_committed_and_pushed
+    approval_env: HARNESS_DELIVERY_APPROVED
     fail_closed: true
     run_on_final_work_item_only: true
 - id: complete-change-set
   kind: git
   name: Complete active ChangeSet only after wiki and PR delivery gates succeed
+  command: python3 -m harness_codex.runtime.change_set_delivery complete --change-set <CHG-ID> --run-id <RUN-ID>
   needs:
   - create-change-set-pr
   inputs:
@@ -248,5 +251,6 @@ steps:
     stage: complete
     scope: change_set
     condition: all_affected_work_item_plans_completed
+    approval_env: HARNESS_DELIVERY_APPROVED
     fail_closed: true
     run_on_final_work_item_only: true

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -239,7 +239,7 @@ steps:
 - id: complete-change-set
   kind: git
   name: Complete active ChangeSet only after wiki and PR delivery gates succeed
-  command: python3 -m harness_codex.runtime.change_set_delivery complete --change-set <CHG-ID> --run-id <RUN-ID>
+  command: python3 -m harness_codex.runtime.change_set_completion_delivery --change-set <CHG-ID> --run-id <RUN-ID>
   needs:
   - create-change-set-pr
   inputs:

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -1,5 +1,42 @@
 """Runtime support package for harness-codex."""
 
+from __future__ import annotations
+
+from importlib import import_module
+
 __all__ = ["__version__"]
 
 __version__ = "0.1.125"
+
+
+def _install_cli_materializer_compatibility() -> None:
+    """Accept pre-run-id materializer extensions during the transition period."""
+
+    cli = import_module("harness_codex.cli")
+    if getattr(cli, "_materializer_run_id_compatibility_installed", False):
+        return
+
+    original_apply_workflow = cli._apply_workflow
+
+    def apply_workflow(*args, **kwargs):
+        materializer = cli.materialize_workflow_for_scope
+
+        def materialize_with_compatibility(*materializer_args, **materializer_kwargs):
+            try:
+                return materializer(*materializer_args, **materializer_kwargs)
+            except TypeError as exc:
+                if "run_id" not in materializer_kwargs or "unexpected keyword argument" not in str(exc):
+                    raise
+                return materializer(*materializer_args)
+
+        cli.materialize_workflow_for_scope = materialize_with_compatibility
+        try:
+            return original_apply_workflow(*args, **kwargs)
+        finally:
+            cli.materialize_workflow_for_scope = materializer
+
+    cli._apply_workflow = apply_workflow
+    cli._materializer_run_id_compatibility_installed = True
+
+
+_install_cli_materializer_compatibility()

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -62,6 +62,10 @@ from harness_codex.runtime.runner import (
     ConfigurableCliAgentAdapter,
     StepRunner,
 )
+from harness_codex.runtime.delivery_runner_patch import apply_delivery_runner_patch
+
+apply_delivery_runner_patch()
+
 from harness_codex.runtime.agent_context import (
     AGENT_CONTEXT_FILES,
     HARNESS_AGENT_CONTEXT_MARKER,

--- a/harness_codex/runtime/change_set_completion_delivery.py
+++ b/harness_codex/runtime/change_set_completion_delivery.py
@@ -1,0 +1,105 @@
+"""Scope-safe final ChangeSet completion command.
+
+This is deliberately separate from PR delivery: an interrupted or failed delivery can
+be retried without moving an active ChangeSet or staging unrelated worktree changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from harness_codex.runtime.change_set_delivery import (
+    DELIVERY_APPROVAL_ENV,
+    DeliveryBlocked,
+    _changed_paths,
+    _git_add_paths,
+    _git_lines,
+    _require_delivery_approval,
+    _require_git_worktree,
+    _require_success,
+    _run,
+)
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.completion import ChangeSetCompletionBlocked, complete_change_set_if_ready
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--change-set", required=True)
+    parser.add_argument("--run-id", required=True)
+    args = parser.parse_args(argv)
+    try:
+        result = complete_change_set_delivery(
+            Path(args.repo_root).resolve(),
+            change_set_id=args.change_set,
+            run_id=args.run_id,
+        )
+    except DeliveryBlocked as exc:
+        print(f"BLOCKED: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+def complete_change_set_delivery(
+    repo_root: Path,
+    *,
+    change_set_id: str,
+    run_id: str,
+) -> dict[str, object]:
+    """Move and commit only the active/completed ChangeSet paths."""
+
+    _require_delivery_approval()
+    _require_git_worktree(repo_root)
+    dirty_before = _changed_paths(repo_root)
+    if dirty_before:
+        raise DeliveryBlocked(
+            "dirty worktree blocks ChangeSet completion; preserved without staging: "
+            + ", ".join(dirty_before)
+        )
+
+    active_relative = Path("docs/changes/active") / f"{change_set_id}.md"
+    completed_relative = Path("docs/changes/completed") / f"{change_set_id}.md"
+    active_path = repo_root / active_relative
+    completed_path = repo_root / completed_relative
+    already_completed = completed_path.exists() and not active_path.exists()
+
+    if not already_completed:
+        if not active_path.exists():
+            raise DeliveryBlocked(f"active ChangeSet file not found: {active_relative}")
+        change_set = parse_changeset_markdown(
+            active_path.read_text(encoding="utf-8"),
+            path=active_relative,
+        )
+        try:
+            complete_change_set_if_ready(repo_root, change_set, run_id=run_id)
+        except ChangeSetCompletionBlocked as exc:
+            raise DeliveryBlocked(f"ChangeSet completion blocked: {exc.reason}") from exc
+
+    _git_add_paths(repo_root, (active_relative.as_posix(), completed_relative.as_posix()))
+    staged_paths = _git_lines(repo_root, "diff", "--cached", "--name-only")
+    allowed = {active_relative.as_posix(), completed_relative.as_posix()}
+    unexpected = tuple(path for path in staged_paths if path not in allowed)
+    if unexpected:
+        raise DeliveryBlocked("refusing to commit non-completion paths: " + ", ".join(unexpected))
+    if staged_paths:
+        _require_success(_run(repo_root, "git", "commit", "-m", f"{change_set_id} ChangeSet completion"))
+    _require_success(_run(repo_root, "git", "push", "origin", "HEAD"))
+
+    return {
+        "change_set_id": change_set_id,
+        "completed_path": completed_relative.as_posix(),
+        "completion_report": str(Path(".harness/runs") / run_id / "changeset-completion-report.md"),
+        "already_completed": already_completed,
+        "committed_paths": staged_paths,
+        "approval_env": DELIVERY_APPROVAL_ENV,
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness_codex/runtime/change_set_completion_delivery.py
+++ b/harness_codex/runtime/change_set_completion_delivery.py
@@ -82,14 +82,11 @@ def complete_change_set_delivery(
         except ChangeSetCompletionBlocked as exc:
             raise DeliveryBlocked(f"ChangeSet 완료 조건이 충족되지 않았습니다: {exc.reason}") from exc
 
-    _git_add_paths(
-        repo_root,
-        (
-            active_relative.as_posix(),
-            completed_relative.as_posix(),
-            report_relative.as_posix(),
-        ),
-    )
+    stage_targets = [completed_relative.as_posix(), report_relative.as_posix()]
+    if not already_completed:
+        stage_targets.insert(0, active_relative.as_posix())
+    _git_add_paths(repo_root, stage_targets)
+
     staged_paths = _git_lines(repo_root, "diff", "--cached", "--name-only")
     allowed = {
         active_relative.as_posix(),

--- a/harness_codex/runtime/change_set_completion_delivery.py
+++ b/harness_codex/runtime/change_set_completion_delivery.py
@@ -12,11 +12,11 @@ from harness_codex.runtime.change_set_delivery import (
     DELIVERY_APPROVAL_ENV,
     DeliveryBlocked,
     _changed_paths,
+    _command_error,
     _git_add_paths,
     _git_lines,
     _require_delivery_approval,
     _require_git_worktree,
-    _require_success,
     _run,
 )
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
@@ -95,6 +95,11 @@ def complete_change_set_delivery(
         "committed_paths": staged_paths,
         "approval_env": DELIVERY_APPROVAL_ENV,
     }
+
+
+def _require_success(completed) -> None:
+    if completed.returncode != 0:
+        raise DeliveryBlocked(_command_error(completed))
 
 
 if __name__ == "__main__":

--- a/harness_codex/runtime/change_set_completion_delivery.py
+++ b/harness_codex/runtime/change_set_completion_delivery.py
@@ -1,8 +1,4 @@
-"""Scope-safe final ChangeSet completion command.
-
-This is deliberately separate from PR delivery: an interrupted or failed delivery can
-be retried without moving an active ChangeSet or staging unrelated worktree changes.
-"""
+"""범위 안전한 최종 ChangeSet 완료 명령."""
 
 from __future__ import annotations
 
@@ -52,14 +48,14 @@ def complete_change_set_delivery(
     change_set_id: str,
     run_id: str,
 ) -> dict[str, object]:
-    """Move and commit only the active/completed ChangeSet paths."""
+    """활성/완료 ChangeSet 경로만 이동·커밋·푸시한다."""
 
     _require_delivery_approval()
     _require_git_worktree(repo_root)
     dirty_before = _changed_paths(repo_root)
     if dirty_before:
         raise DeliveryBlocked(
-            "dirty worktree blocks ChangeSet completion; preserved without staging: "
+            "작업 트리가 변경되어 ChangeSet 완료를 중단했습니다. 스테이징하지 않고 보존한 경로: "
             + ", ".join(dirty_before)
         )
 
@@ -71,7 +67,7 @@ def complete_change_set_delivery(
 
     if not already_completed:
         if not active_path.exists():
-            raise DeliveryBlocked(f"active ChangeSet file not found: {active_relative}")
+            raise DeliveryBlocked(f"활성 ChangeSet 파일이 없습니다: {active_relative}")
         change_set = parse_changeset_markdown(
             active_path.read_text(encoding="utf-8"),
             path=active_relative,
@@ -79,16 +75,16 @@ def complete_change_set_delivery(
         try:
             complete_change_set_if_ready(repo_root, change_set, run_id=run_id)
         except ChangeSetCompletionBlocked as exc:
-            raise DeliveryBlocked(f"ChangeSet completion blocked: {exc.reason}") from exc
+            raise DeliveryBlocked(f"ChangeSet 완료 조건이 충족되지 않았습니다: {exc.reason}") from exc
 
     _git_add_paths(repo_root, (active_relative.as_posix(), completed_relative.as_posix()))
     staged_paths = _git_lines(repo_root, "diff", "--cached", "--name-only")
     allowed = {active_relative.as_posix(), completed_relative.as_posix()}
     unexpected = tuple(path for path in staged_paths if path not in allowed)
     if unexpected:
-        raise DeliveryBlocked("refusing to commit non-completion paths: " + ", ".join(unexpected))
+        raise DeliveryBlocked("완료와 무관한 경로의 커밋을 거부했습니다: " + ", ".join(unexpected))
     if staged_paths:
-        _require_success(_run(repo_root, "git", "commit", "-m", f"{change_set_id} ChangeSet completion"))
+        _require_success(_run(repo_root, "git", "commit", "-m", f"{change_set_id} 변경 세트 완료"))
     _require_success(_run(repo_root, "git", "push", "origin", "HEAD"))
 
     return {

--- a/harness_codex/runtime/change_set_completion_delivery.py
+++ b/harness_codex/runtime/change_set_completion_delivery.py
@@ -48,22 +48,27 @@ def complete_change_set_delivery(
     change_set_id: str,
     run_id: str,
 ) -> dict[str, object]:
-    """활성/완료 ChangeSet 경로만 이동·커밋·푸시한다."""
+    """활성/완료 ChangeSet과 완료 보고서만 이동·커밋·푸시한다."""
 
     _require_delivery_approval()
     _require_git_worktree(repo_root)
-    dirty_before = _changed_paths(repo_root)
-    if dirty_before:
-        raise DeliveryBlocked(
-            "작업 트리가 변경되어 ChangeSet 완료를 중단했습니다. 스테이징하지 않고 보존한 경로: "
-            + ", ".join(dirty_before)
-        )
 
     active_relative = Path("docs/changes/active") / f"{change_set_id}.md"
     completed_relative = Path("docs/changes/completed") / f"{change_set_id}.md"
+    report_relative = Path(".harness/runs") / run_id / "changeset-completion-report.md"
     active_path = repo_root / active_relative
     completed_path = repo_root / completed_relative
+    report_path = repo_root / report_relative
     already_completed = completed_path.exists() and not active_path.exists()
+
+    dirty_before = set(_changed_paths(repo_root))
+    allowed_preexisting = {report_relative.as_posix()} if report_path.exists() else set()
+    unexpected_dirty = tuple(sorted(dirty_before - allowed_preexisting))
+    if unexpected_dirty:
+        raise DeliveryBlocked(
+            "작업 트리가 변경되어 ChangeSet 완료를 중단했습니다. 스테이징하지 않고 보존한 경로: "
+            + ", ".join(unexpected_dirty)
+        )
 
     if not already_completed:
         if not active_path.exists():
@@ -77,9 +82,20 @@ def complete_change_set_delivery(
         except ChangeSetCompletionBlocked as exc:
             raise DeliveryBlocked(f"ChangeSet 완료 조건이 충족되지 않았습니다: {exc.reason}") from exc
 
-    _git_add_paths(repo_root, (active_relative.as_posix(), completed_relative.as_posix()))
+    _git_add_paths(
+        repo_root,
+        (
+            active_relative.as_posix(),
+            completed_relative.as_posix(),
+            report_relative.as_posix(),
+        ),
+    )
     staged_paths = _git_lines(repo_root, "diff", "--cached", "--name-only")
-    allowed = {active_relative.as_posix(), completed_relative.as_posix()}
+    allowed = {
+        active_relative.as_posix(),
+        completed_relative.as_posix(),
+        report_relative.as_posix(),
+    }
     unexpected = tuple(path for path in staged_paths if path not in allowed)
     if unexpected:
         raise DeliveryBlocked("완료와 무관한 경로의 커밋을 거부했습니다: " + ", ".join(unexpected))
@@ -90,7 +106,7 @@ def complete_change_set_delivery(
     return {
         "change_set_id": change_set_id,
         "completed_path": completed_relative.as_posix(),
-        "completion_report": str(Path(".harness/runs") / run_id / "changeset-completion-report.md"),
+        "completion_report": report_relative.as_posix(),
         "already_completed": already_completed,
         "committed_paths": staged_paths,
         "approval_env": DELIVERY_APPROVAL_ENV,

--- a/harness_codex/runtime/change_set_delivery.py
+++ b/harness_codex/runtime/change_set_delivery.py
@@ -1,0 +1,461 @@
+"""Scope-safe, explicitly approved ChangeSet delivery operations.
+
+This module is intentionally independent from the workflow runner so delivery can be
+retried without changing ChangeSet completion state.  It stages only files covered by
+the ChangeSet and affected-files contracts; unrelated worktree changes remain untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.completion import ChangeSetCompletionBlocked, complete_change_set_if_ready
+
+
+DELIVERY_APPROVAL_ENV = "HARNESS_DELIVERY_APPROVED"
+_PATH_CODE_RE = re.compile(r"`([^`]+)`")
+
+
+class DeliveryBlocked(RuntimeError):
+    """Raised when delivery must stop without changing ChangeSet completion state."""
+
+
+@dataclass(frozen=True)
+class DeliveryScope:
+    allowed_patterns: tuple[str, ...]
+    blocked_patterns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    change_set_id: str
+    branch: str
+    base_branch: str
+    committed_paths: tuple[str, ...]
+    pull_request: str
+    already_exists: bool
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("pull-request", "complete"))
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--change-set", required=True)
+    parser.add_argument("--run-id", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.action == "pull-request":
+            result = create_change_set_pull_request(
+                Path(args.repo_root).resolve(),
+                change_set_id=args.change_set,
+                run_id=args.run_id,
+            )
+            print(json.dumps(asdict(result), ensure_ascii=False, indent=2))
+        else:
+            result = complete_change_set_delivery(
+                Path(args.repo_root).resolve(),
+                change_set_id=args.change_set,
+                run_id=args.run_id,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+    except DeliveryBlocked as exc:
+        print(f"BLOCKED: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def create_change_set_pull_request(
+    repo_root: Path,
+    *,
+    change_set_id: str,
+    run_id: str,
+) -> DeliveryResult:
+    """Commit only in-scope changes, push them, then create or reuse a PR."""
+
+    _require_delivery_approval()
+    if shutil.which("gh") is None:
+        raise DeliveryBlocked("GitHub CLI `gh` is required to create ChangeSet PR")
+    _require_git_worktree(repo_root)
+
+    branch = _git_stdout(repo_root, "branch", "--show-current")
+    if not branch:
+        raise DeliveryBlocked("target repo has no current branch")
+    origin = _run(repo_root, "git", "remote", "get-url", "origin")
+    if origin.returncode != 0 or not origin.stdout.strip():
+        raise DeliveryBlocked("target repo has no origin remote")
+
+    base_branch = _default_base_branch(repo_root)
+    if branch == base_branch:
+        raise DeliveryBlocked(f"current branch `{branch}` is the PR base branch")
+
+    scope = resolve_delivery_scope(repo_root, change_set_id)
+    changed_paths = _changed_paths(repo_root)
+    outside_scope = tuple(sorted(path for path in changed_paths if not _in_scope(path, scope)))
+    _write_delivery_scope_report(
+        repo_root,
+        run_id=run_id,
+        change_set_id=change_set_id,
+        scope=scope,
+        changed_paths=changed_paths,
+        outside_scope=outside_scope,
+    )
+    if outside_scope:
+        raise DeliveryBlocked(
+            "dirty worktree contains ChangeSet-out-of-scope changes; preserved without staging: "
+            + ", ".join(outside_scope)
+        )
+
+    staged_before = set(_git_lines(repo_root, "diff", "--cached", "--name-only"))
+    staged_outside_scope = tuple(sorted(path for path in staged_before if not _in_scope(path, scope)))
+    if staged_outside_scope:
+        raise DeliveryBlocked(
+            "index contains ChangeSet-out-of-scope changes; preserved without committing: "
+            + ", ".join(staged_outside_scope)
+        )
+
+    if changed_paths:
+        _git_add_paths(repo_root, changed_paths)
+
+    staged_paths = tuple(sorted(_git_lines(repo_root, "diff", "--cached", "--name-only")))
+    staged_outside_scope = tuple(path for path in staged_paths if not _in_scope(path, scope))
+    if staged_outside_scope:
+        raise DeliveryBlocked(
+            "refusing to commit ChangeSet-out-of-scope staged changes: "
+            + ", ".join(staged_outside_scope)
+        )
+
+    if staged_paths:
+        committed = _run(repo_root, "git", "commit", "-m", f"{change_set_id} 변경사항 완료")
+        if committed.returncode != 0:
+            raise DeliveryBlocked(_command_error(committed))
+
+    pushed = _run(repo_root, "git", "push", "-u", "origin", "HEAD")
+    if pushed.returncode != 0:
+        raise DeliveryBlocked(_command_error(pushed))
+
+    existing = _run(repo_root, "gh", "pr", "view", "--json", "url,number,title")
+    if existing.returncode == 0:
+        payload = _parse_pr_payload(existing.stdout)
+        result = DeliveryResult(
+            change_set_id=change_set_id,
+            branch=branch,
+            base_branch=base_branch,
+            committed_paths=staged_paths,
+            pull_request=str(payload.get("url") or existing.stdout.strip()),
+            already_exists=True,
+        )
+        _write_pr_result(repo_root, run_id, result)
+        return result
+
+    created = _run(
+        repo_root,
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        base_branch,
+        "--head",
+        branch,
+        "--title",
+        f"{change_set_id} ChangeSet delivery",
+        "--body",
+        _change_set_pr_body(change_set_id),
+    )
+    if created.returncode != 0:
+        existing = _run(repo_root, "gh", "pr", "view", "--json", "url,number,title")
+        if existing.returncode == 0:
+            payload = _parse_pr_payload(existing.stdout)
+            result = DeliveryResult(
+                change_set_id=change_set_id,
+                branch=branch,
+                base_branch=base_branch,
+                committed_paths=staged_paths,
+                pull_request=str(payload.get("url") or existing.stdout.strip()),
+                already_exists=True,
+            )
+            _write_pr_result(repo_root, run_id, result)
+            return result
+        raise DeliveryBlocked(_command_error(created))
+
+    payload = _parse_pr_payload(created.stdout)
+    result = DeliveryResult(
+        change_set_id=change_set_id,
+        branch=branch,
+        base_branch=base_branch,
+        committed_paths=staged_paths,
+        pull_request=str(payload.get("url") or created.stdout.strip()),
+        already_exists=False,
+    )
+    _write_pr_result(repo_root, run_id, result)
+    return result
+
+
+def complete_change_set_delivery(
+    repo_root: Path,
+    *,
+    change_set_id: str,
+    run_id: str,
+) -> dict[str, object]:
+    """Complete and push the ChangeSet without broad staging.
+
+    This runs only after PR delivery.  A failed push leaves the completed ChangeSet
+    available for a later retry and never stages unrelated paths.
+    """
+
+    _require_delivery_approval()
+    _require_git_worktree(repo_root)
+    dirty_before = _changed_paths(repo_root)
+    if dirty_before:
+        raise DeliveryBlocked(
+            "dirty worktree blocks ChangeSet completion; preserved without staging: "
+            + ", ".join(sorted(dirty_before))
+        )
+
+    active_path = repo_root / "docs/changes/active" / f"{change_set_id}.md"
+    completed_path = repo_root / "docs/changes/completed" / f"{change_set_id}.md"
+    completion_report = repo_root / ".harness/runs" / run_id / "changeset-completion-report.md"
+    already_completed = completed_path.exists() and not active_path.exists()
+
+    if not already_completed:
+        if not active_path.exists():
+            raise DeliveryBlocked(f"active ChangeSet file not found: {active_path.relative_to(repo_root)}")
+        change_set = parse_changeset_markdown(
+            active_path.read_text(encoding="utf-8"),
+            path=str(active_path.relative_to(repo_root)),
+        )
+        try:
+            complete_change_set_if_ready(repo_root, change_set, run_id=run_id)
+        except ChangeSetCompletionBlocked as exc:
+            raise DeliveryBlocked(f"ChangeSet completion blocked: {exc.reason}") from exc
+
+    _git_add_paths(
+        repo_root,
+        (
+            active_path.relative_to(repo_root).as_posix(),
+            completed_path.relative_to(repo_root).as_posix(),
+        ),
+    )
+    staged_paths = tuple(sorted(_git_lines(repo_root, "diff", "--cached", "--name-only")))
+    allowed_completion_paths = {
+        active_path.relative_to(repo_root).as_posix(),
+        completed_path.relative_to(repo_root).as_posix(),
+    }
+    unexpected = tuple(path for path in staged_paths if path not in allowed_completion_paths)
+    if unexpected:
+        raise DeliveryBlocked(
+            "refusing to commit non-completion paths: " + ", ".join(unexpected)
+        )
+    if staged_paths:
+        committed = _run(repo_root, "git", "commit", "-m", f"{change_set_id} ChangeSet completion")
+        if committed.returncode != 0:
+            raise DeliveryBlocked(_command_error(committed))
+
+    pushed = _run(repo_root, "git", "push", "origin", "HEAD")
+    if pushed.returncode != 0:
+        raise DeliveryBlocked(_command_error(pushed))
+
+    return {
+        "change_set_id": change_set_id,
+        "completed_path": completed_path.relative_to(repo_root).as_posix(),
+        "completion_report": completion_report.relative_to(repo_root).as_posix(),
+        "already_completed": already_completed,
+        "committed_paths": staged_paths,
+    }
+
+
+def resolve_delivery_scope(repo_root: Path, change_set_id: str) -> DeliveryScope:
+    """Resolve delivery paths from the ChangeSet and per-work-item contracts."""
+
+    change_set_path = repo_root / "docs/changes/active" / f"{change_set_id}.md"
+    if not change_set_path.is_file():
+        raise DeliveryBlocked(f"missing active ChangeSet file: {change_set_path.relative_to(repo_root)}")
+    change_set = parse_changeset_markdown(
+        change_set_path.read_text(encoding="utf-8"),
+        path=str(change_set_path.relative_to(repo_root)),
+    )
+
+    allowed: list[str] = [change_set_path.relative_to(repo_root).as_posix()]
+    allowed.extend(document.path.as_posix() for document in change_set.changed_documents)
+    allowed.extend(_extract_path_patterns(change_set.included_scope))
+    blocked = _extract_path_patterns(change_set.excluded_scope + change_set.forbidden_changes)
+
+    for item in change_set.ordered_work_items():
+        work_item_id = item.work_item_id
+        allowed.extend(
+            (
+                f"docs/plans/active/{work_item_id}/plan.md",
+                f"docs/plans/completed/{work_item_id}/plan.md",
+            )
+        )
+        affected_files = repo_root / item.slice_path / "affected-files.md"
+        if affected_files.is_file():
+            allowed.append(affected_files.relative_to(repo_root).as_posix())
+            allowed.extend(_extract_path_patterns((affected_files.read_text(encoding="utf-8"),)))
+
+    normalized_allowed = tuple(dict.fromkeys(_normalize_pattern(value) for value in allowed if _normalize_pattern(value)))
+    normalized_blocked = tuple(dict.fromkeys(_normalize_pattern(value) for value in blocked if _normalize_pattern(value)))
+    if not normalized_allowed:
+        raise DeliveryBlocked("ChangeSet delivery scope has no allowed paths")
+    return DeliveryScope(normalized_allowed, normalized_blocked)
+
+
+def _extract_path_patterns(values: Iterable[str]) -> list[str]:
+    patterns: list[str] = []
+    for value in values:
+        patterns.extend(match.group(1) for match in _PATH_CODE_RE.finditer(value))
+    return patterns
+
+
+def _normalize_pattern(value: str) -> str:
+    pattern = value.strip().strip("|,;:)").removeprefix("./")
+    if not pattern or "/" not in pattern:
+        return ""
+    return pattern
+
+
+def _in_scope(path: str, scope: DeliveryScope) -> bool:
+    if any(_matches(path, pattern) for pattern in scope.blocked_patterns):
+        return False
+    return any(_matches(path, pattern) for pattern in scope.allowed_patterns)
+
+
+def _matches(path: str, pattern: str) -> bool:
+    if pattern.endswith("/**"):
+        root = pattern[:-3].rstrip("/")
+        return path == root or path.startswith(root + "/")
+    return fnmatch.fnmatchcase(path, pattern)
+
+
+def _changed_paths(repo_root: Path) -> tuple[str, ...]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--name-only"),
+        ("diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        paths.update(_git_lines(repo_root, *args))
+    return tuple(sorted(paths))
+
+
+def _git_add_paths(repo_root: Path, paths: Iterable[str]) -> None:
+    unique = tuple(dict.fromkeys(path for path in paths if path))
+    if not unique:
+        return
+    added = _run(repo_root, "git", "add", "--", *unique)
+    if added.returncode != 0:
+        raise DeliveryBlocked(_command_error(added))
+
+
+def _require_delivery_approval() -> None:
+    value = os.environ.get(DELIVERY_APPROVAL_ENV, "").strip().lower()
+    if value not in {"1", "true", "yes"}:
+        raise DeliveryBlocked(
+            f"explicit delivery approval is required; set {DELIVERY_APPROVAL_ENV}=1"
+        )
+
+
+def _require_git_worktree(repo_root: Path) -> None:
+    checked = _run(repo_root, "git", "rev-parse", "--is-inside-work-tree")
+    if checked.returncode != 0 or checked.stdout.strip() != "true":
+        raise DeliveryBlocked("target repo is not a git worktree")
+
+
+def _default_base_branch(repo_root: Path) -> str:
+    remote_head = _git_stdout(repo_root, "symbolic-ref", "refs/remotes/origin/HEAD", "--short")
+    if remote_head.startswith("origin/"):
+        return remote_head.split("/", 1)[1]
+    return "main"
+
+
+def _git_stdout(repo_root: Path, *args: str) -> str:
+    completed = _run(repo_root, "git", *args)
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _git_lines(repo_root: Path, *args: str) -> tuple[str, ...]:
+    completed = _run(repo_root, "git", *args)
+    if completed.returncode != 0:
+        raise DeliveryBlocked(_command_error(completed))
+    return tuple(line.strip() for line in completed.stdout.splitlines() if line.strip())
+
+
+def _run(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _command_error(completed: subprocess.CompletedProcess[str]) -> str:
+    return completed.stderr.strip() or completed.stdout.strip() or "delivery command failed"
+
+
+def _change_set_pr_body(change_set_id: str) -> str:
+    return "\n".join(
+        (
+            f"## ChangeSet\n\n- ChangeSet: `{change_set_id}`",
+            "\n## Delivery safety\n\n- Only ChangeSet-scoped paths were staged.",
+            "- Delivery required explicit approval via `HARNESS_DELIVERY_APPROVED=1`.",
+        )
+    )
+
+
+def _parse_pr_payload(raw: str) -> dict[str, object]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"url": raw.strip()}
+    return parsed if isinstance(parsed, dict) else {"url": raw.strip()}
+
+
+def _write_pr_result(repo_root: Path, run_id: str, result: DeliveryResult) -> None:
+    target = repo_root / ".harness/runs" / run_id / "pull-request.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(asdict(result), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_delivery_scope_report(
+    repo_root: Path,
+    *,
+    run_id: str,
+    change_set_id: str,
+    scope: DeliveryScope,
+    changed_paths: Sequence[str],
+    outside_scope: Sequence[str],
+) -> None:
+    target = repo_root / ".harness/runs" / run_id / "delivery-scope.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "change_set_id": change_set_id,
+                "allowed_patterns": scope.allowed_patterns,
+                "blocked_patterns": scope.blocked_patterns,
+                "changed_paths": list(changed_paths),
+                "outside_scope": list(outside_scope),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness_codex/runtime/change_set_pr_delivery.py
+++ b/harness_codex/runtime/change_set_pr_delivery.py
@@ -1,0 +1,182 @@
+"""범위 안전한 ChangeSet PR 전달 명령."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Sequence
+
+from harness_codex.runtime.change_set_delivery import (
+    DeliveryBlocked,
+    DeliveryResult,
+    _changed_paths,
+    _command_error,
+    _default_base_branch,
+    _git_add_paths,
+    _git_lines,
+    _git_stdout,
+    _parse_pr_payload,
+    _require_delivery_approval,
+    _require_git_worktree,
+    _run,
+    _write_delivery_scope_report,
+    _write_pr_result,
+    resolve_delivery_scope,
+    _in_scope,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--change-set", required=True)
+    parser.add_argument("--run-id", required=True)
+    args = parser.parse_args(argv)
+    try:
+        result = create_change_set_pull_request(
+            Path(args.repo_root).resolve(),
+            change_set_id=args.change_set,
+            run_id=args.run_id,
+        )
+    except DeliveryBlocked as exc:
+        print(f"BLOCKED: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(asdict(result), ensure_ascii=False, indent=2))
+    return 0
+
+
+def create_change_set_pull_request(
+    repo_root: Path,
+    *,
+    change_set_id: str,
+    run_id: str,
+) -> DeliveryResult:
+    """허용된 ChangeSet 경로만 커밋하고 한국어 PR을 생성·재사용한다."""
+
+    _require_delivery_approval()
+    if shutil.which("gh") is None:
+        raise DeliveryBlocked("ChangeSet PR 생성에는 GitHub CLI `gh`가 필요합니다")
+    _require_git_worktree(repo_root)
+
+    branch = _git_stdout(repo_root, "branch", "--show-current")
+    if not branch:
+        raise DeliveryBlocked("대상 저장소에 현재 브랜치가 없습니다")
+    origin = _run(repo_root, "git", "remote", "get-url", "origin")
+    if origin.returncode != 0 or not origin.stdout.strip():
+        raise DeliveryBlocked("대상 저장소에 origin remote가 없습니다")
+    base_branch = _default_base_branch(repo_root)
+    if branch == base_branch:
+        raise DeliveryBlocked(f"현재 브랜치 `{branch}`는 PR 기준 브랜치입니다")
+
+    scope = resolve_delivery_scope(repo_root, change_set_id)
+    changed_paths = _changed_paths(repo_root)
+    outside_scope = tuple(path for path in changed_paths if not _in_scope(path, scope))
+    _write_delivery_scope_report(
+        repo_root,
+        run_id=run_id,
+        change_set_id=change_set_id,
+        scope=scope,
+        changed_paths=changed_paths,
+        outside_scope=outside_scope,
+    )
+    if outside_scope:
+        raise DeliveryBlocked(
+            "ChangeSet 범위 밖 변경을 스테이징하지 않고 보존했습니다: " + ", ".join(outside_scope)
+        )
+
+    staged_before = _git_lines(repo_root, "diff", "--cached", "--name-only")
+    staged_outside_scope = tuple(path for path in staged_before if not _in_scope(path, scope))
+    if staged_outside_scope:
+        raise DeliveryBlocked(
+            "인덱스에 ChangeSet 범위 밖 변경이 있어 커밋하지 않았습니다: "
+            + ", ".join(staged_outside_scope)
+        )
+    if changed_paths:
+        _git_add_paths(repo_root, changed_paths)
+
+    staged_paths = _git_lines(repo_root, "diff", "--cached", "--name-only")
+    staged_outside_scope = tuple(path for path in staged_paths if not _in_scope(path, scope))
+    if staged_outside_scope:
+        raise DeliveryBlocked("범위 밖 스테이징 변경의 커밋을 거부했습니다: " + ", ".join(staged_outside_scope))
+    if staged_paths:
+        committed = _run(repo_root, "git", "commit", "-m", f"{change_set_id} 변경사항 완료")
+        if committed.returncode != 0:
+            raise DeliveryBlocked(_command_error(committed))
+
+    pushed = _run(repo_root, "git", "push", "-u", "origin", "HEAD")
+    if pushed.returncode != 0:
+        raise DeliveryBlocked(_command_error(pushed))
+
+    existing = _run(repo_root, "gh", "pr", "view", "--json", "url,number,title")
+    if existing.returncode == 0:
+        result = _result(change_set_id, branch, base_branch, staged_paths, existing.stdout, True)
+        _write_pr_result(repo_root, run_id, result)
+        return result
+
+    created = _run(
+        repo_root,
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        base_branch,
+        "--head",
+        branch,
+        "--title",
+        f"{change_set_id} 변경 세트 전달",
+        "--body",
+        _pr_body(change_set_id),
+    )
+    if created.returncode != 0:
+        existing = _run(repo_root, "gh", "pr", "view", "--json", "url,number,title")
+        if existing.returncode == 0:
+            result = _result(change_set_id, branch, base_branch, staged_paths, existing.stdout, True)
+            _write_pr_result(repo_root, run_id, result)
+            return result
+        raise DeliveryBlocked(_command_error(created))
+
+    result = _result(change_set_id, branch, base_branch, staged_paths, created.stdout, False)
+    _write_pr_result(repo_root, run_id, result)
+    return result
+
+
+def _result(
+    change_set_id: str,
+    branch: str,
+    base_branch: str,
+    staged_paths: tuple[str, ...],
+    raw: str,
+    already_exists: bool,
+) -> DeliveryResult:
+    payload = _parse_pr_payload(raw)
+    return DeliveryResult(
+        change_set_id=change_set_id,
+        branch=branch,
+        base_branch=base_branch,
+        committed_paths=staged_paths,
+        pull_request=str(payload.get("url") or raw.strip()),
+        already_exists=already_exists,
+    )
+
+
+def _pr_body(change_set_id: str) -> str:
+    return "\n".join(
+        (
+            "## ChangeSet",
+            "",
+            f"- ChangeSet: `{change_set_id}`",
+            "",
+            "## 전달 안전성",
+            "",
+            "- ChangeSet 범위로 승인된 경로만 스테이징했습니다.",
+            "- 명시적인 전달 승인 후에만 PR을 생성했습니다.",
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness_codex/runtime/change_set_pr_delivery.py
+++ b/harness_codex/runtime/change_set_pr_delivery.py
@@ -73,7 +73,10 @@ def create_change_set_pull_request(
         raise DeliveryBlocked(f"현재 브랜치 `{branch}`는 PR 기준 브랜치입니다")
 
     scope = resolve_delivery_scope(repo_root, change_set_id)
-    changed_paths = _changed_paths(repo_root)
+    delivery_artifacts = _delivery_artifact_paths(run_id)
+    changed_paths = tuple(
+        path for path in _changed_paths(repo_root) if path not in delivery_artifacts
+    )
     outside_scope = tuple(path for path in changed_paths if not _in_scope(path, scope))
     _write_delivery_scope_report(
         repo_root,
@@ -142,6 +145,16 @@ def create_change_set_pull_request(
     result = _result(change_set_id, branch, base_branch, staged_paths, created.stdout, False)
     _write_pr_result(repo_root, run_id, result)
     return result
+
+
+def _delivery_artifact_paths(run_id: str) -> frozenset[str]:
+    run_root = Path(".harness/runs") / run_id
+    return frozenset(
+        (
+            (run_root / "delivery-scope.json").as_posix(),
+            (run_root / "pull-request.json").as_posix(),
+        )
+    )
 
 
 def _result(

--- a/harness_codex/runtime/changes/__init__.py
+++ b/harness_codex/runtime/changes/__init__.py
@@ -1,5 +1,7 @@
 """ChangeSet parsing and affected use-case resolution."""
 
+from pathlib import Path
+
 from harness_codex.runtime.changes.models import (
     AffectedMaintenanceItem,
     AffectedUseCase,
@@ -22,6 +24,31 @@ from harness_codex.runtime.changes.resolver import (
     ChangeSetResolver,
     NoActiveChangeSetsError,
 )
+from harness_codex.runtime.changes.work_item_documents import missing_required_documents
+
+
+def _missing_maintenance_documents(repo_root: Path, slice_path: Path) -> tuple[Path, ...]:
+    """Keep the legacy maintenance preflight helper aligned with typed contracts."""
+
+    return missing_required_documents(
+        repo_root,
+        AffectedWorkItem(
+            work_item_id=slice_path.name,
+            work_item_type=WorkItemType.MAINTENANCE,
+            name="",
+            impact_type="",
+            slice_path=slice_path,
+        ),
+    )
+
+
+# The planner-alignment test and external extensions historically import this helper
+# from ``resolver``.  Keep that public compatibility surface while delegating the
+# source of truth to the typed work-item document contract.
+import harness_codex.runtime.changes.resolver as _resolver
+
+_resolver._missing_maintenance_documents = _missing_maintenance_documents
+
 
 __all__ = [
     "AffectedMaintenanceItem",

--- a/harness_codex/runtime/delivery_runner_patch.py
+++ b/harness_codex/runtime/delivery_runner_patch.py
@@ -1,0 +1,108 @@
+"""Runner integration for explicitly approved, resumable delivery commands."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+_APPROVED_VALUES = {"1", "true", "yes"}
+
+
+def apply_delivery_runner_patch() -> None:
+    """Teach command-backed delivery steps to honor ``approval_env`` metadata.
+
+    The generic runner intentionally remains unchanged for ordinary commands.  Only a
+    workflow step declaring ``metadata.approval_env`` receives this behavior: missing
+    consent returns a blocked, environment-classified result; approved runs receive a
+    sanitized affirmative value in the child process environment; and a delivery
+    command's documented ``BLOCKED:`` / exit-code-2 result remains resumable.
+    """
+
+    from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
+    from harness_codex.runtime.runner import BasicStepRunner, _relative_to_repo
+
+    if getattr(BasicStepRunner, "_delivery_approval_patch_applied", False):
+        return
+
+    original = BasicStepRunner._run_command
+
+    def run_command(self, step, context, step_dir: Path):
+        approval_env = str(step.metadata.get("approval_env", "")).strip()
+        if not approval_env:
+            return original(self, step, context, step_dir)
+
+        requested = context.metadata.get("delivery_approved")
+        candidate = requested if requested is not None else os.environ.get(approval_env, "")
+        approved = str(candidate).strip().lower() in _APPROVED_VALUES
+        result_path = step_dir / "result.txt"
+        if not approved:
+            message = (
+                "explicit delivery approval is required; "
+                f"set {approval_env}=1 or pass delivery_approved in the run context"
+            )
+            (step_dir / "stdout.txt").write_text("", encoding="utf-8")
+            (step_dir / "stderr.txt").write_text(f"BLOCKED: {message}\n", encoding="utf-8")
+            result_path.write_text("exit_code=2\n", encoding="utf-8")
+            return StepResult(
+                step_id=step.id,
+                status=StepStatus.BLOCKED,
+                exit_code=2,
+                output_path=_relative_to_repo(result_path, context),
+                error=message,
+                failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
+                metadata={"approval_env": approval_env, "delivery_approved": False},
+            )
+
+        command = step.command
+        if not command:
+            return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error="command is required")
+        if step.id == "verify-work-item" and context.metadata.get("force_verification"):
+            command = f"{command} --force-verification"
+        env = {**os.environ, approval_env: "1"}
+        completed = subprocess.run(
+            command,
+            cwd=context.workdir,
+            shell=True,
+            text=True,
+            capture_output=True,
+            timeout=step.timeout_sec,
+            check=False,
+            env=env,
+        )
+        (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
+        (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+        result_path.write_text(f"exit_code={completed.returncode}\n", encoding="utf-8")
+        error = completed.stderr.strip() or completed.stdout.strip()
+        is_delivery_blocked = completed.returncode == 2 and "BLOCKED:" in error
+        if is_delivery_blocked:
+            return StepResult(
+                step_id=step.id,
+                status=StepStatus.BLOCKED,
+                exit_code=completed.returncode,
+                output_path=_relative_to_repo(result_path, context),
+                error=error.removeprefix("BLOCKED:").strip(),
+                failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
+                metadata={"approval_env": approval_env, "delivery_approved": True},
+            )
+        if completed.returncode != 0:
+            return StepResult(
+                step_id=step.id,
+                status=StepStatus.FAILED,
+                exit_code=completed.returncode,
+                output_path=_relative_to_repo(result_path, context),
+                error=error,
+                failure_kind=FailureKind.IMPLEMENTATION,
+                metadata={"approval_env": approval_env, "delivery_approved": True},
+            )
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.SUCCEEDED,
+            exit_code=0,
+            output_path=_relative_to_repo(result_path, context),
+            metadata={"approval_env": approval_env, "delivery_approved": True},
+        )
+
+    BasicStepRunner._run_command = run_command
+    BasicStepRunner._delivery_approval_patch_applied = True

--- a/harness_codex/runtime/delivery_runner_patch.py
+++ b/harness_codex/runtime/delivery_runner_patch.py
@@ -1,4 +1,4 @@
-"""Runner integration for explicitly approved, resumable delivery commands."""
+"""승인된 전달 명령과 레거시 완료 경계의 실행기 통합."""
 
 from __future__ import annotations
 
@@ -11,27 +11,24 @@ _APPROVED_VALUES = {"1", "true", "yes"}
 
 
 def apply_delivery_runner_patch() -> None:
-    """Teach command-backed delivery steps to honor ``approval_env`` metadata.
+    """전달 단계의 승인·차단·재개 규칙을 실행기에 연결한다."""
 
-    The generic runner intentionally remains unchanged for ordinary commands.  Only a
-    workflow step declaring ``metadata.approval_env`` receives this behavior: missing
-    consent returns a blocked, environment-classified result; approved runs receive a
-    sanitized affirmative value in the child process environment; and a delivery
-    command's documented ``BLOCKED:`` / exit-code-2 result remains resumable.
-    """
-
+    from harness_codex.runtime.changes.parser import parse_changeset_markdown
+    from harness_codex.runtime.completion import ChangeSetCompletionBlocked, complete_change_set_if_ready
     from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
-    from harness_codex.runtime.runner import BasicStepRunner, _relative_to_repo
+    import harness_codex.runtime.runner as runner_module
 
+    BasicStepRunner = runner_module.BasicStepRunner
+    relative_to_repo = runner_module._relative_to_repo
     if getattr(BasicStepRunner, "_delivery_approval_patch_applied", False):
         return
 
-    original = BasicStepRunner._run_command
+    original_command = BasicStepRunner._run_command
 
     def run_command(self, step, context, step_dir: Path):
         approval_env = str(step.metadata.get("approval_env", "")).strip()
         if not approval_env:
-            return original(self, step, context, step_dir)
+            return original_command(self, step, context, step_dir)
 
         requested = context.metadata.get("delivery_approved")
         candidate = requested if requested is not None else os.environ.get(approval_env, "")
@@ -39,8 +36,8 @@ def apply_delivery_runner_patch() -> None:
         result_path = step_dir / "result.txt"
         if not approved:
             message = (
-                "explicit delivery approval is required; "
-                f"set {approval_env}=1 or pass delivery_approved in the run context"
+                "명시적인 전달 승인이 필요합니다. "
+                f"{approval_env}=1 또는 RunContext.delivery_approved를 설정하세요."
             )
             (step_dir / "stdout.txt").write_text("", encoding="utf-8")
             (step_dir / "stderr.txt").write_text(f"BLOCKED: {message}\n", encoding="utf-8")
@@ -49,7 +46,7 @@ def apply_delivery_runner_patch() -> None:
                 step_id=step.id,
                 status=StepStatus.BLOCKED,
                 exit_code=2,
-                output_path=_relative_to_repo(result_path, context),
+                output_path=relative_to_repo(result_path, context),
                 error=message,
                 failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
                 metadata={"approval_env": approval_env, "delivery_approved": False},
@@ -60,7 +57,6 @@ def apply_delivery_runner_patch() -> None:
             return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error="command is required")
         if step.id == "verify-work-item" and context.metadata.get("force_verification"):
             command = f"{command} --force-verification"
-        env = {**os.environ, approval_env: "1"}
         completed = subprocess.run(
             command,
             cwd=context.workdir,
@@ -69,19 +65,18 @@ def apply_delivery_runner_patch() -> None:
             capture_output=True,
             timeout=step.timeout_sec,
             check=False,
-            env=env,
+            env={**os.environ, approval_env: "1"},
         )
         (step_dir / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
         (step_dir / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
         result_path.write_text(f"exit_code={completed.returncode}\n", encoding="utf-8")
         error = completed.stderr.strip() or completed.stdout.strip()
-        is_delivery_blocked = completed.returncode == 2 and "BLOCKED:" in error
-        if is_delivery_blocked:
+        if completed.returncode == 2 and "BLOCKED:" in error:
             return StepResult(
                 step_id=step.id,
                 status=StepStatus.BLOCKED,
                 exit_code=completed.returncode,
-                output_path=_relative_to_repo(result_path, context),
+                output_path=relative_to_repo(result_path, context),
                 error=error.removeprefix("BLOCKED:").strip(),
                 failure_kind=FailureKind.ENVIRONMENT_BLOCKER,
                 metadata={"approval_env": approval_env, "delivery_approved": True},
@@ -91,7 +86,7 @@ def apply_delivery_runner_patch() -> None:
                 step_id=step.id,
                 status=StepStatus.FAILED,
                 exit_code=completed.returncode,
-                output_path=_relative_to_repo(result_path, context),
+                output_path=relative_to_repo(result_path, context),
                 error=error,
                 failure_kind=FailureKind.IMPLEMENTATION,
                 metadata={"approval_env": approval_env, "delivery_approved": True},
@@ -100,9 +95,53 @@ def apply_delivery_runner_patch() -> None:
             step_id=step.id,
             status=StepStatus.SUCCEEDED,
             exit_code=0,
-            output_path=_relative_to_repo(result_path, context),
+            output_path=relative_to_repo(result_path, context),
             metadata={"approval_env": approval_env, "delivery_approved": True},
+        )
+
+    def complete_change_set_boundary(step, context):
+        """Keep the legacy move-only boundary side-effect free.
+
+        Canonical workflows use the explicit completion-delivery command.  The legacy
+        boundary therefore only validates and archives the ChangeSet; it never calls
+        `git add -A`, commits, or pushes unrelated worktree state.
+        """
+
+        change_set_path = context.repo_root / step.inputs[0]
+        if not change_set_path.exists():
+            return StepResult(
+                step_id=step.id,
+                status=StepStatus.BLOCKED,
+                error=f"missing source: {step.inputs[0]}",
+            )
+        change_set = parse_changeset_markdown(
+            change_set_path.read_text(encoding="utf-8"),
+            path=step.inputs[0],
+        )
+        try:
+            completion = complete_change_set_if_ready(
+                context.repo_root,
+                change_set,
+                run_id=context.run_id,
+            )
+        except ChangeSetCompletionBlocked as exc:
+            return StepResult(
+                step_id=step.id,
+                status=StepStatus.BLOCKED,
+                error=f"ChangeSet completion blocked: {exc.reason}",
+            )
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.SUCCEEDED,
+            output_path=completion.report_path,
+            metadata={
+                "completed_path": str(completion.completed_path),
+                "completed_work_items": list(completion.completed_work_items),
+                "already_completed": completion.already_completed,
+                "completion_published": False,
+            },
         )
 
     BasicStepRunner._run_command = run_command
     BasicStepRunner._delivery_approval_patch_applied = True
+    runner_module._complete_change_set_boundary = complete_change_set_boundary

--- a/tests/runtime/test_change_set_completion_delivery.py
+++ b/tests/runtime/test_change_set_completion_delivery.py
@@ -76,6 +76,7 @@ def test_completion_push_failure_is_resumable_without_restaging_other_paths(
         _git(tmp_path, "show", "--no-renames", "--format=", "--name-only", "HEAD").stdout.splitlines()
     )
     assert committed_paths == {
+        ".harness/runs/run-376/changeset-completion-report.md",
         "docs/changes/active/CHG-376.md",
         "docs/changes/completed/CHG-376.md",
     }

--- a/tests/runtime/test_change_set_completion_delivery.py
+++ b/tests/runtime/test_change_set_completion_delivery.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import harness_codex.runtime.change_set_completion_delivery as completion_delivery
+import harness_codex.runtime.change_set_delivery as delivery
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _init_repository(repo_root: Path) -> None:
+    _git(repo_root, "init", "-b", "main")
+    _git(repo_root, "config", "user.name", "Harness Test")
+    _git(repo_root, "config", "user.email", "harness@example.test")
+    active = repo_root / "docs/changes/active/CHG-376.md"
+    active.parent.mkdir(parents=True, exist_ok=True)
+    active.write_text("# ChangeSet CHG-376\n", encoding="utf-8")
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-m", "기본 상태")
+    _git(repo_root, "remote", "add", "origin", "https://example.invalid/harness.git")
+
+
+def _complete_active_change_set(repo_root: Path, _change_set, *, run_id: str) -> None:
+    active = repo_root / "docs/changes/active/CHG-376.md"
+    completed = repo_root / "docs/changes/completed/CHG-376.md"
+    completed.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(active, completed)
+    report = repo_root / ".harness/runs" / run_id / "changeset-completion-report.md"
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("완료\n", encoding="utf-8")
+
+
+def _install_push_stub(monkeypatch, *, fail: bool) -> None:
+    actual_run = delivery._run
+
+    def fake_run(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ("git", "push"):
+            return subprocess.CompletedProcess(list(args), 1 if fail else 0, "", "push failed" if fail else "")
+        return actual_run(repo_root, *args)
+
+    monkeypatch.setattr(delivery, "_run", fake_run)
+    monkeypatch.setattr(completion_delivery, "_run", fake_run)
+
+
+def test_completion_push_failure_is_resumable_without_restaging_other_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _init_repository(tmp_path)
+    monkeypatch.setenv(delivery.DELIVERY_APPROVAL_ENV, "1")
+    monkeypatch.setattr(completion_delivery, "complete_change_set_if_ready", _complete_active_change_set)
+    _install_push_stub(monkeypatch, fail=True)
+
+    with pytest.raises(delivery.DeliveryBlocked, match="push failed"):
+        completion_delivery.complete_change_set_delivery(
+            tmp_path,
+            change_set_id="CHG-376",
+            run_id="run-376",
+        )
+
+    assert not (tmp_path / "docs/changes/active/CHG-376.md").exists()
+    assert (tmp_path / "docs/changes/completed/CHG-376.md").exists()
+    assert _git(tmp_path, "show", "--format=", "--name-only", "HEAD").stdout.splitlines() == [
+        "docs/changes/completed/CHG-376.md",
+        "docs/changes/active/CHG-376.md",
+    ]
+
+    _install_push_stub(monkeypatch, fail=False)
+    resumed = completion_delivery.complete_change_set_delivery(
+        tmp_path,
+        change_set_id="CHG-376",
+        run_id="run-376",
+    )
+
+    assert resumed["already_completed"] is True
+    assert resumed["committed_paths"] == ()
+
+
+def test_completion_blocks_dirty_worktree_before_moving_changeset(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _init_repository(tmp_path)
+    monkeypatch.setenv(delivery.DELIVERY_APPROVAL_ENV, "1")
+    (tmp_path / "README.md").write_text("보존해야 하는 변경\n", encoding="utf-8")
+
+    with pytest.raises(delivery.DeliveryBlocked, match="작업 트리"):
+        completion_delivery.complete_change_set_delivery(
+            tmp_path,
+            change_set_id="CHG-376",
+            run_id="run-376",
+        )
+
+    assert (tmp_path / "docs/changes/active/CHG-376.md").exists()
+    assert not (tmp_path / "docs/changes/completed/CHG-376.md").exists()
+    assert _git(tmp_path, "diff", "--cached", "--name-only").stdout == ""

--- a/tests/runtime/test_change_set_completion_delivery.py
+++ b/tests/runtime/test_change_set_completion_delivery.py
@@ -72,10 +72,13 @@ def test_completion_push_failure_is_resumable_without_restaging_other_paths(
 
     assert not (tmp_path / "docs/changes/active/CHG-376.md").exists()
     assert (tmp_path / "docs/changes/completed/CHG-376.md").exists()
-    assert _git(tmp_path, "show", "--format=", "--name-only", "HEAD").stdout.splitlines() == [
-        "docs/changes/completed/CHG-376.md",
+    committed_paths = set(
+        _git(tmp_path, "show", "--no-renames", "--format=", "--name-only", "HEAD").stdout.splitlines()
+    )
+    assert committed_paths == {
         "docs/changes/active/CHG-376.md",
-    ]
+        "docs/changes/completed/CHG-376.md",
+    }
 
     _install_push_stub(monkeypatch, fail=False)
     resumed = completion_delivery.complete_change_set_delivery(

--- a/tests/runtime/test_change_set_delivery.py
+++ b/tests/runtime/test_change_set_delivery.py
@@ -143,6 +143,66 @@ def test_delivery_commits_only_changeset_scope_with_pathspec_and_korean_pr_metad
     assert not any(args[:3] == ("git", "add", "-A") for args in calls)
 
 
+def test_delivery_reuses_pr_on_same_run_without_staging_its_own_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _init_repository(tmp_path)
+    (tmp_path / "src/allowed/service.py").write_text("VALUE = 'changed'\n", encoding="utf-8")
+    actual_run = delivery._run
+    calls: list[tuple[str, ...]] = []
+    pr_exists = False
+
+    def fake_run(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        nonlocal pr_exists
+        calls.append(args)
+        if args[:2] == ("git", "push"):
+            return subprocess.CompletedProcess(list(args), 0, "", "")
+        if args[:3] == ("gh", "pr", "view"):
+            if pr_exists:
+                return subprocess.CompletedProcess(
+                    list(args),
+                    0,
+                    '{"url":"https://github.com/example/harness/pull/376"}',
+                    "",
+                )
+            return subprocess.CompletedProcess(list(args), 1, "", "no pull request")
+        if args[:3] == ("gh", "pr", "create"):
+            pr_exists = True
+            return subprocess.CompletedProcess(
+                list(args),
+                0,
+                "https://github.com/example/harness/pull/376\n",
+                "",
+            )
+        return actual_run(repo_root, *args)
+
+    monkeypatch.setattr(delivery, "_run", fake_run)
+    monkeypatch.setattr(pr_delivery, "_run", fake_run)
+    monkeypatch.setattr(delivery.shutil, "which", lambda _binary: "/usr/bin/gh")
+    monkeypatch.setenv(delivery.DELIVERY_APPROVAL_ENV, "1")
+
+    first = pr_delivery.create_change_set_pull_request(
+        tmp_path,
+        change_set_id="CHG-376",
+        run_id="run-376",
+    )
+    first_head = _git(tmp_path, "rev-parse", "HEAD").stdout.strip()
+    second = pr_delivery.create_change_set_pull_request(
+        tmp_path,
+        change_set_id="CHG-376",
+        run_id="run-376",
+    )
+
+    assert first.already_exists is False
+    assert second.already_exists is True
+    assert second.committed_paths == ()
+    assert _git(tmp_path, "rev-parse", "HEAD").stdout.strip() == first_head
+    assert (tmp_path / ".harness/runs/run-376/delivery-scope.json").is_file()
+    assert (tmp_path / ".harness/runs/run-376/pull-request.json").is_file()
+    assert sum(args[:3] == ("gh", "pr", "create") for args in calls) == 1
+
+
 def test_delivery_requires_explicit_approval_before_git_mutation(tmp_path: Path) -> None:
     _init_repository(tmp_path)
     (tmp_path / "src/allowed/service.py").write_text("VALUE = 'changed'\n", encoding="utf-8")

--- a/tests/runtime/test_change_set_delivery.py
+++ b/tests/runtime/test_change_set_delivery.py
@@ -139,7 +139,7 @@ def test_delivery_commits_only_changeset_scope_with_pathspec_and_korean_pr_metad
     assert ("git", "add", "--", "src/allowed/service.py") in calls
     create_args = next(args for args in calls if args[:3] == ("gh", "pr", "create"))
     assert "CHG-376 변경 세트 전달" in create_args
-    assert "ChangeSet 범위로 승인된 경로만" in create_args
+    assert any("ChangeSet 범위로 승인된 경로만" in value for value in create_args)
     assert not any(args[:3] == ("git", "add", "-A") for args in calls)
 
 

--- a/tests/runtime/test_change_set_delivery.py
+++ b/tests/runtime/test_change_set_delivery.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import harness_codex.runtime.change_set_delivery as delivery
+from harness_codex.runtime.workflows import load_named_workflow
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _write_changeset(repo_root: Path) -> None:
+    path = repo_root / "docs/changes/active/CHG-376.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            (
+                "# ChangeSet CHG-376",
+                "",
+                "## 1. Metadata",
+                "|Item|Value|",
+                "|---|---|",
+                "|ChangeSet ID|`CHG-376`|",
+                "|Status|active|",
+                "",
+                "## 8. Scope Boundary",
+                "### Included",
+                "- `src/allowed/**`",
+                "",
+                "### Excluded",
+                "- `src/unrelated/**`",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+
+def _init_repository(repo_root: Path) -> None:
+    _git(repo_root, "init", "-b", "main")
+    _git(repo_root, "config", "user.name", "Harness Test")
+    _git(repo_root, "config", "user.email", "harness@example.test")
+    (repo_root / "README.md").write_text("base\n", encoding="utf-8")
+    source = repo_root / "src/allowed/service.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("VALUE = 'base'\n", encoding="utf-8")
+    _write_changeset(repo_root)
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-m", "base")
+    _git(repo_root, "checkout", "-b", "feature/chg-376")
+    _git(repo_root, "remote", "add", "origin", "https://example.invalid/harness.git")
+
+
+def _install_delivery_stubs(monkeypatch, *, push_returncode: int = 0):
+    actual_run = delivery._run
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[:2] == ("git", "push"):
+            return subprocess.CompletedProcess(
+                list(args),
+                push_returncode,
+                "",
+                "push failed" if push_returncode else "",
+            )
+        if args[:3] == ("gh", "pr", "view"):
+            return subprocess.CompletedProcess(list(args), 1, "", "no pull request")
+        if args[:3] == ("gh", "pr", "create"):
+            return subprocess.CompletedProcess(
+                list(args),
+                0,
+                "https://github.com/example/harness/pull/376\n",
+                "",
+            )
+        return actual_run(repo_root, *args)
+
+    monkeypatch.setattr(delivery, "_run", fake_run)
+    monkeypatch.setattr(delivery.shutil, "which", lambda _binary: "/usr/bin/gh")
+    monkeypatch.setenv(delivery.DELIVERY_APPROVAL_ENV, "1")
+    return calls
+
+
+def test_delivery_blocks_and_preserves_out_of_scope_dirty_changes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _init_repository(tmp_path)
+    (tmp_path / "src/allowed/service.py").write_text("VALUE = 'changed'\n", encoding="utf-8")
+    unrelated = tmp_path / "src/unrelated/notes.txt"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_text("do not commit\n", encoding="utf-8")
+    calls = _install_delivery_stubs(monkeypatch)
+
+    with pytest.raises(delivery.DeliveryBlocked, match="out-of-scope changes"):
+        delivery.create_change_set_pull_request(
+            tmp_path,
+            change_set_id="CHG-376",
+            run_id="run-376",
+        )
+
+    assert _git(tmp_path, "diff", "--cached", "--name-only").stdout == ""
+    assert unrelated.read_text(encoding="utf-8") == "do not commit\n"
+    report = tmp_path / ".harness/runs/run-376/delivery-scope.json"
+    assert "src/unrelated/notes.txt" in report.read_text(encoding="utf-8")
+    assert not any(args[:3] == ("git", "add", "-A") for args in calls)
+
+
+def test_delivery_commits_only_changeset_scope_with_pathspec(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _init_repository(tmp_path)
+    (tmp_path / "src/allowed/service.py").write_text("VALUE = 'changed'\n", encoding="utf-8")
+    calls = _install_delivery_stubs(monkeypatch)
+
+    result = delivery.create_change_set_pull_request(
+        tmp_path,
+        change_set_id="CHG-376",
+        run_id="run-376",
+    )
+
+    committed_paths = _git(tmp_path, "show", "--format=", "--name-only", "HEAD").stdout.splitlines()
+    assert committed_paths == ["src/allowed/service.py"]
+    assert result.committed_paths == ("src/allowed/service.py",)
+    assert result.pull_request == "https://github.com/example/harness/pull/376"
+    assert ("git", "add", "--", "src/allowed/service.py") in calls
+    assert not any(args[:3] == ("git", "add", "-A") for args in calls)
+
+
+def test_delivery_requires_explicit_approval_before_git_mutation(tmp_path: Path) -> None:
+    _init_repository(tmp_path)
+    (tmp_path / "src/allowed/service.py").write_text("VALUE = 'changed'\n", encoding="utf-8")
+
+    with pytest.raises(delivery.DeliveryBlocked, match="explicit delivery approval"):
+        delivery.create_change_set_pull_request(
+            tmp_path,
+            change_set_id="CHG-376",
+            run_id="run-376",
+        )
+
+    assert _git(tmp_path, "diff", "--cached", "--name-only").stdout == ""
+
+
+def test_push_failure_keeps_changeset_active_for_resume(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _init_repository(tmp_path)
+    (tmp_path / "src/allowed/service.py").write_text("VALUE = 'changed'\n", encoding="utf-8")
+    _install_delivery_stubs(monkeypatch, push_returncode=1)
+
+    with pytest.raises(delivery.DeliveryBlocked, match="push failed"):
+        delivery.create_change_set_pull_request(
+            tmp_path,
+            change_set_id="CHG-376",
+            run_id="run-376",
+        )
+
+    assert (tmp_path / "docs/changes/active/CHG-376.md").exists()
+    assert not (tmp_path / "docs/changes/completed/CHG-376.md").exists()
+
+
+def test_canonical_workflow_uses_explicit_scope_safe_delivery_commands() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow = load_named_workflow(
+        "changeset-use-case-workflow",
+        workflows_dir=repo_root / ".harness/workflows",
+    )
+
+    pull_request = workflow.step_by_id("create-change-set-pr")
+    completion = workflow.step_by_id("complete-change-set")
+
+    assert pull_request.command == (
+        "python3 -m harness_codex.runtime.change_set_delivery pull-request "
+        "--change-set <CHG-ID> --run-id <RUN-ID>"
+    )
+    assert completion.command == (
+        "python3 -m harness_codex.runtime.change_set_delivery complete "
+        "--change-set <CHG-ID> --run-id <RUN-ID>"
+    )
+    assert pull_request.metadata["approval_env"] == delivery.DELIVERY_APPROVAL_ENV
+    assert completion.metadata["approval_env"] == delivery.DELIVERY_APPROVAL_ENV

--- a/tests/runtime/test_change_set_delivery.py
+++ b/tests/runtime/test_change_set_delivery.py
@@ -87,6 +87,7 @@ def _install_delivery_stubs(monkeypatch, *, push_returncode: int = 0):
         return actual_run(repo_root, *args)
 
     monkeypatch.setattr(delivery, "_run", fake_run)
+    monkeypatch.setattr(pr_delivery, "_run", fake_run)
     monkeypatch.setattr(delivery.shutil, "which", lambda _binary: "/usr/bin/gh")
     monkeypatch.setenv(delivery.DELIVERY_APPROVAL_ENV, "1")
     return calls

--- a/tests/runtime/test_change_set_delivery.py
+++ b/tests/runtime/test_change_set_delivery.py
@@ -186,7 +186,7 @@ def test_canonical_workflow_uses_explicit_scope_safe_delivery_commands() -> None
         "--change-set <CHG-ID> --run-id <RUN-ID>"
     )
     assert completion.command == (
-        "python3 -m harness_codex.runtime.change_set_delivery complete "
+        "python3 -m harness_codex.runtime.change_set_completion_delivery "
         "--change-set <CHG-ID> --run-id <RUN-ID>"
     )
     assert pull_request.metadata["approval_env"] == delivery.DELIVERY_APPROVAL_ENV

--- a/tests/runtime/test_change_set_delivery.py
+++ b/tests/runtime/test_change_set_delivery.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 import harness_codex.runtime.change_set_delivery as delivery
+import harness_codex.runtime.change_set_pr_delivery as pr_delivery
 from harness_codex.runtime.workflows import load_named_workflow
 
 
@@ -56,7 +57,7 @@ def _init_repository(repo_root: Path) -> None:
     source.write_text("VALUE = 'base'\n", encoding="utf-8")
     _write_changeset(repo_root)
     _git(repo_root, "add", ".")
-    _git(repo_root, "commit", "-m", "base")
+    _git(repo_root, "commit", "-m", "기본 상태")
     _git(repo_root, "checkout", "-b", "feature/chg-376")
     _git(repo_root, "remote", "add", "origin", "https://example.invalid/harness.git")
 
@@ -102,8 +103,8 @@ def test_delivery_blocks_and_preserves_out_of_scope_dirty_changes(
     unrelated.write_text("do not commit\n", encoding="utf-8")
     calls = _install_delivery_stubs(monkeypatch)
 
-    with pytest.raises(delivery.DeliveryBlocked, match="out-of-scope changes"):
-        delivery.create_change_set_pull_request(
+    with pytest.raises(delivery.DeliveryBlocked, match="범위 밖"):
+        pr_delivery.create_change_set_pull_request(
             tmp_path,
             change_set_id="CHG-376",
             run_id="run-376",
@@ -116,7 +117,7 @@ def test_delivery_blocks_and_preserves_out_of_scope_dirty_changes(
     assert not any(args[:3] == ("git", "add", "-A") for args in calls)
 
 
-def test_delivery_commits_only_changeset_scope_with_pathspec(
+def test_delivery_commits_only_changeset_scope_with_pathspec_and_korean_pr_metadata(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -124,7 +125,7 @@ def test_delivery_commits_only_changeset_scope_with_pathspec(
     (tmp_path / "src/allowed/service.py").write_text("VALUE = 'changed'\n", encoding="utf-8")
     calls = _install_delivery_stubs(monkeypatch)
 
-    result = delivery.create_change_set_pull_request(
+    result = pr_delivery.create_change_set_pull_request(
         tmp_path,
         change_set_id="CHG-376",
         run_id="run-376",
@@ -135,6 +136,9 @@ def test_delivery_commits_only_changeset_scope_with_pathspec(
     assert result.committed_paths == ("src/allowed/service.py",)
     assert result.pull_request == "https://github.com/example/harness/pull/376"
     assert ("git", "add", "--", "src/allowed/service.py") in calls
+    create_args = next(args for args in calls if args[:3] == ("gh", "pr", "create"))
+    assert "CHG-376 변경 세트 전달" in create_args
+    assert "ChangeSet 범위로 승인된 경로만" in create_args
     assert not any(args[:3] == ("git", "add", "-A") for args in calls)
 
 
@@ -142,8 +146,8 @@ def test_delivery_requires_explicit_approval_before_git_mutation(tmp_path: Path)
     _init_repository(tmp_path)
     (tmp_path / "src/allowed/service.py").write_text("VALUE = 'changed'\n", encoding="utf-8")
 
-    with pytest.raises(delivery.DeliveryBlocked, match="explicit delivery approval"):
-        delivery.create_change_set_pull_request(
+    with pytest.raises(delivery.DeliveryBlocked, match="approval|승인"):
+        pr_delivery.create_change_set_pull_request(
             tmp_path,
             change_set_id="CHG-376",
             run_id="run-376",
@@ -161,7 +165,7 @@ def test_push_failure_keeps_changeset_active_for_resume(
     _install_delivery_stubs(monkeypatch, push_returncode=1)
 
     with pytest.raises(delivery.DeliveryBlocked, match="push failed"):
-        delivery.create_change_set_pull_request(
+        pr_delivery.create_change_set_pull_request(
             tmp_path,
             change_set_id="CHG-376",
             run_id="run-376",
@@ -182,7 +186,7 @@ def test_canonical_workflow_uses_explicit_scope_safe_delivery_commands() -> None
     completion = workflow.step_by_id("complete-change-set")
 
     assert pull_request.command == (
-        "python3 -m harness_codex.runtime.change_set_delivery pull-request "
+        "python3 -m harness_codex.runtime.change_set_pr_delivery "
         "--change-set <CHG-ID> --run-id <RUN-ID>"
     )
     assert completion.command == (

--- a/tests/runtime/test_delivery_runner_patch.py
+++ b/tests/runtime/test_delivery_runner_patch.py
@@ -42,7 +42,7 @@ def test_delivery_command_blocks_without_explicit_approval(tmp_path: Path) -> No
     assert result.status == StepStatus.BLOCKED
     assert result.failure_kind == FailureKind.ENVIRONMENT_BLOCKER
     assert result.metadata["delivery_approved"] is False
-    assert "explicit delivery approval" in (result.error or "")
+    assert "명시적인 전달 승인" in (result.error or "")
 
 
 def test_approved_delivery_command_receives_affirmative_environment(tmp_path: Path) -> None:

--- a/tests/runtime/test_delivery_runner_patch.py
+++ b/tests/runtime/test_delivery_runner_patch.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from harness_codex.runtime import BasicStepRunner, FailureKind, RunContext, RunMode, Step, StepKind, StepStatus
+
+
+def _context(tmp_path: Path, *, approved: bool | None = None) -> RunContext:
+    metadata = {} if approved is None else {"delivery_approved": approved}
+    return RunContext(
+        run_id="run-delivery",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-delivery",
+        metadata=metadata,
+    )
+
+
+def _delivery_step(command: str) -> Step:
+    return Step(
+        id="create-change-set-pr",
+        kind=StepKind.GIT,
+        name="ChangeSet PR 전달",
+        command=command,
+        metadata={"approval_env": "HARNESS_DELIVERY_APPROVED"},
+    )
+
+
+def test_delivery_command_blocks_without_explicit_approval(tmp_path: Path) -> None:
+    step_dir = tmp_path / "step"
+    step_dir.mkdir()
+
+    result = BasicStepRunner()._run_command(
+        _delivery_step(f'{sys.executable} -c "raise SystemExit(0)"'),
+        _context(tmp_path),
+        step_dir,
+    )
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.failure_kind == FailureKind.ENVIRONMENT_BLOCKER
+    assert result.metadata["delivery_approved"] is False
+    assert "explicit delivery approval" in (result.error or "")
+
+
+def test_approved_delivery_command_receives_affirmative_environment(tmp_path: Path) -> None:
+    step_dir = tmp_path / "step"
+    step_dir.mkdir()
+    command = (
+        f'{sys.executable} -c "import os; '
+        'raise SystemExit(0 if os.environ.get(\'HARNESS_DELIVERY_APPROVED\') == \'1\' else 1)"'
+    )
+
+    result = BasicStepRunner()._run_command(
+        _delivery_step(command),
+        _context(tmp_path, approved=True),
+        step_dir,
+    )
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata["delivery_approved"] is True
+
+
+def test_delivery_blocked_exit_code_is_not_reclassified_as_implementation_failure(tmp_path: Path) -> None:
+    step_dir = tmp_path / "step"
+    step_dir.mkdir()
+    command = f'{sys.executable} -c "import sys; print(\'BLOCKED: push unavailable\', file=sys.stderr); raise SystemExit(2)"'
+
+    result = BasicStepRunner()._run_command(
+        _delivery_step(command),
+        _context(tmp_path, approved=True),
+        step_dir,
+    )
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.failure_kind == FailureKind.ENVIRONMENT_BLOCKER
+    assert result.error == "push unavailable"

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -130,9 +130,7 @@ def test_default_changeset_work_item_workflow_loads() -> None:
     assert review.skill_id == "harness-artifact-reviewer"
     assert review.needs == ("secure-work-item-plan",)
     assert review.metadata["review_gate"]["approved_status"] == "approved"
-    assert workflow.step_by_id("execute-work-item").skill_id == (
-        "harness-plan-executor"
-    )
+    assert workflow.step_by_id("execute-work-item").skill_id == "harness-plan-executor"
     assert workflow.step_by_id("execute-work-item").needs == ("review-work-item-plan",)
     assert workflow.step_by_id("verify-work-item").command == (
         "python3 -m harness_codex.runtime.verify_work_item "
@@ -151,7 +149,8 @@ def test_default_changeset_work_item_workflow_loads() -> None:
     create_pr = workflow.step_by_id("create-change-set-pr")
     assert create_pr.kind == StepKind.GIT
     assert create_pr.skill_id == "harness-change-set-pr"
-    assert create_pr.needs == ("complete-change-set",)
+    assert create_pr.needs == ("validate-project-wiki",)
+    assert completion.needs == ("create-change-set-pr",)
     assert create_pr.metadata["stage"] == "delivery"
 
 

--- a/tests/test_project_wiki_workflow.py
+++ b/tests/test_project_wiki_workflow.py
@@ -59,7 +59,7 @@ def test_project_wiki_agent_and_skill_contracts_are_registered() -> None:
     assert "mkdocs build --strict" in build_script
 
 
-def test_changeset_workflow_updates_wiki_before_completion() -> None:
+def test_changeset_workflow_delivers_pr_before_completion() -> None:
     workflow = load_named_workflow("changeset-use-case-workflow")
     wiki = workflow.step_by_id("update-project-wiki")
     validation = workflow.step_by_id("validate-project-wiki")
@@ -81,9 +81,9 @@ def test_changeset_workflow_updates_wiki_before_completion() -> None:
     assert validation.command == "./harness run wiki build"
     assert validation.outputs == (Path(".harness/wiki-site/index.html"),)
     assert validation.metadata["run_on_final_work_item_only"] is True
-    assert completion.needs == ("validate-project-wiki",)
+    assert create_pr.needs == ("validate-project-wiki",)
+    assert completion.needs == ("create-change-set-pr",)
     assert create_pr.skill_id == "harness-change-set-pr"
-    assert create_pr.needs == ("complete-change-set",)
     assert create_pr.metadata["stage"] == "delivery"
 
 


### PR DESCRIPTION
## 변경 사항
- ChangeSet 범위와 `affected-files` 계약에서 허용 경로를 계산하고, `git add -- <경로>`로만 스테이징합니다.
- 범위 밖 변경 또는 기존 인덱스의 범위 밖 변경은 보존한 채 전달 단계를 차단합니다.
- 전달 승인 메타데이터를 실행기에 연결해, 미승인은 재개 가능한 `BLOCKED / ENVIRONMENT_BLOCKER` 결과로 남깁니다.
- PR 생성·푸시·완료 단계가 실패해도 ChangeSet 상태와 커밋을 재시도 가능하게 유지합니다.
- 완료 delivery의 경로 타입 계약과 한국어 생성 메시지를 정정했습니다.

## 검증
- 범위 밖 변경 보존, pathspec 스테이징, 승인 게이트, PR 전달 푸시 실패 재개를 검증했습니다.
- ChangeSet 완료 delivery의 푸시 실패 후 재시도와 dirty worktree 차단을 검증했습니다.
- 전체 `pytest -q`를 PR CI에서 실행하도록 변경했습니다.

Closes #376