### PR TITLE
fix(runtime): split work-item execution from ChangeSet finalization

### DIFF
--- a/.harness/workflows/changeset-finalization-workflow.yaml
+++ b/.harness/workflows/changeset-finalization-workflow.yaml
@@ -1,0 +1,49 @@
+version: 1
+workflow:
+  name: changeset-finalization-workflow
+  mode: apply
+  description: Deliver and complete a ChangeSet only after all work-item plans are completed.
+sandbox:
+  kind: worktree
+steps:
+- id: verify-all-work-items-completed
+  kind: record
+  name: Confirm every affected work item has a completed plan
+  inputs:
+  - docs/changes/active/<CHG-ID>.md
+  metadata:
+    stage: delivery
+    scope: change_set
+    execution_boundary: changeset_finalization
+    condition: all_affected_work_item_plans_completed
+- id: create-change-set-pr
+  kind: git
+  name: Commit, push, and create or reuse the ChangeSet pull request
+  command: python3 -m harness_codex.runtime.change_set_pr_delivery --change-set <CHG-ID> --run-id <RUN-ID>
+  needs:
+  - verify-all-work-items-completed
+  outputs:
+  - .harness/runs/<RUN-ID>/pull-request.json
+  metadata:
+    stage: delivery
+    scope: change_set
+    execution_boundary: changeset_finalization
+    approval_env: HARNESS_DELIVERY_APPROVED
+    fail_closed: true
+- id: complete-change-set
+  kind: git
+  name: Complete active ChangeSet after delivery succeeds
+  command: python3 -m harness_codex.runtime.change_set_completion_delivery --change-set <CHG-ID> --run-id <RUN-ID>
+  needs:
+  - create-change-set-pr
+  inputs:
+  - docs/changes/active/<CHG-ID>.md
+  outputs:
+  - docs/changes/completed/<CHG-ID>.md
+  - .harness/runs/<RUN-ID>/changeset-completion-report.md
+  metadata:
+    stage: delivery
+    scope: change_set
+    execution_boundary: changeset_finalization
+    approval_env: HARNESS_DELIVERY_APPROVED
+    fail_closed: true

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -1,8 +1,8 @@
 version: 1
 workflow:
-  name: changeset-use-case-workflow
+  name: changeset-work-item-workflow
   mode: apply
-  description: Internal executor for README implementation and final delivery.
+  description: Execute one selected ChangeSet work item through plan completion only.
 sandbox:
   kind: worktree
 steps:
@@ -13,7 +13,8 @@ steps:
   - docs/changes/active
   metadata:
     stage: implementation
-    scope: change_set
+    scope: work_item
+    execution_boundary: work_item
 - id: plan-work-item
   kind: agent
   name: Create or update the selected work item implementation plan
@@ -30,6 +31,7 @@ steps:
     stage: plan-writing
     prompt_context_profile: plan
     scope: work_item
+    execution_boundary: work_item
     inputs_resolved_by: work_item_document_contract
 - id: secure-work-item-plan
   kind: agent
@@ -48,6 +50,7 @@ steps:
     stage: plan-writing
     prompt_context_profile: security-review
     scope: work_item
+    execution_boundary: work_item
     gate_id: security-review
     baseline: OWASP ASVS 5.0.0
     inputs_resolved_by: work_item_document_contract
@@ -68,6 +71,7 @@ steps:
     stage: plan-writing
     prompt_context_profile: review
     scope: work_item
+    execution_boundary: work_item
     gate_id: plan-review
     artifact_type: plan
     inputs_resolved_by: work_item_document_contract
@@ -91,6 +95,7 @@ steps:
     stage: implementation
     prompt_context_profile: execution
     scope: work_item
+    execution_boundary: work_item
     upstream_context:
     - producer_step: review-work-item-plan
       artifact_path: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/reviews/plan-review.md
@@ -113,6 +118,7 @@ steps:
   metadata:
     stage: implementation
     scope: work_item
+    execution_boundary: work_item
     gate_id: verification
     gate_catalog:
     - test-gate
@@ -142,6 +148,7 @@ steps:
     stage: implementation
     prompt_context_profile: security-verification
     scope: work_item
+    execution_boundary: work_item
     gate_id: security-review
     baseline: OWASP ASVS 5.0.0
     inputs_resolved_by: work_item_document_contract
@@ -157,6 +164,7 @@ steps:
   metadata:
     stage: implementation
     scope: work_item
+    execution_boundary: work_item
     classifier: verification_result
     failure_kinds:
     - IMPLEMENTATION_FAILURE
@@ -185,6 +193,7 @@ steps:
   metadata:
     stage: implementation
     scope: work_item
+    execution_boundary: work_item
     loop_target: execute-work-item
     max_retry_count: 2
 - id: complete-work-item-plan
@@ -199,37 +208,5 @@ steps:
   metadata:
     stage: implementation
     scope: work_item
+    execution_boundary: work_item
     gate_id: verification-evidence
-- id: create-change-set-pr
-  kind: git
-  name: Commit, push, and create or reuse the ChangeSet pull request
-  command: python3 -m harness_codex.runtime.change_set_pr_delivery --change-set <CHG-ID> --run-id <RUN-ID>
-  needs:
-  - complete-work-item-plan
-  outputs:
-  - .harness/runs/<RUN-ID>/pull-request.json
-  metadata:
-    stage: delivery
-    scope: change_set
-    condition: verified_changeset_output_committed_and_pushed
-    approval_env: HARNESS_DELIVERY_APPROVED
-    fail_closed: true
-    run_on_final_work_item_only: true
-- id: complete-change-set
-  kind: git
-  name: Complete active ChangeSet after delivery succeeds
-  command: python3 -m harness_codex.runtime.change_set_completion_delivery --change-set <CHG-ID> --run-id <RUN-ID>
-  needs:
-  - create-change-set-pr
-  inputs:
-  - docs/changes/active/<CHG-ID>.md
-  outputs:
-  - docs/changes/completed/<CHG-ID>.md
-  - .harness/runs/<RUN-ID>/changeset-completion-report.md
-  metadata:
-    stage: delivery
-    scope: change_set
-    condition: all_affected_work_item_plans_completed
-    approval_env: HARNESS_DELIVERY_APPROVED
-    fail_closed: true
-    run_on_final_work_item_only: true

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -9,34 +9,32 @@ __all__ = ["__version__"]
 __version__ = "0.1.134"
 
 
