### PR TITLE
[superseded] cleanup: consolidate canonical workflow and runtime state

### DIFF
--- a/.codex/skills/harness-full-workflow/SKILL.md
+++ b/.codex/skills/harness-full-workflow/SKILL.md
@@ -1,195 +1,41 @@
 ---
 name: harness-full-workflow
-description: Run the full harness workflow by orchestrating harness-requirements, harness-usecases, and harness-post-harvest-orchestrator as one resumable flow from early idea through execution. Use when the user wants one skill to carry requirements, use cases, ChangeSet creation, UC slices, event storming, DDD design, technical decisions, planning, execution, verification, and ChangeSet completion while preserving stage state across grill-me and approval pauses.
+description: Guide a user through the canonical harness runtime command path. Use when the user requests one assisted flow from an idea through ChangeSet execution, but keep all workflow state in the persisted runtime.
 ---
 
 # Harness Full Workflow
 
-## Purpose
+This is a **thin command wrapper**, not a workflow engine and not a state store.
+It must not coordinate specialist skills as a parallel orchestration path or
+maintain wrapper-owned stage, approval, completion, or resume state.
 
-Use this wrapper when the user wants one skill to drive the full harness flow
-from early idea to execution.
+## Canonical Command Path
 
-This skill does not replace the specialist skills. It sequences them, preserves
-state across pauses, and resumes from the current gate.
+```bash
+./harness harvest --idea "<request>" --apply --session-id harvest-001
+./harness changes create-from-design --title "<title>" --related-issue "#<issue>"
+./harness changes active
+./harness run-change CHG-YYYYMMDD-001 --apply
+```
 
-Specialist skills:
+For intentionally narrow execution:
 
-- `$harness-requirements`
-- `$harness-usecases`
-- `$harness-post-harvest-orchestrator`
+```bash
+./harness run-work-item CHG-YYYYMMDD-001 <WORK-ITEM-ID> --apply
+./harness run-use-case CHG-YYYYMMDD-001 <UC-ID> --apply
+```
 
-## Entry Conditions
+## Rules
 
-Use this skill only when the user wants these stages treated as one workflow:
+1. Read `docs/architecture/canonical-runtime.md` before selecting a command.
+2. Use `RunState` at `.harness/runs/<RUN-ID>/state.json` as the sole authority
+   for runtime state, gates, blockers, and resume targets.
+3. On interruption, show `./harness resume <RUN-ID>` and
+   `./harness report <RUN-ID>`; do not reconstruct a next step from chat memory.
+4. A harvest question transcript may be used only to continue the harvest CLI
+   session. It must not represent implementation completion state.
+5. Report the ChangeSet ID, run ID, persisted blocker or completion status, and
+   verification evidence returned by the runtime.
 
-1. requirements generation
-2. use-case generation
-3. post-harvest orchestration through execution
-
-If the user wants only one stage, invoke the specialist skill directly instead.
-
-## State Model
-
-Maintain wrapper state across the entire session. Do not drop it after a user
-reply, tool pause, compaction, or specialist-skill question loop.
-
-Track at least:
-
-- `current_stage`
-- `current_skill`
-- `requirements_status`
-- `usecases_status`
-- `post_harvest_status`
-- `pending_grill_me_questions`
-- `pending_grill_me_answers`
-- `active_change_set_id`
-- `affected_uc_ids`
-- `pending_approval_gate`
-
-Valid `current_stage` values:
-
-- `requirements`
-- `usecases`
-- `post-harvest`
-- `waiting-for-user`
-- `complete`
-
-## Orchestration Rules
-
-1. Announce which specialist skill is being invoked.
-2. Run only one specialist skill at a time.
-3. Treat `grill-me` as a blocking sub-loop inside `requirements`, not as a
-   workflow failure.
-4. Do not invoke `$harness-usecases` until requirements are complete.
-5. Do not invoke `$harness-post-harvest-orchestrator` until use cases are
-   complete.
-6. Preserve state and resume from the current gate after every user reply.
-7. Do not bypass approval gates owned by downstream skills.
-
-## Requirements Stage
-
-Set:
-
-- `current_stage=requirements`
-- `current_skill=harness-requirements`
-
-Invoke `$harness-requirements`.
-
-If it invokes `grill-me`:
-
-- keep `current_stage=requirements`
-- set `pending_grill_me_questions`
-- move to `waiting-for-user`
-- store user answers in `pending_grill_me_answers`
-- resume `$harness-requirements` with accumulated answers
-- do not invoke use cases or post-harvest while `grill-me.complete != true`
-
-Requirements stage completes only when:
-
-- `docs/design/요구사항.md` exists and is non-empty
-- unresolved core business policy decisions do not block use-case writing
-
-## Use Cases Stage
-
-After requirements completion:
-
-- `current_stage=usecases`
-- `current_skill=harness-usecases`
-
-Invoke `$harness-usecases`.
-
-If the use-case skill asks clarification questions:
-
-- keep `current_stage=usecases`
-- move to `waiting-for-user`
-- resume use-case generation after the user answers
-
-Use-cases stage completes only when:
-
-- `docs/design/유스케이스.md` exists and is non-empty
-
-## Post-Harvest Stage
-
-After use-case completion:
-
-- `current_stage=post-harvest`
-- `current_skill=harness-post-harvest-orchestrator`
-
-Invoke `$harness-post-harvest-orchestrator`.
-
-Respect all of its gates, especially:
-
-- ChangeSet creation
-- affected UC identification
-- UC slice creation
-- event storming
-- staged DDD approvals
-- technical decision completion
-- final approval before planning
-- mandatory plan execution after approval
-
-If the orchestrator stops for approval or clarification:
-
-- keep `current_stage=post-harvest`
-- record `pending_approval_gate`
-- move to `waiting-for-user`
-- resume from that exact gate after user input
-
-## Resume Rules
-
-On every new user reply during an active wrapper run:
-
-1. Check wrapper state first.
-2. If `pending_grill_me_questions` exists, route the reply back to
-   `$harness-requirements`.
-3. Else if `current_stage=usecases` and use-case clarification is pending,
-   route the reply back to `$harness-usecases`.
-4. Else if `pending_approval_gate` exists, route the reply back to
-   `$harness-post-harvest-orchestrator`.
-5. Else continue with the next stage in sequence.
-
-Do not restart from requirements unless the user explicitly asks to regenerate
-requirements or downstream artifacts became stale because an upstream stage was
-regenerated.
-
-## Regeneration Rules
-
-If requirements are regenerated:
-
-- rerun use cases
-- rerun post-harvest from the earliest invalid downstream gate
-
-If use cases are regenerated:
-
-- rerun post-harvest from affected use-case selection or later, depending on
-  artifact impact
-
-If a downstream skill reports that an upstream artifact is unresolved or stale,
-return to the owning stage and continue from there.
-
-## Completion
-
-Workflow completes only when:
-
-- requirements completed
-- use cases completed
-- post-harvest orchestration completed
-- all affected UC plans completed
-- ChangeSet moved to completed state
-
-Then set:
-
-- `current_stage=complete`
-- `current_skill=none`
-- clear pending questions and pending approvals
-
-## User-Facing Result
-
-When pausing or completing, report:
-
-- current stage
-- current skill
-- current gate artifact path
-- pending question or approval status
-- active ChangeSet ID and affected UCs when available
+Legacy specialist sequencing and wrapper-state instructions are retired. See
+`docs/architecture/legacy-command-migration.md` through 2026-09-30.

