### PR TITLE
fix: 읽기 전용 보안 구현 리뷰 보고서를 runtime에서 생성한다

### DIFF
--- a/.codex/skills/harness-security-implementation-reviewer/SKILL.md
+++ b/.codex/skills/harness-security-implementation-reviewer/SKILL.md
@@ -8,15 +8,15 @@ description: Independently review one implemented ChangeSet work item after prod
 ## Scope
 
 - Read only runtime-declared inputs and the repository diff relevant to the active work item.
-- Do not edit implementation code, plans, ChangeSet documents, or upstream artifacts.
-- Produce exactly one report at the runtime-declared output path.
+- Do not edit implementation code, plans, ChangeSet documents, upstream artifacts, or runtime output files.
+- Return exactly one Markdown report as the final response. The runtime materializes that final response at the workflow-declared security review output path.
 
 ## Review Flow
 
 1. Derive the implemented attack surface from the active ChangeSet, work-item documents, active plan, verification evidence, and changed files.
 2. Review applicable controls against the pinned OWASP sources in `.codex/security/`.
 3. Check that security plan tasks are implemented and supported by focused evidence.
-4. Write the report headings below.
+4. Return the report headings below in the final response only.
 
 ## Report Contract
 

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -128,7 +128,7 @@ steps:
     - static-analysis
     inputs_resolved_by: work_item_document_contract
     test_gate: .codex/test-gate.yaml required stages must PASS when applicable
-- id: verify-work-item-security
+- id: review-work-item-security
   kind: agent
   name: Independently review the implemented work item for security findings
   needs:
@@ -142,8 +142,6 @@ steps:
   - .codex/security/owasp-standards.json
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/verification.md
-  outputs:
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
   metadata:
     stage: implementation
     prompt_context_profile: security-verification
@@ -152,6 +150,30 @@ steps:
     gate_id: security-review
     baseline: OWASP ASVS 5.0.0
     inputs_resolved_by: work_item_document_contract
+    final_response_contract:
+      channel: final-message
+      format: markdown
+      output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
+      status_label: Security Review Status
+      allowed_statuses:
+      - approved
+      - rejected
+- id: verify-work-item-security
+  kind: validator
+  name: Materialize and validate the security review report
+  needs:
+  - review-work-item-security
+  command: python3 -m harness_codex.runtime.materialize_security_review --source .harness/runs/<RUN-ID>/steps/review-work-item-security/final-message.md --output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
+  timeout_sec: 60
+  outputs:
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
+  metadata:
+    stage: implementation
+    scope: work_item
+    execution_boundary: work_item
+    gate_id: security-review
+    baseline: OWASP ASVS 5.0.0
+    materialized_from: .harness/runs/<RUN-ID>/steps/review-work-item-security/final-message.md
     review_gate:
       output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
       status_label: Security Review Status

--- a/docs/architecture/security-review-materialization.md
+++ b/docs/architecture/security-review-materialization.md
@@ -1,0 +1,32 @@
+# Security Review Runtime Materialization
+
+## Purpose
+
+The security implementation reviewer runs with a `read-only` sandbox. It must not write implementation code, plans, ChangeSet documents, upstream artifacts, or runtime artifact paths.
+
+The reviewer returns one Markdown report in its final response. The runtime owns persistence of that response under the workflow-declared report path.
+
+## Workflow Contract
+
+1. `review-work-item-security` invokes `security_implementation_reviewer` with no declared file outputs.
+2. The provider adapter persists the agent final response as:
+   `.harness/runs/<RUN-ID>/steps/review-work-item-security/final-message.md`.
+3. `verify-work-item-security` invokes `harness_codex.runtime.materialize_security_review`.
+4. The materializer validates `Security Review Status: approved|rejected`, writes:
+   `.harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md`, and returns:
+   - `0` for `approved`;
+   - `2` for `rejected`, after the report has been written;
+   - `1` for a missing, empty, or malformed final response.
+
+Only the materialized report is the security gate artifact. An approved report permits the workflow to continue; rejected or malformed responses stop the validator step.
+
+## Report Shape
+
+The final response must include the required status line and these sections:
+
+- `## Reviewed Inputs`
+- `## Security Findings`
+- `## Remediation Target`
+- `## Evidence`
+
+An approved review declares `none` for the remediation target. A rejected review identifies `plan` or `implementation` as the owner.

