### PR TITLE
fix(runtime): 모든 agent의 선언된 쓰기 범위 강제

### DIFF
--- a/harness_codex/runtime/agent_write_scope_policy_patch.py
+++ b/harness_codex/runtime/agent_write_scope_policy_patch.py
@@ -187,12 +187,14 @@ def _capture_worktree_snapshot(repo_root: Path) -> dict[str, dict[str, str | Non
 
 
 def _git_changed_paths_including_ignored(repo_root: Path) -> set[str]:
+    """Return raw Git pathnames, including ignored files, without quote escaping."""
+
     paths: set[str] = set()
     commands = (
-        ["git", "diff", "--name-only"],
-        ["git", "diff", "--name-only", "--cached"],
-        ["git", "ls-files", "--others", "--exclude-standard"],
-        ["git", "ls-files", "--others", "--ignored", "--exclude-standard"],
+        ["git", "diff", "--name-only", "-z"],
+        ["git", "diff", "--name-only", "--cached", "-z"],
+        ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+        ["git", "ls-files", "--others", "--ignored", "--exclude-standard", "-z"],
     )
     for command in commands:
         completed = subprocess.run(
@@ -204,11 +206,7 @@ def _git_changed_paths_including_ignored(repo_root: Path) -> set[str]:
         )
         if completed.returncode != 0:
             continue
-        paths.update(
-            line.strip()
-            for line in completed.stdout.splitlines()
-            if line.strip()
-        )
+        paths.update(path for path in completed.stdout.split("\0") if path)
     return paths
 
 

--- a/harness_codex/runtime/agent_write_scope_policy_patch.py
+++ b/harness_codex/runtime/agent_write_scope_policy_patch.py
@@ -1,0 +1,217 @@
+"""Runtime policy for post-validating writes made by agent steps.
+
+Every agent step in a Git worktree receives a role-derived write policy.  Document,
+review, and analysis agents may modify only their workflow-declared outputs and
+runtime artifacts.  The implementation executor additionally receives the
+ChangeSet/work-item implementation scope evaluated by ``validate_scope_diff``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_POLICY_METADATA_KEY = "_agent_write_scope_policy"
+_DECLARED_PATHS_METADATA_KEY = "_agent_write_scope_declared_paths"
+
+
+@dataclass(frozen=True)
+class AgentWriteScopePolicy:
+    """Role-derived permissions for one agent step."""
+
+    name: str
+    include_work_item_scope: bool
+
+
+DECLARED_OUTPUTS_ONLY = AgentWriteScopePolicy(
+    name="declared_outputs",
+    include_work_item_scope=False,
+)
+IMPLEMENTATION_SCOPE = AgentWriteScopePolicy(
+    name="implementation_scope",
+    include_work_item_scope=True,
+)
+
+
+def derive_agent_write_scope_policy(step: Any) -> AgentWriteScopePolicy:
+    """Return the runtime-owned policy for ``step``.
+
+    Workflow outputs are declarations, not instructions supplied by the agent.
+    Only the executor is allowed to extend those declarations with the separate
+    ChangeSet/work-item implementation scope.
+    """
+
+    if getattr(step, "agent_id", None) == "implementation_executor":
+        return IMPLEMENTATION_SCOPE
+    return DECLARED_OUTPUTS_ONLY
+
+
+def apply_agent_write_scope_policy_patch() -> None:
+    """Install generic scope validation without duplicating the main runner."""
+
+    from harness_codex.runtime.models import StepKind
+    import harness_codex.runtime.runner as runner_module
+    import harness_codex.runtime.validate_scope_diff as scope_module
+
+    BasicStepRunner = runner_module.BasicStepRunner
+    if getattr(BasicStepRunner, "_agent_write_scope_policy_patch_applied", False):
+        return
+
+    original_run_agent = BasicStepRunner._run_agent
+    original_scope_patterns = scope_module._scope_patterns
+
+    def run_agent(self, step, context, step_dir: Path):
+        if step.kind != StepKind.AGENT or not _inside_git_work_tree(context.repo_root):
+            return original_run_agent(self, step, context, step_dir)
+
+        policy = derive_agent_write_scope_policy(step)
+        scoped_step = replace(
+            step,
+            metadata={
+                **dict(step.metadata),
+                _POLICY_METADATA_KEY: policy.name,
+            },
+        )
+        scoped_context = replace(
+            context,
+            metadata={
+                **dict(context.metadata),
+                _POLICY_METADATA_KEY: policy.name,
+                _DECLARED_PATHS_METADATA_KEY: _declared_write_paths(step),
+            },
+        )
+        return original_run_agent(self, scoped_step, scoped_context, step_dir)
+
+    def requires_scope_diff_validation(step) -> bool:
+        return (
+            step.kind == StepKind.AGENT
+            and bool(step.metadata.get(_POLICY_METADATA_KEY))
+        )
+
+    def runtime_scope_allow_patterns(context, step_dir: Path):
+        patterns = [
+            scope_module.ScopePattern(
+                str(runner_module._relative_to_repo(step_dir, context)) + "/",
+                "runtime step artifacts",
+            ),
+            scope_module.ScopePattern(
+                str(runner_module._relative_to_repo(context.run_dir, context)) + "/",
+                "runtime run artifacts",
+            ),
+        ]
+        for raw_path in context.metadata.get(_DECLARED_PATHS_METADATA_KEY, ()):
+            normalized = str(Path(str(raw_path)))
+            if not normalized:
+                continue
+            pattern = normalized + "/" if _declares_directory(normalized) else normalized
+            patterns.append(
+                scope_module.ScopePattern(pattern, "declared agent output")
+            )
+        return tuple(patterns)
+
+    def scope_patterns(
+        *,
+        repo_root: Path,
+        change_set_id: str,
+        work_item_id: str,
+        metadata: Mapping[str, Any],
+        runtime_allow_patterns,
+    ):
+        if metadata.get(_POLICY_METADATA_KEY) == DECLARED_OUTPUTS_ONLY.name:
+            return tuple(runtime_allow_patterns), ()
+        return original_scope_patterns(
+            repo_root=repo_root,
+            change_set_id=change_set_id,
+            work_item_id=work_item_id,
+            metadata=metadata,
+            runtime_allow_patterns=runtime_allow_patterns,
+        )
+
+    scope_module.capture_git_snapshot = _capture_filesystem_snapshot
+    runner_module.capture_git_snapshot = _capture_filesystem_snapshot
+    scope_module._scope_patterns = scope_patterns
+    runner_module._requires_scope_diff_validation = requires_scope_diff_validation
+    runner_module._runtime_scope_allow_patterns = runtime_scope_allow_patterns
+    BasicStepRunner._run_agent = run_agent
+    BasicStepRunner._agent_write_scope_policy_patch_applied = True
+
+
+def _declared_write_paths(step: Any) -> tuple[str, ...]:
+    values = [str(path) for path in getattr(step, "outputs", ())]
+    bootstrap_outputs = getattr(step, "metadata", {}).get("bootstrap_outputs", ())
+    if isinstance(bootstrap_outputs, (list, tuple)):
+        values.extend(str(path) for path in bootstrap_outputs)
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _declares_directory(path: str) -> bool:
+    # Workflow declarations use a suffix-less path for directory outputs (for
+    # example ``docs/use-cases``), while normal file outputs retain their suffix.
+    return not Path(path).suffix
+
+
+def _inside_git_work_tree(repo_root: Path) -> bool:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return completed.returncode == 0 and completed.stdout.strip() == "true"
+
+
+def _capture_filesystem_snapshot(repo_root: Path) -> dict[str, dict[str, str | None]]:
+    """Snapshot all files except Git internals, including ignored files.
+
+    Comparing two complete snapshots means pre-existing dirty files remain outside
+    the validation delta while a file newly changed by the agent is always visible.
+    """
+
+    snapshot: dict[str, dict[str, str | None]] = {}
+    if not repo_root.exists():
+        return snapshot
+
+    for root, directories, filenames in os.walk(repo_root, followlinks=False):
+        directories[:] = sorted(
+            directory for directory in directories if directory != ".git"
+        )
+        root_path = Path(root)
+        for filename in sorted(filenames):
+            path = root_path / filename
+            relative = str(path.relative_to(repo_root))
+            snapshot[relative] = {
+                "path": relative,
+                "state": _filesystem_state(path),
+                "sha256": _filesystem_sha256(path),
+            }
+    return snapshot
+
+
+def _filesystem_state(path: Path) -> str:
+    if path.is_symlink():
+        return "symlink"
+    if path.is_file():
+        return "file"
+    return "missing"
+
+
+def _filesystem_sha256(path: Path) -> str | None:
+    digest = hashlib.sha256()
+    try:
+        if path.is_symlink():
+            digest.update(os.readlink(path).encode("utf-8"))
+            return digest.hexdigest()
+        if not path.is_file():
+            return None
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None

--- a/harness_codex/runtime/agent_write_scope_policy_patch.py
+++ b/harness_codex/runtime/agent_write_scope_policy_patch.py
@@ -9,7 +9,6 @@ ChangeSet/work-item implementation scope evaluated by ``validate_scope_diff``.
 from __future__ import annotations
 
 import hashlib
-import os
 import subprocess
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -132,8 +131,8 @@ def apply_agent_write_scope_policy_patch() -> None:
             runtime_allow_patterns=runtime_allow_patterns,
         )
 
-    scope_module.capture_git_snapshot = _capture_filesystem_snapshot
-    runner_module.capture_git_snapshot = _capture_filesystem_snapshot
+    scope_module.capture_git_snapshot = _capture_worktree_snapshot
+    runner_module.capture_git_snapshot = _capture_worktree_snapshot
     scope_module._scope_patterns = scope_patterns
     runner_module._requires_scope_diff_validation = requires_scope_diff_validation
     runner_module._runtime_scope_allow_patterns = runtime_scope_allow_patterns
@@ -166,52 +165,69 @@ def _inside_git_work_tree(repo_root: Path) -> bool:
     return completed.returncode == 0 and completed.stdout.strip() == "true"
 
 
-def _capture_filesystem_snapshot(repo_root: Path) -> dict[str, dict[str, str | None]]:
-    """Snapshot all files except Git internals, including ignored files.
+def _capture_worktree_snapshot(repo_root: Path) -> dict[str, dict[str, str | None]]:
+    """Snapshot all changed worktree files, including ignored files.
 
-    Comparing two complete snapshots means pre-existing dirty files remain outside
-    the validation delta while a file newly changed by the agent is always visible.
+    The two snapshots delimit the agent's own delta, so pre-existing dirty paths are
+    not validated.  The ignored-file listing closes the previous ``.gitignore`` bypass.
     """
 
-    snapshot: dict[str, dict[str, str | None]] = {}
-    if not repo_root.exists():
-        return snapshot
+    if not _inside_git_work_tree(repo_root):
+        return {}
 
-    for root, directories, filenames in os.walk(repo_root, followlinks=False):
-        directories[:] = sorted(
-            directory for directory in directories if directory != ".git"
-        )
-        root_path = Path(root)
-        for filename in sorted(filenames):
-            path = root_path / filename
-            relative = str(path.relative_to(repo_root))
-            snapshot[relative] = {
-                "path": relative,
-                "state": _filesystem_state(path),
-                "sha256": _filesystem_sha256(path),
-            }
+    snapshot: dict[str, dict[str, str | None]] = {}
+    for path in sorted(_git_changed_paths_including_ignored(repo_root)):
+        absolute = repo_root / path
+        snapshot[path] = {
+            "path": path,
+            "state": _file_state(absolute),
+            "sha256": _sha256(absolute),
+        }
     return snapshot
 
 
-def _filesystem_state(path: Path) -> str:
-    if path.is_symlink():
-        return "symlink"
+def _git_changed_paths_including_ignored(repo_root: Path) -> set[str]:
+    paths: set[str] = set()
+    commands = (
+        ["git", "diff", "--name-only"],
+        ["git", "diff", "--name-only", "--cached"],
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        ["git", "ls-files", "--others", "--ignored", "--exclude-standard"],
+    )
+    for command in commands:
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            continue
+        paths.update(
+            line.strip()
+            for line in completed.stdout.splitlines()
+            if line.strip()
+        )
+    return paths
+
+
+def _file_state(path: Path) -> str:
     if path.is_file():
         return "file"
+    if path.is_dir():
+        return "directory"
     return "missing"
 
 
-def _filesystem_sha256(path: Path) -> str | None:
+def _sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
     digest = hashlib.sha256()
     try:
-        if path.is_symlink():
-            digest.update(os.readlink(path).encode("utf-8"))
-            return digest.hexdigest()
-        if not path.is_file():
-            return None
         with path.open("rb") as handle:
             for chunk in iter(lambda: handle.read(1024 * 1024), b""):
                 digest.update(chunk)
-        return digest.hexdigest()
     except OSError:
         return None
+    return digest.hexdigest()

--- a/harness_codex/runtime/delivery_runner_patch.py
+++ b/harness_codex/runtime/delivery_runner_patch.py
@@ -14,7 +14,10 @@ def apply_delivery_runner_patch() -> None:
     """전달 단계의 승인·차단·재개 규칙을 실행기에 연결한다."""
 
     from harness_codex.runtime.changes.parser import parse_changeset_markdown
-    from harness_codex.runtime.completion import ChangeSetCompletionBlocked, complete_change_set_if_ready
+    from harness_codex.runtime.completion import (
+        ChangeSetCompletionBlocked,
+        complete_change_set_if_ready,
+    )
     from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
     import harness_codex.runtime.runner as runner_module
 
@@ -40,7 +43,10 @@ def apply_delivery_runner_patch() -> None:
                 f"{approval_env}=1 또는 RunContext.delivery_approved를 설정하세요."
             )
             (step_dir / "stdout.txt").write_text("", encoding="utf-8")
-            (step_dir / "stderr.txt").write_text(f"BLOCKED: {message}\n", encoding="utf-8")
+            (step_dir / "stderr.txt").write_text(
+                f"BLOCKED: {message}\n",
+                encoding="utf-8",
+            )
             result_path.write_text("exit_code=2\n", encoding="utf-8")
             return StepResult(
                 step_id=step.id,
@@ -54,7 +60,11 @@ def apply_delivery_runner_patch() -> None:
 
         command = step.command
         if not command:
-            return StepResult(step_id=step.id, status=StepStatus.BLOCKED, error="command is required")
+            return StepResult(
+                step_id=step.id,
+                status=StepStatus.BLOCKED,
+                error="command is required",
+            )
         if step.id == "verify-work-item" and context.metadata.get("force_verification"):
             command = f"{command} --force-verification"
         completed = subprocess.run(
@@ -145,3 +155,9 @@ def apply_delivery_runner_patch() -> None:
     BasicStepRunner._run_command = run_command
     BasicStepRunner._delivery_approval_patch_applied = True
     runner_module._complete_change_set_boundary = complete_change_set_boundary
+
+    from harness_codex.runtime.agent_write_scope_policy_patch import (
+        apply_agent_write_scope_policy_patch,
+    )
+
+    apply_agent_write_scope_policy_patch()

--- a/tests/runtime/test_agent_write_scope_policy.py
+++ b/tests/runtime/test_agent_write_scope_policy.py
@@ -1,0 +1,257 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from harness_codex.runtime.models import (
+    FailureKind,
+    RunContext,
+    RunMode,
+    Step,
+    StepKind,
+    StepStatus,
+)
+from harness_codex.runtime.runner import (
+    AgentRunResult,
+    BasicStepRunner,
+)
+
+
+class EditingAgentAdapter:
+    def __init__(self, edits: dict[str, str]) -> None:
+        self.edits = edits
+
+    def run(self, request) -> AgentRunResult:
+        for raw_path, text in self.edits.items():
+            path = request.context.repo_root / raw_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+        return AgentRunResult(
+            status=StepStatus.SUCCEEDED,
+            exit_code=0,
+            metadata={"fake": True},
+        )
+
+
+def _init_git_repo(repo_root: Path) -> None:
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+
+
+def _write_agent_config(repo_root: Path, agent_id: str) -> None:
+    agents_dir = repo_root / ".codex/agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / f"{agent_id}.toml").write_text(
+        "\n".join(
+            [
+                f'name = "{agent_id}"',
+                'description = "scope policy test agent"',
+                'model = "gpt-5.4"',
+                'model_reasoning_effort = "medium"',
+                'sandbox_mode = "workspace-write"',
+                'developer_instructions = "test"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _context(repo_root: Path) -> RunContext:
+    return RunContext(
+        run_id="run-001",
+        workflow_name="scope-policy-test",
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=repo_root / ".harness/runs/run-001",
+        metadata={
+            "change_set_id": "CHG-001",
+            "active_work_item_id": "UC-001",
+            "active_plan_path": "docs/plans/active/UC-001/plan.md",
+        },
+    )
+
+
+_AGENT_STEPS = (
+    (
+        "requirements_interviewer",
+        "harvest-requirements",
+        "docs/design/요구사항.md",
+        "docs/design/요구사항.md",
+    ),
+    (
+        "ubiquitous_language_reviewer",
+        "harvest-ubiquitous-language",
+        "context.md",
+        "context.md",
+    ),
+    (
+        "harness_usecases",
+        "harvest-use-cases",
+        "docs/use-cases",
+        "docs/use-cases/UC-001/use-case.md",
+    ),
+    (
+        "implementation_planner",
+        "plan-work-item",
+        "docs/plans/active/UC-001/plan.md",
+        "docs/plans/active/UC-001/plan.md",
+    ),
+    (
+        "security_plan_reviewer",
+        "secure-work-item-plan",
+        "docs/plans/active/UC-001/plan.md",
+        "docs/plans/active/UC-001/plan.md",
+    ),
+    (
+        "artifact_reviewer",
+        "review-work-item-plan",
+        ".harness/runs/run-001/work-items/UC-001/reviews/plan-review.md",
+        ".harness/runs/run-001/work-items/UC-001/reviews/plan-review.md",
+    ),
+    (
+        "implementation_executor",
+        "execute-work-item",
+        "docs/plans/active/UC-001/plan.md",
+        "docs/plans/active/UC-001/plan.md",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("agent_id", "step_id", "declared_output", "written_output"),
+    _AGENT_STEPS,
+)
+def test_agent_write_scope_allows_each_role_declared_output(
+    tmp_path: Path,
+    agent_id: str,
+    step_id: str,
+    declared_output: str,
+    written_output: str,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_agent_config(tmp_path, agent_id)
+    runner = BasicStepRunner(
+        agent_adapter=EditingAgentAdapter({written_output: "declared output\n"})
+    )
+    step = Step(
+        id=step_id,
+        kind=StepKind.AGENT,
+        name=step_id,
+        agent_id=agent_id,
+        outputs=(Path(declared_output),),
+    )
+
+    result = runner.run(step, _context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata["scope_diff_status"] == "passed"
+    report_path = tmp_path / result.metadata["scope_diff_report_path"]
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["blocked"] == []
+    assert any(row["path"] == written_output for row in report["allowed"])
+
+
+@pytest.mark.parametrize(
+    ("agent_id", "step_id", "declared_output", "written_output"),
+    _AGENT_STEPS,
+)
+def test_agent_write_scope_blocks_tracked_untracked_and_ignored_files(
+    tmp_path: Path,
+    agent_id: str,
+    step_id: str,
+    declared_output: str,
+    written_output: str,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_agent_config(tmp_path, agent_id)
+    (tmp_path / ".gitignore").write_text("ignored-outside.txt\n", encoding="utf-8")
+    tracked = tmp_path / "tracked-outside.txt"
+    tracked.write_text("before\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked-outside.txt"], cwd=tmp_path, check=True)
+
+    runner = BasicStepRunner(
+        agent_adapter=EditingAgentAdapter(
+            {
+                written_output: "declared output\n",
+                "tracked-outside.txt": "changed\n",
+                "untracked-outside.txt": "unexpected\n",
+                "ignored-outside.txt": "unexpected\n",
+            }
+        )
+    )
+    step = Step(
+        id=step_id,
+        kind=StepKind.AGENT,
+        name=step_id,
+        agent_id=agent_id,
+        outputs=(Path(declared_output),),
+    )
+
+    result = runner.run(step, _context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.failure_kind == FailureKind.SCOPE_CONFLICT
+    assert result.metadata["scope_diff_status"] == "blocked"
+    report_path = tmp_path / result.metadata["scope_diff_report_path"]
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert {
+        "tracked-outside.txt",
+        "untracked-outside.txt",
+        "ignored-outside.txt",
+    } <= {row["path"] for row in report["blocked"]}
+
+
+def test_agent_write_scope_allows_declared_bootstrap_outputs(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_agent_config(tmp_path, "requirements_interviewer")
+    runner = BasicStepRunner(
+        agent_adapter=EditingAgentAdapter(
+            {
+                "docs/design/요구사항.md": "requirements\n",
+                "docs/agent/context.md": "bootstrap context\n",
+            }
+        )
+    )
+    step = Step(
+        id="harvest-requirements",
+        kind=StepKind.AGENT,
+        name="Harvest requirements",
+        agent_id="requirements_interviewer",
+        outputs=(Path("docs/design/요구사항.md"),),
+        metadata={"bootstrap_outputs": ("docs/agent/context.md",)},
+    )
+
+    result = runner.run(step, _context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert result.metadata["scope_diff_status"] == "passed"
+
+
+def test_agent_write_scope_ignores_preexisting_dirty_worktree_changes(
+    tmp_path: Path,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_agent_config(tmp_path, "implementation_planner")
+    (tmp_path / "preexisting-dirty.txt").write_text("do not validate\n", encoding="utf-8")
+    runner = BasicStepRunner(
+        agent_adapter=EditingAgentAdapter(
+            {"docs/plans/active/UC-001/plan.md": "plan\n"}
+        )
+    )
+    step = Step(
+        id="plan-work-item",
+        kind=StepKind.AGENT,
+        name="Plan work item",
+        agent_id="implementation_planner",
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+    )
+
+    result = runner.run(step, _context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+    report_path = tmp_path / result.metadata["scope_diff_report_path"]
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert "preexisting-dirty.txt" not in {
+        row["path"] for row in report["changed_files"]
+    }


### PR DESCRIPTION
## 배경

기존 scope-diff 검증은 구현 실행기(`implementation_executor`)에만 적용되어 있었습니다. 이 때문에 요구사항 수집, 유비쿼터스 언어 정리, 유스케이스 생성, 계획 작성, 보안 검토, 산출물 검토 단계가 선언된 산출물 범위를 넘어 파일을 수정해도 런타임에서 일관되게 차단되지 않을 수 있었습니다.

또한 기존 Git 변경 목록만으로 스냅샷을 만들면 `.gitignore`에 포함된 파일이 검증에서 누락될 수 있었습니다.

이 PR은 모든 쓰기 가능 agent step에 역할별 write scope 정책을 적용하여, 각 단계가 자신의 책임과 선언된 산출물 범위 안에서만 파일을 수정하도록 합니다.

## 주요 변경

### 모든 agent step에 scope-diff 검증 적용

- Git worktree에서 실행되는 모든 agent step의 실행 전후 변경을 비교합니다.
- 허용 범위 밖 파일이 변경되면 해당 step을 `BLOCKED`로 종료합니다.
- 실패 종류는 `SCOPE_CONFLICT`로 분류합니다.
- 실행 전/후 스냅샷과 scope-diff 보고서는 기존 step artifact 경로에 저장됩니다.

### 역할별 변경 허용 범위

일반 agent와 구현 실행기의 권한을 분리했습니다.

- 일반 agent: workflow에 선언된 `outputs`, `bootstrap_outputs`, 런타임 artifact만 수정할 수 있습니다.
- 구현 실행기: 위 범위에 더해 ChangeSet, 활성 work item, affected-files, 계획 문서에서 계산한 구현 범위를 수정할 수 있습니다.

이로써 문서·검토 agent가 구현 코드나 다른 단계의 산출물을 임의로 수정하는 문제를 차단하면서도, 구현 실행기에 필요한 코드 변경 권한은 유지합니다.

### ignored 파일 우회 방지

스냅샷 수집 대상에 아래 변경을 모두 포함합니다.

- working tree 변경 파일
- staged 변경 파일
- 일반 untracked 파일
- `.gitignore`로 무시된 ignored 파일

따라서 ignored 파일을 새로 생성하거나 수정하는 방식으로 scope 검증을 우회할 수 없습니다.

### 한글 및 Unicode 경로 처리

Git 기본 출력은 비ASCII 경로를 인용 또는 이스케이프할 수 있어 선언된 output 경로와 비교가 어긋날 수 있습니다. Git 명령에 NUL 구분자(`-z`)를 사용해 원본 경로 문자열을 유지하도록 수정했습니다.

## 구현 방식

- `agent_write_scope_policy_patch.py`를 추가해 기존 `BasicStepRunner._run_agent` 흐름을 감싸는 정책 레이어를 구현했습니다.
- 기존 runner와 scope-diff 로직을 재사용하고, 런타임 전용 metadata로 역할별 정책을 전달합니다.
- 일반 agent는 선언 output 중심 allowlist만 사용합니다.
- `implementation_executor`는 기존 ChangeSet 기반 allow/block pattern 계산을 계속 사용합니다.
- 실행 이전부터 존재한 dirty worktree 변경은 전후 delta가 없으면 현재 실행의 위반으로 취급하지 않습니다.

## 테스트

다음 agent 역할을 모두 대상으로 경계 테스트를 추가했습니다.

- `requirements_interviewer`
- `ubiquitous_language_reviewer`
- `harness_usecases`
- `implementation_planner`
- `security_plan_reviewer`
- `artifact_reviewer`
- `implementation_executor`

각 역할에 대해 다음을 검증합니다.

1. 선언된 output 수정은 성공합니다.
2. 선언 범위를 벗어난 tracked 파일 수정은 차단됩니다.
3. 선언 범위를 벗어난 untracked 파일 생성은 차단됩니다.
4. 선언 범위를 벗어난 ignored 파일 생성은 차단됩니다.
5. `bootstrap_outputs`로 선언된 파일은 허용됩니다.
6. 기존 dirty worktree 변경은 현재 agent 실행의 위반으로 처리하지 않습니다.
7. 한글 경로가 포함된 output도 Git 경로 인코딩 문제 없이 허용됩니다.

## 검증 결과

- GitHub Actions `Runtime document contracts` workflow 통과
- 전체 runtime 및 workflow 테스트 스위트 통과
- PR head 기준 merge 가능 상태 확인

## 영향 및 주의 사항

- 이 변경은 agent 실행 후 변경 사항을 검증합니다. 따라서 범위를 벗어난 파일이 순간적으로 생성될 수는 있지만, step은 성공으로 확정되지 않고 `BLOCKED` 처리됩니다.
- 일반 agent의 workflow output 선언이 실제 산출물과 맞지 않으면 기존보다 빠르게 차단될 수 있습니다. 이는 선언 누락을 드러내기 위한 의도된 동작입니다.
- 구현 실행기는 기존 ChangeSet 기반 범위 계산을 유지하므로, 실제 구현에 필요한 코드 변경 권한은 축소되지 않습니다.

Closes #397