--- a/.codex/skills/harness-ultrawork/SKILL.md
+++ b/.codex/skills/harness-ultrawork/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: harness-ultrawork
+description: Compatibility guidance for the retired ultrawork entry point. Translate requests into the canonical harvest, ChangeSet, and runtime commands without retaining workflow state.
+---
+
+# Harness Ultrawork Compatibility Wrapper
+
+`ultrawork` is no longer an orchestration command. Translate it into the
+canonical runtime sequence:
+
+```bash
+./harness harvest --idea "<request>" --apply --session-id harvest-001
+./harness changes create-from-design --title "<title>" --related-issue "#<issue>"
+./harness run-change CHG-YYYYMMDD-001 --apply
+```
+
+Use `run-work-item` or `run-use-case` only when the caller explicitly narrows
+the execution scope.
+
+## State Rule
+
+Do not create a parallel ultrawork state, procedure table, or wrapper
+completion flag. Read `.harness/runs/<RUN-ID>/state.json` and use `resume` or
+`report` to communicate the next runtime action.
+
+This compatibility skill and its migration instructions end on 2026-09-30. See
+`docs/architecture/legacy-command-migration.md`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# harness-codex
+
+`harness-codex` turns an idea or change request into a scoped ChangeSet, a
+materialized work-item workflow, verified implementation evidence, and a
+persisted run record.
+
+The runtime has one official orchestration path and one authoritative execution
+state model. `RunnerEngine` executes work; `.harness/runs/<RUN-ID>/state.json`
+(`RunState`) decides what ran, what is blocked, and what can resume.
+
+Read the full contract in `docs/architecture/canonical-runtime.md`.
+
+## Install
+
+```bash
+python3 -m venv venv
+./venv/bin/python3 -m pip install -U pip pytest pyyaml
+./venv/bin/python3 -m harness_codex --help
+```
+
+When installed in a target repository, use the generated `./harness` launcher.
+
+## Canonical Quick Start
+
+```bash
+# Harvest or update design.
+./harness harvest --idea "add a change request" --apply --session-id harvest-001
+
+# Create a scoped ChangeSet.
+./harness changes create-from-design --title "add a change request" --related-issue "#378"
+
+# Inspect readiness and execute.
+./harness changes active
+./harness run-change CHG-YYYYMMDD-001 --plan
+./harness run-change CHG-YYYYMMDD-001 --apply
+
+# Inspect the persisted runtime result.
+./harness resume run-<id>
+./harness report run-<id>
+```
+
+For a deliberate narrow run, use:
+
+```bash
+./harness run-work-item CHG-YYYYMMDD-001 MAINT-001 --apply
+./harness run-use-case CHG-YYYYMMDD-001 UC-001 --apply
+```
+
+`run-use-case` is a convenience form of `run-work-item` for a use-case work
+item. `run-change` is the default for a ChangeSet.
+
+## Command Map
+
+| Goal | Command |
+| --- | --- |
+| Create or refresh design | `harvest` |
+| Create ChangeSet from design | `changes create-from-design` |
+| Inspect active work and readiness | `changes active` |
+| Execute all ChangeSet work | `run-change` |
+| Execute one work item | `run-work-item` |
+| Execute one use-case item | `run-use-case` |
+| Inspect persisted state | `resume`, `report`, `dashboard` |
+
+Procedure-stage commands and `ultrawork` are legacy entry points. They are not
+part of the official command map. Use
+`docs/architecture/legacy-command-migration.md` through 2026-09-30.
+
+## State and Artifacts
+
+- `docs/changes/active/<CHG-ID>.md`: change intent and affected work items.
+- `docs/use-cases/` and `docs/maintenance/`: executor-facing slices.
+- `docs/plans/active/` and `docs/plans/completed/`: plan lifecycle.
+- `.harness/runs/<RUN-ID>/state.json`: authoritative runtime state.
+- `.harness/runs/<RUN-ID>/report.md`: human-readable run evidence.
+
+Skill wrappers and dashboard/session files are convenience interfaces only. They
+must not create a separate completion, resume, or gate state.
+
+## Verification
+
+```bash
+./venv/bin/python3 -m pytest -q -s tests/runtime
+./venv/bin/python3 -m pytest -q -s
+git diff --check
+```
+
+For detailed operations, bootstrap policy, and legacy migration, see
+`docs/architecture/canonical-runtime.md`.

