### PR TITLE
fix(runtime): executor 권한을 ChangeSet·work-item manifest 교집합으로 제한

### DIFF
--- a/harness_codex/runtime/agent_write_scope_policy_patch.py
+++ b/harness_codex/runtime/agent_write_scope_policy_patch.py
@@ -1,8 +1,8 @@
 """Runtime policy for post-validating writes made by agent steps.
 
-Every agent step in a Git worktree receives a role-derived write policy.  Document,
+Every agent step in a Git worktree receives a role-derived write policy. Document,
 review, and analysis agents may modify only their workflow-declared outputs and
-runtime artifacts.  The implementation executor additionally receives the
+runtime artifacts. The implementation executor additionally receives the
 ChangeSet/work-item implementation scope evaluated by ``validate_scope_diff``.
 """
 
@@ -62,7 +62,7 @@ def apply_agent_write_scope_policy_patch() -> None:
         return
 
     original_run_agent = BasicStepRunner._run_agent
-    original_scope_patterns = scope_module._scope_patterns
+    original_scope_policy = scope_module._scope_policy
 
     def run_agent(self, step, context, step_dir: Path):
         if step.kind != StepKind.AGENT or not _inside_git_work_tree(context.repo_root):
@@ -113,7 +113,7 @@ def apply_agent_write_scope_policy_patch() -> None:
             )
         return tuple(patterns)
 