--- a/harness_codex/runtime/materialize_security_review.py
+++ b/harness_codex/runtime/materialize_security_review.py
@@ -1,0 +1,92 @@
+"""Materialize read-only security review responses into runtime artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+STATUS_LABEL = "Security Review Status"
+APPROVED_STATUS = "approved"
+REJECTED_STATUS = "rejected"
+_ALLOWED_STATUSES = {APPROVED_STATUS, REJECTED_STATUS}
+
+
+class SecurityReviewMaterializationError(ValueError):
+    """Raised when a final response cannot satisfy the security report contract."""
+
+
+class SecurityReviewRejected(SecurityReviewMaterializationError):
+    """Raised after a valid rejected report has been materialized."""
+
+
+def materialize_security_review(source: Path, output: Path) -> str:
+    """Copy one final agent response to the declared report path and validate its status.
+
+    The source is produced by the runtime's agent adapter, outside the reviewer's
+    read-only sandbox. A rejected report is deliberately written before raising so
+    downstream diagnostics retain the review findings while delivery remains blocked.
+    """
+
+    if not source.is_file():
+        raise SecurityReviewMaterializationError(
+            f"missing security review final response: {source}"
+        )
+
+    text = source.read_text(encoding="utf-8")
+    if not text.strip():
+        raise SecurityReviewMaterializationError(
+            f"empty security review final response: {source}"
+        )
+
+    status = security_review_status(text)
+    if status is None:
+        raise SecurityReviewMaterializationError(
+            f"security review final response missing `{STATUS_LABEL}: approved|rejected`"
+        )
+    if status not in _ALLOWED_STATUSES:
+        raise SecurityReviewMaterializationError(
+            f"security review status is `{status}`, expected `approved` or `rejected`"
+        )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text.rstrip() + "\n", encoding="utf-8")
+
+    if status == REJECTED_STATUS:
+        raise SecurityReviewRejected("security review status is `rejected`")
+    return status
+
+
+def security_review_status(text: str) -> str | None:
+    """Return the normalized review status from a Markdown final response."""
+
+    prefix = f"{STATUS_LABEL}:"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            return stripped[len(prefix) :].strip().lower()
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Materialize and validate a read-only security reviewer final response."
+    )
+    parser.add_argument("--source", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        materialize_security_review(args.source, args.output)
+    except SecurityReviewRejected as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except SecurityReviewMaterializationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_materialize_security_review.py
+++ b/tests/runtime/test_materialize_security_review.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from harness_codex.runtime.materialize_security_review import main
+
+
+APPROVED_REPORT = """# Security Review\n\nSecurity Review Status: approved\n\n## Reviewed Inputs\n- ChangeSet and implementation evidence\n\n## Security Findings\n- none\n\n## Remediation Target\nnone\n\n## Evidence\n- focused tests passed\n"""
+
+REJECTED_REPORT = """# Security Review\n\nSecurity Review Status: rejected\n\n## Reviewed Inputs\n- ChangeSet and implementation evidence\n\n## Security Findings\n- Missing authorization check\n\n## Remediation Target\nimplementation\n\n## Evidence\n- focused tests passed\n"""
+
+
+def test_runtime_materializes_approved_security_review_response(tmp_path: Path) -> None:
+    source = tmp_path / "steps/review-work-item-security/final-message.md"
+    output = tmp_path / "work-items/UC-001/security/security-review.md"
+    source.parent.mkdir(parents=True)
+    source.write_text(APPROVED_REPORT, encoding="utf-8")
+
+    exit_code = main(["--source", str(source), "--output", str(output)])
+
+    assert exit_code == 0
+    assert output.read_text(encoding="utf-8") == APPROVED_REPORT
+    assert source.read_text(encoding="utf-8") == APPROVED_REPORT
+
+
+def test_runtime_materializes_rejected_security_review_before_blocking(tmp_path: Path) -> None:
+    source = tmp_path / "steps/review-work-item-security/final-message.md"
+    output = tmp_path / "work-items/UC-001/security/security-review.md"
+    source.parent.mkdir(parents=True)
+    source.write_text(REJECTED_REPORT, encoding="utf-8")
+
+    exit_code = main(["--source", str(source), "--output", str(output)])
+
+    assert exit_code == 2
+    assert output.read_text(encoding="utf-8") == REJECTED_REPORT
+
+
+def test_runtime_fails_when_security_review_final_response_is_missing(tmp_path: Path) -> None:
+    source = tmp_path / "steps/review-work-item-security/final-message.md"
+    output = tmp_path / "work-items/UC-001/security/security-review.md"
+
+    exit_code = main(["--source", str(source), "--output", str(output)])
+
+    assert exit_code == 1
+    assert not output.exists()

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -71,6 +71,7 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
         "review-work-item-plan",
         "execute-work-item",
         "verify-work-item",
