### PR TITLE
docs: README 워크플로우 설명 갱신

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,41 @@
 # harness-codex
 
-`harness-codex` turns an idea or change request into staged artifacts,
-ChangeSets, implementation plans, verified execution, and resumable project
-state. Stages write durable files; later stages read those files rather than
-conversation memory.
+`harness-codex` turns a product request or engineering change into durable design
+artifacts, a ChangeSet, work-item plans, verified implementation evidence, and a
+resumable delivery state.
+
+The runtime is artifact-first: each stage writes files, and downstream stages use
+those files as their handoff contract instead of relying on conversation history.
+
+## Core Model
+
+- A **ChangeSet** is the session and delivery unit for one coherent change.
+- A **work item** is the execution unit inside a ChangeSet. It can be a use case
+  or another typed change such as maintenance, a bug fix, refactoring, or a feature
+  extension.
+- A **work-item workflow** plans, reviews, executes, verifies, and completes one
+  work item.
+- A separate **ChangeSet finalization workflow** runs once only after every work
+  item has a completed plan.
+- Runtime state, evidence, reports, and resumable checkpoints are stored under
+  `.harness/runs/<RUN-ID>/`.
 
 ## Quick Start
 
-Run commands from the repository root. Installed target repositories use the
-`./harness` launcher; local development can use `python3 -m harness_codex`.
+Run commands from the target repository root. Installed target repositories use
+`./harness`; local harness development can use `python3 -m harness_codex`.
 
-## Main Workflow
+```bash
+./harness requirements-definition --title "change title" --idea "short product or engineering goal"
+```
 
-This is the only supported public workflow. Start from the first stage, then
-run the remaining stages in order for the same ChangeSet.
+This starts the requirements stage and creates or updates the active ChangeSet.
+Use the resulting ChangeSet ID in later commands.
+
+## Public Staged Workflow
+
+Run the public stages in this order for the same ChangeSet. A stage must produce
+and verify its durable artifacts before the next stage can consume them.
 
 ```bash
 ./harness requirements-definition --title "change title" --idea "short product or engineering goal"
@@ -22,40 +44,174 @@ run the remaining stages in order for the same ChangeSet.
 ./harness event-storming CHG-YYYYMMDD-001 --uc UC-001
 ./harness ddd-architecture-definition CHG-YYYYMMDD-001 --uc UC-001
 ./harness technical-decisions CHG-YYYYMMDD-001 --uc UC-001
-./harness plan-writing CHG-YYYYMMDD-001 --uc UC-001 --apply
+./harness plan-writing CHG-YYYYMMDD-001 --uc UC-001
 ./harness implementation CHG-YYYYMMDD-001 --apply
 ```
 
-`plan-writing` and `implementation` support `--plan`, `--preview`, and
-`--apply`. The implementation stage runs its internal security review,
-verification, finalization, and approved delivery gates; those are not separate
-public workflow commands.
+The definition stages can pause for focused user input when a required decision
+belongs to that stage. A blocked stage records its state and can be continued
+rather than restarted from scratch.
 
-| Stage command | Main output |
-| --- | --- |
-| `requirements-definition` | `docs/design/요구사항.md`, active ChangeSet |
-| `ubiquitous-language-definition` | `context.md` |
-| `use-case-definition` | `docs/design/유스케이스.md`, UC slices |
-| `event-storming` | `docs/use-cases/<UC-ID>/event-storming.md` |
-| `ddd-architecture-definition` | `docs/use-cases/<UC-ID>/ddd-design.md`, `ARCHITECTURE.md` |
-| `technical-decisions` | `docs/use-cases/<UC-ID>/technical-decisions.md` |
-| `plan-writing` | `docs/plans/active/<UC-ID>/plan.md` |
-| `implementation` | code, tests, verification evidence, completed plan, approved delivery state |
+| Public stage | Scope | Primary durable output |
+| --- | --- | --- |
+| `requirements-definition` | ChangeSet | `docs/design/요구사항.md` and active ChangeSet state |
+| `ubiquitous-language-definition` | ChangeSet | `context.md` |
+| `use-case-definition` | ChangeSet | `docs/design/유스케이스.md` and `docs/use-cases/<UC-ID>/` slices |
+| `event-storming` | one use case | `docs/use-cases/<UC-ID>/event-storming.md` |
+| `ddd-architecture-definition` | one use case | `docs/use-cases/<UC-ID>/ddd-design.md` and, when needed, `ARCHITECTURE.md` |
+| `technical-decisions` | one use case | `docs/use-cases/<UC-ID>/technical-decisions.md` |
+| `plan-writing` | one use case | `docs/plans/active/<UC-ID>/plan.md` |
+| `implementation` | every unfinished work item in the ChangeSet | code, verification evidence, completed plans, and approved delivery state |
 
