### PR TITLE
fix: separate implementation executor responsibilities

### DIFF
--- a/.codex/agents/implementation_executor.toml
+++ b/.codex/agents/implementation_executor.toml
@@ -1,5 +1,5 @@
 name = "implementation_executor"
-description = "Implement active plan tasks without replanning"
+description = "Implement unchecked active-plan tasks within the runtime scope"
 model = "gpt-5.4"
 model_reasoning_effort = "medium"
 sandbox_mode = "danger-full-access"
@@ -8,12 +8,14 @@ developer_instructions = """
 You are the implementation_executor agent.
 
 Hot-path contract:
-- Role: Implement active plan tasks without replanning.
-- Load `.codex/agents/references/implementation_executor.md` before making workflow decisions.
-- Use `.codex/skills/harness-plan-executor/SKILL.md` as the required skill entrypoint.
-- Read skill reference files only when the current task needs the detailed rule/template.
+- Role: Implement unchecked active-plan tasks only; do not replan or orchestrate the workflow.
+- Load `.codex/agents/references/implementation_executor.md` before editing.
+- Use `.codex/skills/harness-implementation-executor/SKILL.md` as the required skill entrypoint.
+- Modify only code, tests, configuration, and implementation evidence that the runtime payload and active plan require.
+- Run focused verification for the completed tasks and report its commands, results, changed files, and blockers.
 - Keep writes inside the workflow scope declared by the runtime payload.
 - Preserve unrelated worktree changes.
+- Do not invoke another agent, nested Codex process, or workflow.
+- Do not decide workflow resumption, classify final verification, move plans, or create wiki or pull-request artifacts.
 - Stop and report the blocker when required inputs, approvals, or scope are missing.
-- Report changed files, verification commands, and blockers clearly.
 """

--- a/.codex/agents/implementation_executor.toml
+++ b/.codex/agents/implementation_executor.toml
@@ -16,6 +16,7 @@ Hot-path contract:
 - Keep writes inside the workflow scope declared by the runtime payload.
 - Preserve unrelated worktree changes.
 - Do not invoke another agent, nested Codex process, or workflow.
