### PR TITLE
Verification failure routing for #375

### DIFF
--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -102,7 +102,7 @@ steps:
   name: Verify the selected work item
   needs:
   - execute-work-item
-  command: python3 -m harness_codex.runtime.verify_work_item --change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>
+  command: python3 -m harness_codex.runtime.structured_verify_work_item --change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>
   timeout_sec: 600
   inputs:
   - docs/plans/active/<WORK-ITEM-ID>/plan.md
@@ -165,6 +165,7 @@ steps:
     - UPSTREAM_DESIGN_CONFLICT
     - ENVIRONMENT_BLOCKER
     - SCOPE_CONFLICT
+    - SECURITY_REVIEW_FAILURE
     - VERIFICATION_GOAL_UNCLEAR
     on_implementation_failure: remediate-work-item
     on_unclear_e2e_goal: e2e-goal-approval
@@ -172,6 +173,7 @@ steps:
     on_upstream_design_failure: upstream-design-stage
     on_environment_blocker: environment
     on_scope_conflict: change-set-revision
+    on_security_review_failure: security-review
     on_verification_goal_unclear: verification-goal-approval
 - id: remediate-work-item
   kind: record

--- a/harness_codex/runtime/dashboard.py
+++ b/harness_codex/runtime/dashboard.py
@@ -22,6 +22,9 @@ class DashboardWorkItem:
     status: RunStatus
     blocker: str = ""
     verification_result: str = ""
+    failure_class: str = ""
+    owner_stage: str = ""
+    recommended_resume_target: str = ""
 
 
 @dataclass(frozen=True)
@@ -49,27 +52,31 @@ def load_dashboard_runs(repo_root: Path | str) -> tuple[DashboardRun, ...]:
     for state_path in sorted(runs_dir.glob("*/state.json")):
         state = store.load(state_path.parent.name)
         work_items = [
-            DashboardWorkItem(
-                work_item_id=item.work_item_id,
-                work_item_type=item.work_item_type,
-                plan_path=item.active_plan_path,
-                current_stage=item.current_step_id,
-                status=item.status,
-                blocker=item.blocker or "",
-                verification_result=item.verification_status,
+            _dashboard_work_item(
+                root,
+                state.run_id,
+                item.work_item_id,
+                item.work_item_type,
+                item.active_plan_path,
+                item.current_step_id,
+                item.status,
+                item.blocker or "",
+                item.verification_status,
             )
             for item in state.work_item_states
         ]
         if not work_items:
             work_items = [
-                DashboardWorkItem(
-                    work_item_id=item.uc_id,
-                    work_item_type=WorkItemType.USE_CASE,
-                    plan_path=item.active_plan_path,
-                    current_stage=item.current_step_id.value,
-                    status=item.status,
-                    blocker=item.blocker or "",
-                    verification_result=item.verification_status,
+                _dashboard_work_item(
+                    root,
+                    state.run_id,
+                    item.uc_id,
+                    WorkItemType.USE_CASE,
+                    item.active_plan_path,
+                    item.current_step_id.value,
+                    item.status,
+                    item.blocker or "",
+                    item.verification_status,
                 )
                 for item in state.use_case_states
             ]
@@ -84,6 +91,54 @@ def load_dashboard_runs(repo_root: Path | str) -> tuple[DashboardRun, ...]:
         )
 
     return tuple(runs)
+
+
+def _dashboard_work_item(
+    repo_root: Path,
+    run_id: str,
+    work_item_id: str,
+    work_item_type: WorkItemType,
+    plan_path: Path,
+    current_stage: object,
+    status: RunStatus,
+    blocker: str,
+    verification_result: str,
+) -> DashboardWorkItem:
+    routing = _verification_routing(repo_root, run_id, work_item_id)
+    return DashboardWorkItem(
+        work_item_id=work_item_id,
+        work_item_type=work_item_type,
+        plan_path=plan_path,
+        current_stage=str(current_stage),
+        status=status,
+        blocker=blocker,
+        verification_result=verification_result,
+        failure_class=routing.get("failure_class", ""),
+        owner_stage=routing.get("owner_stage", ""),
+        recommended_resume_target=routing.get("recommended_resume_target", ""),
+    )
+
+
+def _verification_routing(repo_root: Path, run_id: str, work_item_id: str) -> dict[str, str]:
+    report_path = (
+        repo_root
+        / ".harness/runs"
+        / run_id
+        / "work-items"
+        / work_item_id
+        / "verification/report.json"
+    )
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {
+        key: value
+        for key in ("failure_class", "owner_stage", "recommended_resume_target")
+        if isinstance((value := payload.get(key)), str)
+    }
 
 
 def dashboard_state_json(repo_root: Path | str) -> str:
@@ -104,6 +159,9 @@ def dashboard_state_json(repo_root: Path | str) -> str:
                     "status": item.status.value,
                     "blocker": item.blocker,
                     "verification_result": item.verification_result,
+                    "failure_class": item.failure_class,
+                    "owner_stage": item.owner_stage,
+                    "recommended_resume_target": item.recommended_resume_target,
                 }
                 for item in run.work_items
             ],

--- a/harness_codex/runtime/engine.py
+++ b/harness_codex/runtime/engine.py
@@ -7,15 +7,17 @@ side-effecting tool.
 
 from __future__ import annotations
 
+import json
 from collections import deque
 from dataclasses import dataclass, replace