-## ChangeSets and Resume
+## Before Implementation
 
-A ChangeSet holds the request, stage status, verification evidence, and resume
-point. Use the following supporting commands without substituting a second
-workflow.
+The implementation command is ChangeSet-scoped. Do not pass `--uc` to it: the
+runtime resolves every unfinished work item belonging to the active ChangeSet.
+
+Before execution, the runtime checks that the ChangeSet and its selected work
+items are runnable:
+
+- the active ChangeSet file exists and its ID matches its path;
+- at least one affected work item exists;
+- every work-item slice exists and satisfies its type-specific document contract;
+- use-case work items have their required use-case, event-storming, DDD,
+  technical-decision, and E2E-goal documents;
+- applicable E2E goals and technical decisions are approved before planning.
+
+A failed preflight is a blocker, not a partial implementation run. Fix or approve
+the cited artifact, then continue the ChangeSet.
+
+## What `implementation` Actually Runs
+
+`implementation` has two execution boundaries.
+
+### 1. Per-work-item loop
+
+For each unfinished work item, the runtime materializes a workflow scoped to that
+work item and runs the following gates in order:
+
+1. Create or update the active implementation plan.
+2. Add applicable security controls to the plan.
+3. Review the plan against its scope and test-gate contract.
+4. Execute unchecked plan tasks.
+5. Run structured verification and write verification evidence.
+6. Perform an independent implementation security review.
+7. Classify the result as passed, remediable, blocked by an upstream document or
+   scope conflict, blocked by the environment, or blocked by unclear verification
+   evidence.
+8. Complete the work-item plan only when the applicable gates pass. A remediable
+   result keeps the plan active and routes back to remediation rather than silently
+   completing it.
+
+Completed work-item plans move from:
+
+```text
+docs/plans/active/<WORK-ITEM-ID>/plan.md
+```
+
+into:
+
+```text
+docs/plans/completed/<WORK-ITEM-ID>/plan.md
+```
+
+A completed plan is not enough to finish the ChangeSet. On a later implementation
+run, completed work items are skipped while finalization is still evaluated.
+
+### 2. ChangeSet finalization loop
+
+After every affected work item has a completed plan, the runtime runs finalization
+once:
+
+1. Confirm that all affected work-item plans are complete.
+2. Create or reuse the ChangeSet pull request.
+3. Move the active ChangeSet to `docs/changes/completed/<CHG-ID>.md` only after
+   approved delivery succeeds.
+
+Delivery is fail-closed. The finalization workflow requires the configured
+`HARNESS_DELIVERY_APPROVED` approval environment before pull-request delivery and
+ChangeSet completion can proceed. Without approval or a successful PR delivery,
+the ChangeSet remains active.
+
+## Modes, Continuation, and Inspection
+
+The definition stages and `plan-writing` run as apply stages. `implementation`
+supports explicit execution modes:
+
+```bash
+./harness implementation CHG-YYYYMMDD-001 --plan
+./harness implementation CHG-YYYYMMDD-001 --preview
+./harness implementation CHG-YYYYMMDD-001 --apply
+```
+
+Use the ChangeSet and run-inspection commands to resume the existing workflow;
+do not create a parallel workflow for the same change.
 
 ```bash
 ./harness changes list
 ./harness changes active
 ./harness changes show CHG-YYYYMMDD-001
+./harness changes contents CHG-YYYYMMDD-001
 ./harness changes continue CHG-YYYYMMDD-001 --apply
 ./harness stages list CHG-YYYYMMDD-001
-./harness resume run-<id>
-./harness report run-<id>
+./harness contracts validate CHG-YYYYMMDD-001
+./harness artifacts show CHG-YYYYMMDD-001 <stage>
+./harness resume run-<RUN-ID>
+./harness report run-<RUN-ID>
+```
+
+`changes continue` resolves the next incomplete or blocked public stage. When an
+upstream requirement or use-case decision must be revised, it reports the owning
+stage instead of pretending that the downstream stage can proceed.
+
+## Artifact Layout
+
+```text
+docs/design/                         Canonical requirements and use-case documents
+docs/changes/active/<CHG-ID>.md      Active ChangeSet
+docs/changes/completed/<CHG-ID>.md   Delivered ChangeSet
+docs/use-cases/<UC-ID>/              Executor-facing use-case slice
+docs/maintenance/<MAINT-ID>/         Typed maintenance slice
+docs/plans/active/<WORK-ITEM-ID>/    Incomplete plan
+docs/plans/completed/<WORK-ITEM-ID>/ Verified completed plan
+.harness/runs/<RUN-ID>/              Runtime state, prompts, evidence, reports, and checkpoints
+```
+
+The ChangeSet document is a durable user-facing mirror of runtime progress. The
+run state in `.harness/runs/<RUN-ID>/state.json` is the authoritative runtime
+record for resume targets, gates, failures, and artifact state.
+
+## Agent Context, Memory, and Evolution
+
+Initialize compact repository-local agent context when setting up a target
+repository:
+
+```bash
+./harness init --description "repository purpose"
+# or
+./harness agent-context init --description "repository purpose" --llm
+```
+
+The generated repository context is guidance, not a substitute for the active
+ChangeSet and selected work-item slice.
+
+`memory` is a file-backed long-term knowledge store. Its current public commands
+list, search, and score entries; they do not replace normal workflow gates.
+
+```bash
+./harness memory list
+./harness memory search "plan contract verification"
+./harness memory score candidate.yaml
+```
+
+`evolution` manages reviewable guidance proposals created from recorded
+intent-alignment feedback. It is for reusable user-intent corrections, not for
+ordinary implementation, verifier, test, or environment failures.
+
+```bash
+./harness evolution propose --change-set CHG-YYYYMMDD-001 --work-item UC-001 --run-id run-<RUN-ID>
+./harness evolution accept EVO-YYYYMMDD-001
+./harness evolution reject EVO-YYYYMMDD-001
 ```
 
 ## Runtime Operations