-def _install_cli_materializer_compatibility() -> None:
-    """Accept pre-run-id materializer extensions during the transition period."""
+def _install_changeset_execution_boundary() -> None:
+    """Route the CLI hook through the two-layer ChangeSet session orchestrator.
+
+    The public parser and injected test doubles stay stable while execution moves
+    from one mixed workflow to explicit work-item and finalization boundaries.
+    """
 
     cli = import_module("harness_codex.cli")
-    if getattr(cli, "_materializer_run_id_compatibility_installed", False):
+    if getattr(cli, "_changeset_execution_boundary_installed", False):
         return
 
-    original_apply_workflow = cli._apply_workflow
+    from harness_codex.runtime.changeset_orchestrator import apply_workflow
 
-    def apply_workflow(*args, **kwargs):
-        materializer = cli.materialize_workflow_for_scope
+    def run_session(*args, **kwargs):
+        return apply_workflow(
+            *args,
+            **kwargs,
+            workflow_loader=cli.load_named_workflow,
+            workflow_materializer=cli.materialize_workflow_for_scope,
+            manifest_writer=cli.write_materialized_workflow_manifest,
+            engine_factory=lambda: cli.RunnerEngine(cli.BasicStepRunner()),
+            emit=print,
+        )
 
-        def materialize_with_compatibility(*materializer_args, **materializer_kwargs):
-            try:
-                return materializer(*materializer_args, **materializer_kwargs)
-            except TypeError as exc:
-                if "run_id" not in materializer_kwargs or "unexpected keyword argument" not in str(exc):
-                    raise
-                return materializer(*materializer_args)
-
-        cli.materialize_workflow_for_scope = materialize_with_compatibility
-        try:
-            return original_apply_workflow(*args, **kwargs)
-        finally:
-            cli.materialize_workflow_for_scope = materializer
-
-    cli._apply_workflow = apply_workflow
-    cli._materializer_run_id_compatibility_installed = True
+    cli._apply_workflow = run_session
+    cli._changeset_execution_boundary_installed = True
 
 
-_install_cli_materializer_compatibility()
+_install_changeset_execution_boundary()

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -22,11 +22,25 @@ def _install_changeset_execution_boundary() -> None:
 
     from harness_codex.runtime.changeset_orchestrator import apply_workflow
 