+from pathlib import Path
 
 from harness_codex.runtime.models import (
     FailureKind,
     RunContext,
+    RunMode,
     RunResult,
     RunStatus,
-    RunMode,
     Step,
     StepKind,
     StepResult,
@@ -24,6 +26,10 @@ from harness_codex.runtime.models import (
 )
 from harness_codex.runtime.policy import CommandRequest, PolicyDecision, PolicyEngine
 from harness_codex.runtime.runner import StepRunner
+from harness_codex.runtime.verification_failure import (
+    VerificationFailureClass,
+    structured_failure_from_report,
+)
 
 
 class WorkflowValidationError(ValueError):
@@ -37,8 +43,6 @@ class ExecutionPlan:
     steps: tuple[Step, ...]
 
     def step_ids(self) -> tuple[str, ...]:
-        """Return step IDs in execution order."""
-
         return tuple(step.id for step in self.steps)
 
 
@@ -50,7 +54,7 @@ class _RemediationPath:
 
 
 class RunnerEngine:
-    """Execute workflows through a side-effecting `StepRunner` boundary."""
+    """Execute workflows through a side-effecting ``StepRunner`` boundary."""
 
     def __init__(
         self,
@@ -61,20 +65,12 @@ class RunnerEngine:
         self._policy_engine = policy_engine or PolicyEngine()
 
     def plan(self, workflow: Workflow) -> ExecutionPlan:
-        """Validate the workflow and return dependency-safe execution order."""
-
         steps_by_id = self._index_steps(workflow)
         ordered_ids = self._topological_sort(workflow, steps_by_id)
-
-        return ExecutionPlan(
-            steps=tuple(steps_by_id[step_id] for step_id in ordered_ids)
-        )
+        return ExecutionPlan(steps=tuple(steps_by_id[step_id] for step_id in ordered_ids))
 
     def run(self, workflow: Workflow, context: RunContext) -> RunResult:
-        """Run the workflow until all steps succeed or one step fails/blocks."""
-
         execution_plan = self.plan(workflow)
-
         if context.mode in (RunMode.PLAN, RunMode.PREVIEW):
             return self._dry_run_result(execution_plan, context)
 
@@ -85,20 +81,13 @@ class RunnerEngine:
         next_index = 0
         skipped_runtime_steps: set[str] = set()
         active_context = context
-        step_index = {
-            step.id: index for index, step in enumerate(execution_plan.steps)
-        }
+        step_index = {step.id: index for index, step in enumerate(execution_plan.steps)}
 
         while next_index < len(execution_plan.steps):
             step = execution_plan.steps[next_index]
             next_index += 1
-
-            if step.id in skipped_runtime_steps:
+            if step.id in skipped_runtime_steps or self._is_runtime_remediation_step(step):
                 continue
-
-            if self._is_runtime_remediation_step(step):
-                continue
-
             if self._should_skip_precompleted_work_item_step(step, active_context):
                 results.append(
                     StepResult(
@@ -112,38 +101,34 @@ class RunnerEngine:
                 )
                 continue
 
-            decision = self._evaluate_command_policy(step, active_context)
-            if decision is not None and not decision.allowed:
+            policy_decision = self._evaluate_command_policy(step, active_context)
+            if policy_decision is not None and not policy_decision.allowed:
                 result = StepResult(
                     step_id=step.id,
                     status=StepStatus.BLOCKED,
-                    error=decision.reason,
-                    metadata={"policy_decision": decision.as_metadata()},
+                    error=policy_decision.reason,
+                    metadata={"policy_decision": policy_decision.as_metadata()},
                 )
                 results.append(result)
-
                 return RunResult(
                     run_id=context.run_id,
                     status=RunStatus.BLOCKED,
                     step_results=tuple(results),
                     mode=active_context.mode,
                     failed_step_id=step.id,
-                    blocker=decision.reason,
+                    blocker=policy_decision.reason,
                     retry_count=retry_count,
-                    metadata=self._result_metadata(
-                        execution_plan,
-                        active_context,
-                        tuple(results),
-                    ),
+                    metadata=self._result_metadata(execution_plan, active_context, tuple(results)),
                 )
 
             result = self._step_runner.run(step, active_context)
-            if decision is not None:
+            result = self._structured_verification_result(step, active_context, result)
+            if policy_decision is not None:
                 result = replace(
                     result,
                     metadata={
                         **dict(result.metadata),
-                        "policy_decision": decision.as_metadata(),
+                        "policy_decision": policy_decision.as_metadata(),
                     },
                 )
             results.append(result)
@@ -156,10 +141,7 @@ class RunnerEngine:
                         result.failure_kind.value if result.failure_kind else "",
                         result.error or "",
                     )
-                    if (
-                        previous_failure_signature == signature
-                        or retry_count >= max_retries
-                    ):
+                    if previous_failure_signature == signature or retry_count >= max_retries:
                         return RunResult(
                             run_id=context.run_id,
                             status=RunStatus.BLOCKED,
@@ -176,9 +158,7 @@ class RunnerEngine:
                                 extra={
                                     "remediation_blocked": True,
                                     "max_remediation_retries": max_retries,
-                                    "repeated_failure": (
-                                        previous_failure_signature == signature
-                                    ),
+                                    "repeated_failure": previous_failure_signature == signature,
                                 },
                             ),
                         )
@@ -194,11 +174,7 @@ class RunnerEngine:
                     )
                     if decision_result.status != StepStatus.SUCCEEDED:
                         return self._blocked_result(
-                            execution_plan,
-                            active_context,
-                            tuple(results),
-                            decision_result,
-                            retry_count,
+                            execution_plan, active_context, tuple(results), decision_result, retry_count
                         )
                     remediation_result = self._run_runtime_step(
                         remediation.remediation_step,
@@ -210,11 +186,7 @@ class RunnerEngine:
                     )
                     if remediation_result.status != StepStatus.SUCCEEDED:
                         return self._blocked_result(
-                            execution_plan,
-                            active_context,
-                            tuple(results),
-                            remediation_result,
-                            retry_count,
+                            execution_plan, active_context, tuple(results), remediation_result, retry_count
                         )
                     skipped_runtime_steps.add(remediation.remediation_step.id)
                     next_index = step_index[remediation.loop_target_step.id]
@@ -232,11 +204,7 @@ class RunnerEngine:
                     )
                     if decision_result.status != StepStatus.SUCCEEDED:
                         return self._blocked_result(
-                            execution_plan,
-                            active_context,
-                            tuple(results),
-                            decision_result,
-                            retry_count,
+                            execution_plan, active_context, tuple(results), decision_result, retry_count
                         )
                     return RunResult(
                         run_id=context.run_id,
@@ -247,11 +215,7 @@ class RunnerEngine:
                         failure_kind=result.failure_kind,
                         blocker=result.error,
                         retry_count=retry_count,
-                        metadata=self._result_metadata(
-                            execution_plan,
-                            active_context,
-                            tuple(results),
-                        ),
+                        metadata=self._result_metadata(execution_plan, active_context, tuple(results)),
                     )
 
                 return RunResult(
@@ -263,27 +227,13 @@ class RunnerEngine:
                     failure_kind=result.failure_kind,
                     blocker=result.error,
                     retry_count=retry_count,
-                    metadata=self._result_metadata(
-                        execution_plan,
-                        active_context,
-                        tuple(results),
-                    ),
+                    metadata=self._result_metadata(execution_plan, active_context, tuple(results)),
                 )
 
             if result.status == StepStatus.BLOCKED:
-                if result.failure_kind in {
-                    FailureKind.SCOPE_CONFLICT,
-                    FailureKind.PLAN_REVIEW_REJECTED,
-                }:
-                    loop_target = self._plan_restart_loop_target(
-                        execution_plan,
-                        step_index,
-                    )
-                    signature = (
-                        step.id,
-                        result.failure_kind.value,
-                        result.error or "",
-                    )
+                if result.failure_kind in {FailureKind.SCOPE_CONFLICT, FailureKind.PLAN_REVIEW_REJECTED}:
+                    loop_target = self._plan_restart_loop_target(execution_plan, step_index)
+                    signature = (step.id, result.failure_kind.value, result.error or "")
                     if (
                         loop_target is not None
                         and previous_failure_signature != signature
@@ -299,7 +249,6 @@ class RunnerEngine:
                         )
                         next_index = loop_target
                         continue
-
                 return RunResult(
                     run_id=context.run_id,
                     status=RunStatus.BLOCKED,
@@ -309,11 +258,7 @@ class RunnerEngine:
                     failure_kind=result.failure_kind,
                     blocker=result.error,
                     retry_count=retry_count,
-                    metadata=self._result_metadata(
-                        execution_plan,
-                        active_context,
-                        tuple(results),
-                    ),
+                    metadata=self._result_metadata(execution_plan, active_context, tuple(results)),
                 )
 
         return RunResult(
@@ -325,13 +270,50 @@ class RunnerEngine:
             metadata=self._result_metadata(execution_plan, active_context, tuple(results)),
         )
 
-    def _dry_run_result(
+    def _structured_verification_result(
         self,
-        execution_plan: ExecutionPlan,
+        step: Step,
         context: RunContext,
-    ) -> RunResult:
-        step_results: list[StepResult] = []
+        result: StepResult,
+    ) -> StepResult:
+        """Prefer the verifier's durable JSON contract over a shell exit code."""
 
+        if step.id != "verify-work-item" or result.status != StepStatus.FAILED:
+            return result
+        work_item_id = str(context.metadata.get("active_work_item_id") or "")
+        if not work_item_id:
+            return result
+        report_path = (
+            context.repo_root
+            / ".harness"
+            / "runs"
+            / context.run_id
+            / "work-items"
+            / work_item_id
+            / "verification"
+            / "report.json"
+        )
+        try:
+            payload = json.loads(report_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return result
+        if not isinstance(payload, dict):
+            return result
+        failure = structured_failure_from_report(payload)
+        if failure is None:
+            return result
+        return replace(
+            result,
+            failure_kind=_failure_kind_for(failure.failure_class),
+            metadata={
+                **dict(result.metadata),
+                "verification_report_path": str(report_path.relative_to(context.repo_root)),
+                "verification_failure": failure.as_dict(),
+            },
+        )
+
+    def _dry_run_result(self, execution_plan: ExecutionPlan, context: RunContext) -> RunResult:
+        step_results: list[StepResult] = []
         for step in execution_plan.steps:
             decision = self._evaluate_command_policy(step, context)
             if decision is not None and not decision.allowed:
@@ -342,7 +324,6 @@ class RunnerEngine:
                     metadata={"policy_decision": decision.as_metadata()},
                 )
                 step_results.append(result)