@@ -66,10 +222,10 @@ workflow.
 ./harness ui-server
 ```
 
-Project settings and test gates live in `.codex/repository-settings.md` and
-`.codex/test-gate.yaml`.
+Project-specific working boundaries and verification commands live in
+`.codex/repository-settings.md` and `.codex/test-gate.yaml`.
 
-## Verification
+## Verifying harness-codex Itself
 
 ```bash
 ./venv/bin/python3 -m pytest -q -s tests/runtime


### PR DESCRIPTION
## 구현 의도

- 현재 `origin/main`의 실제 CLI와 ChangeSet 실행 경계를 기준으로 README의 워크플로우 설명을 갱신합니다.

## 구현 접근

- public staged workflow, ChangeSet 사전 검증, work item별 내부 실행 루프, ChangeSet 최종화/PR 전달 게이트를 분리해 설명했습니다.
- `implementation`이 `--uc`가 아닌 ChangeSet 전체 미완료 work item을 처리한다는 점과 delivery fail-closed 동작을 명시했습니다.
- `memory`와 `evolution`을 보조 기능으로 정리해 일반 검증/복구 흐름과 혼동되지 않게 했습니다.

## 검증 방법

- README 서술을 `README.md`, CLI stage parser, ChangeSet orchestrator, work-item workflow, finalization workflow의 현재 정의와 대조했습니다.

## 위험 및 롤백

- 위험: 이후 CLI 또는 workflow 계약이 바뀌면 README가 다시 오래될 수 있습니다.
- 롤백: 이 PR의 README 변경만 되돌리면 됩니다.