+        "review-work-item-security",
         "verify-work-item-security",
         "classify-verification-result",
         "remediate-work-item",
@@ -91,8 +92,31 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
     assert work_item_workflow.step_by_id("execute-work-item").metadata["stage"] == "implementation"
     assert work_item_workflow.step_by_id("execute-work-item").metadata["prompt_context_profile"] == "execution"
     assert (
-        work_item_workflow.step_by_id("verify-work-item-security").metadata["prompt_context_profile"]
+        work_item_workflow.step_by_id("review-work-item-security").metadata["prompt_context_profile"]
         == "security-verification"
+    )
+    assert work_item_workflow.step_by_id("review-work-item-security").outputs == ()
+    assert (
+        work_item_workflow.step_by_id("review-work-item-security").metadata["final_response_contract"]
+        == {
+            "channel": "final-message",
+            "format": "markdown",
+            "output": ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md",
+            "status_label": "Security Review Status",
+            "allowed_statuses": ["approved", "rejected"],
+        }
+    )
+    assert work_item_workflow.step_by_id("verify-work-item-security").kind == StepKind.VALIDATOR
+    assert work_item_workflow.step_by_id("verify-work-item-security").needs == (
+        "review-work-item-security",
+    )
+    assert work_item_workflow.step_by_id("verify-work-item-security").command == (
+        "python3 -m harness_codex.runtime.materialize_security_review "
+        "--source .harness/runs/<RUN-ID>/steps/review-work-item-security/final-message.md "
+        "--output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md"
+    )
+    assert work_item_workflow.step_by_id("verify-work-item-security").outputs == (
+        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md"),
     )
     assert work_item_workflow.step_by_id("verify-work-item").command == (
         "python3 -m harness_codex.runtime.structured_verify_work_item "

--- a/tests/test_issue_372_canonical_finalization.py
+++ b/tests/test_issue_372_canonical_finalization.py
@@ -31,6 +31,7 @@ def test_work_item_workflow_excludes_changeset_finalization() -> None:
         "review-work-item-plan",
         "execute-work-item",
         "verify-work-item",
+        "review-work-item-security",
         "verify-work-item-security",
         "classify-verification-result",
         "remediate-work-item",


### PR DESCRIPTION
## 관련 이슈

Closes #396

## 배경

보안 구현 리뷰 단계는 `security_implementation_reviewer`를 `read-only` sandbox로 실행하면서도, 동시에 리뷰어가 다음 runtime artifact를 직접 생성하도록 요구하고 있었습니다.

```text
.harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
```

이 계약은 서로 충돌합니다. 리뷰어가 파일을 직접 생성하면 read-only sandbox 제약을 위반하고, 제약을 지키면 workflow가 선언된 output 파일의 부재로 실패합니다.

## 변경 내용

### 1. 보안 리뷰 단계와 artifact 검증 단계를 분리

기존의 `verify-work-item-security` agent 단계를 다음 두 단계로 분리했습니다.

```text
verify-work-item
  → review-work-item-security
  → verify-work-item-security
  → classify-verification-result
```

- `review-work-item-security`
  - `security_implementation_reviewer`를 read-only sandbox로 실행합니다.
  - 구현 코드, active plan, ChangeSet, upstream artifact, runtime output 파일을 수정하지 않습니다.
  - 보안 리뷰 Markdown을 final response로만 반환합니다.
  - 직접 생성해야 하는 workflow output은 선언하지 않습니다.

- `verify-work-item-security`
  - validator 단계로 변경했습니다.
  - runtime이 저장한 final response를 읽어 canonical security report 경로에 기록합니다.
  - status 형식과 허용 값을 검증한 뒤 security gate 결과를 반환합니다.

### 2. runtime materializer 추가

`harness_codex.runtime.materialize_security_review`를 추가했습니다.

```bash
python3 -m harness_codex.runtime.materialize_security_review \
  --source .harness/runs/<RUN-ID>/steps/review-work-item-security/final-message.md \
  --output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
```

runtime이 최종적으로 생성하는 canonical artifact는 아래 경로입니다.

```text
.harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
```

### 3. status 처리 규칙

최종 응답에는 다음 중 하나가 반드시 포함되어야 합니다.

```text
Security Review Status: approved
Security Review Status: rejected
```

| 상태 | 동작 | 종료 코드 |
| --- | --- | ---: |
| `approved` | 보고서를 저장하고 다음 workflow 단계로 진행 | `0` |
| `rejected` | 보고서를 먼저 저장해 진단 근거를 보존한 뒤 security gate를 차단 | `2` |
| status 누락·빈 응답·허용되지 않은 status | 보고서를 생성하지 않고 계약 위반으로 실패 | `1` |

거절된 리뷰도 canonical 경로에 남기므로, workflow가 차단되어도 security finding과 remediation 근거를 확인할 수 있습니다.

### 4. agent/skill/workflow 계약 정렬

security implementation reviewer skill을 다음 원칙에 맞게 수정했습니다.

- reviewer는 runtime artifact를 포함한 어떤 파일도 직접 수정하지 않습니다.
- reviewer는 최종 응답으로 Markdown report 하나만 반환합니다.
- final response의 persistence와 canonical artifact 생성은 runtime의 책임입니다.
- report에는 아래 필수 항목을 유지합니다.

```text
Security Review Status: approved|rejected
## Reviewed Inputs
## Security Findings
## Remediation Target
## Evidence
```

### 5. 문서와 테스트 추가

- `docs/architecture/security-review-materialization.md`
  - reviewer와 runtime의 책임 경계
  - artifact 경로
  - 승인·거절·형식 오류별 동작
  - security report 형식 계약을 문서화했습니다.

- `tests/runtime/test_materialize_security_review.py`
  - approved response가 canonical report로 저장되고 통과하는지 검증합니다.
  - rejected response가 report로 저장된 뒤 workflow를 차단하는지 검증합니다.
  - final response가 누락되었을 때 실패하는지 검증합니다.

- workflow contract 테스트
  - read-only reviewer 단계에 직접 output이 없는지 검증합니다.
  - final response contract 및 materializer command를 검증합니다.
  - canonical workflow 단계 목록에 `review-work-item-security`를 반영했습니다.

## 검증

- `python3 -m py_compile harness_codex/runtime/materialize_security_review.py`
- materializer CLI smoke test
  - approved 경로
  - rejected 경로
  - missing final response 경로
- GitHub Actions `Runtime document contracts`
  - 첫 실행에서 기존 canonical workflow 테스트의 단계 기대값 누락으로 실패했습니다.
  - 실제 구현 오류가 아니라 새 `review-work-item-security` 단계를 고정 단계 목록에 반영하지 않은 문제였습니다.
  - 해당 테스트를 수정해 PR에 추가 반영했고, 후속 CI 실행으로 재검증 중입니다.

## 자체 검토

- read-only reviewer는 구현물이나 runtime artifact에 쓰기 권한을 요구하지 않습니다.
- final response를 canonical report로 저장하는 책임은 runtime validator에만 있습니다.
- `rejected` 보고서는 보존되지만, workflow는 통과하지 않습니다.
- 기존 security review status 및 report shape 계약은 유지합니다.