--- a/docs/agent/commands.md
+++ b/docs/agent/commands.md
@@ -1,47 +1,32 @@
 # Agent Commands
 
-## Python Runtime
+See `docs/architecture/canonical-runtime.md` for the authoritative workflow.
 
-- Full Python test gate: `./venv/bin/python3 -m pytest -q -s`
-- List active ChangeSets: `python3 -m harness_codex changes list`
-- Show ChangeSet: `python3 -m harness_codex changes show <CHG-ID>`
-- Preview use-case workflow: `python3 -m harness_codex run-use-case <CHG-ID> <UC-ID> --preview`
-- Preview work item workflow: `python3 -m harness_codex run-work-item <CHG-ID> <WORK-ITEM-ID> --preview`
-- Show run report: `python3 -m harness_codex report <RUN-ID>`
-- Bootstrap target repo agent context: `python3 -m harness_codex agent-context init --description "<repo description>"`
+## Canonical Runtime
 
-Use `python3` for Python commands. Use the repository-root `venv` for dependencies and test execution.
+- Harvest design: `python3 -m harness_codex harvest --idea "<request>" --apply --session-id harvest-001`
+- Resume harvest: `python3 -m harness_codex harvest --apply --session-id harvest-001 --resume`
+- Create scope: `python3 -m harness_codex changes create-from-design --title "<title>"`
+- Inspect readiness: `python3 -m harness_codex changes active`
+- Execute ChangeSet: `python3 -m harness_codex run-change CHG-YYYYMMDD-001 --apply`
+- Execute work item: `python3 -m harness_codex run-work-item CHG-YYYYMMDD-001 MAINT-001 --apply`
+- Execute use case: `python3 -m harness_codex run-use-case CHG-YYYYMMDD-001 UC-001 --apply`
+- Resume runtime: `python3 -m harness_codex resume run-<id>`
+- Read run report: `python3 -m harness_codex report run-<id>`
 
-## UI
+`RunState` at `.harness/runs/<RUN-ID>/state.json` is authoritative. Do not
+store a parallel workflow state in a skill, dashboard, or hand-maintained
+session file.
 
-- Lint UI: `cd ui && npm run lint`
-- Build UI: `cd ui && npm run build`
-- Run UI dev server: `cd ui && npm run dev`
+Procedure-stage commands and `ultrawork` are legacy. Follow
+`docs/architecture/legacy-command-migration.md`; compatibility documentation
+ends on 2026-09-30.
 
-## Agent Context Measurement
-
-- Agent files word count: `find . -name AGENTS.md -print | sort | xargs -r wc -w`
-- Docs markdown word count: `find docs -type f -name '*.md' -print0 2>/dev/null | xargs -0 wc -w | tail -1`
-- Agent docs word count: `wc -w docs/agent/*.md`
-
-## Verification For Context Compaction
-
-Run after agent-context edits:
+## Verification
 
 ```bash
-find . -name AGENTS.md -print | sort | xargs -r wc -w
-wc -w docs/agent/*.md
-rg -n -P "\p{Hangul}" AGENTS.md docs/agent || true
-git diff --stat
+./venv/bin/python3 -m pytest -q -s tests/runtime
+./venv/bin/python3 -m pytest -q -s
+git diff --check
 git status --porcelain=v1 -uno
 ```
-
-Full test suite is optional for docs-only context changes. Use `./venv/bin/python3 -m pytest -q -s` when behavior or workflow logic changes.
-
-## Diagnostic Order
-
-1. Use concise status commands first.
-2. Use diff stats before targeted diffs.
-3. Run narrow tests before full test gates when scope is small.
-4. Summarize logs and failures instead of pasting full output.
-5. Cap routine command output near 4k tokens.

--- a/docs/architecture/canonical-runtime.md
+++ b/docs/architecture/canonical-runtime.md
@@ -62,7 +62,6 @@ Bootstrap creates only compact, reusable agent context:
 - `AGENTS.md`
 - `docs/agent/context.md`
 - `docs/agent/commands.md`