-
                 return RunResult(
                     run_id=context.run_id,
                     status=RunStatus.BLOCKED,
@@ -350,40 +331,22 @@ class RunnerEngine:
                     mode=context.mode,
                     failed_step_id=step.id,
                     blocker=decision.reason,
-                    metadata=self._result_metadata(
-                        execution_plan,
-                        context,
-                        tuple(step_results),
-                    ),
+                    metadata=self._result_metadata(execution_plan, context, tuple(step_results)),
                 )
-
             metadata = {
                 "mode": context.mode.value,
                 "would_run": context.mode == RunMode.PREVIEW,
                 "side_effects": False,
             }
-
             if decision is not None:
                 metadata["policy_decision"] = decision.as_metadata()
-
-            step_results.append(
-                StepResult(
-                    step_id=step.id,
-                    status=StepStatus.SKIPPED,
-                    metadata=metadata,
-                )
-            )
-
+            step_results.append(StepResult(step_id=step.id, status=StepStatus.SKIPPED, metadata=metadata))
         return RunResult(
             run_id=context.run_id,
             status=RunStatus.SUCCEEDED,
             step_results=tuple(step_results),
             mode=context.mode,
-            metadata=self._result_metadata(
-                execution_plan,
-                context,
-                tuple(step_results),
-            ),
+            metadata=self._result_metadata(execution_plan, context, tuple(step_results)),
         )
 
     def _result_metadata(
@@ -399,10 +362,7 @@ class RunnerEngine:
             if "policy_decision" in result.metadata
         )
         decisions = tuple(
-            {
-                "step_id": result.step_id,
-                **dict(result.metadata["decision"]),
-            }
+            {"step_id": result.step_id, **dict(result.metadata["decision"])}
             for result in step_results
             if "decision" in result.metadata
         )
@@ -419,14 +379,10 @@ class RunnerEngine:
             if "execution_mode" in result.metadata
         )
         phase_metrics = tuple(
-            {
-                "step_id": result.step_id,
-                "phase_metrics": result.metadata["phase_metrics"],
-            }
+            {"step_id": result.step_id, "phase_metrics": result.metadata["phase_metrics"]}
             for result in step_results
             if "phase_metrics" in result.metadata
         )
-
         metadata: dict[str, object] = {
             "mode": context.mode.value,
             "workflow_name": context.workflow_name,
@@ -451,19 +407,11 @@ class RunnerEngine:
         failed_step: Step,
         failed_result: StepResult,
     ) -> StepResult:
-        runtime_context = replace(
+        runtime_context = self._runtime_failure_context(
             context,
-            metadata={
-                **dict(context.metadata),
-                "runtime_retry_count": retry_count,
-                "runtime_failed_step_id": failed_step.id,
-                "runtime_failure_kind": (
-                    failed_result.failure_kind.value
-                    if failed_result.failure_kind is not None
-                    else ""
-                ),
-                "runtime_failure_error": failed_result.error or "",
-            },
+            retry_count=retry_count,
+            failed_step=failed_step,
+            failed_result=failed_result,
         )
         result = self._step_runner.run(step, runtime_context)
         results.append(result)
@@ -483,12 +431,9 @@ class RunnerEngine:
                 **dict(context.metadata),
                 "runtime_retry_count": retry_count,
                 "runtime_failed_step_id": failed_step.id,
-                "runtime_failure_kind": (
-                    failed_result.failure_kind.value
-                    if failed_result.failure_kind is not None
-                    else ""
-                ),
+                "runtime_failure_kind": failed_result.failure_kind.value if failed_result.failure_kind else "",
                 "runtime_failure_error": failed_result.error or "",
+                "runtime_failure_metadata": dict(failed_result.metadata),
             },
         )
 
@@ -512,27 +457,15 @@ class RunnerEngine:
             metadata=self._result_metadata(execution_plan, context, results),
         )
 
-    def _should_skip_precompleted_work_item_step(
-        self,
-        step: Step,
-        context: RunContext,
-    ) -> bool:
+    def _should_skip_precompleted_work_item_step(self, step: Step, context: RunContext) -> bool:
         return bool(
             context.metadata.get("skip_precompleted_work_item_steps")
             and step.metadata.get("scope") == "work_item"
         )
 
-    def _evaluate_command_policy(
-        self,
-        step: Step,
-        context: RunContext,
-    ) -> PolicyDecision | None:
-        if step.command is None:
+    def _evaluate_command_policy(self, step: Step, context: RunContext) -> PolicyDecision | None:
+        if step.command is None or step.kind not in {StepKind.GIT, StepKind.SHELL, StepKind.VALIDATOR}:
             return None
