### PR TITLE
[scope] typed maintenance work-item 문서 계약 강화

### DIFF
--- a/.codex/skills/harness-code-planner/references/detailed-instructions.md
+++ b/.codex/skills/harness-code-planner/references/detailed-instructions.md
@@ -42,11 +42,19 @@ Optional:
 
 ### Maintenance work-item slice
 
+Maintenance work items are not use cases. Never invent, request, or materialize a `docs/use-cases/<UC-ID>/` path for them.
+
 Required:
 
+- `docs/maintenance/<MAINT-ID>/scope.md`
 - `docs/maintenance/<MAINT-ID>/change-intent.md`
 - `docs/maintenance/<MAINT-ID>/affected-files.md`
+- `docs/maintenance/<MAINT-ID>/maintenance-spec.md`
+- `docs/maintenance/<MAINT-ID>/architecture-impact.md`
 - `docs/maintenance/<MAINT-ID>/verification-goal.md`
+- `docs/maintenance/<MAINT-ID>/links.md`
+
+The scope record must name the bounded context and the smallest affected aggregate, application service, module/package, adapter, or port. `architecture-impact.md` is always an assessment; `Decision: none` is valid when the change does not alter a canonical architecture contract. When the decision is `update`, `create`, or `adr`, put the exact canonical architecture document changes in the plan.
 
 Optional:
 
@@ -56,7 +64,8 @@ Optional:
 
 ## Verification and Domain Planning Requirements
 
-- Stop when `technical-decisions.md` is not explicitly approved.
+- Stop when a required work-item document is absent. Do not substitute a UC slice for a maintenance slice.
+- Stop when `technical-decisions.md` is present but not explicitly approved.
 - Include build and test verification such as `./gradlew build` and `./gradlew test`, or the concrete repository equivalents from `.codex/test-gate.yaml` and `.codex/repository-settings.md`.
 - Include E2E or maintenance verification tied to the approved E2E/verification goal.
 - Include `domain-impact.md`, `aggregate-delta.md`, and canonical references such as `docs/domain/<BC-ID>/aggregates/<AGG-ID>.md` whenever the work item affects domain elements.

--- a/.codex/skills/harness-code-planner/references/detailed-instructions.md
+++ b/.codex/skills/harness-code-planner/references/detailed-instructions.md
@@ -65,7 +65,7 @@ Optional:
 ## Verification and Domain Planning Requirements
 
 - Stop when a required work-item document is absent. Do not substitute a UC slice for a maintenance slice.
-- Stop when `technical-decisions.md` is present but not explicitly approved.
+- Treat optional `technical-decisions.md` as a planning reference only; it does not create a maintenance preflight gate.
 - Include build and test verification such as `./gradlew build` and `./gradlew test`, or the concrete repository equivalents from `.codex/test-gate.yaml` and `.codex/repository-settings.md`.
 - Include E2E or maintenance verification tied to the approved E2E/verification goal.
 - Include `domain-impact.md`, `aggregate-delta.md`, and canonical references such as `docs/domain/<BC-ID>/aggregates/<AGG-ID>.md` whenever the work item affects domain elements.

--- a/harness_codex/runtime/changes/work_item_documents.py
+++ b/harness_codex/runtime/changes/work_item_documents.py
@@ -1,6 +1,6 @@
 """Typed work-item document contracts and non-destructive scaffolding.
 
-Use-case slices are created by the README design stages.  Non-UC work items use
+Use-case slices are created by the README design stages. Non-UC work items use
 this module to create a small, type-specific slice without inventing a use case.
 The generator only creates missing files; it never replaces authored content.
 """