-- `docs/agent/codebase-artifacts.md`
 
 The following are diagnostics or ephemeral handoff material, not required
 workflow inputs: `docs/agent/session-state.md`,

--- a/docs/architecture/canonical-runtime.md
+++ b/docs/architecture/canonical-runtime.md
@@ -1,0 +1,91 @@
+# Canonical Runtime Workflow
+
+## Authority
+
+`RunnerEngine` executes the workflow. The persisted run record at
+`.harness/runs/<RUN-ID>/state.json` (`RunState`) is the authoritative state for
+execution, resumption, gate results, artifact acceptance, downstream dirtiness,
+and failure status.
+
+A ChangeSet describes the requested scope; it does not replace `RunState` as
+execution state. Skill wrappers, chat summaries, dashboard sessions, and
+harvest question transcripts are convenience context only. They must never
+override a persisted `RunState` decision.
+
+## Official Command Path
+
+Use this sequence for every new change:
+
+```bash
+# 1. Harvest or refresh project-level design.
+./harness harvest --idea "<product or change request>" --apply --session-id harvest-001
+
+# 2. Create the scoped ChangeSet from the resulting design.
+./harness changes create-from-design \
+  --title "<change title>" \
+  --related-issue "#378"
+
+# 3. Inspect readiness and select execution scope.
+./harness changes active
+./harness run-change CHG-YYYYMMDD-001 --plan
+
+# 4. Execute all work items or a deliberately narrow item.
+./harness run-change CHG-YYYYMMDD-001 --apply
+./harness run-work-item CHG-YYYYMMDD-001 MAINT-001 --apply
+./harness run-use-case CHG-YYYYMMDD-001 UC-001 --apply
+
+# 5. Resume and inspect persisted runtime evidence.
+./harness resume run-<id>
+./harness report run-<id>
+```
+
+`run-change` executes every ready work item in the ChangeSet. `run-work-item`
+is the general narrow-scope command. `run-use-case` is only a convenience alias
+for a `use_case` work item.
+
+## State Ownership
+
+| Concern | Owner | Non-authoritative helpers |
+| --- | --- | --- |
+| Change intent and affected work items | active ChangeSet | README and planning notes |
+| Materialized workflow and per-step result | `RunnerEngine` | skill instructions |
+| Resume target, gate status, artifacts, and blockers | `RunState` | wrapper/session notes and dashboard cache |
+| Human-readable evidence | run report | terminal output |
+
+When a helper disagrees with `RunState`, inspect the persisted state and report
+rather than attempting to repair state from the helper.
+
+## Bootstrap Output Policy
+
+Bootstrap creates only compact, reusable agent context:
+
+- `AGENTS.md`
+- `docs/agent/context.md`
+- `docs/agent/commands.md`
+- `docs/agent/codebase-artifacts.md`
+
+The following are diagnostics or ephemeral handoff material, not required
+workflow inputs: `docs/agent/session-state.md`,
+`docs/agent/design-conformance-report.md`, and
+`docs/agent/token-reduction-report.md`. Do not add a gate, prompt dependency,
+or dashboard dependency on them. Generate them only through an explicit
+analysis/report command when that capability is needed.
+
+## Wiki Bootstrap Policy
+
+`harness run wiki` must distinguish two operations:
+
+1. **Initial bootstrap**: create the repository wiki contract only when it is
+   missing.
+2. **Incremental update**: preserve existing project-written pages and update
+   only generated index/navigation or explicitly selected workflow pages.
+
+A routine runtime execution must never overwrite a project wiki as though it
+were a first bootstrap.
+
+## Compatibility Window
+
+The procedure-stage commands and `ultrawork` are replaced by the official path
+above. Their compatibility documentation remains until **2026-09-30**. New
+code, skills, README examples, and shell completion must not advertise them.
+See `docs/architecture/legacy-command-migration.md` for exact replacements.

