### PR TITLE
fix(verification): persist structured failure-routing decisions

### DIFF
--- a/harness_codex/runtime/verification_routing_engine_patch.py
+++ b/harness_codex/runtime/verification_routing_engine_patch.py
@@ -77,6 +77,7 @@ def _structured_decision_result(
     decision = {
         "classifier": "verification_result",
         "decision": failure.failure_class.name,
+        "failure_class": failure.failure_class.value,
         "failed_step_id": failed_result.step_id,
         "source_failure_kind": (
             failed_result.failure_kind.value
@@ -84,6 +85,7 @@ def _structured_decision_result(
             else None
         ),
         "route": failure.recommended_resume_target,
+        "recommended_resume_target": failure.recommended_resume_target,
         "blocked": blocked,
         "owner_stage": failure.owner_stage,
         "reason": reason,

--- a/harness_codex/runtime/verification_routing_engine_patch.py
+++ b/harness_codex/runtime/verification_routing_engine_patch.py
@@ -1,7 +1,15 @@
-"""Structured verification routing integration."""
+"""Structured verification routing integration.
+
+The runtime engine reads the verifier's durable JSON report before it decides
+whether a failed work item is eligible for implementation remediation.  This
+compatibility layer keeps that routing available to the current engine while
+also persisting the decision as a first-class run artifact.
+"""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 from harness_codex.runtime import engine as engine_module
@@ -13,6 +21,8 @@ from harness_codex.runtime.verification_failure import (
 
 
 def apply_verification_routing_engine_patch() -> None:
+    """Install structured-report routing once after the engine is importable."""
+
     if getattr(engine_module.RunnerEngine, "_verification_routing_patch_applied", False):
         return
     engine_module._failure_kind_for = _failure_kind_for
@@ -36,7 +46,7 @@ def _run_runtime_step(
         failed_step=failed_step,
         failed_result=failed_result,
     )
-    result = _structured_decision_result(step, failed_result)
+    result = _structured_decision_result(step, runtime_context, failed_result)
     if result is None:
         result = self._step_runner.run(step, runtime_context)
     results.append(result)
@@ -45,8 +55,11 @@ def _run_runtime_step(
 
 def _structured_decision_result(
     step: Step,
+    context: Any,
     failed_result: StepResult,
 ) -> StepResult | None:
+    """Route a verifier failure without falling back to an exit-code guess."""
+
     if step.kind != StepKind.DECISION:
         return None
     raw_failure = failed_result.metadata.get("verification_failure")
@@ -61,29 +74,58 @@ def _structured_decision_result(
         f"verification classified as {failure.failure_class.value}; "
         f"resume at {failure.recommended_resume_target}"
     )
+    decision = {
+        "classifier": "verification_result",
+        "decision": failure.failure_class.name,
+        "failed_step_id": failed_result.step_id,
+        "source_failure_kind": (
+            failed_result.failure_kind.value
+            if failed_result.failure_kind is not None
+            else None
+        ),
+        "route": failure.recommended_resume_target,
+        "blocked": blocked,
+        "owner_stage": failure.owner_stage,
+        "reason": reason,
+        "evidence": list(failure.evidence),
+    }
+    evidence_path = _write_decision_evidence(context, step, decision)
     return StepResult(
         step_id=step.id,
         status=StepStatus.BLOCKED if blocked else StepStatus.SUCCEEDED,
+        output_path=_relative_to_repo(evidence_path, context),
         error=reason if blocked else None,
         failure_kind=_failure_kind_for(failure.failure_class) if blocked else None,
         metadata={
-            "decision": {
-                "classifier": "verification_result",
-                "decision": failure.failure_class.name,
-                "failed_step_id": failed_result.step_id,
-                "source_failure_kind": (
-                    failed_result.failure_kind.value
-                    if failed_result.failure_kind is not None
-                    else None
-                ),
-                "route": failure.recommended_resume_target,
-                "blocked": blocked,
-                "owner_stage": failure.owner_stage,
-                "reason": reason,
-                "evidence": list(failure.evidence),
-            }
+            "decision": decision,
+            "verification_failure": failure.as_dict(),
         },
     )
+
+
+def _write_decision_evidence(context: Any, step: Step, decision: dict[str, object]) -> Path:
+    """Persist the decision so CLI, reports, and dashboard agree on the route."""
+
+    path = context.run_dir / "steps" / step.id / "decision.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "step_id": step.id,
+        "work_item_id": context.metadata.get("active_work_item_id"),
+        "change_set_id": context.metadata.get("change_set_id"),
+        **decision,
+    }
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _relative_to_repo(path: Path, context: Any) -> Path:
+    try:
+        return path.relative_to(context.repo_root)
+    except ValueError:
+        return path
 
 
 def _failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
@@ -94,6 +136,8 @@ def _failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
         VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: FailureKind.UPSTREAM_DESIGN,
         VerificationFailureClass.ENVIRONMENT_BLOCKER: FailureKind.ENVIRONMENT_BLOCKER,
         VerificationFailureClass.SCOPE_CONFLICT: FailureKind.SCOPE_CONFLICT,
+        # The public decision payload retains the explicit security class.  The
+        # current generic runtime enum intentionally treats it as non-retriable.
         VerificationFailureClass.SECURITY_REVIEW_FAILURE: FailureKind.UNKNOWN,
         VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: FailureKind.VERIFICATION_GOAL_UNCLEAR,
     }

--- a/tests/runtime/test_structured_verification_routing.py
+++ b/tests/runtime/test_structured_verification_routing.py
@@ -97,8 +97,20 @@ def test_environment_report_blocks_without_remediation(tmp_path: Path) -> None:
     assert result.status is RunStatus.BLOCKED
     assert result.failure_kind is FailureKind.ENVIRONMENT_BLOCKER
     assert runner.calls == ["verify-work-item"]
-    assert result.metadata["decisions"][-1]["route"] == "environment"
-    assert result.metadata["decisions"][-1]["owner_stage"] == "environment"
+    decision = result.metadata["decisions"][-1]
+    assert decision["route"] == "environment"
+    assert decision["owner_stage"] == "environment"
+    assert decision["evidence"] == ["stderr: verification/command-01.stderr.txt"]
+
+    decision_path = (
+        tmp_path
+        / ".harness/runs/run-1/steps/classify-verification-result/decision.json"
+    )
+    payload = json.loads(decision_path.read_text(encoding="utf-8"))
+    assert payload["decision"] == "ENVIRONMENT_BLOCKER"
+    assert payload["route"] == "environment"
+    assert payload["owner_stage"] == "environment"
+    assert payload["evidence"] == ["stderr: verification/command-01.stderr.txt"]
 
 
 def test_implementation_report_retries_only_the_remediation_loop(tmp_path: Path) -> None:

--- a/tests/runtime/test_structured_verification_routing.py
+++ b/tests/runtime/test_structured_verification_routing.py
@@ -98,7 +98,9 @@ def test_environment_report_blocks_without_remediation(tmp_path: Path) -> None:
     assert result.failure_kind is FailureKind.ENVIRONMENT_BLOCKER
     assert runner.calls == ["verify-work-item"]
     decision = result.metadata["decisions"][-1]
+    assert decision["failure_class"] == "environment_blocker"
     assert decision["route"] == "environment"
+    assert decision["recommended_resume_target"] == "environment"
     assert decision["owner_stage"] == "environment"
     assert decision["evidence"] == ["stderr: verification/command-01.stderr.txt"]
 
@@ -107,8 +109,10 @@ def test_environment_report_blocks_without_remediation(tmp_path: Path) -> None:
         / ".harness/runs/run-1/steps/classify-verification-result/decision.json"
     )
     payload = json.loads(decision_path.read_text(encoding="utf-8"))
+    assert payload["failure_class"] == "environment_blocker"
     assert payload["decision"] == "ENVIRONMENT_BLOCKER"
     assert payload["route"] == "environment"
+    assert payload["recommended_resume_target"] == "environment"
     assert payload["owner_stage"] == "environment"
     assert payload["evidence"] == ["stderr: verification/command-01.stderr.txt"]
 


### PR DESCRIPTION
Closes #375.

## 변경 내용
- structured verification report를 우선 사용해 decision 결과를 만들 때, `decision.json`을 run artifact로 항상 기록합니다.
- decision artifact에 실패 유형, 담당 stage, 재개 대상, 증거를 함께 저장합니다.
- 환경/문서/보안 등 implementation 이외의 실패는 remediation task를 만들지 않고 해당 resume target으로 BLOCKED 처리되는 기존 계약을 회귀 테스트로 고정합니다.

## 검증
- `tests/runtime/test_structured_verification_routing.py`
  - environment blocker가 remediation으로 들어가지 않음
  - implementation failure만 remediation loop로 재시도됨
  - security review failure가 security stage route를 유지함
  - structured decision artifact가 durable JSON으로 저장됨

## 비고
기존 report/dashboard 필드는 유지하며, 이번 변경은 runner가 structured report를 처리할 때 해당 결정을 파일 증거로 남기지 않던 간극을 보완합니다.