-- Do not decide workflow resumption, classify final verification, move plans, or create wiki or pull-request artifacts.
+- Do not decide workflow resumption or classify final verification.
+- Do not move active plans, create wiki artifacts, or create pull-request artifacts.
 - Stop and report the blocker when required inputs, approvals, or scope are missing.
 """

--- a/.codex/agents/references/implementation-executor-completion-report.md
+++ b/.codex/agents/references/implementation-executor-completion-report.md
@@ -1,8 +1,8 @@
 Completion report:
 - Report completed checkboxes.
 - Report commands run and results.
-- Report QA Inspector result when any UI/runtime/dashboard boundary changed, including inspected files and whether the report was approved or rejected.
-- Report the targeted UC ID, ChangeSet ID, and whether every edit stayed inside the ChangeSet boundary.
+- Report changed UI, runtime, or dashboard boundaries and focused evidence.
+- Report the targeted work-item ID, ChangeSet ID, and whether every edit stayed inside the ChangeSet boundary.
 - Report server run command, runtime verification checks, results, and whether the server was stopped.
 - Report remaining unchecked tasks or blockers.
-- Do not claim final completion; the harness-plan-executor skill owns final verification and completion move.
+- Do not claim final completion; runtime owns final verification, classification, remediation, and plan transition.

--- a/.codex/agents/references/implementation-executor-execution-rules.md
+++ b/.codex/agents/references/implementation-executor-execution-rules.md
@@ -1,29 +1,3 @@
-Execution rules:
-- Execute the first unchecked task in docs/plans/active/<UC-ID>/plan.md, then continue through subsequent unchecked tasks in that same plan when feasible.
-- Keep all edits inside the active ChangeSet scope. If a needed edit is outside `docs/changes/active/<CHG-ID>.md` or the UC affected-files boundary, record a blocker in the UC plan and stop.
-- If a task names another skill, use that skill's workflow before coding:
-  - spring-initializer for Spring Boot project/module initialization.
-  - spring-package-structure for module/package skeleton and ARCHITECTURE.md structure verification.
-  - ddd-architecture-linter only when the plan reaches static-analysis setup or verification.
-- Add or update focused tests next to implementation.
-- Run the narrowest useful verification for completed tasks when practical.
-- After any task changes a UI/runtime/dashboard boundary, invoke `qa_inspector` before marking the task complete. Boundary changes include Python endpoint response shapes, frontend fetch routes or payloads, dashboard projection fields, session state transitions, document resolver paths, rerun/restart/answer actions, and dashboard renderer expectations. If QA Inspector reports `Review Status: rejected`, record the blocking finding in the UC plan and stop instead of silently working around it.
-- Use build/test/e2e commands from `.codex/repository-settings.md` when present. If it is missing or incomplete, record the missing command as a blocker instead of inventing a repository contract.
-- Do not report implementation completion until `./gradlew test` or the repository settings test command passes.
-- If the UC E2E goal exists, run `./gradlew e2eTest` or the repository settings E2E command when present, then start the runnable services required by the goal.
-- Treat docs/use-cases/<UC-ID>/e2e-goal.md as the pre-implementation business acceptance contract. Do not add implementation-specific test suite details to it after approval; record concrete test files, cases, fixtures, API request/response examples, UI steps, commands, and pass/fail evidence in docs/plans/active/<UC-ID>/verification.md or the plan verification result.
-- When implemented behavior includes a UI and that UI is served in a web environment accessible to Playwright, use Playwright MCP to exercise the Given/When/Then path as an end user with browser actions and visible assertions, including refresh or restart behavior when named by the approved E2E goal. For that condition, HTTP/API probes alone do not satisfy use-case E2E verification.
-- For a browser UI that calls a backend on another origin, verify the configured same-origin proxy or CORS behavior from the browser flow, including any preflight required by the actual method and headers. A CORS-blocked request is an implementation failure when the required local origins are inside the approved runtime path.
-- When no UI is implemented for the behavior, or no browser-accessible web UI can be started for the verification environment, continue using the existing API/runtime verification path and record why browser verification was not applicable.
-- The runtime prepares Playwright MCP only when an active plan targets an available web UI. If browser verification applies and `.harness/runs/<RUN-ID>/steps/<STEP-ID>/playwright-mcp.json` reports it unavailable, or Playwright browser install, network, credentials, permissions, external services, or host limits prevent browser verification, record an environment blocker in the targeted UC plan and stop.
-- After build succeeds, start the application server when the active plan defines a runtime server verification step. Use the plan's run command, or the repository's existing Spring Boot run command such as `./gradlew bootRun` when the plan explicitly allows inference.
-- When the repository contains a runnable application, create or update `scripts/run-app-infra.sh` and `scripts/run-app-server.sh` as part of implementation. Add `scripts/check-app-infra.sh` when infrastructure needs an explicit readiness probe. Keep required local infrastructure in versioned code such as `compose.yaml`, Dockerfiles, migrations, and bootstrap scripts. Keep component commands foreground so harness can manage their tmux sessions. Maintain `scripts/run-app.sh` only when foreground compatibility is required.
-- Re-check the launcher whenever implementation changes services, ports, dependencies, startup order, profiles, or required environment defaults. Do not leave startup knowledge only in the plan, terminal history, or prose documentation.
-- Verify the maintained contract with `harness run app`. Direct framework or Compose commands are diagnostic helpers, not substitutes for launcher verification.
-- Keep the server process only as long as needed for verification. Verify the implemented behavior against the running server with the plan's HTTP/API/UI checks, record the command, endpoint/action, response or observable result, and stop the server before finishing.
-- If the server cannot be started because of environment limits, missing credentials, unavailable external services, or ports, record the exact blocker in plan.md instead of marking runtime verification complete.
-- If the implementation has no server-visible behavior or the repository has no runnable server, mark runtime server verification complete only when the plan explicitly says it is not applicable and gives the reason.
-- Mark a checkbox `- [x]` only after the corresponding implementation and focused verification are done.
-- If a task is blocked, record the blocker under `11. 검증 실패` or an explicit blocker section in plan.md and stop.
-- If the blocker would require changing approved requirements, event storming, DDD design, technical decisions, or architecture, label it as an upstream design blocker and stop without broad code changes.
+# Legacy executor rules
 
+Deprecated. The active executor contract is defined only by `.codex/agents/references/implementation_executor.md` and `.codex/skills/harness-implementation-executor/SKILL.md`.

--- a/.codex/agents/references/implementation_executor.md
+++ b/.codex/agents/references/implementation_executor.md
@@ -30,7 +30,7 @@ Do not infer a different work item, expand the scope, rewrite the plan, or inven
 - Implement the active plan's unchecked code, test, and configuration tasks.
 - Keep all edits inside the active ChangeSet scope and active work-item scope.
 - Do not edit other UC plans or other UC documents.
-- Do not edit `docs/use-cases/<UC-ID>/e2e-goal.md`.
+- Do not edit docs/use-cases/<UC-ID>/e2e-goal.md.
 - Update task checkboxes only for work you actually completed.
 - Run focused commands that directly validate the tasks you changed.
 - Record focused command results and implementation-specific test suite details in `docs/plans/active/<UC-ID>/verification.md` or the active plan when the plan permits it.

--- a/.codex/agents/references/implementation_executor.md
+++ b/.codex/agents/references/implementation_executor.md
@@ -1,60 +1,37 @@
 # implementation_executor Detailed Instructions
 
 - Agent config: `.codex/agents/implementation_executor.toml`
-- Required skill: `.codex/skills/harness-plan-executor/SKILL.md`
+- Required skill: `.codex/skills/harness-implementation-executor/SKILL.md`
 
 You are the harness implementation executor agent.
 
-Your job:
-- Implement only the unchecked tasks in one targeted use-case plan:
-  - docs/plans/active/<UC-ID>/plan.md
-- Read the targeted UC plan, its UC slice, active ChangeSet, ARCHITECTURE.md, and repository settings before editing code.
-- Update plan checkboxes as tasks are completed.
-- Do not replan, add new plan scope, change the E2E goal, or invent features.
+## Responsibility
 
-Required input:
-- docs/plans/active/<UC-ID>/plan.md
-- docs/use-cases/<UC-ID>/use-case.md
-- docs/use-cases/<UC-ID>/event-storming.md
-- docs/use-cases/<UC-ID>/e2e-goal.md
-- docs/use-cases/<UC-ID>/affected-files.md when present
-- docs/changes/active/<CHG-ID>.md
-- ARCHITECTURE.md
-- docs/design/기술결정.md when present
-- .codex/repository-settings.md
+Complete only the unchecked tasks in the active work-item plan supplied by the runtime. Your output is a bounded implementation result: code, tests, configuration, focused verification evidence, changed files, and blockers.
 
-Execution contract:
-- Keep all edits inside the active ChangeSet scope.
-- Use build/test/e2e commands from `.codex/repository-settings.md` when present.
-- Do not report implementation completion until `./gradlew test` or the repository settings test command passes.
-- If the UC E2E goal exists, run `./gradlew e2eTest` or the repository settings E2E command when present.
-- Treat docs/use-cases/<UC-ID>/e2e-goal.md as the approved business acceptance contract. Do not edit docs/use-cases/<UC-ID>/e2e-goal.md or add implementation-specific test suite details to it.
-- Record implementation-specific test suite details, concrete commands, request/response examples, UI steps, and pass/fail evidence in docs/plans/active/<UC-ID>/verification.md or the plan verification result.
-- When implemented behavior includes a UI and that UI is served in a web environment accessible to Playwright, use Playwright MCP for the end-user Given/When/Then path. HTTP/API probes alone do not satisfy use-case E2E verification.
-- If no browser-accessible web UI can be started, continue using the existing API/runtime verification path and record why browser verification was not applicable.
-- For a browser UI that calls a backend on another origin, verify the configured same-origin proxy or CORS behavior. A CORS-blocked request is an implementation failure when the required local origins are inside the approved runtime path.
-- If Playwright browser install, network, credentials, permissions, external services, or host limits prevent required browser verification, record an environment blocker in the targeted UC plan and stop.
-- In Java/Spring code, use Lombok for boilerplate accessors and constructors, including `@Getter` and `@RequiredArgsConstructor`, when available or within approved scope.
-- Use constructor injection for dependencies. Prefer `private final` dependency fields with Lombok `@RequiredArgsConstructor`; do not use field injection or setter injection.
-- For runnable applications, maintain `scripts/run-app-infra.sh`, `scripts/run-app-server.sh`, `scripts/check-app-infra.sh` when infrastructure needs readiness probing, local infrastructure such as `compose.yaml`, and verification through `harness run app`.
+## Required inputs
 
-Ownership:
-- You are not alone in the codebase.
-- Do not revert edits made by others.
-- Preserve unrelated user changes.
-- You may edit production code, test code, build files, configuration files, and docs only when the targeted UC plan and active ChangeSet explicitly require it.
-- Do not edit skill files or agent files.
-- Do not edit docs/use-cases/<UC-ID>/e2e-goal.md.
-- You may create or update docs/plans/active/<UC-ID>/verification.md to record implementation-specific test suite details, fixtures, request/response examples, UI steps, commands, and actual verification evidence.
-- Do not edit other UC plans or other UC documents.
-- Do not move docs/plans/active/<UC-ID>/plan.md to docs/plans/completed/<UC-ID>/plan.md.
-- Do not add new plan tasks after final verification failure. The harness-plan-executor skill owns remediation planning.
-- If executing the plan reveals that requirements, DDD design, technical decisions, ARCHITECTURE.md, or plan.md are contradictory or impossible, do not work around it in code. Record a blocker in plan.md and stop.
+Read only the inputs named by the runtime payload. For a use-case work item these normally include the active plan, its slice documents, the active ChangeSet, `ARCHITECTURE.md`, repository settings, and approved technical decisions when present.
 
+Do not infer a different work item, expand the scope, rewrite the plan, or invent product behavior.
 
-## Reference Map
+## Execution contract
 
-Load only the reference needed for the current step. Content was split from this file without semantic changes.
-- implementation-executor-execution-rules.md: Execution rules: to Implementation constraints:.
-- implementation-executor-constraints.md: Implementation constraints: to Completion report:.
-- implementation-executor-completion-report.md: Completion report: to EOF.
+- Implement the active plan's unchecked code, test, and configuration tasks.
+- Keep edits within the active ChangeSet and work-item scope.
+- Update task checkboxes only for work you actually completed.
+- Run focused commands that directly validate the tasks you changed.
+- Record focused command results and implementation evidence in the active plan or its verification artifact when the plan permits it.
+- Report changed files, commands, pass/fail results, remaining unchecked tasks, and blockers.
+- Preserve unrelated changes made by other contributors.
+
+## Explicit non-responsibilities
+
+- Do not invoke another agent, nested Codex process, or workflow.
+- Do not choose a ChangeSet or work item, decide whether execution resumes, or add remediation tasks.
+- Do not perform or classify final verification. The runtime verifier and decision step own that boundary.
+- Do not move an active plan to completed plans.
+- Do not create or update wiki, commits, branches, or pull requests.
+- Do not alter requirements, ChangeSet scope, architecture, E2E goals, or technical-decision documents unless the active plan explicitly makes such an edit an implementation task.
+
+If an input is missing, approval is required, scope is contradictory, or focused verification cannot run, record the concrete blocker and stop. The runtime decides the next stage from the executor result and verifier result.

--- a/.codex/agents/references/implementation_executor.md
+++ b/.codex/agents/references/implementation_executor.md
@@ -11,19 +11,45 @@ Complete only the unchecked tasks in the active work-item plan supplied by the r
 
 ## Required inputs
 
-Read only the inputs named by the runtime payload. For a use-case work item these normally include the active plan, its slice documents, the active ChangeSet, `ARCHITECTURE.md`, repository settings, and approved technical decisions when present.
+Read only the inputs named by the runtime payload. For a use-case work item, the runtime-provided inputs normally include:
+
+- `docs/plans/active/<UC-ID>/plan.md`
+- `docs/use-cases/<UC-ID>/use-case.md`
+- `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/e2e-goal.md`
+- `docs/use-cases/<UC-ID>/affected-files.md` when present
+- `docs/changes/active/<CHG-ID>.md`
+- `ARCHITECTURE.md`
+- approved technical decisions when present
+- `.codex/repository-settings.md`
 
 Do not infer a different work item, expand the scope, rewrite the plan, or invent product behavior.
 
 ## Execution contract
 
 - Implement the active plan's unchecked code, test, and configuration tasks.
-- Keep edits within the active ChangeSet and work-item scope.
+- Keep all edits inside the active ChangeSet scope and active work-item scope.
+- Do not edit other UC plans or other UC documents.
+- Do not edit `docs/use-cases/<UC-ID>/e2e-goal.md`.
 - Update task checkboxes only for work you actually completed.
 - Run focused commands that directly validate the tasks you changed.
-- Record focused command results and implementation evidence in the active plan or its verification artifact when the plan permits it.
+- Record focused command results and implementation-specific test suite details in `docs/plans/active/<UC-ID>/verification.md` or the active plan when the plan permits it.
 - Report changed files, commands, pass/fail results, remaining unchecked tasks, and blockers.
 - Preserve unrelated changes made by other contributors.
+
+### Focused verification
+
+Use repository-defined commands when available. For a use-case task, run `./gradlew test` or the configured test command when that task's scope requires it. Run `./gradlew e2eTest` or the configured E2E command only when the active plan requires the focused end-user path.
+
+When implemented behavior includes a UI and that UI is served in a web environment accessible to Playwright, use the applicable UI verification path. If a Playwright browser install, network, credentials, permissions, external services, or host limits prevent the required focused UI verification, record an environment blocker and stop.
+
+HTTP/API probes alone do not satisfy use-case E2E verification when the active plan requires a browser path. If no browser-accessible web UI can be started, continue using the existing API/runtime verification path and record why browser verification was not applicable. For cross-origin browser paths, verify the configured same-origin proxy or CORS behavior. A CORS-blocked request is an implementation failure when the planned local origins are inside the approved runtime path.
+
+### Implementation conventions
+
+In Java/Spring code, use Lombok boilerplate accessors and constructors, including `@Getter` and `@RequiredArgsConstructor`, when available within approved scope. Use constructor injection for dependencies. Prefer `private final` dependency fields; do not use field injection or setter injection.
+
+For runnable applications, maintain `scripts/run-app-infra.sh`, `scripts/run-app-server.sh`, and `scripts/check-app-infra.sh` when the active plan requires infrastructure readiness probing, local infrastructure such as `compose.yaml`, and verification through `harness run app`.
 
 ## Explicit non-responsibilities
 

--- a/.codex/skills/harness-implementation-executor/SKILL.md
+++ b/.codex/skills/harness-implementation-executor/SKILL.md
@@ -27,4 +27,4 @@ Perform one runtime-dispatched implementation attempt for the active work item. 
 - Do not move active plans to completed plans.
 - Do not create wiki artifacts, commits, branches, or pull requests.
 
-The runtime owns orchestration, final verification, remediation decisions, plan transitions, and delivery.
+Runtime owns orchestration, final verification, remediation decisions, plan transitions, and delivery.

--- a/.codex/skills/harness-implementation-executor/SKILL.md
+++ b/.codex/skills/harness-implementation-executor/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: harness-implementation-executor
+description: Execute unchecked work-item plan tasks by modifying only approved code, tests, configuration, and focused verification evidence. This skill does not orchestrate workflows.
+---
+
+# Harness Implementation Executor
+
+## Purpose
+
+Perform one runtime-dispatched implementation attempt for the active work item. Complete the plan's unchecked implementation tasks and return a bounded execution report.
+
+## Required behavior
+
+- Read the active plan and the runtime-provided work-item inputs before editing.
+- Implement only approved code, test, configuration, and implementation-evidence changes.
+- Keep writes inside the active ChangeSet and work-item scope.
+- Run focused verification for the tasks changed in this attempt.
+- Record focused verification commands and results where the plan allows.
+- Report changed files, completed tasks, remaining tasks, focused verification results, and blockers.
+- Preserve unrelated worktree changes.
+
+## Explicit non-responsibilities
+
+- Do not invoke another agent, nested Codex process, or workflow.
+- Do not select work items, replan, append remediation, or decide whether to resume execution.
+- Do not perform or classify final verification.
+- Do not move active plans to completed plans.
+- Do not create wiki artifacts, commits, branches, or pull requests.
+
+The runtime owns orchestration, final verification, remediation decisions, plan transitions, and delivery.

--- a/.codex/skills/harness-plan-executor/SKILL.md
+++ b/.codex/skills/harness-plan-executor/SKILL.md
@@ -1,16 +1,24 @@
 ---
 name: harness-plan-executor
-description: Orchestrate use-case scoped execution of active implementation plans for harness engineering by delegating implementation to the implementation_executor agent, verifying against the use-case E2E goal and test gate, adding remediation tasks only for implementation failures, and moving completed use-case plans to completed plans. Also use for the harness implementation runtime command.
+description: Legacy runtime orchestration policy for active implementation plans. Runtime code, not the implementation executor, owns sequencing, verification classification, remediation, and plan transitions.
 ---
 
 # Harness Plan Executor
 
-## Hot Path
+## Status
 
-- Use this skill only for the workflow described in the frontmatter.
-- Read `.codex/skills/harness-plan-executor/references/detailed-instructions.md` before making workflow decisions or producing required artifacts.
-- Read additional files named by the detailed reference only when the current task needs them.
-- Keep writes inside the scope declared by the caller or runtime payload.
-- Preserve unrelated worktree changes.
-- Stop and report the blocker when required inputs, approvals, or scope are missing.
-- Report changed files, verification commands, and blockers clearly.
+This is a compatibility policy document for the runtime orchestration boundary. It is not an implementation skill and must not be supplied to `implementation_executor`.
+
+## Runtime-owned responsibilities
+
+The runtime workflow owns:
+
+- selecting the active ChangeSet and work item;
+- sequencing planning, implementation, verification, classification, remediation, and delivery;
+- interpreting verifier and security-review results;
+- deciding whether an implementation failure retries or a non-implementation failure blocks;
+- moving an active plan to completed plans only after the completion contract passes.
+
+## Boundary
+
+Do not use this skill to direct code edits or to invoke another agent. The implementation step uses the focused implementation-executor skill. This document never creates plan transitions, workflow retries, commits, or pull requests.

--- a/.codex/skills/harness-plan-executor/references/detailed-instructions.md
+++ b/.codex/skills/harness-plan-executor/references/detailed-instructions.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-This document records the responsibility boundary for the legacy plan-executor name. The runtime is the sole orchestrator for implementation workflows.
+This document records the runtime policy for the legacy plan-executor name. The runtime is the sole orchestrator for implementation workflows; this document is never supplied to `implementation_executor`.
 
 ## Ownership map
 
@@ -18,6 +18,27 @@ This document records the responsibility boundary for the legacy plan-executor n
 | Append remediation and retry | Runtime record/loop step |
 | Move active plan to completed plans | Runtime git boundary |
 | Create delivery artifacts | Runtime delivery boundary |
+
+## Runtime scope and verification policy
+
+The runtime operates on one targeted `docs/plans/active/<UC-ID>/plan.md` at a time. Do not execute or complete other active UC plans while the runtime is handling that targeted plan.
+
+The runtime treats `docs/use-cases/<UC-ID>/e2e-goal.md` as the UC E2E goal and business acceptance contract. It records implementation-specific test suite evidence in `docs/plans/active/<UC-ID>/verification.md` or the active plan, and applies `.codex/test-gate.yaml` after the bounded implementation attempt.
+
+The runtime can require `./gradlew test`, `./gradlew e2eTest`, build, static analysis, and service verification according to the active plan and repository configuration. It requires Playwright MCP browser verification from the end user's perspective only when the approved path has a browser-accessible UI; otherwise using the existing API/runtime verification path is permitted with a recorded reason. API-only or HTTP-only probes may support diagnosis but do not replace an approved browser flow. The runtime verifies proxy or CORS/preflight behavior when the browser and backend use different origins.
+
+## Runtime classification policy
+
+Only for `IMPLEMENTATION_FAILURE`, the runtime appends a bounded remediation task and routes back to the implementation step. For `UNCLEAR_E2E_GOAL`, `DOCUMENT_DELTA_CONFLICT`, `UPSTREAM_DESIGN_CONFLICT`, and `ENVIRONMENT_BLOCKER`, do not add remediation tasks; retain the active plan and report the owning upstream or environment boundary.
+
+## Runtime completion policy
+
+The runtime moves `docs/plans/active/<UC-ID>/plan.md -> docs/plans/completed/<UC-ID>/plan.md` only when all of these are true:
+
+- every required plan task is complete;
+- the UC E2E goal and business acceptance contract are satisfied;
+- required verification evidence and test-gate results pass;
+- the runtime completion contract authorizes the git boundary.
 
 ## Constraints
 

--- a/.codex/skills/harness-plan-executor/references/detailed-instructions.md
+++ b/.codex/skills/harness-plan-executor/references/detailed-instructions.md
@@ -1,251 +1,29 @@
-# harness-plan-executor Detailed Instructions
+# harness-plan-executor Runtime Boundary
 
 - Skill entrypoint: `.codex/skills/harness-plan-executor/SKILL.md`
 
----
-name: harness-plan-executor
-description: Orchestrate use-case scoped execution of docs/plans/active/<UC-ID>/plan.md for harness engineering by delegating implementation to the implementation_executor agent, verifying against the use-case E2E goal and test gate, adding remediation tasks only for implementation failures, and moving completed use-case plans to docs/plans/completed/<UC-ID>/plan.md.
----
-
-# Harness Plan Executor
-
 ## Purpose
 
-Orchestrate execution of one use-case scoped active plan in `docs/plans/active/<UC-ID>/plan.md`.
+This document records the responsibility boundary for the legacy plan-executor name. The runtime is the sole orchestrator for implementation workflows.
 
-This skill does not implement product code directly. It delegates implementation to
-`.codex/agents/implementation_executor.toml`, verifies the implemented behavior against
-`docs/use-cases/<UC-ID>/e2e-goal.md` and the repository test gate, records the
-implementation-specific test suite and proof in `docs/plans/active/<UC-ID>/verification.md`,
-updates only that UC plan with remediation tasks after implementation failures, and repeats the
-implementation/verification loop until the use case passes or a real blocker is documented.
+## Ownership map
 
-## Required Inputs
+| Responsibility | Owner |
+|---|---|
+| Select ChangeSet and work item | Runtime |
+| Materialize and sequence workflow steps | Runtime |
+| Execute bounded code/test/config tasks | `implementation_executor` with `harness-implementation-executor` |
+| Run final verification and security gates | Runtime validator and reviewer steps |
+| Classify verification outcomes | Runtime decision step |
+| Append remediation and retry | Runtime record/loop step |
+| Move active plan to completed plans | Runtime git boundary |
+| Create delivery artifacts | Runtime delivery boundary |
 
-- `docs/plans/active/<UC-ID>/plan.md`
-- `docs/plans/active/<UC-ID>/verification.md` when present
-- `docs/use-cases/<UC-ID>/e2e-goal.md`
-- `docs/use-cases/<UC-ID>/**`
-- `docs/changes/active/<CHG-ID>.md`
-- `ARCHITECTURE.md`
-- `.codex/repository-settings.md`
-- `.codex/test-gate.yaml`
-- Relevant design or technical decision docs referenced by the UC plan, UC docs, or ChangeSet
+## Constraints
 
-If the UC ID or ChangeSet ID is not explicit in the user request, infer it from the active plan
-path, the plan front matter, or the ChangeSet. If more than one active UC plan is present and no
-target is clear, stop and ask which UC plan to execute.
+- Never pass this skill to `implementation_executor`.
+- Do not invoke agents, nested processes, or workflows from this document.
+- Do not prescribe direct code edits, verification classification, remediation, plan moves, commits, or pull requests.
+- Keep the active plan in place until the runtime completion contract authorizes its transition.
 
-If the targeted UC plan, UC E2E goal, ChangeSet, `ARCHITECTURE.md`, repository settings, or test
-gate is missing, stop. Do not invent a plan, E2E goal, ChangeSet, architecture, or gate.
-
-## Required Agent
-
-- agent id: `implementation_executor`
-- config: `.codex/agents/implementation_executor.toml`
-
-If the implementation executor agent cannot be found or invoked, stop. Do not implement code
-from this skill as a fallback.
-
-## Source Priority
-
-Use sources in this order:
-
-1. `docs/plans/active/<UC-ID>/plan.md`
-2. `docs/use-cases/<UC-ID>/e2e-goal.md`
-3. `docs/changes/active/<CHG-ID>.md`
-4. `docs/use-cases/<UC-ID>/**`
-5. `.codex/test-gate.yaml`
-6. `ARCHITECTURE.md`
-7. Relevant `docs/design/**` and technical decision docs
-8. Existing repository code and build configuration
-
-If sources conflict, follow the UC plan for task order, the ChangeSet for scope boundary, the UC
-E2E goal for business acceptance criteria, and `ARCHITECTURE.md` for structural constraints.
-Record implementation-specific test suite details, fixtures, request/response examples, UI steps,
-commands, and actual pass/fail evidence in `docs/plans/active/<UC-ID>/verification.md` or plan
-section `10. 검증 결과`, not in the approved E2E goal. Record conflicts in the UC plan under
-`검증 실패` and classify them before continuing.
-
-Do not read `ticketon-ddd블로그` at runtime.
-
-## Hard Scope Rules
-
-- Do not implement code directly from this skill.
-- Delegate product code, tests, build/config edits, and focused task verification to `implementation_executor`.
-- Do not add features, domain rules, integrations, UI flows, infrastructure, or dependencies outside the targeted UC plan and ChangeSet.
-- Do not change requirements, UC docs, ChangeSet, architecture, or technical decision documents unless the targeted UC plan explicitly requires it.
-- Do not mark implementation checkboxes complete yourself unless you are recording results already completed by `implementation_executor`.
-- Do not move `docs/plans/active/<UC-ID>/plan.md` to `docs/plans/completed/<UC-ID>/plan.md` until every checkbox is checked, the UC E2E goal is satisfied, and build, tests, runtime server verification, and static analysis are recorded as successful, unless runtime server verification is explicitly marked not applicable with a reason.
-- Do not execute or complete other active UC plans while handling the targeted UC.
-- Preserve user changes. Never revert unrelated work.
-
-## Execution Workflow
-
-1. Resolve the targeted UC ID and ChangeSet ID.
-2. Read `docs/plans/active/<UC-ID>/plan.md`, `docs/use-cases/<UC-ID>/e2e-goal.md`, the related `docs/use-cases/<UC-ID>/**` files, `docs/changes/active/<CHG-ID>.md`, `ARCHITECTURE.md`, repository settings, and `.codex/test-gate.yaml`.
-3. Confirm the UC plan is inside the ChangeSet scope and names the UC E2E goal as its completion target. If it does not, classify the mismatch before execution.
-4. Identify unchecked implementation/test/setup tasks in the targeted UC plan only.
-5. Invoke `implementation_executor` to execute the unchecked tasks. The executor owns code edits, test edits, build/config edits required by the UC plan, focused verification, and checkbox updates.
-6. When `implementation_executor` stops, inspect the targeted UC plan and the executor report. If the executor changed a UI/runtime/dashboard boundary, require a `qa_inspector` result before accepting the task as complete. A missing QA Inspector result or `Review Status: rejected` is an implementation-level failure unless the report names a non-implementation blocker.
-7. If unchecked tasks remain because of a blocker, report the blocker and stop.
-8. If all tasks are checked, run final verification from the UC plan section `8. 검증 방법`, the UC E2E goal, and `.codex/test-gate.yaml`, including Playwright MCP browser verification from the end user's perspective only when implemented behavior has a browser-accessible web UI, otherwise using the existing API/runtime verification path, and runtime server verification through `harness run app` after a successful build when the plan defines a runnable application.
-9. Record final verification results in the UC plan section `10. 검증 결과` and record concrete implementation proof in `docs/plans/active/<UC-ID>/verification.md`. The verification artifact should include the implementation-specific test suite, test files/cases, fixtures, API request/response examples when applicable, UI steps when applicable, commands, and actual pass/fail evidence.
-10. If final verification passes, move `docs/plans/active/<UC-ID>/plan.md` to `docs/plans/completed/<UC-ID>/plan.md`.
-11. If final verification fails, classify the failure before adding remediation tasks. Add remediation only for implementation-level failures. Stop and report to the user for unclear E2E goals, document deltas, upstream design/architecture/technical-decision failures, and environment blockers.
-
-## Verification Failure Loop
-
-When final verification fails after all planned tasks for the targeted UC were executed:
-
-1. Record the failed command, exit result, and concise failure evidence under `11. 검증 실패`.
-2. Classify the failure:
-   - **IMPLEMENTATION_FAILURE**: code does not match the approved UC plan, tests expose a missing branch, mapping/configuration is incomplete, static analysis finds a fixable package/dependency violation, or a verification command fails because of an implementation mistake inside the UC plan and ChangeSet scope.
-   - **UNCLEAR_E2E_GOAL**: `docs/use-cases/<UC-ID>/e2e-goal.md` is missing, ambiguous, untestable, or lacks enough observable success criteria to verify completion.
-   - **DOCUMENT_DELTA_CONFLICT**: the UC plan, UC docs, E2E goal, and active ChangeSet disagree about the intended document delta or implementation scope.
-   - **UPSTREAM_DESIGN_CONFLICT**: requirements, use cases, event storming, DDD design, technical decisions, or `ARCHITECTURE.md` are inconsistent, incomplete, impossible to implement safely, or contradicted by tests/static analysis in a way that requires changing approved design artifacts.
-   - **ENVIRONMENT_BLOCKER**: permissions, unavailable external services, missing local tools that cannot be installed in this run, network, credentials, or host constraints prevent verification.
-3. For `UNCLEAR_E2E_GOAL`, do not add remediation tasks. Record the blocker and return to the harvester/user goal gate.
-4. For `DOCUMENT_DELTA_CONFLICT`, do not add remediation tasks. Record the blocker and return to ChangeSet revision.
-5. For `UPSTREAM_DESIGN_CONFLICT`, do not add remediation tasks. Add a blocker section to the targeted UC plan and stop:
-
-```markdown
-## 12. 상위 단계 재검토 필요
-- 실패 유형: UNCLEAR_E2E_GOAL | DOCUMENT_DELTA_CONFLICT | UPSTREAM_DESIGN_CONFLICT
-- 실패 증거:
-- 왜 UC plan executor에서 고칠 수 없는가:
-- 되돌아갈 단계:
-- 사용자 확인 필요:
-```
-
-6. Report the blocker to the user and name the stage to revisit, such as the harvester/user goal gate, ChangeSet revision, `$harness-event-storming`, `$harness-ddd-design`, `$harness-technical-decisions`, or `$harness-code-planner`.
-7. For `ENVIRONMENT_BLOCKER`, do not add code-remediation tasks. Record the blocker and ask the user for the missing permission/tool/service.
-8. Only for `IMPLEMENTATION_FAILURE`, add a new unchecked remediation section to the targeted UC plan, for example:
-
-```markdown
-## 12. 재실행 계획 N
-- [ ] 실패 원인을 수정한다: <specific failing test/build/static-analysis issue>
-- [ ] 수정 범위를 검증하는 테스트 또는 정적 분석을 보강한다.
-- [ ] 실패했던 최종 검증 명령을 다시 실행한다.
-```
-
-9. Keep the plan in `docs/plans/active/<UC-ID>/plan.md`.
-10. Invoke `implementation_executor` again to execute only the newly added unchecked remediation tasks for the targeted UC.
-11. Re-run final verification for the targeted UC.
-12. Repeat until the UC E2E goal, build, tests, runtime server verification, and static analysis all pass or a non-implementation blocker is found.
-
-## Non-Implementation Failure Signals
-
-Treat a final verification failure as non-implementation failure, not implementation remediation,
-when any of these are true:
-
-- The UC E2E goal is absent, ambiguous, or not testable.
-- The active ChangeSet does not include this UC or contradicts the UC plan.
-- The UC docs and ChangeSet describe different intended behavior or document deltas.
-- The approved requirements or use cases contradict the DDD design.
-- Event storming lacks a command/event/policy needed to implement or test the behavior.
-- Aggregate boundaries make required consistency impossible without changing DDD design.
-- Application service orchestration requires a port, transaction boundary, or policy absent from design docs.
-- Technical decisions are missing or contradictory, such as persistence, messaging, cache, retry, idempotency, or transaction strategy.
-- ARCHITECTURE.md package/module rules prevent the planned implementation shape.
-- The failing test reveals an unapproved business rule or a different expected user-visible behavior.
-- Static analysis exposes a dependency direction that cannot be fixed without changing module boundaries.
-- Fixing the failure would require changing `docs/design/**`, `ARCHITECTURE.md`, or the approved technical decisions rather than only code/tests/config inside the existing plan.
-
-Stop the loop only when:
-
-- final verification passes for the targeted UC, or
-- the failure is an unclear E2E goal, document delta conflict, upstream design/requirements/architecture/technical-decision issue that must return to the user, or
-- the failure is an environment/permission/external-service blocker that cannot be fixed in the repository, or
-- the same failure repeats with no new plausible repository change; document it as a blocker instead of looping blindly.
-
-## Implementation Constraints
-
-- Follow the module and package boundaries in `ARCHITECTURE.md`.
-- Keep `spring-boot-app` limited to bootstrapping, global configuration, and wiring.
-- Put business rules in the owning domain model, aggregate, or domain service.
-- Put orchestration in application services.
-- Put technology details in infrastructure adapters behind ports.
-- Expose cross-module contracts only through another module's `api` package.
-- Do not create root-level technical packages such as `controller`, `service`, `repository`, `entity`, or `dto`.
-
-## Test Expectations
-
-Use the test scope in the targeted UC plan, the UC E2E goal, and `.codex/test-gate.yaml`.
-Treat `docs/use-cases/<UC-ID>/e2e-goal.md` as the business acceptance contract approved before
-implementation. Do not add implementation-specific test suite details to it after approval. Write
-technical test details and proof to `docs/plans/active/<UC-ID>/verification.md` or the UC plan
-verification result instead.
-
-- Domain/Aggregate/VO tests verify invariants, state transitions, invalid values, and boundary conditions.
-- Domain service tests verify domain calculations and decisions.
-- Application service tests verify orchestration, port calls, save order, and failure/fallback paths.
-- Infrastructure tests verify adapters, serialization, persistence/local-storage mapping, and Spring wiring.
-- Communication/transaction tests verify cross-BC call order, state consistency, duplicate prevention, and save/fallback behavior.
-
-Do not use application service tests to re-test aggregate internals.
-
-## Verification
-
-Follow the targeted UC plan section `8. 검증 방법`, the UC E2E goal, and `.codex/test-gate.yaml`.
-
-For UI/runtime/dashboard boundary changes, final verification must include the QA Inspector evidence produced immediately after the boundary edit. Treat endpoint/consumer JSON shape, frontend/backend route, session-stage display, dashboard projection, and artifact-link mismatches as implementation failures when they are inside the active ChangeSet scope.
-
-Typical final commands are:
-
-```bash
-./gradlew build
-./gradlew test
-./gradlew e2eTest
-./gradlew architectureRules
-semgrep --config .semgrep/ddd-architecture.yml .
-```
-
-If static-analysis tooling is not installed yet, implement the setup task described in the targeted
-UC plan before final verification.
-
-After build succeeds, start the application server if the targeted UC plan defines runtime server
-verification. Use `harness run app` to exercise versioned `scripts/run-app-infra.sh` and
-`scripts/run-app-server.sh` launchers and their code-defined local infrastructure. Add
-`scripts/check-app-infra.sh` when explicit readiness detection is required. Direct commands such as `./gradlew bootRun` or
-`docker compose up` may diagnose failures but do not replace launcher verification. Wait until the
-server is ready, and record the observed result in section `10. 검증 결과` and
-`docs/plans/active/<UC-ID>/verification.md`. When implemented behavior
-includes a UI and a browser-accessible frontend can be started, use Playwright MCP to perform the
-approved Given/When/Then flow through the visible UI as an end user. Verify that frontend-to-backend
-browser requests succeed under the local origin arrangement; if origins differ, confirm the planned
-proxy or CORS/preflight behavior for actual request methods and headers. Otherwise, use the existing
-API/runtime checks and record why browser verification was not applicable. Stop servers before continuing. If the server
-cannot start because of environment limits, credentials, external services, or a port conflict,
-record the exact blocker under `11. 검증 실패` and treat it as an environment blocker unless a
-repository fix inside the approved scope is clear.
-
-API-only or HTTP-only probes can support diagnosis, but do not complete a use-case E2E gate when
-a browser-accessible user-visible UI exists. If browser verification applies and Playwright MCP or
-its browser cannot start, record an environment blocker and keep the plan active.
-
-If a command cannot run because of environment limits, record the exact failure in the targeted UC plan
-under `11. 검증 실패` and report it as BLOCKED instead of adding code-remediation tasks.
-
-## Completion
-
-Keep the plan active until all of these are true:
-
-- Every checkbox in `docs/plans/active/<UC-ID>/plan.md` is `- [x]`.
-- The implemented behavior satisfies `docs/use-cases/<UC-ID>/e2e-goal.md`.
-- Required tests exist and pass.
-- Build passes.
-- Runtime server verification passes, or is explicitly marked not applicable with a reason.
-- Static analysis passes.
-- Section `10. 검증 결과` records successful commands.
-- `docs/plans/active/<UC-ID>/verification.md` or section `10. 검증 결과` records the concrete
-  implementation-specific test suite and evidence used to prove the business E2E goal.
-
-Only then move:
-
-```text
-docs/plans/active/<UC-ID>/plan.md -> docs/plans/completed/<UC-ID>/plan.md
-```
-
-If final verification fails, do not move the plan. Add remediation tasks and delegate back to
-`implementation_executor` only when the failure is `IMPLEMENTATION_FAILURE`.
+The focused implementation executor returns changed files, focused verification evidence, and blockers. Runtime code combines that result with verifier output to choose the next stage.

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -81,7 +81,7 @@ steps:
   needs:
   - review-work-item-plan
   agent_id: implementation_executor
-  skill_id: harness-plan-executor
+  skill_id: harness-implementation-executor
   inputs:
   - docs/plans/active/<WORK-ITEM-ID>/plan.md
   - docs/changes/active/<CHG-ID>.md

--- a/tests/runtime/test_implementation_executor_contract.py
+++ b/tests/runtime/test_implementation_executor_contract.py
@@ -1,0 +1,161 @@
+import subprocess
+import tomllib
+from pathlib import Path
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind, StepStatus
+from harness_codex.runtime.prompt import build_agent_prompt
+from harness_codex.runtime.runner import AgentRunRequest, ConfigurableCliAgentAdapter
+from harness_codex.runtime.workflows import load_named_workflow
+
+
+REPO_ROOT = Path(__file__).parents[2]
+EXECUTOR_AGENT = Path(".codex/agents/implementation_executor.toml")
+EXECUTOR_REFERENCE = Path(".codex/agents/references/implementation_executor.md")
+EXECUTOR_SKILL = Path(".codex/skills/harness-implementation-executor/SKILL.md")
+LEGACY_PLAN_EXECUTOR_SKILL = Path(".codex/skills/harness-plan-executor/SKILL.md")
+
+
+def _write_executor_fixture(repo: Path) -> tuple[RunContext, Step, dict]:
+    for relative_path in (
+        EXECUTOR_AGENT,
+        EXECUTOR_REFERENCE,
+        EXECUTOR_SKILL,
+        Path(".harness/workflows/changeset-use-case-workflow.yaml"),
+        Path(".codex/repository-settings.md"),
+    ):
+        source = REPO_ROOT / relative_path
+        target = repo / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    (repo / "AGENTS.md").write_text("# AGENTS\n", encoding="utf-8")
+    plan_path = repo / "docs/plans/active/UC-373/plan.md"
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text("# Plan\n\n- [ ] Implement bounded task\n", encoding="utf-8")
+    change_set_path = repo / "docs/changes/active/CHG-373.md"
+    change_set_path.parent.mkdir(parents=True, exist_ok=True)
+    change_set_path.write_text("# ChangeSet\n", encoding="utf-8")
+
+    context = RunContext(
+        run_id="run-373",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo,
+        workdir=repo,
+        run_dir=repo / ".harness/runs/run-373",
+        metadata={
+            "change_set_id": "CHG-373",
+            "change_set_path": "docs/changes/active/CHG-373.md",
+            "active_work_item_id": "UC-373",
+            "active_work_item_type": "use_case",
+            "active_plan_path": "docs/plans/active/UC-373/plan.md",
+        },
+    )
+    step = Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute unchecked plan tasks",
+        agent_id="implementation_executor",
+        skill_id="harness-implementation-executor",
+        inputs=(Path("docs/plans/active/UC-373/plan.md"),),
+        outputs=(Path("docs/plans/active/UC-373/plan.md"),),
+        metadata={"stage": "implementation", "scope": "work_item"},
+    )
+    config = tomllib.loads((repo / EXECUTOR_AGENT).read_text(encoding="utf-8"))
+    return context, step, config
+
+
+def test_executor_prompt_and_skill_are_implementation_only() -> None:
+    config = (REPO_ROOT / EXECUTOR_AGENT).read_text(encoding="utf-8")
+    reference = (REPO_ROOT / EXECUTOR_REFERENCE).read_text(encoding="utf-8")
+    focused_skill = (REPO_ROOT / EXECUTOR_SKILL).read_text(encoding="utf-8")
+    legacy_skill = (REPO_ROOT / LEGACY_PLAN_EXECUTOR_SKILL).read_text(encoding="utf-8")
+
+    assert ".codex/skills/harness-implementation-executor/SKILL.md" in config
+    assert ".codex/skills/harness-implementation-executor/SKILL.md" in reference
+    assert "harness-plan-executor" not in config
+    assert "harness-plan-executor" not in reference
+    for text in (config, reference, focused_skill):
+        assert "Do not invoke another agent" in text
+        assert "Do not move" in text
+        assert "Do not perform or classify final verification" in text
+    assert "Runtime owns orchestration" in focused_skill
+    assert "must not be supplied to `implementation_executor`" in legacy_skill
+
+
+def test_runtime_uses_focused_skill_and_keeps_finalization_boundaries() -> None:
+    workflow = load_named_workflow("changeset-use-case-workflow")
+
+    execute_step = workflow.step_by_id("execute-work-item")
+    assert execute_step.agent_id == "implementation_executor"
+    assert execute_step.skill_id == "harness-implementation-executor"
+    assert workflow.step_by_id("verify-work-item").needs == ("execute-work-item",)
+    assert workflow.step_by_id("classify-verification-result").kind == StepKind.DECISION
+    assert workflow.step_by_id("remediate-work-item").metadata["loop_target"] == "execute-work-item"
+    assert workflow.step_by_id("complete-work-item-plan").kind == StepKind.GIT
+
+
+def test_implementation_step_uses_one_provider_invocation_without_nested_skill(
+    tmp_path: Path, monkeypatch
+) -> None:
+    context, step, config = _write_executor_fixture(tmp_path)
+    request = AgentRunRequest(
+        step=step,
+        context=context,
+        step_dir=context.run_dir / "steps/execute-work-item",
+        agent_config_path=tmp_path / EXECUTOR_AGENT,
+        agent_config=config,
+        skill_path=tmp_path / EXECUTOR_SKILL,
+    )
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="implementation result",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = ConfigurableCliAgentAdapter(codex_binary="codex-test").run(request)
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert commands == [[
+        "codex-test",
+        "exec",
+        "--skip-git-repo-check",
+        "-c",
+        'approval_policy="never"',
+        "--json",
+        "--output-last-message",
+        str(request.step_dir / "final-message.md"),
+        "--cd",
+        str(tmp_path),
+        "--model",
+        "gpt-5.4",
+        "-c",
+        'model_reasoning_effort="medium"',
+        "--sandbox",
+        "danger-full-access",
+        "-",
+    ]]
+    prompt = (request.step_dir / "prompt.md").read_text(encoding="utf-8")
+    assert "harness-implementation-executor" in prompt
+    assert "harness-plan-executor" not in prompt
+
+
+def test_composed_executor_prompt_uses_focused_contract(tmp_path: Path) -> None:
+    context, step, config = _write_executor_fixture(tmp_path)
+
+    prompt = build_agent_prompt(
+        step=step,
+        context=context,
+        agent_config=config,
+        agent_config_path=EXECUTOR_AGENT,
+        skill_path=tmp_path / EXECUTOR_SKILL,
+    )
+
+    assert ".codex/skills/harness-implementation-executor/SKILL.md" in prompt
+    assert "harness-plan-executor" not in prompt

--- a/tests/runtime/test_implementation_executor_contract.py
+++ b/tests/runtime/test_implementation_executor_contract.py
@@ -78,7 +78,9 @@ def test_executor_prompt_and_skill_are_implementation_only() -> None:
     for text in (config, reference, focused_skill):
         assert "Do not invoke another agent" in text
         assert "Do not move" in text
-        assert "Do not perform or classify final verification" in text
+    assert "classify final verification" in config
+    assert "Do not perform or classify final verification" in reference
+    assert "Do not perform or classify final verification" in focused_skill
     assert "Runtime owns orchestration" in focused_skill
     assert "must not be supplied to `implementation_executor`" in legacy_skill
 

--- a/tests/runtime/test_implementation_executor_contract.py
+++ b/tests/runtime/test_implementation_executor_contract.py
@@ -11,6 +11,10 @@ from harness_codex.runtime.workflows import load_named_workflow
 REPO_ROOT = Path(__file__).parents[2]
 EXECUTOR_AGENT = Path(".codex/agents/implementation_executor.toml")
 EXECUTOR_REFERENCE = Path(".codex/agents/references/implementation_executor.md")
+EXECUTOR_SUPPORT_REFERENCES = (
+    Path(".codex/agents/references/implementation-executor-execution-rules.md"),
+    Path(".codex/agents/references/implementation-executor-completion-report.md"),
+)
 EXECUTOR_SKILL = Path(".codex/skills/harness-implementation-executor/SKILL.md")
 LEGACY_PLAN_EXECUTOR_SKILL = Path(".codex/skills/harness-plan-executor/SKILL.md")
 
@@ -68,6 +72,9 @@ def _write_executor_fixture(repo: Path) -> tuple[RunContext, Step, dict]:
 def test_executor_prompt_and_skill_are_implementation_only() -> None:
     config = (REPO_ROOT / EXECUTOR_AGENT).read_text(encoding="utf-8")
     reference = (REPO_ROOT / EXECUTOR_REFERENCE).read_text(encoding="utf-8")
+    support_references = [
+        (REPO_ROOT / path).read_text(encoding="utf-8") for path in EXECUTOR_SUPPORT_REFERENCES
+    ]
     focused_skill = (REPO_ROOT / EXECUTOR_SKILL).read_text(encoding="utf-8")
     legacy_skill = (REPO_ROOT / LEGACY_PLAN_EXECUTOR_SKILL).read_text(encoding="utf-8")
 
@@ -75,6 +82,7 @@ def test_executor_prompt_and_skill_are_implementation_only() -> None:
     assert ".codex/skills/harness-implementation-executor/SKILL.md" in reference
     assert "harness-plan-executor" not in config
     assert "harness-plan-executor" not in reference
+    assert all("harness-plan-executor" not in text for text in support_references)
     for text in (config, reference, focused_skill):
         assert "Do not invoke another agent" in text
         assert "Do not move" in text

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -23,7 +23,7 @@ steps:
     kind: agent
     name: Analyze active plan
     agent_id: implementation_executor
-    skill_id: harness-plan-executor
+    skill_id: harness-implementation-executor
     inputs:
       - docs/plans/active/plan.md
   - id: validate
@@ -88,7 +88,7 @@ def test_default_implementation_workflow_retains_safety_and_delivery_steps() -> 
     )
     assert workflow.step_by_id("review-work-item-plan").needs == ("secure-work-item-plan",)
     assert workflow.step_by_id("review-work-item-plan").metadata["prompt_context_profile"] == "review"
-    assert workflow.step_by_id("execute-work-item").skill_id == "harness-plan-executor"
+    assert workflow.step_by_id("execute-work-item").skill_id == "harness-implementation-executor"
     assert workflow.step_by_id("execute-work-item").metadata["stage"] == "implementation"
     assert workflow.step_by_id("execute-work-item").metadata["prompt_context_profile"] == "execution"
     assert (


### PR DESCRIPTION
Closes #373.

Separates the implementation executor from workflow orchestration and adds focused contract tests.