--- a/docs/architecture/legacy-command-migration.md
+++ b/docs/architecture/legacy-command-migration.md
@@ -1,0 +1,39 @@
+# Legacy Command Migration
+
+The canonical runtime commands are `harvest`, `changes create-from-design`,
+`run-change`, `run-work-item`, and `run-use-case`. The older procedure-stage
+commands and `ultrawork` describe a parallel workflow and are no longer an
+official execution interface.
+
+## Migration Map
+
+| Legacy entry point | Replacement | Notes |
+| --- | --- | --- |
+| `requirements-definition` | `harvest --idea "..." --apply` | Harvest owns requirements and use-case design generation. |
+| `ubiquitous-language-definition` | `harvest --apply --resume` | Continue the same harvest session when clarification is required. |
+| `use-case-definition` | `harvest --apply --resume` | Harvest produces runtime-ready use-case slices. |
+| `event-storming` | `run-work-item <CHG-ID> <ITEM-ID> --apply` | Work-item workflow owns planning through verification. |
+| `ddd-architecture-definition` | `run-work-item <CHG-ID> <ITEM-ID> --apply` | Do not keep an independent stage table. |
+| `technical-decisions` | `run-work-item <CHG-ID> <ITEM-ID> --apply` | Decisions are work-item inputs and plan evidence. |
+| `plan-writing` | `run-work-item <CHG-ID> <ITEM-ID> --apply` | The materialized workflow invokes the planner. |
+| `implementation` | `run-change <CHG-ID> --apply` | Use `run-work-item` for an intentional narrow run. |
+| `ultrawork` | `harvest` → `changes create-from-design` → `run-change` | This explicit sequence preserves inspectable boundaries. |
+| `harness-full-workflow` skill | Thin wrapper around the same canonical commands | It may guide command choice but may not own workflow state. |
+
+## Compatibility Contract
+
+- Do not add new callers of legacy entries.
+- Do not generate procedure tables or wrapper-owned completion state.
+- Keep migration documentation through **2026-09-30**.
+- Remove remaining compatibility documentation after that date only when usage
+  has been checked in release notes and installed-template documentation.
+
+## Recovering an Existing Legacy Run
+
+1. Identify the active ChangeSet and its affected work items.
+2. Validate it with `./harness changes active`.
+3. Run `./harness run-change <CHG-ID> --preview`.
+4. Continue with `--apply`, or choose one ready work item with
+   `run-work-item`.
+5. Use `resume` and the persisted report as the source of truth; do not copy
+   status from a legacy procedure table into `RunState`.

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -1,0 +1,97 @@
+# harness-codex Operating Guide
+
+## Canonical Orchestration
+
+Harness has one official execution path:
+
+```text
+harvest
+  -> changes create-from-design
+  -> run-change | run-work-item | run-use-case
+  -> resume / report
+```
+
+`RunnerEngine` executes each materialized workflow. `RunState`, stored at
+`.harness/runs/<RUN-ID>/state.json`, is the source of truth for execution,
+artifacts, verification, blockers, and resumption.
+
+A ChangeSet remains the source of truth for **scope**, not for mutable runtime
+status. The dashboard, a skill wrapper, a session note, and terminal output
+must only project `RunState`; they must not override it.
+
+## Standard Flow
+
+### 1. Harvest design
+
+```bash
+./harness harvest --idea "<request>" --apply --session-id harvest-001
+```
+
+Reuse `--session-id` with `--resume` when clarification interrupts harvest.
+The harvest transcript may hold unanswered questions, but it is not a second
+workflow-state machine.
+
+### 2. Create a ChangeSet
+
+```bash
+./harness changes create-from-design --title "<title>" --related-issue "#378"
+./harness changes active
+```
+
+`changes active` is the preflight view: it shows active ChangeSets, their
+latest run, work items, plans, verification goals, and readiness blockers.
+
+### 3. Execute
+
+```bash
+# default: every ready work item in the ChangeSet
+./harness run-change CHG-YYYYMMDD-001 --apply
+
+# intentionally narrow execution
+./harness run-work-item CHG-YYYYMMDD-001 MAINT-001 --apply
+./harness run-use-case CHG-YYYYMMDD-001 UC-001 --apply
+```
+
+All execution commands require exactly one mode:
+
+- `--plan`: show intended scope with no writes.
+- `--preview`: validate inputs and current readiness with no writes.
+- `--apply`: materialize, execute, verify, and persist the run result.
+
+### 4. Resume and report
+
+```bash
+./harness resume run-<id>
+./harness report run-<id>
+./harness dashboard
+```
+
+Resume from the result reported by `RunState`. Do not reproduce a run by
+manually copying a table or asking a skill wrapper to infer the next stage.
+
+## Artifact Boundaries
+
+| Artifact | Role |
+| --- | --- |
+| `docs/design/` | canonical project design |
+| `docs/changes/active/` | active ChangeSet scope |
+| `docs/use-cases/`, `docs/maintenance/` | work-item slices |
+| `docs/plans/active/` | active implementation plan |
+| `docs/plans/completed/` | verified completed plan |
+| `.harness/runs/` | authoritative runtime state and reports |
+
+## Bootstrap and Wiki Updates
+
+Bootstrap writes compact agent context. Diagnostics such as session-state,
+token-reduction, and design-conformance reports are optional; they cannot be
+required by prompts, validators, or dashboard views.
+
+Wiki generation distinguishes initial bootstrap from incremental update. An
+existing project wiki is preserved unless an explicit update selects a generated
+page or navigation element.
+
+## Legacy Migration
+
+Procedure-stage commands and `ultrawork` are not part of the command map. The
+migration table is in `docs/architecture/legacy-command-migration.md` and is
+maintained through 2026-09-30.

--- a/harness_codex/runtime/agent_context.py
+++ b/harness_codex/runtime/agent_context.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-
 HARNESS_AGENT_CONTEXT_MARKER = "<!-- harness-agent-context:v1 -->"
 AGENT_CONTEXT_FILES = (
     Path("AGENTS.md"),
     Path("docs/agent/context.md"),
     Path("docs/agent/commands.md"),
-    Path("docs/agent/session-state.md"),
-    Path("docs/agent/token-reduction-report.md"),
 )
 
 
@@ -31,260 +28,32 @@ class AgentContextBootstrapResult:
 
     @property
     def changed_paths(self) -> tuple[Path, ...]:
-        return tuple(
-            item.path for item in self.files if item.action in {"created", "updated"}
-        )
+        return tuple(item.path for item in self.files if item.action in {"created", "updated"})
 
 
-def bootstrap_agent_context(
-    repo_root: Path | str,
-    repo_description: str,
-    *,
-    force: bool = False,
-) -> AgentContextBootstrapResult:
-    """Create or update compact agent context files for a target repo."""
-
+def bootstrap_agent_context(repo_root: Path | str, repo_description: str, *, force: bool = False) -> AgentContextBootstrapResult:
+    del force
     repo = Path(repo_root)
     description = repo_description.strip() or "Repository managed by the harness workflow."
-    baseline_agent_words = _word_count(repo / "AGENTS.md")
-    existing_agents_text = _read_text(repo / "AGENTS.md")
-    preserve_agents = bool(
-        existing_agents_text and HARNESS_AGENT_CONTEXT_MARKER not in existing_agents_text
-    )
-
-    rendered_docs = _render_docs(
-        description=description,
-        baseline_agent_words=baseline_agent_words,
-        preserve_agents=preserve_agents,
-    )
+    baseline = _word_count(repo / "AGENTS.md")
+    existing = _read_text(repo / "AGENTS.md")
+    preserve = bool(existing and HARNESS_AGENT_CONTEXT_MARKER not in existing)
+    docs = _render_docs(description)
     results: list[AgentContextFileResult] = []
-
     for relative_path in AGENT_CONTEXT_FILES:
-        absolute_path = repo / relative_path
-        if relative_path == Path("AGENTS.md") and preserve_agents:
+        if relative_path == Path("AGENTS.md") and preserve:
             results.append(AgentContextFileResult(relative_path, "preserved"))
-            continue
-
-        action = _write_if_changed(absolute_path, rendered_docs[relative_path])
-        results.append(AgentContextFileResult(relative_path, action))
-
-    final_agent_words = _word_count(repo / "AGENTS.md")
-    rendered_report = _render_token_reduction_report(
-        baseline_agent_words=baseline_agent_words,
-        final_agent_words=final_agent_words,
-        doc_counts={
-            path: _word_count(repo / path)
-            for path in AGENT_CONTEXT_FILES
-            if path != Path("AGENTS.md")
-        },
-        preserve_agents=preserve_agents,
-    )
-    report_path = repo / "docs/agent/token-reduction-report.md"
-    report_action = _write_if_changed(report_path, rendered_report)
-    results = [
-        AgentContextFileResult(item.path, report_action)
-        if item.path == Path("docs/agent/token-reduction-report.md")
-        else item
-        for item in results
-    ]
-
-    return AgentContextBootstrapResult(
-        files=tuple(results),
-        baseline_agent_words=baseline_agent_words,
-        final_agent_words=final_agent_words,
-        preserved_existing_agents=preserve_agents,
-    )
+        else:
+            results.append(AgentContextFileResult(relative_path, _write_if_changed(repo / relative_path, docs[relative_path])))
+    return AgentContextBootstrapResult(tuple(results), baseline, _word_count(repo / "AGENTS.md"), preserve)
 
 
-def _render_docs(
-    *,
-    description: str,
-    baseline_agent_words: int,
-    preserve_agents: bool,
-) -> dict[Path, str]:
+def _render_docs(description: str) -> dict[Path, str]:
     return {
-        Path("AGENTS.md"): _render_agents(description),
-        Path("docs/agent/context.md"): _render_context(description),
-        Path("docs/agent/commands.md"): _render_commands(),
-        Path("docs/agent/session-state.md"): _render_session_state(
-            preserve_agents=preserve_agents
-        ),
-        Path("docs/agent/token-reduction-report.md"): _render_token_reduction_report(
-            baseline_agent_words=baseline_agent_words,
-            final_agent_words=0,
-            doc_counts={},
-            preserve_agents=preserve_agents,
-        ),
+        Path("AGENTS.md"): f"# Agent Context\n{HARNESS_AGENT_CONTEXT_MARKER}\n\nThis repo is: {description}\n\n- Read `docs/agent/context.md` for scope.\n- Read `docs/agent/commands.md` for canonical runtime commands.\n- `RunState` in `.harness/runs/<RUN-ID>/state.json` is authoritative for runtime status and resume.\n",
+        Path("docs/agent/context.md"): f"# Agent Context Map\n\n{description}\n\nRead the active ChangeSet, selected work-item slice, current plan, then `RunState`. Do not create a parallel session or procedure state.\n",
+        Path("docs/agent/commands.md"): "# Agent Commands\n\n- `python3 -m harness_codex harvest --idea \"<request>\" --apply --session-id harvest-001`\n- `python3 -m harness_codex changes create-from-design --title \"<title>\"`\n- `python3 -m harness_codex changes active`\n- `python3 -m harness_codex run-change <CHG-ID> --apply`\n- `python3 -m harness_codex run-work-item <CHG-ID> <WORK-ITEM-ID> --apply`\n- `python3 -m harness_codex resume <RUN-ID>`\n\nLegacy procedure commands and `ultrawork` are migration-only through 2026-09-30.\n",
     }