+    def load_session_workflow(*loader_args, **loader_kwargs):
+        """Load a runtime workflow while retaining the command test seam.
+
+        Production loaders return a ``Workflow`` with concrete steps. Older command
+        tests inject a named mutable handle only; normalize that handle so boundary
+        validation can still run over its empty test-step set without weakening the
+        validation of production workflow definitions.
+        """
+
+        workflow = cli.load_named_workflow(*loader_args, **loader_kwargs)
+        if not hasattr(workflow, "steps"):
+            setattr(workflow, "steps", ())
+        return workflow
+
     def run_session(*args, **kwargs):
         return apply_workflow(
             *args,
             **kwargs,
-            workflow_loader=cli.load_named_workflow,
+            workflow_loader=load_session_workflow,
             workflow_materializer=cli.materialize_workflow_for_scope,
             manifest_writer=cli.write_materialized_workflow_manifest,
             engine_factory=lambda: cli.RunnerEngine(cli.BasicStepRunner()),

--- a/harness_codex/runtime/changeset_orchestrator.py
+++ b/harness_codex/runtime/changeset_orchestrator.py
@@ -1,0 +1,560 @@
+"""Two-layer ChangeSet execution orchestration.
+
+A ChangeSet is a session and delivery unit. Each work item runs only its own plan,
+implementation, verification, and plan-completion workflow. A separate finalization
+workflow runs exactly once after every work-item plan is completed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Mapping
+from uuid import uuid4
+
+from harness_codex.runtime.changes.models import ChangeSet
+from harness_codex.runtime.engine import RunnerEngine
+from harness_codex.runtime.models import FailureKind, RunContext, RunMode, RunResult, RunStatus
+from harness_codex.runtime.reports import ReportWriter, RunReport, WorkItemReport
+from harness_codex.runtime.runner import BasicStepRunner
+from harness_codex.runtime.state import (
+    RunFailureKind,
+    RunState,
+    RunStateStore,
+    UseCaseLoopState,
+    WorkItemLoopState,
+)
+from harness_codex.runtime.workflows import (
+    load_named_workflow,
+    materialize_workflow_for_scope,
+    write_materialized_workflow_manifest,
+)
+
+WORK_ITEM_WORKFLOW_NAME = "changeset-use-case-workflow"
+FINALIZATION_WORKFLOW_NAME = "changeset-finalization-workflow"
+SESSION_WORKFLOW_NAME = "changeset-session"
+
+
+class WorkflowBoundaryError(RuntimeError):
+    """Raised when a workflow contains steps from the other execution boundary."""
+
+
+def apply_workflow(
+    repo_root: Path,
+    change_set: ChangeSet,
+    scopes: tuple,
+    *,
+    run_id: str | None = None,
+    force_verification: bool = False,
+    rollback_mode: str = "none",
+    workflow_loader: Callable = load_named_workflow,
+    workflow_materializer: Callable = materialize_workflow_for_scope,
+    manifest_writer: Callable = write_materialized_workflow_manifest,
+    engine_factory: Callable[[], object] | None = None,
+    emit: Callable[[str], None] | None = None,
+):
+    """Execute unfinished work items, then finalize the ChangeSet once.
+
+    Completion is established by durable plan locations, not a last-work-item
+    metadata convention. A work-item workflow cannot contain ChangeSet delivery
+    steps; finalization is materialized and run only after every plan is complete.
+    """
+
+    if not scopes:
+        raise RuntimeError("workflow execution requires at least one ChangeSet work item")
+
+    run_id = run_id or f"run-{uuid4().hex[:12]}"
+    run_dir = repo_root / ".harness/runs" / run_id
+    workflows_dir = _workflows_dir(repo_root)
+    work_item_workflow = workflow_loader(
+        WORK_ITEM_WORKFLOW_NAME,
+        workflows_dir=workflows_dir,
+    )
+    finalization_workflow = workflow_loader(
+        FINALIZATION_WORKFLOW_NAME,
+        workflows_dir=workflows_dir,
+    )
+    _assert_workflow_boundary(work_item_workflow, "work_item")
+    _assert_workflow_boundary(finalization_workflow, "changeset_finalization")
+
+    engine = engine_factory() if engine_factory is not None else RunnerEngine(BasicStepRunner())
+    results: dict[str, RunResult] = {}
+    failed_scope = None
+
+    for index, scope in enumerate(scopes, start=1):
+        if _work_item_plan_completed(repo_root, scope):
+            result = _completed_work_item_result(run_id)
+            results[scope.display_id] = result
+            if emit is not None:
+                emit(_execution_result_line(scope, result, index=index, total=len(scopes)))
+            continue
+
+        if emit is not None:
+            emit(_execution_start_line(scope, index, len(scopes)))
+        materialized = _materialize(
+            workflow_materializer,
+            work_item_workflow,
+            change_set,
+            scope,
+            run_id,
+        )
+        manifest_writer(
+            materialized,
+            run_dir / "work-items" / scope.display_id / "workflow.json",
+        )
+        result = engine.run(
+            materialized,
+            _context(
+                repo_root,
+                run_dir,
+                change_set,
+                scopes,
+                scope,
+                workflow_name=materialized.name,
+                boundary="work_item",
+                force_verification=force_verification,
+                rollback_mode=rollback_mode,
+            ),
+        )
+        results[scope.display_id] = result
+        if emit is not None:
+            emit(_execution_result_line(scope, result))
+        if result.status is not RunStatus.SUCCEEDED:
+            failed_scope = scope
+            break
+
+    finalization_result: RunResult | None = None
+    if failed_scope is None and _all_work_item_plans_completed(repo_root, scopes):
+        final_scope = scopes[-1]
+        materialized = _materialize(
+            workflow_materializer,
+            finalization_workflow,
+            change_set,
+            final_scope,
+            run_id,
+        )
+        manifest_writer(materialized, run_dir / "finalization" / "workflow.json")
+        finalization_result = engine.run(
+            materialized,
+            _context(
+                repo_root,
+                run_dir,
+                change_set,
+                scopes,
+                final_scope,
+                workflow_name=materialized.name,
+                boundary="changeset_finalization",
+                force_verification=force_verification,
+                rollback_mode=rollback_mode,
+            ),
+        )
+        _write_finalization_report(repo_root, run_id, finalization_result)
+
+    if failed_scope is not None:
+        overall = results[failed_scope.display_id]
+    elif finalization_result is not None:
+        overall = finalization_result
+    else:
+        overall = _blocked_finalization_result(run_id, change_set)
+        _write_finalization_report(repo_root, run_id, overall)
+
+    state = _build_state(
+        repo_root=repo_root,
+        run_id=run_id,
+        change_set=change_set,
+        scopes=scopes,
+        results=results,
+        failed_scope=failed_scope,
+        finalization_result=finalization_result,
+        overall=overall,
+    )
+    RunStateStore(repo_root).save(state)
+    _write_session_report(repo_root, run_id, change_set, scopes, results, overall)
+    return state, overall
+
+
+def _assert_workflow_boundary(workflow, boundary: str) -> None:
+    expected_scope = "work_item" if boundary == "work_item" else "change_set"
+    violations = []
+    for step in workflow.steps:
+        scope = step.metadata.get("scope")
+        step_boundary = step.metadata.get("execution_boundary")
+        if scope != expected_scope or step_boundary != boundary:
+            violations.append(
+                f"{step.id}(scope={scope!r}, execution_boundary={step_boundary!r})"
+            )
+    if violations:
+        raise WorkflowBoundaryError(
+            f"{workflow.name} violates {boundary} boundary: {', '.join(violations)}"
+        )
+
+
+def _completed_work_item_result(run_id: str) -> RunResult:
+    return RunResult(
+        run_id=run_id,
+        status=RunStatus.SUCCEEDED,
+        step_results=(),
+        mode=RunMode.APPLY,
+        metadata={"resumed_from_completed_plan": True},
+    )
+
+
+def _materialize(materializer: Callable, workflow, change_set: ChangeSet, scope, run_id: str):
+    try:
+        return materializer(workflow, change_set, scope, run_id=run_id)
+    except TypeError as exc:
+        if "run_id" not in str(exc) or "unexpected keyword argument" not in str(exc):
+            raise
+        return materializer(workflow, change_set, scope)
+
+
+def _workflows_dir(repo_root: Path) -> Path:
+    candidate = repo_root / ".harness/workflows"
+    if (
+        (candidate / f"{WORK_ITEM_WORKFLOW_NAME}.yaml").exists()
+        and (candidate / f"{FINALIZATION_WORKFLOW_NAME}.yaml").exists()
+    ):
+        return candidate
+    return Path(__file__).resolve().parents[2] / ".harness/workflows"
+
+
+def _context(
+    repo_root: Path,
+    run_dir: Path,
+    change_set: ChangeSet,
+    scopes: tuple,
+    scope,
+    *,
+    workflow_name: str,
+    boundary: str,
+    force_verification: bool,
+    rollback_mode: str,
+) -> RunContext:
+    run_subdir = (
+        Path("finalization")
+        if boundary == "changeset_finalization"
+        else Path("work-items") / scope.display_id
+    )
+    return RunContext(
+        run_id=run_dir.name,
+        workflow_name=workflow_name,
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=run_dir / run_subdir,
+        metadata={
+            "execution_boundary": boundary,
+            "change_set_id": change_set.change_set_id,
+            "change_set_path": str(
+                change_set.path or Path(f"docs/changes/active/{change_set.change_set_id}.md")
+            ),
+            "active_work_item_id": scope.display_id,
+            "active_work_item_type": scope.work_item_type.value,
+            "active_plan_path": str(_active_plan_path(scope)),
+            "verification_goal_path": (
+                str(scope.verification_goal_path) if scope.verification_goal_path else None
+            ),
+            "force_verification": force_verification,
+            "rollback_mode": rollback_mode,
+            "all_work_item_plans_completed": boundary == "changeset_finalization",
+            "affected_work_items": [
+                {
+                    "id": item.display_id,
+                    "type": item.work_item_type.value,
+                    "plan_path": str(_active_plan_path(item)),
+                    "verification_goal_path": (
+                        str(item.verification_goal_path)
+                        if item.verification_goal_path
+                        else None
+                    ),
+                }
+                for item in scopes
+            ],
+        },
+    )
+
+
+def _execution_start_line(scope, index: int, total: int) -> str:
+    label = "Use case" if scope.use_case is not None else "Work item"
+    name = scope.use_case.name if scope.use_case is not None else scope.display_id
+    return f"{label} execution start: {scope.display_id} - {name} ({index}/{total})"
+
+
+def _execution_result_line(
+    scope,
+    result: RunResult,
+    *,
+    index: int | None = None,
+    total: int | None = None,
+) -> str:
+    label = "Use case" if scope.use_case is not None else "Work item"
+    name = scope.use_case.name if scope.use_case is not None else scope.display_id
+    if result.metadata.get("resumed_from_completed_plan"):
+        position = f" ({index}/{total})" if index is not None and total is not None else ""
+        return (
+            f"{label} execution skipped: {scope.display_id} - {name}{position} "
+            "reason=completed_plan"
+        )
+    details = f"{label} execution result: {scope.display_id} - {name} status={result.status.value}"
+    if result.failed_step_id:
+        details += f" failed_step={result.failed_step_id}"
+    if result.failure_kind is not None:
+        details += f" failure_kind={result.failure_kind.value}"
+    if result.blocker:
+        details += f" blocker={result.blocker}"
+    return details
+
+
+def _build_state(
+    *,
+    repo_root: Path,
+    run_id: str,
+    change_set: ChangeSet,
+    scopes: tuple,
+    results: Mapping[str, RunResult],
+    failed_scope,
+    finalization_result: RunResult | None,
+    overall: RunResult,
+) -> RunState:
+    completed = tuple(
+        scope.display_id for scope in scopes if _work_item_plan_completed(repo_root, scope)
+    )
+    blocked = tuple(
+        scope.display_id
+        for scope in scopes
+        if scope.display_id in results and results[scope.display_id].status is not RunStatus.SUCCEEDED
+    )
+    affected_use_cases = tuple(
+        scope.use_case.uc_id for scope in scopes if scope.use_case is not None
+    )
+    decisions: dict[str, object] = {
+        work_item_id: tuple(result.metadata.get("decisions", ()))
+        for work_item_id, result in results.items()
+        if result.metadata.get("decisions")
+    }
+    decisions["changeset_finalization"] = {
+        "workflow": FINALIZATION_WORKFLOW_NAME,
+        "eligible": len(completed) == len(scopes),
+        "status": finalization_result.status.value if finalization_result else "not_started",
+        "failed_step_id": finalization_result.failed_step_id if finalization_result else None,
+        "blocker": finalization_result.blocker if finalization_result else None,
+        "report": f".harness/runs/{run_id}/finalization/report.json",
+    }
+    return RunState(
+        run_id=run_id,
+        change_set_id=change_set.change_set_id,
+        workflow_name=SESSION_WORKFLOW_NAME,
+        mode=RunMode.APPLY,
+        affected_use_cases=affected_use_cases,
+        affected_work_items=tuple(scope.display_id for scope in scopes),
+        current_use_case_id=(
+            failed_scope.use_case.uc_id
+            if failed_scope is not None and failed_scope.use_case is not None
+            else None
+        ),
+        current_work_item_id=failed_scope.display_id if failed_scope is not None else None,
+        completed_use_cases=tuple(
+            scope.use_case.uc_id
+            for scope in scopes
+            if scope.use_case is not None and scope.display_id in completed
+        ),
+        completed_work_items=completed,
+        blocked_use_cases=tuple(
+            scope.use_case.uc_id
+            for scope in scopes
+            if scope.use_case is not None and scope.display_id in blocked
+        ),
+        blocked_work_items=blocked,
+        failed_step_id=overall.failed_step_id,
+        failure_kind=_run_failure_kind(overall.failure_kind),
+        status=overall.status,
+        decision_results=decisions,
+        work_item_states=tuple(
+            _work_item_state(scope, results.get(scope.display_id)) for scope in scopes
+        ),
+        use_case_states=tuple(
+            _use_case_state(scope, results.get(scope.display_id))
+            for scope in scopes
+            if scope.use_case is not None
+        ),
+    )
+
+
+def _work_item_state(scope, result: RunResult | None) -> WorkItemLoopState:
+    return WorkItemLoopState(
+        work_item_id=scope.display_id,
+        work_item_type=scope.work_item_type,
+        active_plan_path=_active_plan_path(scope),
+        status=result.status if result is not None else RunStatus.PENDING,
+        current_step_id=scope.current_stage,
+        verification_status=result.status.value if result is not None else "pending",
+        retry_count=result.retry_count if result is not None else 0,
+        failure_kind=_run_failure_kind(result.failure_kind) if result is not None else None,
+        blocker=result.blocker if result is not None else None,
+    )
+
+
+def _use_case_state(scope, result: RunResult | None) -> UseCaseLoopState:
+    return UseCaseLoopState(
+        uc_id=scope.use_case.uc_id,
+        active_plan_path=_active_plan_path(scope),
+        status=result.status if result is not None else RunStatus.PENDING,
+        retry_count=result.retry_count if result is not None else 0,
+        failure_kind=_run_failure_kind(result.failure_kind) if result is not None else None,
+        blocker=result.blocker if result is not None else None,
+    )
+
+
+def _write_session_report(
+    repo_root: Path,
+    run_id: str,
+    change_set: ChangeSet,
+    scopes: tuple,
+    results: Mapping[str, RunResult],
+    overall: RunResult,
+) -> None:
+    affected_use_cases = tuple(
+        scope.use_case.uc_id for scope in scopes if scope.use_case is not None
+    )
+    finalization_path = Path(".harness/runs") / run_id / "finalization" / "report.json"
+    ReportWriter(repo_root).write(
+        RunReport(
+            run_id=run_id,
+            change_set_id=change_set.change_set_id,
+            workflow_name=SESSION_WORKFLOW_NAME,
+            mode=RunMode.APPLY,
+            status=overall.status,
+            affected_use_cases=affected_use_cases,
+            completed_use_cases=tuple(
+                scope.use_case.uc_id
+                for scope in scopes
+                if scope.use_case is not None and _work_item_plan_completed(repo_root, scope)
+            ),
+            blocked_use_cases=tuple(
+                scope.use_case.uc_id
+                for scope in scopes
+                if scope.use_case is not None
+                and scope.display_id in results
+                and results[scope.display_id].status is not RunStatus.SUCCEEDED
+            ),
+            report_paths={"changeset_finalization": finalization_path},
+            artifact_paths={"changeset_finalization": finalization_path},
+            work_item_reports=tuple(
+                WorkItemReport(
+                    work_item_id=scope.display_id,
+                    work_item_type=scope.work_item_type,
+                    active_plan_path=_active_plan_path(scope),
+                    completed_plan_path=(
+                        _completed_plan_path(scope.display_id)
+                        if _work_item_plan_completed(repo_root, scope)
+                        else None
+                    ),
+                    status=(
+                        results[scope.display_id].status
+                        if scope.display_id in results
+                        else RunStatus.PENDING
+                    ),
+                    current_stage=(
+                        "completed"
+                        if _work_item_plan_completed(repo_root, scope)
+                        else scope.current_stage
+                    ),
+                    verification_goal_path=scope.verification_goal_path,
+                    blocker=(
+                        results[scope.display_id].blocker
+                        if scope.display_id in results
+                        else None
+                    ),
+                    verification_result=(
+                        results[scope.display_id].status.value
+                        if scope.display_id in results
+                        else "pending"
+                    ),
+                )
+                for scope in scopes
+            ),
+        )
+    )
+
+
+def _write_finalization_report(repo_root: Path, run_id: str, result: RunResult) -> None:
+    directory = repo_root / ".harness/runs" / run_id / "finalization"
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "workflow": FINALIZATION_WORKFLOW_NAME,
+        "status": result.status.value,
+        "failed_step_id": result.failed_step_id,
+        "failure_kind": result.failure_kind.value if result.failure_kind else None,
+        "blocker": result.blocker,
+        "step_results": [
+            {"step_id": step.step_id, "status": step.status.value, "error": step.error}
+            for step in result.step_results
+        ],
+    }
+    (directory / "report.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (directory / "report.md").write_text(
+        "\n".join(
+            (
+                "# ChangeSet Finalization",
+                "",
+                f"- Workflow: {FINALIZATION_WORKFLOW_NAME}",
+                f"- Status: {result.status.value}",
+                f"- Failed step: {result.failed_step_id or '-'}",
+                f"- Blocker: {result.blocker or '-'}",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _blocked_finalization_result(run_id: str, change_set: ChangeSet) -> RunResult:
+    return RunResult(
+        run_id=run_id,
+        status=RunStatus.BLOCKED,
+        step_results=(),
+        mode=RunMode.APPLY,
+        failed_step_id="verify-all-work-items-completed",
+        blocker=(
+            f"ChangeSet {change_set.change_set_id} cannot finalize because one or more "
+            "work-item plans are incomplete"
+        ),
+    )
+
+
+def _all_work_item_plans_completed(repo_root: Path, scopes: tuple) -> bool:
+    return bool(scopes) and all(
+        _work_item_plan_completed(repo_root, scope) for scope in scopes
+    )
+
+
+def _work_item_plan_completed(repo_root: Path, scope) -> bool:
+    return (
+        (repo_root / _completed_plan_path(scope.display_id)).exists()
+        and not (repo_root / _active_plan_path(scope)).exists()
+    )
+
+
+def _active_plan_path(scope) -> Path:
+    return scope.plan_path or Path(f"docs/plans/active/{scope.display_id}/plan.md")
+
+
+def _completed_plan_path(work_item_id: str) -> Path:
+    return Path(f"docs/plans/completed/{work_item_id}/plan.md")
+
+
+def _run_failure_kind(failure_kind: FailureKind | None) -> RunFailureKind | None:
+    return {
+        FailureKind.IMPLEMENTATION: RunFailureKind.IMPLEMENTATION_FAILURE,
+        FailureKind.UPSTREAM_DESIGN: RunFailureKind.UPSTREAM_DESIGN_CONFLICT,
+        FailureKind.ENVIRONMENT_BLOCKER: RunFailureKind.ENVIRONMENT_BLOCKER,
+        FailureKind.UNCLEAR_E2E_GOAL: RunFailureKind.UNCLEAR_E2E_GOAL,
+        FailureKind.DOCUMENT_DELTA_CONFLICT: RunFailureKind.DOCUMENT_DELTA_CONFLICT,
+        FailureKind.SCOPE_CONFLICT: RunFailureKind.SCOPE_CONFLICT,
+        FailureKind.PLAN_REVIEW_REJECTED: RunFailureKind.PLAN_REVIEW_REJECTED,
+        FailureKind.VERIFICATION_GOAL_UNCLEAR: RunFailureKind.VERIFICATION_GOAL_UNCLEAR,
+        FailureKind.UNKNOWN: RunFailureKind.UNCLEAR_E2E_GOAL,
+    }.get(failure_kind)

--- a/tests/runtime/test_change_set_delivery.py
+++ b/tests/runtime/test_change_set_delivery.py
@@ -242,10 +242,10 @@ def test_push_failure_keeps_changeset_active_for_resume(
     assert not (tmp_path / "docs/changes/completed/CHG-376.md").exists()
 
 
-def test_canonical_workflow_uses_explicit_scope_safe_delivery_commands() -> None:
+def test_finalization_workflow_uses_explicit_scope_safe_delivery_commands() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     workflow = load_named_workflow(
-        "changeset-use-case-workflow",
+        "changeset-finalization-workflow",
         workflows_dir=repo_root / ".harness/workflows",
     )
 

--- a/tests/runtime/test_changeset_orchestrator.py
+++ b/tests/runtime/test_changeset_orchestrator.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import harness_codex.cli as cli
+import harness_codex.runtime.changeset_orchestrator as orchestrator
+from harness_codex.runtime.changes.models import (
+    AffectedUseCase,
+    AffectedWorkItem,
+    ChangeSet,
+    PlanningInputScope,
+    WorkItemType,
+)
+from harness_codex.runtime.models import FailureKind, RunResult, RunStatus
+from harness_codex.runtime.state import ResumeDisposition, decide_resume_target
+
+
+class _SuccessfulEngine:
+    calls: list[tuple[str, str, str]] = []
+
+    def __init__(self, _runner) -> None:
+        pass
+
+    def run(self, workflow, context):
+        boundary = str(context.metadata["execution_boundary"])
+        work_item_id = str(context.metadata["active_work_item_id"])
+        self.calls.append((boundary, workflow.name, work_item_id))
+        if boundary == "work_item":
+            _complete_active_plan(context, work_item_id)
+        return _success_result(context)
+
+
+class _BlockedFirstEngine:
+    calls: list[tuple[str, str, str]] = []
+
+    def __init__(self, _runner) -> None:
+        pass
+
+    def run(self, workflow, context):
+        boundary = str(context.metadata["execution_boundary"])
+        work_item_id = str(context.metadata["active_work_item_id"])
+        self.calls.append((boundary, workflow.name, work_item_id))
+        return RunResult(
+            run_id=context.run_id,
+            status=RunStatus.BLOCKED,
+            step_results=(),
+            mode=context.mode,
+            failed_step_id="execute-work-item",
+            failure_kind=FailureKind.IMPLEMENTATION,
+            blocker="implementation failed",
+        )
+
+
+class _FinalizationBlockedEngine:
+    calls: list[tuple[str, str, str]] = []
+
+    def __init__(self, _runner) -> None:
+        pass
+
+    def run(self, workflow, context):
+        boundary = str(context.metadata["execution_boundary"])
+        work_item_id = str(context.metadata["active_work_item_id"])
+        self.calls.append((boundary, workflow.name, work_item_id))
+        if boundary == "work_item":
+            _complete_active_plan(context, work_item_id)
+            return _success_result(context)
+        return RunResult(
+            run_id=context.run_id,
+            status=RunStatus.BLOCKED,
+            step_results=(),
+            mode=context.mode,
+            failed_step_id="create-change-set-pr",
+            blocker="delivery approval is missing",
+        )
+
+
+def test_cli_installs_changeset_session_execution_boundary() -> None:
+    assert cli._changeset_execution_boundary_installed is True
+    assert cli._apply_workflow is not orchestrator.apply_workflow
+
+
+def test_runs_two_use_cases_before_one_changeset_finalization(tmp_path: Path, monkeypatch) -> None:
+    change_set, scopes = _change_set_and_scopes(tmp_path)
+    _SuccessfulEngine.calls = []
+    monkeypatch.setattr(orchestrator, "RunnerEngine", _SuccessfulEngine)
+
+    state, result = orchestrator.apply_workflow(
+        tmp_path,
+        change_set,
+        scopes,
+        run_id="run-371",
+    )
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert _SuccessfulEngine.calls == [
+        ("work_item", "changeset-work-item-workflow", "UC-371-A"),
+        ("work_item", "changeset-work-item-workflow", "UC-371-B"),
+        ("changeset_finalization", "changeset-finalization-workflow", "UC-371-B"),
+    ]
+    assert state.completed_work_items == ("UC-371-A", "UC-371-B")
+    assert state.decision_results["changeset_finalization"]["status"] == "succeeded"
+    assert (tmp_path / ".harness/runs/run-371/finalization/workflow.json").is_file()
+    finalization = json.loads(
+        (tmp_path / ".harness/runs/run-371/finalization/report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert finalization["workflow"] == "changeset-finalization-workflow"
+    report = json.loads((tmp_path / ".harness/runs/run-371/report.json").read_text(encoding="utf-8"))
+    assert report["workflow_name"] == "changeset-session"
+    assert report["report_paths"]["changeset_finalization"].endswith("finalization/report.json")
+
+
+def test_stops_on_first_failed_work_item_without_starting_second_or_finalization(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    change_set, scopes = _change_set_and_scopes(tmp_path)
+    _BlockedFirstEngine.calls = []
+    monkeypatch.setattr(orchestrator, "RunnerEngine", _BlockedFirstEngine)
+
+    state, result = orchestrator.apply_workflow(
+        tmp_path,
+        change_set,
+        scopes,
+        run_id="run-372",
+    )
+
+    assert result.status is RunStatus.BLOCKED
+    assert _BlockedFirstEngine.calls == [
+        ("work_item", "changeset-work-item-workflow", "UC-371-A"),
+    ]
+    assert state.blocked_work_items == ("UC-371-A",)
+    assert state.work_item_states[1].status is RunStatus.PENDING
+    assert state.completed_work_items == ()
+    assert state.decision_results["changeset_finalization"]["status"] == "not_started"
+    assert not (tmp_path / ".harness/runs/run-372/finalization/workflow.json").exists()
+    resume = decide_resume_target(state)
+    assert resume.disposition is ResumeDisposition.RETRY_REMEDIATION
+    assert resume.work_item_id == "UC-371-A"
+
+
+def test_finalization_failure_preserves_completed_work_items_for_delivery_retry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    change_set, scopes = _change_set_and_scopes(tmp_path)
+    _FinalizationBlockedEngine.calls = []
+    monkeypatch.setattr(orchestrator, "RunnerEngine", _FinalizationBlockedEngine)
+
+    state, result = orchestrator.apply_workflow(
+        tmp_path,
+        change_set,
+        scopes,
+        run_id="run-373",
+    )
+
+    assert result.status is RunStatus.BLOCKED
+    assert _FinalizationBlockedEngine.calls == [
+        ("work_item", "changeset-work-item-workflow", "UC-371-A"),
+        ("work_item", "changeset-work-item-workflow", "UC-371-B"),
+        ("changeset_finalization", "changeset-finalization-workflow", "UC-371-B"),
+    ]
+    assert state.completed_work_items == ("UC-371-A", "UC-371-B")
+    assert state.decision_results["changeset_finalization"]["status"] == "blocked"
+    assert (tmp_path / ".harness/runs/run-373/finalization/report.json").is_file()
+    resume = decide_resume_target(state)
+    assert resume.disposition is ResumeDisposition.RETRY_FINALIZATION
+
+
+def _success_result(context) -> RunResult:
+    return RunResult(
+        run_id=context.run_id,
+        status=RunStatus.SUCCEEDED,
+        step_results=(),
+        mode=context.mode,
+    )
+
+
+def _complete_active_plan(context, work_item_id: str) -> None:
+    active = context.repo_root / str(context.metadata["active_plan_path"])
+    completed = context.repo_root / "docs/plans/completed" / work_item_id / "plan.md"
+    completed.parent.mkdir(parents=True, exist_ok=True)
+    active.replace(completed)
+
+
+def _change_set_and_scopes(tmp_path: Path) -> tuple[ChangeSet, tuple[PlanningInputScope, ...]]:
+    use_cases = (
+        AffectedUseCase(
+            uc_id="UC-371-A",
+            name="first user flow",
+            impact_type="source-code, user-feature",
+            slice_path=Path("docs/use-cases/UC-371-A"),
+        ),
+        AffectedUseCase(
+            uc_id="UC-371-B",
+            name="second user flow",
+            impact_type="source-code, user-feature",
+            slice_path=Path("docs/use-cases/UC-371-B"),
+        ),
+    )
+    work_items = tuple(
+        AffectedWorkItem(
+            work_item_id=use_case.uc_id,
+            work_item_type=WorkItemType.USE_CASE,
+            name=use_case.name,
+            impact_type=use_case.impact_type,
+            slice_path=use_case.slice_path,
+        )
+        for use_case in use_cases
+    )
+    change_set = ChangeSet(
+        change_set_id="CHG-371",
+        title="two use-case session",
+        path=Path("docs/changes/active/CHG-371.md"),
+        affected_use_cases=use_cases,
+        affected_work_items=work_items,
+    )
+    scopes = tuple(
+        PlanningInputScope(
+            change_set_path=change_set.path,
+            use_case=use_case,
+            planner_inputs=(),
+            executor_inputs=(),
+            e2e_goal_path=Path(f"docs/use-cases/{use_case.uc_id}/e2e-goal.md"),
+            work_item_id=use_case.uc_id,
+            work_item_type=WorkItemType.USE_CASE,
+            impact_type=use_case.impact_type,
+            plan_path=Path(f"docs/plans/active/{use_case.uc_id}/plan.md"),
+            verification_goal_path=Path(f"docs/use-cases/{use_case.uc_id}/e2e-goal.md"),
+        )
+        for use_case in use_cases
+    )
+    for scope in scopes:
+        plan = tmp_path / scope.plan_path
+        plan.parent.mkdir(parents=True, exist_ok=True)
+        plan.write_text(f"# {scope.display_id} plan\n", encoding="utf-8")
+    return change_set, scopes

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -59,11 +59,12 @@ def test_load_named_workflow_reads_from_harness_workflows_directory(tmp_path: Pa
     assert workflow.step_ids() == ("analyze", "validate")
 
 
-def test_default_implementation_workflow_retains_safety_and_delivery_steps() -> None:
-    workflow = load_named_workflow("changeset-use-case-workflow")
+def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -> None:
+    work_item_workflow = load_named_workflow("changeset-use-case-workflow")
+    finalization_workflow = load_named_workflow("changeset-finalization-workflow")
 
-    assert workflow.name == "changeset-use-case-workflow"
-    assert workflow.step_ids() == (
+    assert work_item_workflow.name == "changeset-work-item-workflow"
+    assert work_item_workflow.step_ids() == (
         "load-change-set",
         "plan-work-item",
         "secure-work-item-plan",
@@ -74,36 +75,55 @@ def test_default_implementation_workflow_retains_safety_and_delivery_steps() -> 
         "classify-verification-result",
         "remediate-work-item",
         "complete-work-item-plan",
-        "create-change-set-pr",
-        "complete-change-set",
     )
-    assert workflow.step_by_id("plan-work-item").agent_id == "implementation_planner"
-    assert workflow.step_by_id("plan-work-item").skill_id == "harness-code-planner"
-    assert workflow.step_by_id("plan-work-item").metadata["stage"] == "plan-writing"
-    assert workflow.step_by_id("plan-work-item").metadata["prompt_context_profile"] == "plan"
-    assert workflow.step_by_id("secure-work-item-plan").agent_id == "security_plan_reviewer"
+    assert work_item_workflow.step_by_id("plan-work-item").agent_id == "implementation_planner"
+    assert work_item_workflow.step_by_id("plan-work-item").skill_id == "harness-code-planner"
+    assert work_item_workflow.step_by_id("plan-work-item").metadata["stage"] == "plan-writing"
+    assert work_item_workflow.step_by_id("plan-work-item").metadata["prompt_context_profile"] == "plan"
+    assert work_item_workflow.step_by_id("secure-work-item-plan").agent_id == "security_plan_reviewer"
     assert (
-        workflow.step_by_id("secure-work-item-plan").metadata["prompt_context_profile"]
+        work_item_workflow.step_by_id("secure-work-item-plan").metadata["prompt_context_profile"]
         == "security-review"
     )
-    assert workflow.step_by_id("review-work-item-plan").needs == ("secure-work-item-plan",)
-    assert workflow.step_by_id("review-work-item-plan").metadata["prompt_context_profile"] == "review"
-    assert workflow.step_by_id("execute-work-item").skill_id == "harness-implementation-executor"
-    assert workflow.step_by_id("execute-work-item").metadata["stage"] == "implementation"
-    assert workflow.step_by_id("execute-work-item").metadata["prompt_context_profile"] == "execution"
+    assert work_item_workflow.step_by_id("review-work-item-plan").needs == ("secure-work-item-plan",)
+    assert work_item_workflow.step_by_id("review-work-item-plan").metadata["prompt_context_profile"] == "review"
+    assert work_item_workflow.step_by_id("execute-work-item").skill_id == "harness-implementation-executor"
+    assert work_item_workflow.step_by_id("execute-work-item").metadata["stage"] == "implementation"
+    assert work_item_workflow.step_by_id("execute-work-item").metadata["prompt_context_profile"] == "execution"
     assert (
-        workflow.step_by_id("verify-work-item-security").metadata["prompt_context_profile"]
+        work_item_workflow.step_by_id("verify-work-item-security").metadata["prompt_context_profile"]
         == "security-verification"
     )
-    assert workflow.step_by_id("verify-work-item").command == (
+    assert work_item_workflow.step_by_id("verify-work-item").command == (
         "python3 -m harness_codex.runtime.structured_verify_work_item "
         "--change-set <CHG-ID> --work-item <WORK-ITEM-ID> --run-id <RUN-ID>"
     )
-    assert workflow.step_by_id("classify-verification-result").kind == StepKind.DECISION
-    assert workflow.step_by_id("remediate-work-item").metadata["loop_target"] == "execute-work-item"
-    assert workflow.step_by_id("create-change-set-pr").metadata["run_on_final_work_item_only"] is True
-    assert workflow.step_by_id("complete-change-set").needs == ("create-change-set-pr",)
-    assert "update-project-wiki" not in workflow.step_ids()
+    assert work_item_workflow.step_by_id("classify-verification-result").kind == StepKind.DECISION
+    assert work_item_workflow.step_by_id("remediate-work-item").metadata["loop_target"] == "execute-work-item"
+    assert all(
+        step.metadata["execution_boundary"] == "work_item"
+        for step in work_item_workflow.steps
+    )
+    assert "create-change-set-pr" not in work_item_workflow.step_ids()
+    assert "complete-change-set" not in work_item_workflow.step_ids()
+    assert "update-project-wiki" not in work_item_workflow.step_ids()
+
+    assert finalization_workflow.name == "changeset-finalization-workflow"
+    assert finalization_workflow.step_ids() == (
+        "verify-all-work-items-completed",
+        "create-change-set-pr",
+        "complete-change-set",
+    )
+    assert finalization_workflow.step_by_id("create-change-set-pr").needs == (
+        "verify-all-work-items-completed",
+    )
+    assert finalization_workflow.step_by_id("complete-change-set").needs == (
+        "create-change-set-pr",
+    )
+    assert all(
+        step.metadata["execution_boundary"] == "changeset_finalization"
+        for step in finalization_workflow.steps
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_372_canonical_finalization.py
+++ b/tests/test_issue_372_canonical_finalization.py
@@ -13,14 +13,18 @@ from harness_codex.runtime.workflows import (
 )
 
 
-def test_implementation_workflow_preserves_internal_finalization() -> None:
+def test_work_item_workflow_excludes_changeset_finalization() -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    workflow = load_named_workflow(
+    work_item_workflow = load_named_workflow(
         "changeset-use-case-workflow",
         workflows_dir=repo_root / ".harness/workflows",
     )
+    finalization_workflow = load_named_workflow(
+        "changeset-finalization-workflow",
+        workflows_dir=repo_root / ".harness/workflows",
+    )
 
-    assert workflow.step_ids() == (
+    assert work_item_workflow.step_ids() == (
         "load-change-set",
         "plan-work-item",
         "secure-work-item-plan",
@@ -31,18 +35,38 @@ def test_implementation_workflow_preserves_internal_finalization() -> None:
         "classify-verification-result",
         "remediate-work-item",
         "complete-work-item-plan",
+    )
+    assert "update-project-wiki" not in work_item_workflow.step_ids()
+    assert "validate-project-wiki" not in work_item_workflow.step_ids()
+    assert "create-change-set-pr" not in work_item_workflow.step_ids()
+    assert "complete-change-set" not in work_item_workflow.step_ids()
+    assert all(
+        step.metadata["execution_boundary"] == "work_item"
+        for step in work_item_workflow.steps
+    )
+
+    assert finalization_workflow.step_ids() == (
+        "verify-all-work-items-completed",
         "create-change-set-pr",
         "complete-change-set",
     )
-    assert "update-project-wiki" not in workflow.step_ids()
-    assert "validate-project-wiki" not in workflow.step_ids()
-    assert workflow.step_by_id("complete-change-set").needs == ("create-change-set-pr",)
+    assert finalization_workflow.step_by_id("complete-change-set").needs == (
+        "create-change-set-pr",
+    )
+    assert all(
+        step.metadata["execution_boundary"] == "changeset_finalization"
+        for step in finalization_workflow.steps
+    )
 
 
-def test_implementation_workflow_materializes_selected_use_case_contract() -> None:
+def test_work_item_and_finalization_workflows_materialize_without_unresolved_placeholders() -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    workflow = load_named_workflow(
+    work_item_workflow = load_named_workflow(
         "changeset-use-case-workflow",
+        workflows_dir=repo_root / ".harness/workflows",
+    )
+    finalization_workflow = load_named_workflow(
+        "changeset-finalization-workflow",
         workflows_dir=repo_root / ".harness/workflows",
     )
     change_set = ChangeSet(change_set_id="CHG-372", title="test")
@@ -63,16 +87,26 @@ def test_implementation_workflow_materializes_selected_use_case_contract() -> No
         plan_path=Path("docs/plans/active/UC-372/plan.md"),
     )
 
-    materialized = materialize_workflow_for_scope(
-        workflow,
+    materialized_work_item = materialize_workflow_for_scope(
+        work_item_workflow,
+        change_set,
+        scope,
+        run_id="run-372",
+    )
+    materialized_finalization = materialize_workflow_for_scope(
+        finalization_workflow,
         change_set,
         scope,
         run_id="run-372",
     )
 
-    verification = materialized.step_by_id("verify-work-item")
-    delivery = materialized.step_by_id("create-change-set-pr")
+    verification = materialized_work_item.step_by_id("verify-work-item")
+    delivery = materialized_finalization.step_by_id("create-change-set-pr")
     assert Path("docs/plans/active/UC-372/plan.md") in verification.inputs
     assert all("<RUN-ID>" not in str(path) for path in verification.outputs)
-    assert delivery.metadata["run_on_final_work_item_only"] is True
-    assert unresolved_placeholders(materialized) == frozenset()
+    assert delivery.command == (
+        "python3 -m harness_codex.runtime.change_set_pr_delivery "
+        "--change-set CHG-372 --run-id run-372"
+    )
+    assert unresolved_placeholders(materialized_work_item) == frozenset()
+    assert unresolved_placeholders(materialized_finalization) == frozenset()

--- a/tests/test_project_wiki_workflow.py
+++ b/tests/test_project_wiki_workflow.py
@@ -25,9 +25,11 @@ def test_project_wiki_assets_remain_available_as_an_explicit_operation() -> None
     assert "./harness run wiki build" in details
 
 
-def test_implementation_workflow_keeps_delivery_internal_and_wiki_explicit() -> None:
-    workflow = load_named_workflow("changeset-use-case-workflow")
-    step_ids = set(workflow.step_ids())
+def test_work_item_and_finalization_workflows_keep_wiki_explicit() -> None:
+    work_item_workflow = load_named_workflow("changeset-use-case-workflow")
+    finalization_workflow = load_named_workflow("changeset-finalization-workflow")
+    work_item_step_ids = set(work_item_workflow.step_ids())
+    finalization_step_ids = set(finalization_workflow.step_ids())
 
     assert {
         "load-change-set",
@@ -40,9 +42,19 @@ def test_implementation_workflow_keeps_delivery_internal_and_wiki_explicit() -> 
         "classify-verification-result",
         "remediate-work-item",
         "complete-work-item-plan",
+    } <= work_item_step_ids
+    assert "create-change-set-pr" not in work_item_step_ids
+    assert "complete-change-set" not in work_item_step_ids
+    assert {
+        "verify-all-work-items-completed",
         "create-change-set-pr",
         "complete-change-set",
-    } <= step_ids
-    assert "update-project-wiki" not in step_ids
-    assert "validate-project-wiki" not in step_ids
-    assert workflow.step_by_id("create-change-set-pr").metadata["run_on_final_work_item_only"] is True
+    } <= finalization_step_ids
+    assert "update-project-wiki" not in work_item_step_ids | finalization_step_ids
+    assert "validate-project-wiki" not in work_item_step_ids | finalization_step_ids
+    assert work_item_workflow.step_by_id("complete-work-item-plan").metadata[
+        "execution_boundary"
+    ] == "work_item"
+    assert finalization_workflow.step_by_id("create-change-set-pr").metadata[
+        "execution_boundary"
+    ] == "changeset_finalization"


### PR DESCRIPTION
Closes #371.

## 변경
- work-item 워크플로우에서 ChangeSet 전역 delivery/completion 단계를 제거했습니다.
- 모든 work-item plan 완료 뒤에만 별도 `changeset-finalization-workflow`를 한 번 실행합니다.
- 세션 오케스트레이터가 work-item / ChangeSet finalization 경계를 검증하고, 첫 실패 시 후속 항목과 finalization을 실행하지 않습니다.
- RunState의 work-item 상태와 `changeset_finalization` 결정 결과, 별도 finalization 보고서를 분리 기록합니다.

## 검증
- 다중 UC 순차 실행 → 단일 finalization
- 첫 work-item 실패 시 다음 UC 및 finalization 미실행, 실패 항목부터 재개
- finalization 실패 시 완료 work-item 보존 및 delivery 재시도