-
-        if step.kind not in {StepKind.GIT, StepKind.SHELL, StepKind.VALIDATOR}:
-            return None
-
         return self._policy_engine.evaluate(
             CommandRequest(
                 step_id=step.id,
@@ -552,11 +485,9 @@ class RunnerEngine:
     ) -> _RemediationPath | None:
         if failed_result.failure_kind != FailureKind.IMPLEMENTATION:
             return None
-
         decision_step = self._failure_decision_step(execution_plan, failed_step)
         if decision_step is None:
             return None
-
         steps_by_id = {step.id: step for step in execution_plan.steps}
         remediation_steps = tuple(
             step
@@ -565,37 +496,26 @@ class RunnerEngine:
         )
         if not remediation_steps:
             return None
-
         remediation_step = remediation_steps[0]
-        loop_target_id = str(remediation_step.metadata.get("loop_target", ""))
-        loop_target_step = steps_by_id.get(loop_target_id)
+        loop_target_step = steps_by_id.get(str(remediation_step.metadata.get("loop_target", "")))
         if loop_target_step is None:
             return None
+        return _RemediationPath(decision_step, remediation_step, loop_target_step)
 
-        return _RemediationPath(
-            decision_step=decision_step,
-            remediation_step=remediation_step,
-            loop_target_step=loop_target_step,
+    def _failure_decision_step(self, execution_plan: ExecutionPlan, failed_step: Step) -> Step | None:
+        return next(
+            (
+                step
+                for step in execution_plan.steps
+                if failed_step.id in step.needs and step.kind == StepKind.DECISION
+            ),
+            None,
         )
-
-    def _failure_decision_step(
-        self,
-        execution_plan: ExecutionPlan,
-        failed_step: Step,
-    ) -> Step | None:
-        for step in execution_plan.steps:
-            if failed_step.id in step.needs and step.kind == StepKind.DECISION:
-                return step
-        return None
 
     def _is_runtime_remediation_step(self, step: Step) -> bool:
         return bool(step.metadata.get("loop_target"))
 
-    def _plan_restart_loop_target(
-        self,
-        execution_plan: ExecutionPlan,
-        step_index: dict[str, int],
-    ) -> int | None:
+    def _plan_restart_loop_target(self, execution_plan: ExecutionPlan, step_index: dict[str, int]) -> int | None:
         if "plan-work-item" in step_index:
             return step_index["plan-work-item"]
         for index, step in enumerate(execution_plan.steps):
@@ -603,11 +523,7 @@ class RunnerEngine:
                 return index
         return None
 
-    def _max_remediation_retries(
-        self,
-        workflow: Workflow,
-        context: RunContext,
-    ) -> int:
+    def _max_remediation_retries(self, workflow: Workflow, context: RunContext) -> int:
         value = (
             context.metadata.get("max_remediation_retries")
             or workflow.metadata.get("max_remediation_retries")
@@ -629,59 +545,50 @@ class RunnerEngine:
 
     def _index_steps(self, workflow: Workflow) -> dict[str, Step]:
         steps_by_id: dict[str, Step] = {}
-
         for step in workflow.steps:
             if step.id in steps_by_id:
                 raise WorkflowValidationError(f"Duplicate step id: {step.id}")
             steps_by_id[step.id] = step
-
         for step in workflow.steps:
             for needed_step_id in step.needs:
                 if needed_step_id not in steps_by_id:
                     raise WorkflowValidationError(
                         f"Step {step.id} depends on unknown step: {needed_step_id}"
                     )
-
         return steps_by_id
 
-    def _topological_sort(
-        self,
-        workflow: Workflow,
-        steps_by_id: dict[str, Step],
-    ) -> tuple[str, ...]:
-        dependents_by_step_id: dict[str, list[str]] = {
-            step.id: [] for step in workflow.steps
-        }
-        remaining_needs_count: dict[str, int] = {
-            step.id: len(step.needs) for step in workflow.steps
-        }
-
+    def _topological_sort(self, workflow: Workflow, steps_by_id: dict[str, Step]) -> tuple[str, ...]:
+        dependents_by_step_id: dict[str, list[str]] = {step.id: [] for step in workflow.steps}
+        remaining_needs_count: dict[str, int] = {step.id: len(step.needs) for step in workflow.steps}
         for step in workflow.steps:
             for needed_step_id in step.needs:
                 dependents_by_step_id[needed_step_id].append(step.id)
-
-        ready = deque(
-            step.id for step in workflow.steps if remaining_needs_count[step.id] == 0
-        )
-
+        ready = deque(step.id for step in workflow.steps if remaining_needs_count[step.id] == 0)
         ordered: list[str] = []
-
         while ready:
             step_id = ready.popleft()
             ordered.append(step_id)
-
             for dependent_step_id in dependents_by_step_id[step_id]:
                 remaining_needs_count[dependent_step_id] -= 1
-
                 if remaining_needs_count[dependent_step_id] == 0:
                     ready.append(dependent_step_id)
-
         if len(ordered) != len(steps_by_id):
-            unresolved = tuple(
-                step_id for step_id, count in remaining_needs_count.items() if count > 0
-            )
+            unresolved = tuple(step_id for step_id, count in remaining_needs_count.items() if count > 0)
             raise WorkflowValidationError(
                 "Workflow contains cyclic step dependencies: " + ", ".join(unresolved)
             )
-
         return tuple(ordered)
+
+
+def _failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
+    mapping = {
+        VerificationFailureClass.IMPLEMENTATION_FAILURE: FailureKind.IMPLEMENTATION,
+        VerificationFailureClass.UNCLEAR_E2E_GOAL: FailureKind.UNCLEAR_E2E_GOAL,
+        VerificationFailureClass.DOCUMENT_DELTA_CONFLICT: FailureKind.DOCUMENT_DELTA_CONFLICT,
+        VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: FailureKind.UPSTREAM_DESIGN,
+        VerificationFailureClass.ENVIRONMENT_BLOCKER: FailureKind.ENVIRONMENT_BLOCKER,
+        VerificationFailureClass.SCOPE_CONFLICT: FailureKind.SCOPE_CONFLICT,
+        VerificationFailureClass.SECURITY_REVIEW_FAILURE: FailureKind.SECURITY_REVIEW_FAILURE,
+        VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: FailureKind.VERIFICATION_GOAL_UNCLEAR,
+    }
+    return mapping[failure_class]

--- a/harness_codex/runtime/structured_verify_work_item.py
+++ b/harness_codex/runtime/structured_verify_work_item.py
@@ -1,0 +1,122 @@
+"""CLI wrapper that enriches verifier output with structured failure routing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from harness_codex.runtime.verification_failure import classify_verification_failure
+from harness_codex.runtime.verify_work_item import verify_work_item
+
+
+def verify_and_classify(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    run_id: str,
+    force_verification: bool = False,
+) -> int:
+    root = Path(repo_root)
+    result = verify_work_item(
+        root,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        run_id=run_id,
+        force_verification=force_verification,
+    )
+    report_path = root / result.evidence_dir / "report.json"
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+
+    if not result.passed:
+        command_failures: list[str] = []
+        evidence: list[str] = []
+        if result.blocker:
+            evidence.append(f"blocker: {result.blocker}")
+        evidence.extend(f"missing obligation: {item}" for item in result.missing_obligations)
+        for command in result.command_results:
+            if command.passed:
+                continue
+            evidence.extend(
+                (
+                    f"failed command: {command.command}",
+                    f"stdout: {command.stdout_path}",
+                    f"stderr: {command.stderr_path}",
+                )
+            )
+            stderr_path = root / command.stderr_path
+            stdout_path = root / command.stdout_path
+            for path in (stderr_path, stdout_path):
+                if path.is_file():
+                    command_failures.append(path.read_text(encoding="utf-8", errors="replace"))
+        failure = classify_verification_failure(
+            blocker=result.blocker,
+            missing_obligations=result.missing_obligations,
+            command_failures=command_failures,
+            evidence=evidence,
+        )
+        payload.update(failure.as_dict())
+    else:
+        payload.update(
+            {
+                "failure_class": None,
+                "owner_stage": None,
+                "recommended_resume_target": None,
+                "evidence": [],
+            }
+        )
+
+    report_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    _write_markdown_summary(root / result.evidence_dir / "verification.md", payload)
+
+    status = "PASS" if result.passed else "FAIL"
+    print(f"{status} work-item verification: {result.evidence_dir / 'report.json'}")
+    if not result.passed:
+        print(f"Failure class: {payload['failure_class']}")
+        print(f"Owner stage: {payload['owner_stage']}")
+        print(f"Recommended resume target: {payload['recommended_resume_target']}")
+    return 0 if result.passed else 1
+
+
+def _write_markdown_summary(path: Path, payload: dict[str, object]) -> None:
+    if not payload.get("failure_class"):
+        return
+    lines = path.read_text(encoding="utf-8").rstrip().splitlines()
+    lines.extend(
+        (
+            "",
+            "## Failure Routing",
+            f"- Failure class: `{payload['failure_class']}`",
+            f"- Owner stage: `{payload['owner_stage']}`",
+            f"- Recommended resume target: `{payload['recommended_resume_target']}`",
+            "",
+            "## Failure Evidence",
+            *[f"- {item}" for item in payload.get("evidence", [])],
+        )
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify one ChangeSet work item and write structured failure routing."
+    )
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--change-set", required=True)
+    parser.add_argument("--work-item", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--force-verification", action="store_true")
+    args = parser.parse_args(argv)
+    return verify_and_classify(
+        args.repo_root,
+        change_set_id=args.change_set,
+        work_item_id=args.work_item,
+        run_id=args.run_id,
+        force_verification=args.force_verification,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness_codex/runtime/verification_failure.py
+++ b/harness_codex/runtime/verification_failure.py
@@ -1,9 +1,4 @@
-"""Structured classification for work-item verification failures.
-
-This module is deliberately independent of the runner so the verifier can write a
-stable report and the decision step can consume it without re-parsing command
-exit codes or relying on free-form strings.
-"""
+"""Structured classification and routing for work-item verification failures."""
 
 from __future__ import annotations
 
@@ -25,7 +20,7 @@ class VerificationFailureClass(str, Enum):
 
 @dataclass(frozen=True)
 class VerificationFailure:
-    """A durable verification failure contract written to ``report.json``."""
+    """Durable failure contract written to a verification report."""
 
     failure_class: VerificationFailureClass
     owner_stage: str
@@ -85,6 +80,7 @@ _ENVIRONMENT_MARKERS = (
 def structured_failure_from_report(payload: Mapping[str, object]) -> VerificationFailure | None:
     """Read the report contract when all structured fields are present and valid."""
 
+    _install_engine_routing()
     raw_class = payload.get("failure_class")
     if not isinstance(raw_class, str) or not raw_class.strip():
         return None
@@ -98,11 +94,15 @@ def structured_failure_from_report(payload: Mapping[str, object]) -> Verificatio
         return None
     if not isinstance(resume_target, str) or not resume_target.strip():
         return None
-    evidence = tuple(
-        str(item)
-        for item in raw_evidence
-        if isinstance(item, (str, int, float))
-    ) if isinstance(raw_evidence, list) else ()
+    evidence = (
+        tuple(
+            str(item)
+            for item in raw_evidence
+            if isinstance(item, (str, int, float))
+        )
+        if isinstance(raw_evidence, list)
+        else ()
+    )
     return VerificationFailure(
         failure_class=failure_class,
         owner_stage=owner_stage,
@@ -118,12 +118,7 @@ def classify_verification_failure(
     command_failures: Iterable[str] = (),
     evidence: Iterable[str] = (),
 ) -> VerificationFailure:
-    """Classify a failed verifier outcome without treating exit code as its cause.
-
-    Explicit failure labels in evidence win. Otherwise this only recognizes stable
-    environmental/document/scope/design conditions and keeps ordinary failing
-    tests as implementation failures.
-    """
+    """Classify a failed verifier outcome without treating exit code as its cause."""
 
     evidence_items = tuple(str(item) for item in evidence if str(item).strip())
     text_parts = [blocker or "", *missing_obligations, *command_failures, *evidence_items]
@@ -161,6 +156,97 @@ def classify_verification_failure(
 
 def failure_defaults(failure_class: VerificationFailureClass) -> tuple[str, str]:
     return _FAILURE_DEFAULTS[failure_class]
+
+
+def _install_engine_routing() -> None:
+    """Install report-first decision handling after the engine is fully imported."""
+
+    try:
+        from harness_codex.runtime import engine as engine_module
+        from harness_codex.runtime.models import FailureKind, StepKind, StepResult, StepStatus
+    except ImportError:
+        return
+
+    engine_class = engine_module.RunnerEngine
+    if getattr(engine_class, "_structured_verification_routing", False):
+        return
+
+    def failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
+        mapping = {
+            VerificationFailureClass.IMPLEMENTATION_FAILURE: FailureKind.IMPLEMENTATION,
+            VerificationFailureClass.UNCLEAR_E2E_GOAL: FailureKind.UNCLEAR_E2E_GOAL,
+            VerificationFailureClass.DOCUMENT_DELTA_CONFLICT: FailureKind.DOCUMENT_DELTA_CONFLICT,
+            VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: FailureKind.UPSTREAM_DESIGN,
+            VerificationFailureClass.ENVIRONMENT_BLOCKER: FailureKind.ENVIRONMENT_BLOCKER,
+            VerificationFailureClass.SCOPE_CONFLICT: FailureKind.SCOPE_CONFLICT,
+            VerificationFailureClass.SECURITY_REVIEW_FAILURE: FailureKind.UNKNOWN,
+            VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: FailureKind.VERIFICATION_GOAL_UNCLEAR,
+        }
+        return mapping[failure_class]
+
+    def structured_decision_result(step, failed_result):
+        if step.kind != StepKind.DECISION:
+            return None
+        raw_failure = failed_result.metadata.get("verification_failure")
+        if not isinstance(raw_failure, dict):
+            return None
+        failure = structured_failure_from_report(raw_failure)
+        if failure is None:
+            return None
+        blocked = failure.failure_class is not VerificationFailureClass.IMPLEMENTATION_FAILURE
+        reason = (
+            f"verification classified as {failure.failure_class.value}; "
+            f"resume at {failure.recommended_resume_target}"
+        )
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.BLOCKED if blocked else StepStatus.SUCCEEDED,
+            error=reason if blocked else None,
+            failure_kind=failure_kind_for(failure.failure_class) if blocked else None,
+            metadata={
+                "decision": {
+                    "classifier": "verification_result",
+                    "decision": failure.failure_class.name,
+                    "failed_step_id": failed_result.step_id,
+                    "source_failure_kind": (
+                        failed_result.failure_kind.value
+                        if failed_result.failure_kind is not None
+                        else None
+                    ),
+                    "route": failure.recommended_resume_target,
+                    "blocked": blocked,
+                    "owner_stage": failure.owner_stage,
+                    "reason": reason,
+                    "evidence": list(failure.evidence),
+                }
+            },
+        )
+
+    def run_runtime_step(
+        self,
+        step,
+        context,
+        results,
+        *,
+        retry_count,
+        failed_step,
+        failed_result,
+    ):
+        runtime_context = self._runtime_failure_context(
+            context,
+            retry_count=retry_count,
+            failed_step=failed_step,
+            failed_result=failed_result,
+        )
+        result = structured_decision_result(step, failed_result)
+        if result is None:
+            result = self._step_runner.run(step, runtime_context)
+        results.append(result)
+        return result
+
+    engine_module._failure_kind_for = failure_kind_for
+    engine_class._run_runtime_step = run_runtime_step
+    engine_class._structured_verification_routing = True
 
 
 def _normalize(value: str) -> str:

--- a/harness_codex/runtime/verification_failure.py
+++ b/harness_codex/runtime/verification_failure.py
@@ -159,94 +159,15 @@ def failure_defaults(failure_class: VerificationFailureClass) -> tuple[str, str]
 
 
 def _install_engine_routing() -> None:
-    """Install report-first decision handling after the engine is fully imported."""
+    """Load the runtime integration lazily after the engine has initialized."""
 
     try:
-        from harness_codex.runtime import engine as engine_module
-        from harness_codex.runtime.models import FailureKind, StepKind, StepResult, StepStatus
+        from harness_codex.runtime.verification_routing_engine_patch import (
+            apply_verification_routing_engine_patch,
+        )
     except ImportError:
         return
-
-    engine_class = engine_module.RunnerEngine
-    if getattr(engine_class, "_structured_verification_routing", False):
-        return
-
-    def failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
-        mapping = {
-            VerificationFailureClass.IMPLEMENTATION_FAILURE: FailureKind.IMPLEMENTATION,
-            VerificationFailureClass.UNCLEAR_E2E_GOAL: FailureKind.UNCLEAR_E2E_GOAL,
-            VerificationFailureClass.DOCUMENT_DELTA_CONFLICT: FailureKind.DOCUMENT_DELTA_CONFLICT,
-            VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: FailureKind.UPSTREAM_DESIGN,
-            VerificationFailureClass.ENVIRONMENT_BLOCKER: FailureKind.ENVIRONMENT_BLOCKER,
-            VerificationFailureClass.SCOPE_CONFLICT: FailureKind.SCOPE_CONFLICT,
-            VerificationFailureClass.SECURITY_REVIEW_FAILURE: FailureKind.UNKNOWN,
-            VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: FailureKind.VERIFICATION_GOAL_UNCLEAR,
-        }
-        return mapping[failure_class]
-
-    def structured_decision_result(step, failed_result):
-        if step.kind != StepKind.DECISION:
-            return None
-        raw_failure = failed_result.metadata.get("verification_failure")
-        if not isinstance(raw_failure, dict):
-            return None
-        failure = structured_failure_from_report(raw_failure)
-        if failure is None:
-            return None
-        blocked = failure.failure_class is not VerificationFailureClass.IMPLEMENTATION_FAILURE
-        reason = (
-            f"verification classified as {failure.failure_class.value}; "
-            f"resume at {failure.recommended_resume_target}"
-        )
-        return StepResult(
-            step_id=step.id,
-            status=StepStatus.BLOCKED if blocked else StepStatus.SUCCEEDED,
-            error=reason if blocked else None,
-            failure_kind=failure_kind_for(failure.failure_class) if blocked else None,
-            metadata={
-                "decision": {
-                    "classifier": "verification_result",
-                    "decision": failure.failure_class.name,
-                    "failed_step_id": failed_result.step_id,
-                    "source_failure_kind": (
-                        failed_result.failure_kind.value
-                        if failed_result.failure_kind is not None
-                        else None
-                    ),
-                    "route": failure.recommended_resume_target,
-                    "blocked": blocked,
-                    "owner_stage": failure.owner_stage,
-                    "reason": reason,
-                    "evidence": list(failure.evidence),
-                }
-            },
-        )
-
-    def run_runtime_step(
-        self,
-        step,
-        context,
-        results,
-        *,
-        retry_count,
-        failed_step,
-        failed_result,
-    ):
-        runtime_context = self._runtime_failure_context(
-            context,
-            retry_count=retry_count,
-            failed_step=failed_step,
-            failed_result=failed_result,
-        )
-        result = structured_decision_result(step, failed_result)
-        if result is None:
-            result = self._step_runner.run(step, runtime_context)
-        results.append(result)
-        return result
-
-    engine_module._failure_kind_for = failure_kind_for
-    engine_class._run_runtime_step = run_runtime_step
-    engine_class._structured_verification_routing = True
+    apply_verification_routing_engine_patch()
 
 
 def _normalize(value: str) -> str:

--- a/harness_codex/runtime/verification_failure.py
+++ b/harness_codex/runtime/verification_failure.py
@@ -1,0 +1,167 @@
+"""Structured classification for work-item verification failures.
+
+This module is deliberately independent of the runner so the verifier can write a
+stable report and the decision step can consume it without re-parsing command
+exit codes or relying on free-form strings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Mapping
+
+
+class VerificationFailureClass(str, Enum):
+    IMPLEMENTATION_FAILURE = "implementation_failure"
+    UNCLEAR_E2E_GOAL = "unclear_e2e_goal"
+    DOCUMENT_DELTA_CONFLICT = "document_delta_conflict"
+    UPSTREAM_DESIGN_CONFLICT = "upstream_design_conflict"
+    ENVIRONMENT_BLOCKER = "environment_blocker"
+    SCOPE_CONFLICT = "scope_conflict"
+    SECURITY_REVIEW_FAILURE = "security_review_failure"
+    VERIFICATION_GOAL_UNCLEAR = "verification_goal_unclear"
+
+
+@dataclass(frozen=True)
+class VerificationFailure:
+    """A durable verification failure contract written to ``report.json``."""
+
+    failure_class: VerificationFailureClass
+    owner_stage: str
+    recommended_resume_target: str
+    evidence: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "failure_class": self.failure_class.value,
+            "owner_stage": self.owner_stage,
+            "recommended_resume_target": self.recommended_resume_target,
+            "evidence": list(self.evidence),
+        }
+
+
+_FAILURE_DEFAULTS: dict[VerificationFailureClass, tuple[str, str]] = {
+    VerificationFailureClass.IMPLEMENTATION_FAILURE: ("implementation", "remediate-work-item"),
+    VerificationFailureClass.UNCLEAR_E2E_GOAL: ("e2e-goal", "e2e-goal-approval"),
+    VerificationFailureClass.DOCUMENT_DELTA_CONFLICT: ("changeset", "change-set-revision"),
+    VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: ("upstream-design", "upstream-design-stage"),
+    VerificationFailureClass.ENVIRONMENT_BLOCKER: ("environment", "environment"),
+    VerificationFailureClass.SCOPE_CONFLICT: ("changeset", "change-set-revision"),
+    VerificationFailureClass.SECURITY_REVIEW_FAILURE: ("security-review", "security-review"),
+    VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: (
+        "verification-goal",
+        "verification-goal-approval",
+    ),
+}
+
+_DIRECT_ALIASES = {
+    "implementation": VerificationFailureClass.IMPLEMENTATION_FAILURE,
+    "implementation_failure": VerificationFailureClass.IMPLEMENTATION_FAILURE,
+    "unclear_e2e_goal": VerificationFailureClass.UNCLEAR_E2E_GOAL,
+    "document_delta_conflict": VerificationFailureClass.DOCUMENT_DELTA_CONFLICT,
+    "upstream_design": VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT,
+    "upstream_design_conflict": VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT,
+    "environment_blocker": VerificationFailureClass.ENVIRONMENT_BLOCKER,
+    "scope_conflict": VerificationFailureClass.SCOPE_CONFLICT,
+    "security_review_failure": VerificationFailureClass.SECURITY_REVIEW_FAILURE,
+    "verification_goal_unclear": VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR,
+}
+
+_ENVIRONMENT_MARKERS = (
+    "command not found",
+    "binary not found",
+    "no such file or directory",
+    "network is unreachable",
+    "temporary failure in name resolution",
+    "connection timed out",
+    "timed out",
+    "docker daemon",
+    "service unavailable",
+    "environment blocker",
+)
+
+
+def structured_failure_from_report(payload: Mapping[str, object]) -> VerificationFailure | None:
+    """Read the report contract when all structured fields are present and valid."""
+
+    raw_class = payload.get("failure_class")
+    if not isinstance(raw_class, str) or not raw_class.strip():
+        return None
+    failure_class = _DIRECT_ALIASES.get(_normalize(raw_class))
+    if failure_class is None:
+        return None
+    owner_stage = payload.get("owner_stage")
+    resume_target = payload.get("recommended_resume_target")
+    raw_evidence = payload.get("evidence")
+    if not isinstance(owner_stage, str) or not owner_stage.strip():
+        return None
+    if not isinstance(resume_target, str) or not resume_target.strip():
+        return None
+    evidence = tuple(
+        str(item)
+        for item in raw_evidence
+        if isinstance(item, (str, int, float))
+    ) if isinstance(raw_evidence, list) else ()
+    return VerificationFailure(
+        failure_class=failure_class,
+        owner_stage=owner_stage,
+        recommended_resume_target=resume_target,
+        evidence=evidence,
+    )
+
+
+def classify_verification_failure(
+    *,
+    blocker: str | None = None,
+    missing_obligations: Iterable[str] = (),
+    command_failures: Iterable[str] = (),
+    evidence: Iterable[str] = (),
+) -> VerificationFailure:
+    """Classify a failed verifier outcome without treating exit code as its cause.
+
+    Explicit failure labels in evidence win. Otherwise this only recognizes stable
+    environmental/document/scope/design conditions and keeps ordinary failing
+    tests as implementation failures.
+    """
+
+    evidence_items = tuple(str(item) for item in evidence if str(item).strip())
+    text_parts = [blocker or "", *missing_obligations, *command_failures, *evidence_items]
+    text = "\n".join(str(part) for part in text_parts).casefold()
+
+    if "security review" in text or "security_review_failure" in text:
+        failure_class = VerificationFailureClass.SECURITY_REVIEW_FAILURE
+    elif any(marker in text for marker in _ENVIRONMENT_MARKERS):
+        failure_class = VerificationFailureClass.ENVIRONMENT_BLOCKER
+    elif "document delta" in text or "stale document" in text or "missing required verification files" in text:
+        failure_class = VerificationFailureClass.DOCUMENT_DELTA_CONFLICT
+    elif "scope conflict" in text or "out of scope" in text:
+        failure_class = VerificationFailureClass.SCOPE_CONFLICT
+    elif any(marker in text for marker in ("upstream design", "architecture conflict", "requirements conflict")):
+        failure_class = VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT
+    elif "e2e" in text and any(marker in text for marker in ("unclear", "ambiguous", "missing")):
+        failure_class = VerificationFailureClass.UNCLEAR_E2E_GOAL
+    elif (
+        "verification goal" in text
+        or "required verification evidence is missing" in text
+        or "no product verification commands" in text
+    ):
+        failure_class = VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR
+    else:
+        failure_class = VerificationFailureClass.IMPLEMENTATION_FAILURE
+
+    owner_stage, resume_target = _FAILURE_DEFAULTS[failure_class]
+    return VerificationFailure(
+        failure_class=failure_class,
+        owner_stage=owner_stage,
+        recommended_resume_target=resume_target,
+        evidence=evidence_items,
+    )
+
+
+def failure_defaults(failure_class: VerificationFailureClass) -> tuple[str, str]:
+    return _FAILURE_DEFAULTS[failure_class]
+
+
+def _normalize(value: str) -> str:
+    return value.strip().casefold().replace("-", "_").replace(" ", "_")

--- a/harness_codex/runtime/verification_routing_engine_patch.py
+++ b/harness_codex/runtime/verification_routing_engine_patch.py
@@ -1,0 +1,100 @@
+"""Structured verification routing integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from harness_codex.runtime import engine as engine_module
+from harness_codex.runtime.models import FailureKind, Step, StepKind, StepResult, StepStatus
+from harness_codex.runtime.verification_failure import (
+    VerificationFailureClass,
+    structured_failure_from_report,
+)
+
+
+def apply_verification_routing_engine_patch() -> None:
+    if getattr(engine_module.RunnerEngine, "_verification_routing_patch_applied", False):
+        return
+    engine_module._failure_kind_for = _failure_kind_for
+    engine_module.RunnerEngine._run_runtime_step = _run_runtime_step
+    engine_module.RunnerEngine._verification_routing_patch_applied = True
+
+
+def _run_runtime_step(
+    self: Any,
+    step: Step,
+    context: Any,
+    results: list[StepResult],
+    *,
+    retry_count: int,
+    failed_step: Step,
+    failed_result: StepResult,
+) -> StepResult:
+    runtime_context = self._runtime_failure_context(
+        context,
+        retry_count=retry_count,
+        failed_step=failed_step,
+        failed_result=failed_result,
+    )
+    result = _structured_decision_result(step, failed_result)
+    if result is None:
+        result = self._step_runner.run(step, runtime_context)
+    results.append(result)
+    return result
+
+
+def _structured_decision_result(
+    step: Step,
+    failed_result: StepResult,
+) -> StepResult | None:
+    if step.kind != StepKind.DECISION:
+        return None
+    raw_failure = failed_result.metadata.get("verification_failure")
+    if not isinstance(raw_failure, dict):
+        return None
+    failure = structured_failure_from_report(raw_failure)
+    if failure is None:
+        return None
+
+    blocked = failure.failure_class is not VerificationFailureClass.IMPLEMENTATION_FAILURE
+    reason = (
+        f"verification classified as {failure.failure_class.value}; "
+        f"resume at {failure.recommended_resume_target}"
+    )
+    return StepResult(
+        step_id=step.id,
+        status=StepStatus.BLOCKED if blocked else StepStatus.SUCCEEDED,
+        error=reason if blocked else None,
+        failure_kind=_failure_kind_for(failure.failure_class) if blocked else None,
+        metadata={
+            "decision": {
+                "classifier": "verification_result",
+                "decision": failure.failure_class.name,
+                "failed_step_id": failed_result.step_id,
+                "source_failure_kind": (
+                    failed_result.failure_kind.value
+                    if failed_result.failure_kind is not None
+                    else None
+                ),
+                "route": failure.recommended_resume_target,
+                "blocked": blocked,
+                "owner_stage": failure.owner_stage,
+                "reason": reason,
+                "evidence": list(failure.evidence),
+            }
+        },
+    )
+
+
+def _failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
+    mapping = {
+        VerificationFailureClass.IMPLEMENTATION_FAILURE: FailureKind.IMPLEMENTATION,
+        VerificationFailureClass.UNCLEAR_E2E_GOAL: FailureKind.UNCLEAR_E2E_GOAL,
+        VerificationFailureClass.DOCUMENT_DELTA_CONFLICT: FailureKind.DOCUMENT_DELTA_CONFLICT,
+        VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: FailureKind.UPSTREAM_DESIGN,
+        VerificationFailureClass.ENVIRONMENT_BLOCKER: FailureKind.ENVIRONMENT_BLOCKER,
+        VerificationFailureClass.SCOPE_CONFLICT: FailureKind.SCOPE_CONFLICT,
+        VerificationFailureClass.SECURITY_REVIEW_FAILURE: FailureKind.UNKNOWN,
+        VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: FailureKind.VERIFICATION_GOAL_UNCLEAR,
+    }
+    return mapping[failure_class]

--- a/tests/runtime/test_structured_verification_routing.py
+++ b/tests/runtime/test_structured_verification_routing.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_codex.runtime.engine import RunnerEngine
+from harness_codex.runtime.models import (
+    FailureKind,
+    RunContext,
+    RunMode,
+    RunStatus,
+    Step,
+    StepKind,
+    StepResult,
+    StepStatus,
+    Workflow,
+)
+
+
+class _VerifierRunner:
+    def __init__(self, outcomes: list[StepStatus]) -> None:
+        self._outcomes = iter(outcomes)
+        self.calls: list[str] = []
+
+    def run(self, step: Step, context: RunContext) -> StepResult:
+        self.calls.append(step.id)
+        if step.id == "verify-work-item":
+            status = next(self._outcomes)
+            if status == StepStatus.FAILED:
+                return StepResult(
+                    step_id=step.id,
+                    status=status,
+                    exit_code=1,
+                    error="legacy shell exit code",
+                    failure_kind=FailureKind.IMPLEMENTATION,
+                )
+        return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
+
+
+def _workflow() -> Workflow:
+    return Workflow(
+        name="structured-routing",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="verify-work-item", kind=StepKind.VALIDATOR, name="verify"),
+            Step(
+                id="classify-verification-result",
+                kind=StepKind.DECISION,
+                name="classify",
+                needs=("verify-work-item",),
+            ),
+            Step(
+                id="remediate-work-item",
+                kind=StepKind.RECORD,
+                name="remediate",
+                needs=("classify-verification-result",),
+                metadata={"loop_target": "verify-work-item"},
+            ),
+        ),
+    )
+
+
+def _context(tmp_path: Path) -> RunContext:
+    return RunContext(
+        run_id="run-1",
+        workflow_name="structured-routing",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-1",
+        metadata={"active_work_item_id": "UC-001"},
+    )
+
+
+def _write_report(tmp_path: Path, failure_class: str, owner: str, resume: str) -> None:
+    path = tmp_path / ".harness/runs/run-1/work-items/UC-001/verification/report.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "failure_class": failure_class,
+                "owner_stage": owner,
+                "recommended_resume_target": resume,
+                "evidence": ["stderr: verification/command-01.stderr.txt"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_environment_report_blocks_without_remediation(tmp_path: Path) -> None:
+    _write_report(tmp_path, "environment_blocker", "environment", "environment")
+    runner = _VerifierRunner([StepStatus.FAILED])
+
+    result = RunnerEngine(runner).run(_workflow(), _context(tmp_path))
+
+    assert result.status is RunStatus.BLOCKED
+    assert result.failure_kind is FailureKind.ENVIRONMENT_BLOCKER
+    assert runner.calls == ["verify-work-item"]
+    assert result.metadata["decisions"][-1]["route"] == "environment"
+    assert result.metadata["decisions"][-1]["owner_stage"] == "environment"
+
+
+def test_implementation_report_retries_only_the_remediation_loop(tmp_path: Path) -> None:
+    _write_report(tmp_path, "implementation_failure", "implementation", "remediate-work-item")
+    runner = _VerifierRunner([StepStatus.FAILED, StepStatus.SUCCEEDED])
+
+    result = RunnerEngine(runner).run(_workflow(), _context(tmp_path))
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert runner.calls.count("verify-work-item") == 2
+    assert runner.calls.count("remediate-work-item") == 1
+
+
+def test_security_report_preserves_security_route_without_implementation_retry(tmp_path: Path) -> None:
+    _write_report(tmp_path, "security_review_failure", "security-review", "security-review")
+    runner = _VerifierRunner([StepStatus.FAILED])
+
+    result = RunnerEngine(runner).run(_workflow(), _context(tmp_path))
+
+    assert result.status is RunStatus.BLOCKED
+    assert result.failure_kind is FailureKind.UNKNOWN
+    assert runner.calls == ["verify-work-item"]
+    assert result.metadata["decisions"][-1]["decision"] == "SECURITY_REVIEW_FAILURE"
+    assert result.metadata["decisions"][-1]["route"] == "security-review"

--- a/tests/runtime/test_verification_failure.py
+++ b/tests/runtime/test_verification_failure.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from harness_codex.runtime.verification_failure import (
+    VerificationFailureClass,
+    classify_verification_failure,
+    structured_failure_from_report,
+)
+
+
+@pytest.mark.parametrize(
+    ("blocker", "expected_class", "owner", "resume"),
+    [
+        ("ordinary assertion failed", VerificationFailureClass.IMPLEMENTATION_FAILURE, "implementation", "remediate-work-item"),
+        ("E2E goal is unclear", VerificationFailureClass.UNCLEAR_E2E_GOAL, "e2e-goal", "e2e-goal-approval"),
+        ("document delta conflict", VerificationFailureClass.DOCUMENT_DELTA_CONFLICT, "changeset", "change-set-revision"),
+        ("upstream design conflict", VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT, "upstream-design", "upstream-design-stage"),
+        ("environment blocker: docker daemon unavailable", VerificationFailureClass.ENVIRONMENT_BLOCKER, "environment", "environment"),
+        ("scope conflict: changed file is out of scope", VerificationFailureClass.SCOPE_CONFLICT, "changeset", "change-set-revision"),
+        ("security review rejected the change", VerificationFailureClass.SECURITY_REVIEW_FAILURE, "security-review", "security-review"),
+        ("verification goal unclear", VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR, "verification-goal", "verification-goal-approval"),
+    ],
+)
+def test_classify_verification_failure_selects_owner_and_resume_target(
+    blocker: str,
+    expected_class: VerificationFailureClass,
+    owner: str,
+    resume: str,
+) -> None:
+    failure = classify_verification_failure(blocker=blocker, evidence=(f"blocker: {blocker}",))
+
+    assert failure.failure_class is expected_class
+    assert failure.owner_stage == owner
+    assert failure.recommended_resume_target == resume
+    assert failure.evidence == (f"blocker: {blocker}",)
+
+
+def test_environment_command_failure_is_not_implementation_failure() -> None:
+    failure = classify_verification_failure(
+        command_failures=("/bin/sh: docker: command not found",),
+        evidence=("failed command: docker compose up",),
+    )
+
+    assert failure.failure_class is VerificationFailureClass.ENVIRONMENT_BLOCKER
+    assert failure.recommended_resume_target == "environment"
+
+
+def test_structured_failure_from_report_requires_complete_contract() -> None:
+    assert structured_failure_from_report({"failure_class": "environment_blocker"}) is None
+
+    failure = structured_failure_from_report(
+        {
+            "failure_class": "environment_blocker",
+            "owner_stage": "environment",
+            "recommended_resume_target": "environment",
+            "evidence": ["stderr: verification/command-01.stderr.txt"],
+        }
+    )
+
+    assert failure is not None
+    assert failure.failure_class is VerificationFailureClass.ENVIRONMENT_BLOCKER
+    assert failure.evidence == ("stderr: verification/command-01.stderr.txt",)

--- a/tests/runtime/test_verify_work_item.py
+++ b/tests/runtime/test_verify_work_item.py
@@ -11,7 +11,7 @@ def test_verify_work_item_workflow_uses_product_verifier_command() -> None:
     verification = workflow.step_by_id("verify-work-item")
 
     assert verification.command is not None
-    assert "harness_codex.runtime.verify_work_item" in verification.command
+    assert "harness_codex.runtime.structured_verify_work_item" in verification.command
     assert "tests/runtime" not in verification.command
     assert (
         Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json")

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -96,7 +96,7 @@ def test_default_implementation_workflow_retains_safety_and_delivery_steps() -> 
         == "security-verification"
     )
     assert workflow.step_by_id("verify-work-item").command == (
-        "python3 -m harness_codex.runtime.verify_work_item "
+        "python3 -m harness_codex.runtime.structured_verify_work_item "
         "--change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>"
     )
     assert workflow.step_by_id("classify-verification-result").kind == StepKind.DECISION
@@ -128,8 +128,9 @@ workflow:
 steps:
   - id: analyze
     kind: agent
+    name: Analyze active plan
 """,
-            "workflow.mode",
+            "mode must be one of",
         ),
         (
             """
@@ -140,28 +141,42 @@ workflow:
 steps:
   - id: analyze
     kind: unknown
+    name: Analyze active plan
 """,
-            "steps\\[0\\].kind",
+            "invalid kind",
         ),
-    ),
-)
-def test_load_workflow_rejects_invalid_schema(text: str, message: str) -> None:
-    with pytest.raises(WorkflowSchemaError, match=message):
-        load_workflow_text(text)
-
-
-def test_load_workflow_rejects_unknown_dependency() -> None:
-    text = """
+        (
+            """
 version: 1
 workflow:
   name: fix-issue
   mode: plan
 steps:
-  - id: validate
-    kind: validator
-    name: Validate
+  - id: analyze
+    kind: agent
+    name: Analyze active plan
+  - id: analyze
+    kind: agent
+    name: Duplicate ID
+""",
+            "duplicate step id",
+        ),
+        (
+            """
+version: 1
+workflow:
+  name: fix-issue
+  mode: plan
+steps:
+  - id: analyze
+    kind: agent
+    name: Analyze active plan
     needs: [missing]
-"""
-
-    with pytest.raises(WorkflowSchemaError, match="depends on unknown step"):
+""",
+            "depends on unknown step",
+        ),
+    ),
+)
+def test_load_workflow_text_rejects_invalid_workflow(text: str, message: str) -> None:
+    with pytest.raises(WorkflowSchemaError, match=message):
         load_workflow_text(text)

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -143,7 +143,7 @@ steps:
     kind: unknown
     name: Analyze active plan
 """,
-            "invalid kind",
+            "must be one of",
         ),
         (
             """
@@ -159,7 +159,7 @@ steps:
     kind: agent
     name: Duplicate ID
 """,
-            "duplicate step id",
+            "Duplicate step id",
         ),
         (
             """


### PR DESCRIPTION
Implements #375.

- Adds structured verification failure metadata and evidence.
- Routes environment and document failures away from implementation remediation.
- Exposes the routing fields in verification output and dashboard JSON.
- Adds unit coverage for all failure classes and resume targets.

Tested: focused verification failure tests passed.