@@ -25,6 +25,7 @@ _COMMON_DOCUMENTS = (
 _TYPE_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
     WorkItemType.USE_CASE: (),
     WorkItemType.MAINTENANCE: (
+        "scope.md",
         "change-intent.md",
         "affected-files.md",
         "maintenance-spec.md",
@@ -34,7 +35,9 @@ _TYPE_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
     WorkItemType.FEATURE_EXTENSION: ("acceptance-delta.md",),
 }
 
-# Existing maintenance slices are intentionally kept compatible during migration.
+# A maintenance slice is independent of a UC slice. Its required documents make
+# the operational scope, code boundary, architecture assessment, and verification
+# contract explicit, so planner/executor inputs never fall back to UC-only paths.
 _REQUIRED_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
     WorkItemType.USE_CASE: (
         "use-case.md",
@@ -44,9 +47,13 @@ _REQUIRED_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
         "e2e-goal.md",
     ),
     WorkItemType.MAINTENANCE: (
+        "scope.md",
         "change-intent.md",
         "affected-files.md",
+        "maintenance-spec.md",
+        "architecture-impact.md",
         "verification-goal.md",
+        "links.md",
     ),
     WorkItemType.BUG_FIX: _COMMON_DOCUMENTS + ("reproduction.md", "regression-goal.md"),
     WorkItemType.REFACTORING: _COMMON_DOCUMENTS + ("refactoring-contract.md",),
@@ -132,7 +139,7 @@ def scaffold_work_item_documents(
 ) -> tuple[Path, ...]:
     """Create missing non-UC document templates and return created relative paths.
 
-    The function deliberately does not scaffold use-case design artifacts.  Those
+    The function deliberately does not scaffold use-case design artifacts. Those
     files are owned by the README stages from use-case-definition through
     technical-decisions and must not be replaced with empty templates.
     """
@@ -196,14 +203,23 @@ def _render_document(work_item: AffectedWorkItem, filename: str) -> str:
     bodies = {
         "brief.md": (
             "## Goal\n\n- TODO: describe the intended outcome.\n\n"
-            "## Scope\n\n- Bounded context: TODO\n- Aggregate, component, module, or adapter: TODO\n\n"
             "## Non-goals\n\n- TODO\n\n## Dependencies\n\n- TODO\n"
+        ),
+        "scope.md": (
+            "## Maintenance Scope\n\n"
+            "- Bounded context: TODO\n"
+            "- Aggregate: TODO or `none`\n"
+            "- Application service: TODO or `none`\n"
+            "- Module or package: TODO\n"
+            "- Adapter or port: TODO or `none`\n"
+            "- Why this boundary is the smallest safe change: TODO\n"
         ),
         "architecture-impact.md": (
             "## Architecture Impact\n\n"
             "- Decision: `none` (`none` | `update` | `create` | `adr`)\n"
             "- Reason: TODO\n"
             "- Canonical architecture references: TODO or `none`\n"
+            "- Required canonical document update: TODO or `none`\n"
         ),
         "verification-goal.md": (
             "## Verification Goal\n\n"
@@ -226,6 +242,7 @@ def _render_document(work_item: AffectedWorkItem, filename: str) -> str:
             "## Affected Files and Boundaries\n\n"
             "- Included modules or files: TODO\n"
             "- Excluded modules or files: TODO\n"
+            "- Caller-facing or persistence compatibility boundary: TODO\n"
         ),
         "maintenance-spec.md": (
             "## Maintenance Specification\n\n"

--- a/tests/runtime/test_affected_use_case_resolver.py
+++ b/tests/runtime/test_affected_use_case_resolver.py
@@ -7,8 +7,7 @@ from harness_codex.runtime.changes import (
     NoActiveChangeSetsError,
     PlanningBlocked,
 )
-from harness_codex.runtime.changes.models import WorkItemType
-from harness_codex.runtime.changes.models import ChangeSet
+from harness_codex.runtime.changes.models import ChangeSet, WorkItemType
 
 
 def write_changeset(tmp_path: Path, body: str) -> Path:
@@ -150,13 +149,13 @@ def test_resolver_builds_per_use_case_planning_scope(tmp_path: Path) -> None:
     path = write_changeset(tmp_path, CHANGESET)
     write_use_case_slice(tmp_path)
     resolver = ChangeSetResolver(tmp_path)
-    change_set = resolver.load(path)
 
-    scopes = resolver.resolve_planning_scopes(change_set)
+    scopes = resolver.resolve_planning_scopes(resolver.load(path))
 
     assert not isinstance(scopes, PlanningBlocked)
     scope = scopes[0]
     assert scope.change_set_path == Path("docs/changes/active/CHG-001.md")
+    assert scope.use_case is not None
     assert scope.use_case.uc_id == "UC-001"
     assert Path("docs/changes/active/CHG-001.md") in scope.planner_inputs
     assert Path("docs/use-cases/UC-001/e2e-goal.md") in scope.planner_inputs
@@ -196,9 +195,7 @@ def test_resolver_blocks_missing_use_case_documents(tmp_path: Path) -> None:
     assert "Use case work item UC-001 is missing required documents" in result.reason
 
 
-def test_resolver_blocks_missing_technical_decisions_before_planning(
-    tmp_path: Path,
-) -> None:
+def test_resolver_blocks_missing_technical_decisions_before_planning(tmp_path: Path) -> None:
     path = write_changeset(tmp_path, CHANGESET)
     write_use_case_slice(tmp_path, include_technical_decisions=False)
     resolver = ChangeSetResolver(tmp_path)
@@ -270,9 +267,7 @@ def test_resolver_blocks_pending_e2e_approval_before_planning(tmp_path: Path) ->
     assert "docs/use-cases/UC-001/e2e-goal.md" in result.reason
 
 
-def test_resolver_prefers_e2e_front_matter_approval_over_body_table(
-    tmp_path: Path,
-) -> None:
+def test_resolver_prefers_e2e_front_matter_approval_over_body_table(tmp_path: Path) -> None:
     path = write_changeset(tmp_path, CHANGESET)
     write_use_case_slice(tmp_path, approval_status="approved")
     e2e_goal = tmp_path / "docs/use-cases/UC-001/e2e-goal.md"
@@ -341,7 +336,15 @@ def test_resolver_allows_approved_e2e_goal(tmp_path: Path) -> None:
 def test_resolver_builds_maintenance_planning_scope(tmp_path: Path) -> None:
     maintenance_dir = tmp_path / "docs/maintenance/MAINT-001"
     maintenance_dir.mkdir(parents=True)
-    for name in ("change-intent.md", "affected-files.md", "verification-goal.md"):
+    for name in (
+        "scope.md",
+        "change-intent.md",
+        "affected-files.md",
+        "maintenance-spec.md",
+        "architecture-impact.md",
+        "verification-goal.md",
+        "links.md",
+    ):
         (maintenance_dir / name).write_text(name, encoding="utf-8")
     body = """# ChangeSet CHG-001
 
@@ -367,6 +370,8 @@ def test_resolver_builds_maintenance_planning_scope(tmp_path: Path) -> None:
     assert scope.work_item_type == WorkItemType.MAINTENANCE
     assert scope.plan_path == Path("docs/plans/active/MAINT-001/plan.md")
     assert Path("docs/maintenance/MAINT-001/verification-goal.md") in scope.planner_inputs
+    assert Path("docs/maintenance/MAINT-001/scope.md") in scope.planner_inputs
+    assert Path("docs/maintenance/MAINT-001/architecture-impact.md") in scope.planner_inputs
 
 
 def test_resolver_blocks_missing_maintenance_documents(tmp_path: Path) -> None:

--- a/tests/runtime/test_work_item_documents.py
+++ b/tests/runtime/test_work_item_documents.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+from harness_codex.runtime.changes.models import AffectedWorkItem, WorkItemType
+from harness_codex.runtime.changes.work_item_documents import (
+    missing_required_documents,
+    planner_input_paths,
+    scaffold_work_item_documents,
+)
+
+
+def maintenance_item() -> AffectedWorkItem:
+    return AffectedWorkItem(
+        work_item_id="MAINT-001",
+        work_item_type=WorkItemType.MAINTENANCE,
+        name="dispatcher worker tuning",
+        impact_type="source-code",
+        slice_path=Path("docs/maintenance/MAINT-001"),
+    )
+
+
+def test_maintenance_scaffold_creates_complete_typed_contract(tmp_path: Path) -> None:
+    item = maintenance_item()
+
+    created = scaffold_work_item_documents(tmp_path, item)
+
+    expected = {
+        Path("docs/maintenance/MAINT-001/brief.md"),
+        Path("docs/maintenance/MAINT-001/scope.md"),
+        Path("docs/maintenance/MAINT-001/change-intent.md"),
+        Path("docs/maintenance/MAINT-001/affected-files.md"),
+        Path("docs/maintenance/MAINT-001/maintenance-spec.md"),
+        Path("docs/maintenance/MAINT-001/architecture-impact.md"),
+        Path("docs/maintenance/MAINT-001/verification-goal.md"),
+        Path("docs/maintenance/MAINT-001/links.md"),
+    }
+    assert set(created) == expected
+    assert missing_required_documents(tmp_path, item) == ()
+
+    scope = (tmp_path / "docs/maintenance/MAINT-001/scope.md").read_text(encoding="utf-8")
+    assert "Bounded context:" in scope
+    assert "Aggregate:" in scope
+    assert "Application service:" in scope
+    assert "Module or package:" in scope
+    assert "Adapter or port:" in scope
+
+    architecture_impact = (
+        tmp_path / "docs/maintenance/MAINT-001/architecture-impact.md"
+    ).read_text(encoding="utf-8")
+    assert "`none` (`none` | `update` | `create` | `adr`)" in architecture_impact
+
+
+def test_maintenance_planner_inputs_are_typed_and_never_include_uc_slice(tmp_path: Path) -> None:
+    item = maintenance_item()
+    scaffold_work_item_documents(tmp_path, item)
+
+    inputs = planner_input_paths(
+        tmp_path,
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        work_item=item,
+    )
+
+    assert Path("docs/changes/active/CHG-001.md") in inputs
+    assert Path("docs/maintenance/MAINT-001/scope.md") in inputs
+    assert Path("docs/maintenance/MAINT-001/architecture-impact.md") in inputs
+    assert Path("docs/maintenance/MAINT-001/verification-goal.md") in inputs
+    assert not any(str(path).startswith("docs/use-cases/") for path in inputs)
+
+
+def test_maintenance_preflight_requires_scope_and_architecture_assessment(tmp_path: Path) -> None:
+    item = maintenance_item()
+    slice_dir = tmp_path / item.slice_path
+    slice_dir.mkdir(parents=True)
+    for filename in ("change-intent.md", "affected-files.md", "verification-goal.md"):
+        (slice_dir / filename).write_text("# authored\n", encoding="utf-8")
+
+    missing = set(missing_required_documents(tmp_path, item))
+
+    assert Path("docs/maintenance/MAINT-001/scope.md") in missing
+    assert Path("docs/maintenance/MAINT-001/maintenance-spec.md") in missing
+    assert Path("docs/maintenance/MAINT-001/architecture-impact.md") in missing
+    assert Path("docs/maintenance/MAINT-001/links.md") in missing

--- a/tests/runtime/test_workflow_materializer.py
+++ b/tests/runtime/test_workflow_materializer.py
@@ -69,6 +69,118 @@ def test_materialize_workflow_for_use_case_scope_replaces_paths_and_metadata() -
     assert unresolved_placeholders(materialized) == frozenset()
 
 
+def test_materialize_workflow_for_maintenance_scope_removes_uc_only_inputs() -> None:
+    workflow = Workflow(
+        name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="plan-<WORK-ITEM-ID>",
+                kind=StepKind.AGENT,
+                name="Plan selected work item",
+                inputs=(
+                    Path("docs/changes/active/<CHG-ID>.md"),
+                    Path("docs/use-cases/<UC-ID>/use-case.md"),
+                    Path("docs/maintenance/<MAINT-ID>/scope.md"),
+                ),
+                metadata={"stage": "plan"},
+            ),
+        ),
+    )
+    change_set = ChangeSet(
+        change_set_id="CHG-001",
+        title="typed work items",
+        path=Path("docs/changes/active/CHG-001.md"),
+    )
+    scope = PlanningInputScope(
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        use_case=None,
+        planner_inputs=(
+            Path("docs/maintenance/MAINT-001/scope.md"),
+            Path("docs/maintenance/MAINT-001/architecture-impact.md"),
+        ),
+        executor_inputs=(),
+        e2e_goal_path=None,
+        work_item_id="MAINT-001",
+        work_item_type=WorkItemType.MAINTENANCE,
+        plan_path=Path("docs/plans/active/MAINT-001/plan.md"),
+        verification_goal_path=Path("docs/maintenance/MAINT-001/verification-goal.md"),
+    )
+
+    materialized = materialize_workflow_for_scope(workflow, change_set, scope)
+
+    step = materialized.steps[0]
+    assert Path("docs/use-cases/<UC-ID>/use-case.md") not in step.inputs
+    assert Path("docs/use-cases//use-case.md") not in step.inputs
+    assert Path("docs/maintenance/MAINT-001/scope.md") in step.inputs
+    assert Path("docs/maintenance/MAINT-001/architecture-impact.md") in step.inputs
+    assert step.id == "plan-MAINT-001"
+    assert unresolved_placeholders(materialized) == frozenset()
+
+
+def test_materialize_workflow_keeps_use_case_and_maintenance_inputs_separate_in_mixed_changeset() -> None:
+    workflow = Workflow(
+        name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(
+                id="plan-<WORK-ITEM-ID>",
+                kind=StepKind.AGENT,
+                name="Plan selected work item",
+                inputs=(
+                    Path("docs/use-cases/<UC-ID>/use-case.md"),
+                    Path("docs/maintenance/<MAINT-ID>/scope.md"),
+                ),
+                metadata={"stage": "plan"},
+            ),
+        ),
+    )
+    change_set = ChangeSet(
+        change_set_id="CHG-001",
+        title="mixed work items",
+        path=Path("docs/changes/active/CHG-001.md"),
+    )
+    use_case = AffectedUseCase(
+        uc_id="UC-001",
+        name="승인",
+        impact_type="source-code",
+        slice_path=Path("docs/use-cases/UC-001"),
+    )
+    use_case_scope = PlanningInputScope(
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        use_case=use_case,
+        planner_inputs=(Path("docs/use-cases/UC-001/e2e-goal.md"),),
+        executor_inputs=(),
+        e2e_goal_path=Path("docs/use-cases/UC-001/e2e-goal.md"),
+        work_item_id="UC-001",
+        work_item_type=WorkItemType.USE_CASE,
+        plan_path=Path("docs/plans/active/UC-001/plan.md"),
+    )
+    maintenance_scope = PlanningInputScope(
+        change_set_path=Path("docs/changes/active/CHG-001.md"),
+        use_case=None,
+        planner_inputs=(Path("docs/maintenance/MAINT-001/verification-goal.md"),),
+        executor_inputs=(),
+        e2e_goal_path=None,
+        work_item_id="MAINT-001",
+        work_item_type=WorkItemType.MAINTENANCE,
+        plan_path=Path("docs/plans/active/MAINT-001/plan.md"),
+        verification_goal_path=Path("docs/maintenance/MAINT-001/verification-goal.md"),
+    )
+
+    use_case_workflow = materialize_workflow_for_scope(workflow, change_set, use_case_scope)
+    maintenance_workflow = materialize_workflow_for_scope(workflow, change_set, maintenance_scope)
+
+    use_case_inputs = use_case_workflow.steps[0].inputs
+    maintenance_inputs = maintenance_workflow.steps[0].inputs
+    assert Path("docs/use-cases/UC-001/use-case.md") in use_case_inputs
+    assert Path("docs/maintenance/MAINT-001/scope.md") not in use_case_inputs
+    assert Path("docs/maintenance/MAINT-001/scope.md") in maintenance_inputs
+    assert Path("docs/use-cases/UC-001/use-case.md") not in maintenance_inputs
+    assert unresolved_placeholders(use_case_workflow) == frozenset()
+    assert unresolved_placeholders(maintenance_workflow) == frozenset()
+
+
 def test_materialize_workflow_blocks_unresolved_placeholders() -> None:
     workflow = Workflow(
         name="workflow",

--- a/tests/test_planner_use_case_scope.py
+++ b/tests/test_planner_use_case_scope.py
@@ -31,9 +31,13 @@ def test_planner_uses_changeset_and_work_item_slice_as_inputs() -> None:
         "docs/use-cases/<UC-ID>/event-storming.md",
         "docs/use-cases/<UC-ID>/ddd-design.md",
         "docs/use-cases/<UC-ID>/e2e-goal.md",
+        "docs/maintenance/<MAINT-ID>/scope.md",
         "docs/maintenance/<MAINT-ID>/change-intent.md",
         "docs/maintenance/<MAINT-ID>/affected-files.md",
+        "docs/maintenance/<MAINT-ID>/maintenance-spec.md",
+        "docs/maintenance/<MAINT-ID>/architecture-impact.md",
         "docs/maintenance/<MAINT-ID>/verification-goal.md",
+        "docs/maintenance/<MAINT-ID>/links.md",
         ".codex/repository-settings.md",
         "ARCHITECTURE.md",
     ]
@@ -53,7 +57,9 @@ def test_planner_requires_e2e_or_maintenance_and_repository_gate_verification() 
     assert ".codex/test-gate.yaml" in planner
     assert "E2E or maintenance verification" in planner
     assert "E2E/verification goal" in planner
-    assert "technical-decisions.md` is not explicitly approved" in planner
+    assert "Stop when a required work-item document is absent" in planner
+    assert "optional `technical-decisions.md`" in planner
+    assert "does not create a maintenance preflight gate" in planner
 
 
 def test_planner_tracks_domain_impact_and_compatibility() -> None:

--- a/tests/test_planner_work_item_alignment.py
+++ b/tests/test_planner_work_item_alignment.py
@@ -34,9 +34,9 @@ def read_agent_contract() -> str:
 
 def required_skill_paths(skill: str, section: str) -> tuple[str, ...]:
     match = re.search(
-        rf"### {re.escape(section)}\n\nRequired:\n\n(?P<body>.*?)\n\n(?:The scope record|Optional)",
+        rf"### {re.escape(section)}\n(?:(?!^### ).)*?^Required:\n\n(?P<body>.*?)\n\n(?:The scope record|Optional)",
         skill,
-        flags=re.DOTALL,
+        flags=re.DOTALL | re.MULTILINE,
     )
     assert match is not None
     return tuple(re.findall(r"`([^`]+)`", match.group("body")))

--- a/tests/test_planner_work_item_alignment.py
+++ b/tests/test_planner_work_item_alignment.py
@@ -1,10 +1,9 @@
 import re
 from pathlib import Path
 
-from harness_codex.runtime.changes.resolver import (
-    _missing_maintenance_documents,
-    _missing_use_case_documents,
-)
+from harness_codex.runtime.changes.models import AffectedWorkItem, WorkItemType
+from harness_codex.runtime.changes.resolver import _missing_use_case_documents
+from harness_codex.runtime.changes.work_item_documents import required_document_paths
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -35,7 +34,7 @@ def read_agent_contract() -> str:
 
 def required_skill_paths(skill: str, section: str) -> tuple[str, ...]:
     match = re.search(
-        rf"### {re.escape(section)}\n\nRequired:\n\n(?P<body>.*?)\n\nOptional",
+        rf"### {re.escape(section)}\n\nRequired:\n\n(?P<body>.*?)\n\n(?:The scope record|Optional)",
         skill,
         flags=re.DOTALL,
     )
@@ -121,15 +120,28 @@ def test_skill_use_case_gate_matches_runtime_preflight(tmp_path: Path) -> None:
     assert skill_paths == runtime_paths
 
 
-def test_skill_maintenance_gate_matches_runtime_preflight(tmp_path: Path) -> None:
+def test_skill_maintenance_gate_matches_runtime_preflight() -> None:
     skill = read_skill_contract()
     skill_paths = set(required_skill_paths(skill, "Maintenance work-item slice"))
+    item = AffectedWorkItem(
+        work_item_id="MAINT-001",
+        work_item_type=WorkItemType.MAINTENANCE,
+        name="maintenance",
+        impact_type="source-code",
+        slice_path=Path("docs/maintenance/MAINT-001"),
+    )
     runtime_paths = {
         str(path).replace("MAINT-001", "<MAINT-ID>")
-        for path in _missing_maintenance_documents(
-            tmp_path,
-            Path("docs/maintenance/MAINT-001"),
-        )
+        for path in required_document_paths(item)
     }
 
     assert skill_paths == runtime_paths
+
+
+def test_skill_explicitly_forbids_uc_slice_substitution_for_maintenance() -> None:
+    skill = read_skill_contract()
+
+    assert "Maintenance work items are not use cases." in skill
+    assert "Never invent, request, or materialize a `docs/use-cases/<UC-ID>/` path for them." in skill
+    assert "- `docs/maintenance/<MAINT-ID>/scope.md`" in skill
+    assert "- `docs/maintenance/<MAINT-ID>/architecture-impact.md`" in skill


### PR DESCRIPTION
## Summary

Closes #374.

- maintenance slice를 UC와 독립된 typed contract로 강화했습니다.
  - `scope.md`: bounded context와 aggregate/application service/module/package/adapter/port 경계 기록
  - `maintenance-spec.md`, `architecture-impact.md`, `links.md`를 preflight required input으로 승격
  - architecture impact는 `none | update | create | adr` assessment로 기록
- planner skill이 maintenance 작업에 UC slice를 생성·요구·materialize하지 않도록 명시했습니다.
- maintenance-only 및 mixed ChangeSet에서 UC 전용 input이 제거되는 materialization 테스트를 추가했습니다.
- runtime required-document contract와 planner skill required paths의 정합성 테스트를 추가했습니다.

## Verification

Added coverage for:

- maintenance slice scaffolding and required contract enforcement
- maintenance planner inputs excluding `docs/use-cases/**`
- UC-only, maintenance-only, and mixed workflow materialization
- skill/runtime required-document parity

Local pytest could not be run from this connector-only environment because no runnable repository checkout is mounted. Repository commands:

```bash
./venv/bin/python3 -m pytest -q -s tests/runtime
./venv/bin/python3 -m pytest -q -s
```

## Review focus

- This intentionally upgrades the maintenance preflight contract. Existing minimal three-file maintenance slices must be scaffolded/filled before planning; no authored file is overwritten by the scaffolder.
- The patch does not alter UC required documents or UC E2E flow.
- Optional `technical-decisions.md` is a planner reference; it is not a new maintenance preflight gate.
