### PR TITLE
feat(workflow): 리뷰 결과물 우선 참조 힌트 추가

### DIFF
--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -89,6 +89,11 @@ steps:
     stage: implementation
     prompt_context_profile: execution
     scope: work_item
+    upstream_context:
+    - producer_step: review-work-item-plan
+      artifact_path: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/reviews/plan-review.md
+      priority: high
+      purpose: Review findings, approval conditions, and rejected approaches for the active plan.
     inputs_resolved_by: work_item_document_contract
 - id: verify-work-item
   kind: validator

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Read only the smallest relevant context file. Prefer `rg`, targeted file reads, 
 - Use `python3` for Python commands.
 - Manage dependencies with the repository-root `venv`.
 - Preserve existing ChangeSet, use-case, maintenance, and plan workflow boundaries.
+- When the current runtime payload declares `upstream_context`, inspect high-priority artifacts before acting when their stated purpose applies. These are reading-priority hints, not generic required inputs.
 - Do not edit runtime code unless the task explicitly requires it.
 - Do not overwrite unrelated worktree changes.
 

--- a/tests/runtime/test_upstream_context_hints.py
+++ b/tests/runtime/test_upstream_context_hints.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind
+from harness_codex.runtime.prompt import build_agent_prompt
+
+
+def test_declared_upstream_context_is_visible_as_a_reading_priority(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
+    step = Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute work item",
+        agent_id="implementation_executor",
+        metadata={
+            "stage": "implementation",
+            "upstream_context": [
+                {
+                    "producer_step": "review-work-item-plan",
+                    "artifact_path": ".harness/runs/run-001/work-items/UC-001/reviews/plan-review.md",
+                    "priority": "high",
+                    "purpose": "Review findings for the active plan.",
+                }
+            ],
+        },
+    )
+    context = RunContext(
+        run_id="run-001",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-001",
+    )
+
+    prompt = build_agent_prompt(
+        step=step,
+        context=context,
+        agent_config={},
+        agent_config_path=Path(".codex/agents/implementation_executor.toml"),
+    )
+
+    assert '"upstream_context"' in prompt
+    assert "review-work-item-plan" in prompt
+    assert "plan-review.md" in prompt
+    assert '"priority": "high"' in prompt


### PR DESCRIPTION
## 구현 의도

`review-work-item-plan`이 성공한 뒤 `execute-work-item`이 실행될 때, plan review 산출물을 자동 필수 입력으로 강제하지 않으면서 우선적으로 참조하도록 유도합니다.

## 구현 접근

- 최신 `main`의 workflow 구조를 기준으로 충돌을 해소했습니다.
- `execute-work-item` metadata에 `upstream_context`를 선언했습니다.
  - producer: `review-work-item-plan`
  - artifact: materialized `plan-review.md`
  - priority: `high`
  - purpose: 리뷰 지적, 승인 조건, 배제된 접근 방식
- `AGENTS.md`에 현재 runtime payload의 high-priority `upstream_context`를 목적이 관련될 때 작업 전에 확인하도록 규칙을 추가했습니다.
- runtime payload는 기존처럼 step metadata를 전달하므로 별도 prompt.py 변경 없이 hint가 전달됩니다.
- prompt 조립 테스트를 추가했습니다.

## 검증 방법

- `tests/runtime/test_upstream_context_hints.py` 추가
- 원격 CI는 아직 실행 결과를 확인하지 못했습니다.

## 위험 및 롤백

- 위험: agent가 hint의 목적을 과도하게 넓게 해석해 추가 파일을 읽을 수 있습니다.
- 완화: high-priority artifact도 목적이 현재 작업에 적용될 때만 읽도록 명시했습니다.
- 롤백: `AGENTS.md`, workflow metadata, 추가 테스트를 되돌리면 됩니다.