-
-
-def _render_agents(description: str) -> str:
-    return f"""# Agent Context
-{HARNESS_AGENT_CONTEXT_MARKER}
-
-Write all agent input/output and user-facing output in English.
-
-This repo is: {description}
-
-## Fast Context
-- Repo map: `docs/agent/context.md`
-- Commands and verification: `docs/agent/commands.md`
-- Current handoff state: `docs/agent/session-state.md`
-- Token-reduction report: `docs/agent/token-reduction-report.md`
-- Module-specific guidance: nearest nested `AGENTS.md`
-
-Read only the smallest relevant context file. Prefer `rg`, targeted file reads, Serena, and Graphify over broad dumps. Use concise output for routine work.
-
-## Hard Rules
-- Preserve project-specific rules from existing local docs and config.
-- Documents created or updated under `docs/` must be written in English unless the repo explicitly requires another language.
-- Use the repo-preferred runtime and dependency manager.
-- Preserve ChangeSet, use-case, maintenance, and plan workflow boundaries when present.
-- Do not edit runtime code unless the task explicitly requires it.
-- Do not overwrite unrelated worktree changes.
-
-## PR Body Requirements
-Each PR must include:
-- Implementation intent
-- Implementation approach
-- Verification method
-- Risks and rollback
-
-## Output Budget
-- Cap routine command output near 4k tokens.
-- Use concise status commands.
-- Use diff stats before targeted diffs.
-- Summarize logs/tests instead of pasting full output.
-"""
-
-
-def _render_context(description: str) -> str:
-    return f"""# Agent Context Map
-
-## Repository Purpose
-
-{description}
-
-## Main Paths
-
-- `AGENTS.md`: hot-path agent rules.
-- `docs/agent/`: cold-path agent context, commands, session state, and token reports.
-- `docs/design/`: canonical requirements and design documents when present.
-- `docs/changes/`: active and completed ChangeSet documents when present.
-- `docs/use-cases/`: executor-facing use-case slices when present.
-- `docs/maintenance/`: executor-facing maintenance slices when present.
-- `docs/plans/`: active and completed implementation plans when present.
-- Source and test paths: discover with `rg --files`, package manifests, and build config.
-
-## Context Loading Guidance
-
-Start with the nearest `AGENTS.md`, then read only the smallest relevant file from `docs/agent/`. Prefer targeted search and symbol tools. Avoid broad design-doc or source dumps unless needed for the current decision.
-
-## Harness Workflow Guidance
-
-When ChangeSet docs exist, use the active ChangeSet and selected work-item slice as the primary scope. Read canonical design docs only when the slice points there or shared design context is required.
-"""
-
-
-def _render_commands() -> str:
-    return """# Agent Commands
-
-## Discovery
-
-- List files: `rg --files`
-- Search text: `rg -n "<pattern>"`
-- Git status: `git status --porcelain=v1 -uno`
-- Diff stat: `git diff --stat`
-
-## Harness Commands
-
-- Harvest plan: `python3 -m harness_codex harvest --idea "<idea>" --plan`
-- Create ChangeSet from design: `python3 -m harness_codex changes create-from-design --title "<title>"`
-- List active ChangeSets: `python3 -m harness_codex changes list`
-- Preview use-case workflow: `python3 -m harness_codex run-use-case <CHG-ID> <UC-ID> --preview`
-- Bootstrap agent context: `python3 -m harness_codex agent-context init --description "<repo description>"`
-
-## Agent Context Verification
-
-```bash
-find . -name AGENTS.md -print | sort | xargs -r wc -w
-wc -w docs/agent/*.md
-rg -n -P "\\p{Hangul}" AGENTS.md docs/agent || true
-git diff --stat
-git status --porcelain=v1 -uno
-```
-
-## Output Budget
-
-Use concise status commands first. Use diff stats before targeted diffs. Summarize logs and failures instead of pasting full output. Cap routine command output near 4k tokens.
-"""
-
-
-def _render_session_state(*, preserve_agents: bool) -> str:
-    agents_state = (
-        "Existing unmarked root `AGENTS.md` was preserved."
-        if preserve_agents
-        else "Root `AGENTS.md` is harness-managed."
-    )
-    return f"""# Agent Session State
-
-## Current State
-
-- {agents_state}
-- `docs/agent/` contains cold-path context generated by harness bootstrap.
-- Check `git status --porcelain=v1 -uno` before modifying files.
-
-## Handoff Rules
-
-- Preserve unrelated staged and unstaged work.
-- Keep generated docs in English unless the repository explicitly requires another language.
-- Prefer targeted context reads over full-file dumps.
-- Update this file when long-running work leaves important handoff state.
-"""
-
-
-def _render_token_reduction_report(
-    *,
-    baseline_agent_words: int,
-    final_agent_words: int,
-    doc_counts: dict[Path, int],
-    preserve_agents: bool,
-) -> str:
-    doc_rows = "\n".join(
-        f"- `{path}`: {count} words" for path, count in sorted(doc_counts.items())
-    )
-    doc_rows = doc_rows or "- pending"
-    root_note = (
-        "Existing root `AGENTS.md` was preserved because it was not harness-managed."
-        if preserve_agents
-        else "Root `AGENTS.md` is managed by harness bootstrap."
-    )
-    return f"""# Token Reduction Report
-
-## Baseline
-
-- `AGENTS.md` word count before bootstrap: {baseline_agent_words} words.
-
-## Result
-
-- `AGENTS.md` word count after bootstrap: {final_agent_words} words.
-- {root_note}
-- Detailed repo context now lives under `docs/agent/`.
-
-## Agent Doc Counts
-
-{doc_rows}
-
-## Verification Commands
-
-```bash
-find . -name AGENTS.md -print | sort | xargs -r wc -w
-wc -w docs/agent/*.md
-rg -n -P "\\p{{Hangul}}" AGENTS.md docs/agent || true
-git diff --stat
-git status --porcelain=v1 -uno
-```
-"""
 
 
 def _write_if_changed(path: Path, text: str) -> str:
@@ -297,12 +66,8 @@ def _write_if_changed(path: Path, text: str) -> str:
 
 
 def _read_text(path: Path) -> str:
-    if not path.exists():
-        return ""
-    return path.read_text(encoding="utf-8")
+    return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
 def _word_count(path: Path) -> int:
-    if not path.exists():
-        return 0
-    return len(path.read_text(encoding="utf-8").split())
+    return len(_read_text(path).split())

--- a/tests/runtime/test_agent_context.py
+++ b/tests/runtime/test_agent_context.py
@@ -8,21 +8,22 @@ from harness_codex.runtime.agent_context import (
 )
 
 
-def test_bootstrap_agent_context_creates_expected_files(tmp_path: Path) -> None:
+def test_bootstrap_agent_context_creates_only_reusable_files(tmp_path: Path) -> None:
     result = bootstrap_agent_context(tmp_path, "Sample project")
 
     assert result.baseline_agent_words == 0
     assert result.final_agent_words > 0
+    assert {item.path for item in result.files} == set(AGENT_CONTEXT_FILES)
     for path in AGENT_CONTEXT_FILES:
         assert (tmp_path / path).is_file()
+    assert not (tmp_path / "docs/agent/session-state.md").exists()
+    assert not (tmp_path / "docs/agent/token-reduction-report.md").exists()
     assert HARNESS_AGENT_CONTEXT_MARKER in (tmp_path / "AGENTS.md").read_text(
         encoding="utf-8"
     )
 
 
-def test_bootstrap_agent_context_preserves_unmarked_agents(
-    tmp_path: Path,
-) -> None:
+def test_bootstrap_agent_context_preserves_unmarked_agents(tmp_path: Path) -> None:
     agents = tmp_path / "AGENTS.md"
     agents.write_text("# Local Rules\n\nDo not overwrite.\n", encoding="utf-8")
 
@@ -31,15 +32,9 @@ def test_bootstrap_agent_context_preserves_unmarked_agents(
     assert agents.read_text(encoding="utf-8") == "# Local Rules\n\nDo not overwrite.\n"
     assert result.preserved_existing_agents is True
     assert (tmp_path / "docs/agent/context.md").is_file()
-    session_state = (tmp_path / "docs/agent/session-state.md").read_text(
-        encoding="utf-8"
-    )
-    assert "Existing unmarked root `AGENTS.md` was preserved." in session_state
 
 
-def test_bootstrap_agent_context_updates_managed_agents_with_force(
-    tmp_path: Path,
-) -> None:
+def test_bootstrap_agent_context_updates_managed_agents(tmp_path: Path) -> None:
     bootstrap_agent_context(tmp_path, "Old description")
 
     result = bootstrap_agent_context(tmp_path, "New description", force=True)
@@ -49,35 +44,19 @@ def test_bootstrap_agent_context_updates_managed_agents_with_force(
     assert result.preserved_existing_agents is False
 
 
-def test_bootstrap_agent_context_updates_managed_agents_without_force(
-    tmp_path: Path,
-) -> None:
-    bootstrap_agent_context(tmp_path, "Old description")
-
-    bootstrap_agent_context(tmp_path, "New description")
-
-    agents = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
-    assert "New description" in agents
-
-
-def test_bootstrap_agent_context_outputs_have_no_korean(
-    tmp_path: Path,
-) -> None:
+def test_bootstrap_agent_context_outputs_have_no_korean(tmp_path: Path) -> None:
     bootstrap_agent_context(tmp_path, "Sample project")
 
     combined = "\n".join(
-        (tmp_path / path).read_text(encoding="utf-8")
-        for path in AGENT_CONTEXT_FILES
+        (tmp_path / path).read_text(encoding="utf-8") for path in AGENT_CONTEXT_FILES
     )
     assert re.search(r"[가-힣]", combined) is None
 
 
-def test_bootstrap_agent_context_report_records_counts(tmp_path: Path) -> None:
+def test_bootstrap_commands_use_canonical_runtime(tmp_path: Path) -> None:
     bootstrap_agent_context(tmp_path, "Sample project")
 
-    report = (tmp_path / "docs/agent/token-reduction-report.md").read_text(
-        encoding="utf-8"
-    )
-    assert "`AGENTS.md` word count before bootstrap: 0 words" in report
-    assert "`AGENTS.md` word count after bootstrap:" in report
-    assert "`docs/agent/context.md`:" in report
+    commands = (tmp_path / "docs/agent/commands.md").read_text(encoding="utf-8")
+    assert "harvest" in commands
+    assert "run-change" in commands
+    assert "ultrawork" in commands


### PR DESCRIPTION
Superseded because this PR was built from the stale `changeset-first-runtime` branch and incorrectly replaced the README-defined workflow. A replacement targets current `main` and preserves the README's stage-based workflow while consolidating state ownership.