-    def scope_patterns(
+    def scope_policy(
         *,
         repo_root: Path,
         change_set_id: str,
@@ -122,8 +122,13 @@ def apply_agent_write_scope_policy_patch() -> None:
         runtime_allow_patterns,
     ):
         if metadata.get(_POLICY_METADATA_KEY) == DECLARED_OUTPUTS_ONLY.name:
-            return tuple(runtime_allow_patterns), ()
-        return original_scope_patterns(
+            return scope_module.ScopePolicy(
+                runtime_allow=tuple(runtime_allow_patterns),
+                changeset_allow=(),
+                manifest_allow=(),
+                blocked=(),
+            )
+        return original_scope_policy(
             repo_root=repo_root,
             change_set_id=change_set_id,
             work_item_id=work_item_id,
@@ -133,7 +138,7 @@ def apply_agent_write_scope_policy_patch() -> None:
 
     scope_module.capture_git_snapshot = _capture_worktree_snapshot
     runner_module.capture_git_snapshot = _capture_worktree_snapshot
-    scope_module._scope_patterns = scope_patterns
+    scope_module._scope_policy = scope_policy
     runner_module._requires_scope_diff_validation = requires_scope_diff_validation
     runner_module._runtime_scope_allow_patterns = runtime_scope_allow_patterns
     BasicStepRunner._run_agent = run_agent
@@ -169,7 +174,7 @@ def _capture_worktree_snapshot(repo_root: Path) -> dict[str, dict[str, str | Non
     """Snapshot all changed worktree files, including ignored files.
 
     The two snapshots delimit the agent's own delta, so pre-existing dirty paths are
-    not validated.  The ignored-file listing closes the previous ``.gitignore`` bypass.
+    not validated. The ignored-file listing closes the previous ``.gitignore`` bypass.
     """
 
     if not _inside_git_work_tree(repo_root):

--- a/harness_codex/runtime/validate_scope_diff.py
+++ b/harness_codex/runtime/validate_scope_diff.py
@@ -1,4 +1,10 @@
-"""executor worktree 변경을 ChangeSet 범위와 대조한다."""
+"""Validate executor worktree changes against ChangeSet and work-item manifests.
+
+The active implementation plan is an instruction and execution-state artifact. It is
+never an authority source for implementation writes. Code/test writes must be
+permitted by both the ChangeSet included scope and the selected work-item
+``affected-files.md`` manifest.
+"""
 
 from __future__ import annotations
 
@@ -17,6 +23,23 @@ from harness_codex.runtime.changes.parser import parse_changeset_markdown
 
 PATH_CODE_RE = re.compile(r"`([^`]+)`")
 PATH_TOKEN_RE = re.compile(r"(?<![\w.-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.*{}<>, -]+)+)")
+_MANIFEST_LINE_RE = re.compile(
+    r"^\s*(?:[-*+]\s+)?(?P<operation>modify|create|delete|forbidden|"
+    r"수정|생성|삭제|금지)\s*:\s*(?P<value>.+?)\s*$",
+    flags=re.IGNORECASE,
+)
+
+_ALL_OPERATIONS = ("modify", "create", "delete")
+_OPERATION_ALIASES = {
+    "modify": ("modify",),
+    "수정": ("modify",),
+    "create": ("create",),
+    "생성": ("create",),
+    "delete": ("delete",),
+    "삭제": ("delete",),
+    "forbidden": _ALL_OPERATIONS,
+    "금지": _ALL_OPERATIONS,
+}
 
 
 @dataclass(frozen=True)
@@ -24,6 +47,17 @@ class ScopePattern:
     pattern: str
     source: str
     kind: str = "allow"
+    operations: tuple[str, ...] = _ALL_OPERATIONS
+
+
+@dataclass(frozen=True)
+class ScopePolicy:
+    """Authority inputs used by the executor scope boundary."""
+
+    runtime_allow: tuple[ScopePattern, ...]
+    changeset_allow: tuple[ScopePattern, ...]
+    manifest_allow: tuple[ScopePattern, ...]
+    blocked: tuple[ScopePattern, ...]
 
 
 @dataclass(frozen=True)
@@ -35,14 +69,13 @@ class ScopeDiffResult:
 
 
 def capture_git_snapshot(repo_root: Path) -> dict[str, dict[str, str | None]]:
-    """변경된 worktree 파일 상태를 비교 가능한 snapshot으로 기록한다."""
+    """Record modified worktree paths in a comparison-friendly snapshot."""
 
     if not _inside_git_work_tree(repo_root):
         return {}
 
-    changed_paths = _git_changed_paths(repo_root)
     snapshot: dict[str, dict[str, str | None]] = {}
-    for path in sorted(changed_paths):
+    for path in sorted(_git_changed_paths(repo_root)):
         absolute = repo_root / path
         snapshot[path] = {
             "path": path,
@@ -72,17 +105,22 @@ def validate_scope_diff(
     context_metadata: Mapping[str, Any] | None = None,
     runtime_allow_patterns: Sequence[ScopePattern] = (),
 ) -> ScopeDiffResult:
-    """범위 검증 report를 쓰고 범위 밖 파일 목록을 반환한다."""
+    """Write a scope report and block implementation changes outside authority.
+
+    Runtime artifacts and executor-owned active-plan state are treated as a separate
+    ownership boundary. All other files require the conjunction of ChangeSet and
+    manifest matches for the actual operation (modify/create/delete).
+    """
 
     metadata = context_metadata or {}
-    changed_files = _changed_between(before, after)
-    allow_patterns, block_patterns = _scope_patterns(
+    policy = _scope_policy(
         repo_root=repo_root,
         change_set_id=change_set_id,
         work_item_id=work_item_id,
         metadata=metadata,
         runtime_allow_patterns=runtime_allow_patterns,
     )
+    changed_files = _changed_between(before, after)
 
     allowed: list[dict[str, Any]] = []
     suspicious: list[dict[str, Any]] = []
@@ -90,30 +128,47 @@ def validate_scope_diff(
     changed_rows: list[dict[str, Any]] = []
 
     for path in changed_files:
-        block_matches = _matching_sources(path, block_patterns)
-        allow_matches = _matching_sources(path, allow_patterns)
+        operation = _change_operation(before.get(path), after.get(path))
+        runtime_matches = _matching_sources(path, policy.runtime_allow, operation)
+        changeset_matches = _matching_sources(path, policy.changeset_allow, operation)
+        manifest_matches = _matching_sources(path, policy.manifest_allow, operation)
+        block_matches = _matching_sources(path, policy.blocked, operation)
+        implementation_allowed = bool(changeset_matches and manifest_matches)
+        allowed_sources = runtime_matches or (
+            _intersection_sources(changeset_matches, manifest_matches)
+            if implementation_allowed
+            else []
+        )
         row = {
             "path": path,
+            "operation": operation,
             "before": before.get(path),
             "after": after.get(path),
-            "allowed_sources": allow_matches,
+            "allowed_sources": allowed_sources,
+            "change_set_sources": changeset_matches,
+            "manifest_sources": manifest_matches,
+            "runtime_sources": runtime_matches,
             "blocked_sources": block_matches,
         }
         changed_rows.append(row)
-        if block_matches or not allow_matches:
+        if block_matches or not allowed_sources:
             blocked.append(row)
-        elif _is_suspicious_path(path, allow_matches):
+        elif _is_suspicious_path(path, allowed_sources):
             suspicious.append(row)
         else:
             allowed.append(row)
 
     status = "blocked" if blocked else "passed"
-    source_summary = tuple(dict.fromkeys(pattern.source for pattern in allow_patterns))
+    source_summary = _policy_source_summary(policy)
     report = {
         "status": status,
         "run_id": run_id,
         "change_set_id": change_set_id,
         "work_item_id": work_item_id,
+        "authority_model": {
+            "implementation_write_allowlist": "ChangeSet included scope ∩ affected-files manifest",
+            "plan_paths_grant_implementation_authority": False,
+        },
         "changed_files": changed_rows,
         "allowed": allowed,
         "suspicious": suspicious,
@@ -132,7 +187,8 @@ def validate_scope_diff(
         message = (
             "scope diff blocked unexpected files: "
             + ", ".join(blocked_files)
-            + ". allowed scope sources: "
+            + ". implementation files require both ChangeSet included scope and "
+            "affected-files manifest permission. allowed scope sources: "
             + ", ".join(source_summary)
         )
     return ScopeDiffResult(
@@ -170,10 +226,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "active_plan_path": f"docs/plans/active/{args.work_item}/plan.md",
         },
     )
-    if result.message:
-        print(result.message)
-    else:
-        print(f"scope diff {result.status}: {result.report_path}")
+    print(result.message or f"scope diff {result.status}: {result.report_path}")
     return 1 if result.blocked_files else 0
 
 
@@ -247,37 +300,59 @@ def _changed_between(
     return tuple(sorted(path for path in paths if before.get(path) != after.get(path)))
 
 
-def _scope_patterns(
+def _scope_policy(
     *,
     repo_root: Path,
     change_set_id: str,
     work_item_id: str,
     metadata: Mapping[str, Any],
     runtime_allow_patterns: Sequence[ScopePattern],
-) -> tuple[tuple[ScopePattern, ...], tuple[ScopePattern, ...]]:
-    allow: list[ScopePattern] = list(runtime_allow_patterns)
-    block: list[ScopePattern] = []
-
+) -> ScopePolicy:
+    runtime_allow = list(runtime_allow_patterns)
     active_plan_path = _metadata_path(metadata, "active_plan_path")
     if active_plan_path:
-        allow.append(ScopePattern(str(active_plan_path), "active plan output"))
-        allow.extend(_patterns_from_markdown(repo_root / active_plan_path, "active plan"))
+        runtime_allow.append(
+            ScopePattern(str(active_plan_path), "executor-owned active plan state")
+        )
 
+    changeset_allow: list[ScopePattern] = []
+    blocked: list[ScopePattern] = []
     change_set_path = _metadata_path(metadata, "change_set_path") or Path(
         f"docs/changes/active/{change_set_id}.md"
     )
     for pattern in _patterns_from_changeset(repo_root / change_set_path):
         if pattern.kind == "block":
-            block.append(pattern)
+            blocked.append(pattern)
         else:
-            allow.append(pattern)
+            changeset_allow.append(pattern)
 
-    for path in _affected_file_docs(repo_root, work_item_id, metadata):
-        file_allow, file_block = _patterns_from_affected_files(path)
-        allow.extend(file_allow)
-        block.extend(file_block)
+    manifest_allow: list[ScopePattern] = []
+    manifest_paths = _affected_file_docs(repo_root, work_item_id, metadata)
+    for path in manifest_paths:
+        file_allow, file_block = _patterns_from_affected_files(path, repo_root)
+        manifest_allow.extend(file_allow)
+        blocked.extend(file_block)
 
-    return tuple(_dedupe_patterns(allow)), tuple(_dedupe_patterns(block))
+    # Compatibility is deliberately limited to an absent document, never to plan text.
+    # Existing repositories can migrate their work-item documents incrementally while
+    # plan-path injection remains impossible. As soon as a manifest exists, it is the
+    # exclusive implementation authority for that work item.
+    if not any(path.is_file() for path in manifest_paths):
+        manifest_allow.extend(
+            ScopePattern(
+                pattern.pattern,
+                "legacy missing affected-files manifest (ChangeSet fallback)",
+                operations=pattern.operations,
+            )
+            for pattern in changeset_allow
+        )
+
+    return ScopePolicy(
+        runtime_allow=tuple(_dedupe_patterns(runtime_allow)),
+        changeset_allow=tuple(_dedupe_patterns(changeset_allow)),
+        manifest_allow=tuple(_dedupe_patterns(manifest_allow)),
+        blocked=tuple(_dedupe_patterns(blocked)),
+    )
 
 
 def _patterns_from_changeset(path: Path) -> tuple[ScopePattern, ...]:
@@ -286,10 +361,6 @@ def _patterns_from_changeset(path: Path) -> tuple[ScopePattern, ...]:
     text = path.read_text(encoding="utf-8")
     change_set = parse_changeset_markdown(text, path=_relative_path(path))
     patterns: list[ScopePattern] = []
-    for document in change_set.changed_documents:
-        normalized = _normalize_path_token(str(document.path))
-        if normalized:
-            patterns.append(ScopePattern(normalized, "ChangeSet changed documents"))
     for item in change_set.included_scope:
         patterns.extend(
             ScopePattern(pattern, "ChangeSet included scope")
@@ -297,7 +368,11 @@ def _patterns_from_changeset(path: Path) -> tuple[ScopePattern, ...]:
         )
     for item in change_set.forbidden_changes + change_set.excluded_scope:
         patterns.extend(
-            ScopePattern(pattern, "ChangeSet excluded/forbidden scope", "block")
+            ScopePattern(
+                pattern,
+                "ChangeSet excluded/forbidden scope",
+                "block",
+            )
             for pattern in _extract_path_patterns(item)
         )
     return tuple(patterns)
@@ -305,41 +380,74 @@ def _patterns_from_changeset(path: Path) -> tuple[ScopePattern, ...]:
 
 def _patterns_from_affected_files(
     path: Path,
+    repo_root: Path,
 ) -> tuple[tuple[ScopePattern, ...], tuple[ScopePattern, ...]]:
     if not path.is_file():
         return (), ()
     text = path.read_text(encoding="utf-8")
-    sections = _markdown_sections(text)
-    allow_text = "\n".join(
-        content
-        for title, content in sections.items()
-        if not _block_section_title(title)
-    )
-    block_text = "\n".join(
-        content for title, content in sections.items() if _block_section_title(title)
-    )
-    allow = tuple(
-        ScopePattern(pattern, f"affected-files {path.relative_to(path.parents[3])}")
-        for pattern in _extract_path_patterns(allow_text)
-    )
-    block = tuple(
-        ScopePattern(
-            pattern,
-            f"affected-files forbidden {path.relative_to(path.parents[3])}",
-            "block",
-        )
-        for pattern in _extract_path_patterns(block_text)
-    )
-    return allow, block
+    source_path = _manifest_source_path(path, repo_root)
+    allow: list[ScopePattern] = []
+    block: list[ScopePattern] = []
+    recognized: set[tuple[str, str]] = set()
 
+    for title, content in _markdown_sections(text).items():
+        operation = _manifest_operation(title)
+        if operation is None and _block_section_title(title):
+            operation = "forbidden"
+        if operation is None:
+            continue
+        for pattern in _extract_path_patterns(content):
+            key = (operation, pattern)
+            recognized.add(key)
+            target = block if operation == "forbidden" else allow
+            target.append(
+                ScopePattern(
+                    pattern,
+                    f"affected-files {operation} {source_path}",
+                    "block" if operation == "forbidden" else "allow",
+                    _operations_for_manifest_label(operation),
+                )
+            )
 
-def _patterns_from_markdown(path: Path, source: str) -> tuple[ScopePattern, ...]:
-    if not path.is_file():
-        return ()
-    return tuple(
-        ScopePattern(pattern, source)
-        for pattern in _extract_path_patterns(path.read_text(encoding="utf-8"))
-    )
+    for line in text.splitlines():
+        match = _MANIFEST_LINE_RE.match(line)
+        if not match:
+            continue
+        canonical = _canonical_manifest_operation(match.group("operation"))
+        if canonical is None:
+            continue
+        for pattern in _extract_path_patterns(match.group("value")):
+            key = (canonical, pattern)
+            if key in recognized:
+                continue
+            target = block if canonical == "forbidden" else allow
+            target.append(
+                ScopePattern(
+                    pattern,
+                    f"affected-files {canonical} {source_path}",
+                    "block" if canonical == "forbidden" else "allow",
+                    _operations_for_manifest_label(canonical),
+                )
+            )
+
+    # Legacy, non-operation headings can only authorize modifications. New files and
+    # deletions require an explicit create/delete declaration.
+    for title, content in _markdown_sections(text).items():
+        if _manifest_operation(title) is not None or _block_section_title(title):
+            continue
+        for pattern in _extract_path_patterns(content):
+            key = ("modify", pattern)
+            if key in recognized:
+                continue
+            allow.append(
+                ScopePattern(
+                    pattern,
+                    f"affected-files modify (legacy section) {source_path}",
+                    operations=("modify",),
+                )
+            )
+
+    return tuple(_dedupe_patterns(allow)), tuple(_dedupe_patterns(block))
 
 
 def _affected_file_docs(
@@ -362,6 +470,82 @@ def _affected_file_docs(
         )
     )
     return tuple(dict.fromkeys(candidates))
+
+
+def _change_operation(
+    before: Mapping[str, str | None] | None,
+    after: Mapping[str, str | None] | None,
+) -> str:
+    before_exists = _snapshot_exists(before)
+    after_exists = _snapshot_exists(after)
+    if not before_exists and after_exists:
+        return "create"
+    if before_exists and not after_exists:
+        return "delete"
+    return "modify"
+
+
+def _snapshot_exists(snapshot: Mapping[str, str | None] | None) -> bool:
+    return bool(snapshot) and snapshot.get("state") not in {None, "missing"}
+
+
+def _matching_sources(
+    path: str,
+    patterns: Iterable[ScopePattern],
+    operation: str,
+) -> list[str]:
+    return [
+        pattern.source
+        for pattern in patterns
+        if operation in pattern.operations and _matches_pattern(path, pattern.pattern)
+    ]
+
+
+def _matches_pattern(path: str, pattern: str) -> bool:
+    if pattern.endswith("/"):
+        return path.startswith(pattern)
+    if any(char in pattern for char in "*?[]"):
+        return fnmatch.fnmatch(path, pattern)
+    return path == pattern
+
+
+def _intersection_sources(
+    changeset_sources: Sequence[str],
+    manifest_sources: Sequence[str],
+) -> list[str]:
+    return [
+        *[f"{source} (intersection)" for source in dict.fromkeys(changeset_sources)],
+        *[f"{source} (intersection)" for source in dict.fromkeys(manifest_sources)],
+    ]
+
+
+def _policy_source_summary(policy: ScopePolicy) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            [
+                *(pattern.source for pattern in policy.runtime_allow),
+                *(pattern.source for pattern in policy.changeset_allow),
+                *(pattern.source for pattern in policy.manifest_allow),
+            ]
+        )
+    )
+
+
+def _is_suspicious_path(path: str, sources: Sequence[str]) -> bool:
+    config_names = {
+        "build.gradle",
+        "build.gradle.kts",
+        "settings.gradle",
+        "settings.gradle.kts",
+        "pom.xml",
+        "pyproject.toml",
+        "package.json",
+        "package-lock.json",
+    }
+    return Path(path).name in config_names and not any(
+        "ChangeSet included scope" in source or "affected-files" in source
+        for source in sources
+    )
 
 
 def _extract_path_patterns(text: str) -> tuple[str, ...]:
@@ -389,42 +573,8 @@ def _normalize_path_token(value: str) -> str:
     return token
 
 
-def _matching_sources(path: str, patterns: Iterable[ScopePattern]) -> list[str]:
-    return [
-        pattern.source
-        for pattern in patterns
-        if _matches_pattern(path, pattern.pattern)
-    ]
-
-
-def _matches_pattern(path: str, pattern: str) -> bool:
-    if pattern.endswith("/"):
-        return path.startswith(pattern)
-    if any(char in pattern for char in "*?[]"):
-        return fnmatch.fnmatch(path, pattern)
-    return path == pattern
-
-
-def _is_suspicious_path(path: str, sources: Sequence[str]) -> bool:
-    config_names = {
-        "build.gradle",
-        "build.gradle.kts",
-        "settings.gradle",
-        "settings.gradle.kts",
-        "pom.xml",
-        "pyproject.toml",
-        "package.json",
-        "package-lock.json",
-    }
-    return Path(path).name in config_names and not any(
-        source in {"ChangeSet changed documents", "ChangeSet included scope"}
-        or source.startswith("affected-files")
-        for source in sources
-    )
-
-
 def _markdown_sections(text: str) -> dict[str, str]:
-    matches = list(re.finditer(r"^##\s+(.+?)\s*$", text, flags=re.MULTILINE))
+    matches = list(re.finditer(r"^#{1,3}\s+(.+?)\s*$", text, flags=re.MULTILINE))
     sections: dict[str, str] = {}
     for index, match in enumerate(matches):
         start = match.end()
@@ -435,14 +585,54 @@ def _markdown_sections(text: str) -> dict[str, str]:
     return sections
 
 
+def _manifest_operation(title: str) -> str | None:
+    normalized = title.strip().lower().strip("# :")
+    normalized = re.sub(r"\s+", " ", normalized)
+    aliases = {
+        "modify": "modify",
+        "modifications": "modify",
+        "수정": "modify",
+        "create": "create",
+        "creation": "create",
+        "생성": "create",
+        "delete": "delete",
+        "deletion": "delete",
+        "삭제": "delete",
+        "forbidden": "forbidden",
+        "forbid": "forbidden",
+        "금지": "forbidden",
+    }
+    return aliases.get(normalized)
+
+
+def _canonical_manifest_operation(value: str) -> str | None:
+    normalized = value.strip().lower()
+    if normalized in {"modify", "수정"}:
+        return "modify"
+    if normalized in {"create", "생성"}:
+        return "create"
+    if normalized in {"delete", "삭제"}:
+        return "delete"
+    if normalized in {"forbidden", "금지"}:
+        return "forbidden"
+    return None
+
+
+def _operations_for_manifest_label(label: str) -> tuple[str, ...]:
+    canonical = _canonical_manifest_operation(label) or label
+    return _OPERATION_ALIASES.get(canonical, _ALL_OPERATIONS)
+
+
 def _block_section_title(title: str) -> bool:
     lowered = title.lower()
-    return (
-        "forbidden" in lowered
-        or "금지" in title
-        or "excluded" in lowered
-        or "제외" in title
-    )
+    return "forbidden" in lowered or "금지" in title or "excluded" in lowered or "제외" in title
+
+
+def _manifest_source_path(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
 
 
 def _metadata_path(metadata: Mapping[str, Any], key: str) -> Path | None:
@@ -453,10 +643,10 @@ def _metadata_path(metadata: Mapping[str, Any], key: str) -> Path | None:
 
 
 def _dedupe_patterns(patterns: Sequence[ScopePattern]) -> tuple[ScopePattern, ...]:
-    seen: set[tuple[str, str, str]] = set()
+    seen: set[tuple[str, str, str, tuple[str, ...]]] = set()
     result: list[ScopePattern] = []
     for pattern in patterns:
-        key = (pattern.pattern, pattern.source, pattern.kind)
+        key = (pattern.pattern, pattern.source, pattern.kind, pattern.operations)
         if key not in seen:
             seen.add(key)
             result.append(pattern)

--- a/tests/runtime/test_executor_scope_manifest.py
+++ b/tests/runtime/test_executor_scope_manifest.py
@@ -1,0 +1,264 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.validate_scope_diff import ScopePattern, validate_scope_diff
+
+
+CHANGE_SET_PATH = "docs/changes/active/CHG-001.md"
+WORK_ITEM_ID = "UC-001"
+PLAN_PATH = "docs/plans/active/UC-001/plan.md"
+MANIFEST_PATH = "docs/use-cases/UC-001/affected-files.md"
+
+
+def _snapshot(path: str, *, state: str = "file", digest: str = "sha") -> dict[str, dict[str, str]]:
+    return {path: {"path": path, "state": state, "sha256": digest}}
+
+
+def _write_changeset(repo_root: Path, *, included: tuple[str, ...] = ("src/auth/**",)) -> None:
+    target = repo_root / CHANGE_SET_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# ChangeSet CHG-001",
+        "",
+        "## 1. Metadata",
+        "|Item|Value|",
+        "|---|---|",
+        "|ChangeSet ID|`CHG-001`|",
+        "|Status|active|",
+        "",
+        "## 8. Scope Boundary",
+        "### Included",
+        *(f"- `{pattern}`" for pattern in included),
+        "",
+        "### Excluded",
+        "- `src/payment/**`",
+    ]
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_manifest(repo_root: Path, text: str) -> None:
+    target = repo_root / MANIFEST_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+
+
+def _write_plan_with_injected_paths(repo_root: Path) -> None:
+    target = repo_root / PLAN_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        """# Implementation Plan
+
+- Backtick path: `src/payment/PaymentService.py`
+- General path: src/payment/GeneralText.py
+
+```text
+src/payment/CodeBlock.py
+```
+""",
+        encoding="utf-8",
+    )
+
+
+def _metadata() -> dict[str, object]:
+    return {
+        "change_set_path": CHANGE_SET_PATH,
+        "active_plan_path": PLAN_PATH,
+        "active_work_item_id": WORK_ITEM_ID,
+        "affected_work_items": [
+            {
+                "id": WORK_ITEM_ID,
+                "executor_inputs": [PLAN_PATH, MANIFEST_PATH],
+            }
+        ],
+    }
+
+
+def _validate(
+    repo_root: Path,
+    *,
+    before: dict[str, dict[str, str]],
+    after: dict[str, dict[str, str]],
+    runtime_allow_patterns: tuple[ScopePattern, ...] = (),
+):
+    return validate_scope_diff(
+        repo_root=repo_root,
+        run_id="run-001",
+        change_set_id="CHG-001",
+        work_item_id=WORK_ITEM_ID,
+        before=before,
+        after=after,
+        report_path=repo_root / ".harness/runs/run-001/scope-diff-report.json",
+        context_metadata=_metadata(),
+        runtime_allow_patterns=runtime_allow_patterns,
+    )
+
+
+def test_plan_path_injection_never_grants_executor_write_authority(tmp_path: Path) -> None:
+    _write_changeset(tmp_path)
+    _write_manifest(
+        tmp_path,
+        """# Affected Files
+
+## Create
+- `src/auth/**`
+
+## Modify
+- `src/auth/**`
+""",
+    )
+    _write_plan_with_injected_paths(tmp_path)
+
+    result = _validate(
+        tmp_path,
+        before={},
+        after=_snapshot("src/payment/PaymentService.py", digest="created"),
+    )
+
+    assert result.status == "blocked"
+    assert result.blocked_files == ("src/payment/PaymentService.py",)
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    row = report["blocked"][0]
+    assert row["change_set_sources"] == []
+    assert row["manifest_sources"] == []
+    assert not any("active plan" in source for source in report["allowed_scope_sources"])
+    assert report["authority_model"]["plan_paths_grant_implementation_authority"] is False
+
+
+def test_implementation_change_requires_changeset_and_manifest_intersection(
+    tmp_path: Path,
+) -> None:
+    _write_changeset(tmp_path)
+    _write_manifest(
+        tmp_path,
+        """# Affected Files
+
+## Modify
+- `src/auth/allowed.py`
+""",
+    )
+
+    result = _validate(
+        tmp_path,
+        before=_snapshot("src/auth/not-listed.py", digest="before"),
+        after=_snapshot("src/auth/not-listed.py", digest="after"),
+    )
+
+    assert result.status == "blocked"
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    row = report["blocked"][0]
+    assert row["change_set_sources"] == ["ChangeSet included scope"]
+    assert row["manifest_sources"] == []
+
+
+def test_manifest_create_glob_allows_new_helper_and_test_files(tmp_path: Path) -> None:
+    _write_changeset(tmp_path)
+    _write_manifest(
+        tmp_path,
+        """# Affected Files
+
+## Create
+- `src/auth/**`
+- `tests/auth/**`
+
+## Modify
+- `src/auth/**`
+""",
+    )
+
+    result = _validate(
+        tmp_path,
+        before={},
+        after=_snapshot("tests/auth/test_token_helper.py", digest="created"),
+    )
+
+    assert result.status == "passed"
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    assert report["allowed"][0]["operation"] == "create"
+    assert any("affected-files create" in source for source in report["allowed"][0]["allowed_sources"])
+
+
+def test_create_permission_does_not_authorize_modifying_existing_file(tmp_path: Path) -> None:
+    _write_changeset(tmp_path)
+    _write_manifest(
+        tmp_path,
+        """# Affected Files
+
+## Create
+- `src/auth/**`
+""",
+    )
+
+    result = _validate(
+        tmp_path,
+        before=_snapshot("src/auth/existing.py", digest="before"),
+        after=_snapshot("src/auth/existing.py", digest="after"),
+    )
+
+    assert result.status == "blocked"
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    assert report["blocked"][0]["operation"] == "modify"
+    assert report["blocked"][0]["manifest_sources"] == []
+
+
+def test_manifest_forbidden_pattern_overrides_changeset_and_manifest_allow(tmp_path: Path) -> None:
+    _write_changeset(tmp_path)
+    _write_manifest(
+        tmp_path,
+        """# Affected Files
+
+## Modify
+- `src/auth/**`
+
+## Forbidden
+- `src/auth/internal/**`
+""",
+    )
+
+    result = _validate(
+        tmp_path,
+        before=_snapshot("src/auth/internal/secret.py", digest="before"),
+        after=_snapshot("src/auth/internal/secret.py", digest="after"),
+    )
+
+    assert result.status == "blocked"
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    assert report["blocked"][0]["blocked_sources"] == [
+        f"affected-files forbidden {MANIFEST_PATH}"
+    ]
+
+
+def test_executor_plan_state_and_runtime_evidence_are_separately_allowed(tmp_path: Path) -> None:
+    _write_changeset(tmp_path)
+    _write_manifest(
+        tmp_path,
+        """# Affected Files
+
+## Modify
+- `src/auth/**`
+""",
+    )
+
+    before = {
+        **_snapshot(PLAN_PATH, digest="plan-before"),
+        **_snapshot(".harness/runs/run-001/steps/execute-work-item/evidence/build.txt", digest="before"),
+    }
+    after = {
+        **_snapshot(PLAN_PATH, digest="plan-after"),
+        **_snapshot(".harness/runs/run-001/steps/execute-work-item/evidence/build.txt", digest="after"),
+    }
+    result = _validate(
+        tmp_path,
+        before=before,
+        after=after,
+        runtime_allow_patterns=(
+            ScopePattern(".harness/runs/run-001/", "runtime evidence"),
+        ),
+    )
+
+    assert result.status == "passed"
+    report = json.loads(result.report_path.read_text(encoding="utf-8"))
+    sources = {row["path"]: row["allowed_sources"] for row in report["allowed"]}
+    assert sources[PLAN_PATH] == ["executor-owned active plan state"]
+    assert sources[".harness/runs/run-001/steps/execute-work-item/evidence/build.txt"] == [
+        "runtime evidence"
+    ]

--- a/tests/runtime/test_executor_scope_manifest.py
+++ b/tests/runtime/test_executor_scope_manifest.py
@@ -120,7 +120,7 @@ def test_plan_path_injection_never_grants_executor_write_authority(tmp_path: Pat
     row = report["blocked"][0]
     assert row["change_set_sources"] == []
     assert row["manifest_sources"] == []
-    assert not any("active plan" in source for source in report["allowed_scope_sources"])
+    assert row["runtime_sources"] == []
     assert report["authority_model"]["plan_paths_grant_implementation_authority"] is False
 
 
@@ -151,7 +151,7 @@ def test_implementation_change_requires_changeset_and_manifest_intersection(
 
 
 def test_manifest_create_glob_allows_new_helper_and_test_files(tmp_path: Path) -> None:
-    _write_changeset(tmp_path)
+    _write_changeset(tmp_path, included=("src/auth/**", "tests/auth/**"))
     _write_manifest(
         tmp_path,
         """# Affected Files


### PR DESCRIPTION
## 배경

Issue #398은 active `plan.md`에 적힌 경로가 executor의 구현 허용 범위로 섞일 수 있던 문제를 해결합니다. 계획 문서는 구현 지시와 검증 증거를 담는 산출물일 뿐, 구현 파일에 대한 쓰기 권한을 늘려서는 안 됩니다.

Closes #398

## 권한 모델

일반 구현 파일의 허용 조건을 다음처럼 분리했습니다.

```text
implementation write allowlist
= ChangeSet Included 범위
  ∩ affected-files.md operation manifest
  + executor-owned plan state
  + runtime evidence paths
```

따라서 코드·테스트 파일은 반드시 다음을 모두 만족해야 합니다.

1. active ChangeSet의 `Included` 범위에 포함될 것
2. 선택된 work item의 `affected-files.md`가 현재 변경 행위를 허용할 것

ChangeSet의 `Excluded`/forbidden 범위와 manifest의 `Forbidden`은 허용 규칙보다 우선합니다.

## 구현 내용

### 1. plan 본문을 권한 계산에서 제거

active `plan.md` 내부의 backtick, 일반 텍스트, 코드 블록을 더 이상 파싱해 allowlist에 합치지 않습니다. 따라서 plan에 범위 밖 경로를 삽입해도 executor 권한이 확장되지 않습니다.

`plan.md` 파일 자체는 executor가 구현 체크리스트와 검증 결과를 기록해야 하므로 `executor-owned active plan state`로만 별도 허용했습니다.

### 2. ScopePolicy 도입 및 교집합 판정

scope 검증의 입력을 다음 네 종류로 분리했습니다.

- `runtime_allow`: run artifact 및 executor-owned plan state
- `changeset_allow`: ChangeSet `Included`
- `manifest_allow`: `affected-files.md`의 operation별 허용 규칙
- `blocked`: ChangeSet 제외/금지와 manifest `Forbidden`

일반 구현 파일은 `changeset_allow`와 `manifest_allow`가 모두 매치될 때만 통과합니다. scope-diff report에는 파일별로 `operation`, `change_set_sources`, `manifest_sources`, `runtime_sources`, `blocked_sources`를 기록해 차단 사유를 추적할 수 있게 했습니다.

### 3. operation별 manifest 해석

`affected-files.md`에서 아래 형식의 섹션과 bullet 선언을 해석합니다.

```md
## Modify
- `src/auth/**`

## Create
- `src/auth/**`
- `tests/auth/**`

## Delete
- `src/auth/obsolete/**`

## Forbidden
- `src/auth/internal/**`
```

- 새 파일 생성은 `Create` 권한이 필요합니다.
- 기존 파일 변경은 `Modify` 권한이 필요합니다.
- 삭제는 `Delete` 권한이 필요합니다.
- `Forbidden`은 모든 operation에 대해 우선 차단합니다.
- operation이 명시되지 않은 기존 섹션은 호환성을 위해 `Modify`로만 해석합니다. 이 경우 생성·삭제 권한으로 확장되지 않습니다.

### 4. #397 write-scope patch 호환성 수정

#397의 agent write-scope patch가 이전 private hook인 `_scope_patterns`에 의존하고 있어, 새 구조와 결합 시 런타임 로드가 실패할 수 있었습니다. 이를 `_scope_policy` 기반으로 이관했습니다.

- declared-output-only agent는 runtime/declaration 경로만 담은 `ScopePolicy`를 반환합니다.
- implementation executor는 ChangeSet과 manifest를 포함한 원래 scope policy를 사용합니다.

### 5. 점진적 마이그레이션

과거 work item에 `affected-files.md` 자체가 없는 경우에는 ChangeSet Included 범위를 임시 manifest로 사용합니다. 이 호환 경로는 active plan을 전혀 참조하지 않으며, manifest가 존재하면 즉시 비활성화됩니다.

## 회귀 테스트

신규 `tests/runtime/test_executor_scope_manifest.py`를 추가했습니다.

- plan 본문에 주입된 범위 밖 경로가 executor 권한을 얻지 못하는지
- ChangeSet에는 포함되지만 manifest에는 없는 변경이 차단되는지
- ChangeSet과 manifest 양쪽이 허용한 helper/test 파일 생성이 통과하는지
- `Create`만 선언된 glob으로 기존 파일을 수정할 수 없는지
- manifest `Forbidden`이 allow보다 우선하는지
- executor-owned `plan.md`와 runtime evidence가 구현 범위와 분리되어 허용되는지

## 검증

- `Runtime document contracts` GitHub Actions 전체 테스트 성공
- 실행 번호: `216`
- 검증 커밋: `ac87cf788f08b501c0e724e6c551520a2663c92b`

## 자체 리뷰

- [x] plan 본문 경로를 allowlist에 추가하는 로직을 제거했다.
- [x] ChangeSet과 manifest allow를 union하지 않고 교집합으로 판정한다.
- [x] runtime artifact와 plan state를 구현 파일 권한과 분리했다.
- [x] modify/create/delete를 snapshot 전·후 상태로 판정한다.
- [x] explicit deny가 allow보다 먼저 적용된다.
- [x] #397의 private hook 의존을 새 `ScopePolicy` 구조로 이관했다.
- [x] manifest가 없는 기존 work item도 plan 권한 확장 없이 점진적으로 실행할 수 있다.
