### PR TITLE
fix(runtime): work-item plan 상태 전이 책임 분리

### DIFF
--- a/.codex/agents/implementation_planner.toml
+++ b/.codex/agents/implementation_planner.toml
@@ -12,6 +12,7 @@ Hot-path contract:
 - Load `.codex/agents/references/implementation_planner.md` before making workflow decisions.
 - Use `.codex/skills/harness-code-planner/SKILL.md` as the required skill entrypoint.
 - Read skill reference files only when the current task needs the detailed rule/template.
+- Create or update only `docs/plans/active/<WORK-ITEM-ID>/plan.md`; never move, delete, or create a completed plan path.
 - Keep writes inside the workflow scope declared by the runtime payload.
 - Preserve unrelated worktree changes.
 - Stop and report the blocker when required inputs, approvals, or scope are missing.

--- a/.codex/agents/references/implementation_planner.md
+++ b/.codex/agents/references/implementation_planner.md
@@ -24,8 +24,8 @@ skill, agent, runtime workflow, and preflight checks have one rule source.
 ## Ownership
 
 - Preserve unrelated worktree changes.
-- Keep writes limited to the plan paths allowed by the canonical planning
-  contract.
+- Create or update only `docs/plans/active/<WORK-ITEM-ID>/plan.md`.
+- Never create, delete, or move `docs/plans/completed/<WORK-ITEM-ID>/plan.md`; the workflow `complete-work-item-plan` git step owns plan state transition.
 - Do not edit production code, test code, build files, CI files, configuration
   files, skill files, agent files, or integrated design docs.
 - Report changed files, verification commands, and blockers clearly.

--- a/.codex/skills/harness-code-planner/SKILL.md
+++ b/.codex/skills/harness-code-planner/SKILL.md
@@ -10,6 +10,7 @@ description: Create or maintain an executor-ready implementation plan for one ac
 - Use this skill only for the workflow described in the frontmatter.
 - Read `.codex/skills/harness-code-planner/references/detailed-instructions.md` before making workflow decisions or producing required artifacts.
 - Read additional files named by the detailed reference only when the current task needs them.
+- The workflow completion destination is `docs/plans/completed/<WORK-ITEM-ID>/plan.md`; this skill never writes, deletes, or moves that path.
 - Keep writes inside the scope declared by the caller or runtime payload.
 - Preserve unrelated worktree changes.
 - Stop and report the blocker when required inputs, approvals, or scope are missing.

--- a/.codex/skills/harness-code-planner/SKILL.md
+++ b/.codex/skills/harness-code-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-code-planner
-description: Create or maintain an executor-ready implementation plan for one active ChangeSet work item. Use after a ChangeSet and one work-item slice exist and before coding starts, or when updating/completing that work-item plan. Also use for the harness plan-writing runtime command. The skill keeps planning scoped to the active ChangeSet and moves plans to completed only after all checkbox tasks and build/test/e2e/runtime-server/static-analysis verification are complete.
+description: Create or maintain an executor-ready implementation plan for one active ChangeSet work item. Use after a ChangeSet and one work-item slice exist and before coding starts, or when updating that active work-item plan. The skill keeps planning scoped to the active ChangeSet and writes only `docs/plans/active/<WORK-ITEM-ID>/plan.md`.
 ---
 
 # Harness Code Planner

--- a/.codex/skills/harness-code-planner/references/detailed-instructions.md
+++ b/.codex/skills/harness-code-planner/references/detailed-instructions.md
@@ -4,7 +4,7 @@
 
 ---
 name: harness-code-planner
-description: Create or maintain an executor-ready implementation plan for one active ChangeSet work item. Use after a ChangeSet and one work-item slice exist and before coding starts, or when updating/completing that work-item plan. The skill keeps planning scoped to the active ChangeSet, writes only docs/plans/active/<WORK-ITEM-ID>/plan.md, and moves it to docs/plans/completed/<WORK-ITEM-ID>/plan.md only after all checkbox tasks and build/test/e2e/runtime-server/static-analysis verification are complete.
+description: Create or maintain an executor-ready implementation plan for one active ChangeSet work item. Use after a ChangeSet and one work-item slice exist and before coding starts, or when updating that active work-item plan. The skill keeps planning scoped to the active ChangeSet and writes only `docs/plans/active/<WORK-ITEM-ID>/plan.md`.
 ---
 
 # Harness Code Planner
@@ -19,7 +19,7 @@ The planner does not implement code. It does not update integrated source-of-tru
 
 ## Work-item Contract Summary
 
-Plan exactly one work-item slice from `docs/changes/active/<CHG-ID>.md` into `docs/plans/active/<WORK-ITEM-ID>/plan.md`, then move it to `docs/plans/completed/<WORK-ITEM-ID>/plan.md` only after verification is complete.
+Plan exactly one work-item slice from `docs/changes/active/<CHG-ID>.md` into `docs/plans/active/<WORK-ITEM-ID>/plan.md`. The planner never moves, deletes, or creates a completed plan path. After verification evidence passes, the workflow's `complete-work-item-plan` git step exclusively owns the active-to-completed transition.
 
 Always read the selected work-item slice, `ARCHITECTURE.md`, `.codex/repository-settings.md`, approved technical decisions, and the ChangeSet Before/After delta. Use `docs/use-cases/<UC-ID>/` for a use-case work item and `docs/maintenance/<MAINT-ID>/` for a maintenance work item. Integrated documents under the design documentation area are source-of-truth references only. They are not the primary planning input.
 

--- a/.codex/skills/harness-code-planner/references/invocation.md
+++ b/.codex/skills/harness-code-planner/references/invocation.md
@@ -6,17 +6,12 @@ Dedicated agent:
 - config: `.codex/agents/implementation_planner.toml`
 - output file:
   - `docs/plans/active/<WORK-ITEM-ID>/plan.md`
-- completion move:
-  - from `docs/plans/active/<WORK-ITEM-ID>/plan.md`
-  - to `docs/plans/completed/<WORK-ITEM-ID>/plan.md`
 
 Execution rules:
 
 - If the dedicated agent cannot be found or executed, do not perform the agent's work in this skill. Explain the blocker and stop.
 - The dedicated agent must not edit production code, test code, build files, CI files, configuration files, skill files, or agent files.
-- The dedicated agent's write scope is limited to:
-  - `docs/plans/active/<WORK-ITEM-ID>/plan.md`
-  - `docs/plans/completed/<WORK-ITEM-ID>/plan.md` only when moving a fully completed and verified plan
+- The dedicated agent's write scope is limited to `docs/plans/active/<WORK-ITEM-ID>/plan.md`.
+- The planner must never create, delete, or move `docs/plans/completed/<WORK-ITEM-ID>/plan.md`. The workflow `complete-work-item-plan` git step owns that transition after its gates pass.
 - The planner must not update integrated design docs. That belongs to docs-sync after the work item is implemented and verified.
 - The planner must not read blog markdown files as planning standards. Test planning standards are embedded in the agent instruction and this skill.
-

--- a/.codex/skills/harness-code-planner/references/plan-rules.md
+++ b/.codex/skills/harness-code-planner/references/plan-rules.md
@@ -31,7 +31,7 @@ The work-item plan must include:
 - Treat component launcher scripts and their referenced local infrastructure files as maintained production artifacts. Keep component commands foreground for tmux lifecycle management. Update them whenever implementation changes ports, services, dependencies, startup order, profiles, or required environment defaults.
 - Runtime verification must invoke `harness run app` after the script exists. Direct framework commands may support diagnosis but do not replace verification of the maintained launcher contract.
 - If there is no runnable server or no server-visible behavior, state runtime server verification is not applicable and explain why.
-- Completion policy explaining when to move the active plan to the completed path.
+- Completion evidence requirements that the runtime evaluates before the completion git boundary.
 
 ## Checklist Rules
 
@@ -43,11 +43,12 @@ The work-item plan must include:
 - Include test tasks near the implementation task they verify.
 - Keep final verification tasks unchecked until the command has succeeded and the result is recorded.
 
-## Completion Rules
+## Completion Evidence Rules
 
 - Keep the plan at `docs/plans/active/<WORK-ITEM-ID>/plan.md` while any checkbox is unchecked.
 - Keep the plan active if build, tests, E2E or maintenance verification, runtime server verification, test gate, or static analysis failed or were not run, unless runtime server verification is explicitly marked not applicable with a reason.
-- Move the plan to `docs/plans/completed/<WORK-ITEM-ID>/plan.md` only when:
+- The planner must leave the plan at the active path even after its evidence is complete.
+- `complete-work-item-plan` is the sole owner of the active-to-completed transition and may run only when:
   - every checkbox is checked
   - tests required by the plan exist
   - build succeeded
@@ -58,4 +59,3 @@ The work-item plan must include:
   - static analysis succeeded
   - verification results are recorded in the plan
 - Integrated docs and canonical domain docs should be synced by docs-sync/doc-verify before completing the ChangeSet. This planner records the need but does not perform that sync.
-

--- a/.codex/skills/harness-code-planner/references/plan-template.md
+++ b/.codex/skills/harness-code-planner/references/plan-template.md
@@ -1,108 +1,26 @@
 ## Output Template
 
-`docs/plans/active/<WORK-ITEM-ID>/plan.md` must follow this structure:
+The planner writes `docs/plans/active/<WORK-ITEM-ID>/plan.md` using these sections:
 
-```markdown
-# Implementation Plan
+1. `# Implementation Plan`
+2. `## 1. 구현 목표`
+3. `## 2. 구현하지 말아야 할 것`
+4. `## 3. 입력 문서` with a document / purpose / status table
+5. `## 3.1 ChangeSet 및 Work Item` with ChangeSet, work item ID/type/slice, and E2E or verification goal
+6. `## 4. 아키텍처 제약`
+7. `## 5. 구현 범위`
+8. `## 5.1 승인된 기술 결정`
+9. `## 5.2 도메인 영향`
+10. `## 5.3 호환성 확인`
+11. `## 5.4 OWASP Security Review`
+12. `## 6. 구현 계획` with unchecked implementation tasks
+13. `## 7. 테스트 계획` with matching unchecked test tasks
+14. `## 8. 검증 방법` with Build, Tests, E2E or maintenance verification, Test gate, Runtime server verification, and Static analysis tasks
+15. `## 9. 완료 조건` with all required evidence conditions and this rule: the workflow `complete-work-item-plan` git step exclusively performs the active-to-completed transition.
+16. `## 10. 검증 결과` for executor-owned command and evidence results
+17. `## 11. 검증 실패`
 
-## 1. 구현 목표
-- ...
-
-## 2. 구현하지 말아야 할 것
-- ...
-
-## 3. 입력 문서
-|문서|사용 목적|상태|
-|---|---|---|
-
-## 3.1 ChangeSet 및 Work Item
-- ChangeSet:
-- Work item ID:
-- Work item type:
-- Work item slice:
-- E2E/verification goal:
-
-## 4. 아키텍처 제약
-- ARCHITECTURE.md 기준:
-- 모듈/패키지 경계:
-- 의존성 방향:
-- 금지 참조:
-
-## 5. 구현 범위
-- 포함:
-- 제외:
-- 가정:
-
-## 5.1 승인된 기술 결정
-|영역|결정|구현 반영|테스트/검증 반영|
-|---|---|---|---|
-
-## 5.2 도메인 영향
-|type|id|mode|canonical path|plan impact|
-|---|---|---|---|---|
-
-## 5.3 호환성 확인
-- 기존 유스케이스 영향:
-- 같은 도메인 요소를 수정하는 active ChangeSet 충돌 여부:
-
-## 5.4 OWASP Security Review
-- Status: pending `security_plan_reviewer`
-- Attack surface:
-- Applicable standards:
-- Exclusions and rationale:
-
-## 6. 구현 계획
-- [ ] 필요 시 `spring-initializer`를 사용해 Spring Boot 프로젝트 기준 설정 또는 신규 모듈을 초기화한다.
-- [ ] `spring-package-structure`를 사용해 Spring 모듈/패키지 빈 구조와 `ARCHITECTURE.md`가 현재 설계와 일치하는지 생성 또는 검증한다.
-- [ ] ...
-
-## 7. 테스트 계획
-- [ ] Domain/Aggregate/VO 테스트:
-- [ ] Application Service 흐름 테스트:
-- [ ] Infrastructure/Adapter 테스트:
-- [ ] Communication/Transaction 테스트:
-- [ ] Compatibility 테스트:
-
-## 8. 검증 방법
-- [ ] Build:
-  - 명령: `./gradlew build`
-  - 성공 기준:
-- [ ] Tests:
-  - 명령: `./gradlew test`
-  - 성공 기준:
-- [ ] E2E 또는 maintenance verification:
-  - 명령:
-  - 목표:
-  - 성공 기준:
-- [ ] Test gate:
-  - 기준: `.codex/test-gate.yaml` required stage PASS
-- [ ] Runtime server verification:
-  - 서버 실행 명령:
-  - 구현사항 확인 방법:
-  - 성공 기준:
-- [ ] Static analysis:
-  - 절차:
-  - 명령:
-  - 성공 기준:
-
-## 9. 완료 조건
-- 모든 체크박스가 `- [x]` 상태다.
-- 구현 범위의 테스트가 작성되어 통과했다.
-- Build, Tests, E2E 또는 maintenance verification, Test gate, Runtime server verification, Static analysis가 성공했다.
-- 검증 결과가 기록되어 있다.
-- 성공 후 `docs/plans/completed/<WORK-ITEM-ID>/plan.md`로 이동한다.
-
-## 10. 검증 결과
-- Build:
-- Tests:
-- E2E 또는 maintenance verification:
-- Test gate:
-- Runtime server verification:
-- Static analysis:
-
-## 11. 검증 실패
-- 없음
-```
+The executor may only change existing checkbox state and the `## 10. 검증 결과` (or `## 10. Verification Results`) section. The planner must not create, delete, or move a completed plan path.
 
 ## User-Facing Result
 
@@ -110,6 +28,6 @@ After agent completion, report:
 
 - Whether `ARCHITECTURE.md` existed.
 - Whether static-analysis procedures were included in the work-item plan.
-- The active plan path or completed plan path.
+- The active plan path.
 - Whether the plan is ready for executor use.
 - Any missing ChangeSet, work-item, architecture, repository setting, technical decision, or canonical domain inputs.

--- a/.codex/skills/harness-code-planner/references/plan-template.md
+++ b/.codex/skills/harness-code-planner/references/plan-template.md
@@ -1,26 +1,108 @@
 ## Output Template
 
-The planner writes `docs/plans/active/<WORK-ITEM-ID>/plan.md` using these sections:
+`docs/plans/active/<WORK-ITEM-ID>/plan.md` must follow this structure:
 
-1. `# Implementation Plan`
-2. `## 1. 구현 목표`
-3. `## 2. 구현하지 말아야 할 것`
-4. `## 3. 입력 문서` with a document / purpose / status table
-5. `## 3.1 ChangeSet 및 Work Item` with ChangeSet, work item ID/type/slice, and E2E or verification goal
-6. `## 4. 아키텍처 제약`
-7. `## 5. 구현 범위`
-8. `## 5.1 승인된 기술 결정`
-9. `## 5.2 도메인 영향`
-10. `## 5.3 호환성 확인`
-11. `## 5.4 OWASP Security Review`
-12. `## 6. 구현 계획` with unchecked implementation tasks
-13. `## 7. 테스트 계획` with matching unchecked test tasks
-14. `## 8. 검증 방법` with Build, Tests, E2E or maintenance verification, Test gate, Runtime server verification, and Static analysis tasks
-15. `## 9. 완료 조건` with all required evidence conditions and this rule: the workflow `complete-work-item-plan` git step exclusively performs the active-to-completed transition.
-16. `## 10. 검증 결과` for executor-owned command and evidence results
-17. `## 11. 검증 실패`
+~~~markdown
+# Implementation Plan
 
-The executor may only change existing checkbox state and the `## 10. 검증 결과` (or `## 10. Verification Results`) section. The planner must not create, delete, or move a completed plan path.
+## 1. 구현 목표
+- ...
+
+## 2. 구현하지 말아야 할 것
+- ...
+
+## 3. 입력 문서
+|문서|사용 목적|상태|
+|---|---|---|
+
+## 3.1 ChangeSet 및 Work Item
+- ChangeSet:
+- Work item ID:
+- Work item type:
+- Work item slice:
+- E2E/verification goal:
+
+## 4. 아키텍처 제약
+- ARCHITECTURE.md 기준:
+- 모듈/패키지 경계:
+- 의존성 방향:
+- 금지 참조:
+
+## 5. 구현 범위
+- 포함:
+- 제외:
+- 가정:
+
+## 5.1 승인된 기술 결정
+|영역|결정|구현 반영|테스트/검증 반영|
+|---|---|---|---|
+
+## 5.2 도메인 영향
+|type|id|mode|canonical path|plan impact|
+|---|---|---|---|---|
+
+## 5.3 호환성 확인
+- 기존 유스케이스 영향:
+- 같은 도메인 요소를 수정하는 active ChangeSet 충돌 여부:
+
+## 5.4 OWASP Security Review
+- Status: pending `security_plan_reviewer`
+- Attack surface:
+- Applicable standards:
+- Exclusions and rationale:
+
+## 6. 구현 계획
+- [ ] 필요 시 `spring-initializer`를 사용해 Spring Boot 프로젝트 기준 설정 또는 신규 모듈을 초기화한다.
+- [ ] `spring-package-structure`를 사용해 Spring 모듈/패키지 빈 구조와 `ARCHITECTURE.md`가 현재 설계와 일치하는지 생성 또는 검증한다.
+- [ ] ...
+
+## 7. 테스트 계획
+- [ ] Domain/Aggregate/VO 테스트:
+- [ ] Application Service 흐름 테스트:
+- [ ] Infrastructure/Adapter 테스트:
+- [ ] Communication/Transaction 테스트:
+- [ ] Compatibility 테스트:
+
+## 8. 검증 방법
+- [ ] Build:
+  - 명령: `./gradlew build`
+  - 성공 기준:
+- [ ] Tests:
+  - 명령: `./gradlew test`
+  - 성공 기준:
+- [ ] E2E 또는 maintenance verification:
+  - 명령:
+  - 목표:
+  - 성공 기준:
+- [ ] Test gate:
+  - 기준: `.codex/test-gate.yaml` required stage PASS
+- [ ] Runtime server verification:
+  - 서버 실행 명령:
+  - 구현사항 확인 방법:
+  - 성공 기준:
+- [ ] Static analysis:
+  - 절차:
+  - 명령:
+  - 성공 기준:
+
+## 9. 완료 조건
+- 모든 체크박스가 `- [x]` 상태다.
+- 구현 범위의 테스트가 작성되어 통과했다.
+- Build, Tests, E2E 또는 maintenance verification, Test gate, Runtime server verification, Static analysis가 성공했다.
+- 검증 결과가 기록되어 있다.
+- active → completed 전이는 workflow의 `complete-work-item-plan` git step이 수행한다.
+
+## 10. 검증 결과
+- Build:
+- Tests:
+- E2E 또는 maintenance verification:
+- Test gate:
+- Runtime server verification:
+- Static analysis:
+
+## 11. 검증 실패
+- 없음
+~~~
 
 ## User-Facing Result
 

--- a/.codex/skills/harness-implementation-executor/SKILL.md
+++ b/.codex/skills/harness-implementation-executor/SKILL.md
@@ -16,6 +16,8 @@ Perform one runtime-dispatched implementation attempt for the active work item. 
 - Keep writes inside the active ChangeSet and work-item scope.
 - Run focused verification for the tasks changed in this attempt.
 - Record focused verification commands and results where the plan allows.
+- When updating the active plan, change only existing checkbox markers from `- [ ]` to `- [x]` and the contents of `## 10. 검증 결과` or `## 10. Verification Results`.
+- Do not rewrite plan goals, non-goals, input documents, architecture constraints, scope boundaries, task wording, completion policy, or any completed-plan path.
 - Report changed files, completed tasks, remaining tasks, focused verification results, and blockers.
 - Preserve unrelated worktree changes.
 

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -79,6 +79,16 @@ from harness_codex.runtime.delivery_runner_patch import apply_delivery_runner_pa
 
 apply_delivery_runner_patch()
 
+from harness_codex.runtime.plan_transition_policy_patch import (
+    apply_plan_transition_policy_patch,
+)
+from harness_codex.runtime.plan_completion_boundary_patch import (
+    apply_plan_completion_boundary_patch,
+)
+
+apply_plan_transition_policy_patch()
+apply_plan_completion_boundary_patch()
+
 from harness_codex.runtime.agent_context import (
     AGENT_CONTEXT_FILES,
     HARNESS_AGENT_CONTEXT_MARKER,

--- a/harness_codex/runtime/delivery_runner_patch.py
+++ b/harness_codex/runtime/delivery_runner_patch.py
@@ -159,5 +159,9 @@ def apply_delivery_runner_patch() -> None:
     from harness_codex.runtime.agent_write_scope_policy_patch import (
         apply_agent_write_scope_policy_patch,
     )
+    from harness_codex.runtime.plan_transition_policy_patch import (
+        apply_plan_transition_policy_patch,
+    )
 
     apply_agent_write_scope_policy_patch()
+    apply_plan_transition_policy_patch()

--- a/harness_codex/runtime/delivery_runner_patch.py
+++ b/harness_codex/runtime/delivery_runner_patch.py
@@ -19,11 +19,15 @@ def apply_delivery_runner_patch() -> None:
         complete_change_set_if_ready,
     )
     from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
+    from harness_codex.runtime.work_item_plan_state_guard import (
+        apply_work_item_plan_state_guard,
+    )
     import harness_codex.runtime.runner as runner_module
 
     BasicStepRunner = runner_module.BasicStepRunner
     relative_to_repo = runner_module._relative_to_repo
     if getattr(BasicStepRunner, "_delivery_approval_patch_applied", False):
+        apply_work_item_plan_state_guard()
         return
 
     original_command = BasicStepRunner._run_command
@@ -112,7 +116,7 @@ def apply_delivery_runner_patch() -> None:
     def complete_change_set_boundary(step, context):
         """Keep the legacy move-only boundary side-effect free.
 
-        Canonical workflows use the explicit completion-delivery command.  The legacy
+        Canonical workflows use the explicit completion-delivery command. The legacy
         boundary therefore only validates and archives the ChangeSet; it never calls
         `git add -A`, commits, or pushes unrelated worktree state.
         """
@@ -169,3 +173,4 @@ def apply_delivery_runner_patch() -> None:
     apply_agent_write_scope_policy_patch()
     apply_plan_transition_policy_patch()
     apply_plan_completion_boundary_patch()
+    apply_work_item_plan_state_guard()

--- a/harness_codex/runtime/delivery_runner_patch.py
+++ b/harness_codex/runtime/delivery_runner_patch.py
@@ -159,9 +159,13 @@ def apply_delivery_runner_patch() -> None:
     from harness_codex.runtime.agent_write_scope_policy_patch import (
         apply_agent_write_scope_policy_patch,
     )
+    from harness_codex.runtime.plan_completion_boundary_patch import (
+        apply_plan_completion_boundary_patch,
+    )
     from harness_codex.runtime.plan_transition_policy_patch import (
         apply_plan_transition_policy_patch,
     )
 
     apply_agent_write_scope_policy_patch()
     apply_plan_transition_policy_patch()
+    apply_plan_completion_boundary_patch()

--- a/harness_codex/runtime/plan_completion_boundary_patch.py
+++ b/harness_codex/runtime/plan_completion_boundary_patch.py
@@ -1,0 +1,68 @@
+"""Reserve plan archive moves for the explicit work-item completion step."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+_WORK_ITEM_WORKFLOW = "changeset-work-item-workflow"
+_COMPLETION_STEP_ID = "complete-work-item-plan"
+
+
+def apply_plan_completion_boundary_patch() -> None:
+    """Block active-to-completed plan moves from non-completion git steps."""
+
+    from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
+    import harness_codex.runtime.runner as runner_module
+
+    basic_step_runner = runner_module.BasicStepRunner
+    if getattr(basic_step_runner, "_plan_completion_boundary_patch_applied", False):
+        return
+
+    original_run_git_boundary = basic_step_runner._run_git_boundary
+
+    def run_git_boundary(self, step, context, step_dir: Path):
+        if not _is_disallowed_plan_completion_move(step, context, runner_module):
+            return original_run_git_boundary(self, step, context, step_dir)
+
+        error = (
+            "plan transition blocked: only `complete-work-item-plan` may move an "
+            "active work-item plan to the completed path"
+        )
+        evidence = step_dir / "plan-transition.json"
+        evidence.write_text(
+            json.dumps(
+                {
+                    "step_id": step.id,
+                    "status": "blocked",
+                    "error": error,
+                    "expected_completion_step": _COMPLETION_STEP_ID,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.BLOCKED,
+            output_path=runner_module._relative_to_repo(evidence, context),
+            error=error,
+            failure_kind=FailureKind.SCOPE_CONFLICT,
+            metadata={"plan_transition_status": "blocked"},
+        )
+
+    basic_step_runner._run_git_boundary = run_git_boundary
+    basic_step_runner._plan_completion_boundary_patch_applied = True
+
+
+def _is_disallowed_plan_completion_move(step, context, runner_module) -> bool:
+    if context.workflow_name != _WORK_ITEM_WORKFLOW:
+        return False
+    if step.id == _COMPLETION_STEP_ID:
+        return False
+    if len(step.inputs) != 1 or len(step.outputs) != 1:
+        return False
+    return runner_module._is_plan_completion_move(step.inputs[0], step.outputs[0])

--- a/harness_codex/runtime/plan_transition_policy_patch.py
+++ b/harness_codex/runtime/plan_transition_policy_patch.py
@@ -1,25 +1,15 @@
-"""Enforce work-item plan location and executor-owned plan updates."""
+"""Shared plan-state helpers for the work-item runtime boundary."""
 
 from __future__ import annotations
 
-import json
 import re
 import shutil
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 
 
 _PLAN_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
 _CHECKBOX_RE = re.compile(r"^(\s*[-*+]\s*)\[[ xX]\]", flags=re.MULTILINE)
-_GUARDED_AGENT_STEPS = frozenset(
-    {
-        "plan-work-item",
-        "secure-work-item-plan",
-        "review-work-item-plan",
-        "execute-work-item",
-        "review-work-item-security",
-    }
-)
 
 
 @dataclass(frozen=True)
@@ -33,76 +23,12 @@ class _PlanLocationSnapshot:
 
 
 def apply_plan_transition_policy_patch() -> None:
-    """Install the non-completion plan-location boundary around agent steps."""
+    """Retain the public installation hook for the runner-level state guard.
 
-    from harness_codex.runtime.models import FailureKind, StepStatus
-    import harness_codex.runtime.runner as runner_module
-
-    basic_step_runner = runner_module.BasicStepRunner
-    if getattr(basic_step_runner, "_plan_transition_policy_patch_applied", False):
-        return
-
-    original_run_agent = basic_step_runner._run_agent
-
-    def run_agent(self, step, context, step_dir: Path):
-        if step.id not in _GUARDED_AGENT_STEPS:
-            return original_run_agent(self, step, context, step_dir)
-
-        active_path = _active_plan_path(step, context)
-        if active_path is None:
-            return original_run_agent(self, step, context, step_dir)
-        completed_path = _completed_plan_path(active_path)
-
-        recovery_error = _recover_plan_for_retry(active_path, completed_path)
-        if recovery_error is not None:
-            return _blocked_transition_result(
-                runner_module,
-                step,
-                context,
-                step_dir,
-                recovery_error,
-                FailureKind,
-            )
-
-        before = _capture_plan_location(active_path, completed_path)
-        result = original_run_agent(self, step, context, step_dir)
-        after = _capture_plan_location(active_path, completed_path)
-        transition_error = _plan_transition_error(step, before, after)
-        if transition_error is None:
-            return result
-
-        _restore_plan_location(before)
-        evidence = _write_transition_evidence(
-            step_dir,
-            step_id=step.id,
-            active_path=active_path,
-            completed_path=completed_path,
-            error=transition_error,
-        )
-        metadata = {
-            **dict(result.metadata),
-            "plan_transition_status": "blocked",
-            "plan_transition_evidence": str(_relative_to_repo(evidence, context)),
-        }
-        _rewrite_result_artifact(
-            runner_module,
-            step,
-            context,
-            step_dir,
-            status=StepStatus.BLOCKED,
-            error=transition_error,
-            metadata=metadata,
-        )
-        return replace(
-            result,
-            status=StepStatus.BLOCKED,
-            error=transition_error,
-            failure_kind=FailureKind.SCOPE_CONFLICT,
-            metadata=metadata,
-        )
-
-    basic_step_runner._run_agent = run_agent
-    basic_step_runner._plan_transition_policy_patch_applied = True
+    State enforcement runs around ``BasicStepRunner.run`` in
+    ``work_item_plan_state_guard``. Keeping this hook preserves the existing
+    bootstrap contract without layering a second agent-only wrapper.
+    """
 
 
 def _active_plan_path(step, context) -> Path | None:
@@ -169,7 +95,11 @@ def _file_content(path: Path) -> bytes | None:
     return path.read_bytes() if path.is_file() else None
 
 
-def _plan_transition_error(step, before: _PlanLocationSnapshot, after: _PlanLocationSnapshot) -> str | None:
+def _plan_transition_error(
+    step,
+    before: _PlanLocationSnapshot,
+    after: _PlanLocationSnapshot,
+) -> str | None:
     if after.completed_exists:
         return (
             f"plan transition blocked: `{step.id}` created or retained "
@@ -203,6 +133,7 @@ def _executor_plan_content_changed_outside_owned_fields(before: str, after: str)
 
 
 def _canonicalize_executor_plan(text: str) -> str:
+    text = _strip_runtime_metadata(text)
     lines: list[str] = []
     in_verification_results = False
     for line in text.splitlines(keepends=True):
@@ -220,12 +151,21 @@ def _canonicalize_executor_plan(text: str) -> str:
     return "".join(lines)
 
 
+def _strip_runtime_metadata(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    boundary = text.find("\n---\n", len("---\n"))
+    if boundary < 0:
+        return text
+    front_matter = text[: boundary + len("\n---\n")]
+    if "doc_type: plan" not in front_matter and "contract_version:" not in front_matter:
+        return text
+    return text[boundary + len("\n---\n") :]
+
+
 def _restore_plan_location(before: _PlanLocationSnapshot) -> None:
     if before.active_content is not None:
         _write_file(before.active_path, before.active_content)
-    elif before.active_exists:
-        # A non-file active path is invalid, but avoid deleting it while reporting.
-        pass
 
     if before.completed_content is not None:
         _write_file(before.completed_path, before.completed_content)
@@ -245,92 +185,3 @@ def _remove_path(path: Path) -> None:
         shutil.rmtree(path)
     elif path.exists():
         path.unlink()
-
-
-def _blocked_transition_result(runner_module, step, context, step_dir: Path, error: str, failure_kind):
-    evidence = _write_transition_evidence(
-        step_dir,
-        step_id=step.id,
-        active_path=_active_plan_path(step, context),
-        completed_path=(
-            _completed_plan_path(_active_plan_path(step, context))
-            if _active_plan_path(step, context) is not None
-            else None
-        ),
-        error=error,
-    )
-    result = runner_module._blocked_agent_result(step, context, step_dir, error)
-    return replace(
-        result,
-        failure_kind=failure_kind.SCOPE_CONFLICT,
-        metadata={
-            **dict(result.metadata),
-            "plan_transition_status": "blocked",
-            "plan_transition_evidence": str(_relative_to_repo(evidence, context)),
-        },
-    )
-
-
-def _write_transition_evidence(
-    step_dir: Path,
-    *,
-    step_id: str,
-    active_path: Path | None,
-    completed_path: Path | None,
-    error: str,
-) -> Path:
-    evidence = step_dir / "plan-transition.json"
-    evidence.write_text(
-        json.dumps(
-            {
-                "step_id": step_id,
-                "status": "blocked",
-                "active_plan_path": str(active_path) if active_path is not None else None,
-                "completed_plan_path": str(completed_path) if completed_path is not None else None,
-                "error": error,
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    return evidence
-
-
-def _rewrite_result_artifact(
-    runner_module,
-    step,
-    context,
-    step_dir: Path,
-    *,
-    status,
-    error: str,
-    metadata: dict,
-) -> None:
-    result_path = step_dir / "result.json"
-    result_path.write_text(
-        json.dumps(
-            {
-                "step_id": step.id,
-                "agent_id": step.agent_id,
-                "skill_id": runner_module._step_skill_id(step),
-                "status": status.value,
-                "exit_code": None,
-                "error": error,
-                "metadata": metadata,
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    runner_module._write_response_snapshot(context, step.id, result_path)
-
-
-def _relative_to_repo(path: Path, context) -> Path:
-    try:
-        return path.relative_to(context.repo_root)
-    except ValueError:
-        return path

--- a/harness_codex/runtime/plan_transition_policy_patch.py
+++ b/harness_codex/runtime/plan_transition_policy_patch.py
@@ -1,0 +1,336 @@
+"""Enforce work-item plan location and executor-owned plan updates."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+
+_PLAN_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
+_CHECKBOX_RE = re.compile(r"^(\s*[-*+]\s*)\[[ xX]\]", flags=re.MULTILINE)
+_GUARDED_AGENT_STEPS = frozenset(
+    {
+        "plan-work-item",
+        "secure-work-item-plan",
+        "review-work-item-plan",
+        "execute-work-item",
+        "review-work-item-security",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _PlanLocationSnapshot:
+    active_path: Path
+    completed_path: Path
+    active_exists: bool
+    completed_exists: bool
+    active_content: bytes | None
+    completed_content: bytes | None
+
+
+def apply_plan_transition_policy_patch() -> None:
+    """Install the non-completion plan-location boundary around agent steps."""
+
+    from harness_codex.runtime.models import FailureKind, StepStatus
+    import harness_codex.runtime.runner as runner_module
+
+    basic_step_runner = runner_module.BasicStepRunner
+    if getattr(basic_step_runner, "_plan_transition_policy_patch_applied", False):
+        return
+
+    original_run_agent = basic_step_runner._run_agent
+
+    def run_agent(self, step, context, step_dir: Path):
+        if step.id not in _GUARDED_AGENT_STEPS:
+            return original_run_agent(self, step, context, step_dir)
+
+        active_path = _active_plan_path(step, context)
+        if active_path is None:
+            return original_run_agent(self, step, context, step_dir)
+        completed_path = _completed_plan_path(active_path)
+
+        recovery_error = _recover_plan_for_retry(active_path, completed_path)
+        if recovery_error is not None:
+            return _blocked_transition_result(
+                runner_module,
+                step,
+                context,
+                step_dir,
+                recovery_error,
+                FailureKind,
+            )
+
+        before = _capture_plan_location(active_path, completed_path)
+        result = original_run_agent(self, step, context, step_dir)
+        after = _capture_plan_location(active_path, completed_path)
+        transition_error = _plan_transition_error(step, before, after)
+        if transition_error is None:
+            return result
+
+        _restore_plan_location(before)
+        evidence = _write_transition_evidence(
+            step_dir,
+            step_id=step.id,
+            active_path=active_path,
+            completed_path=completed_path,
+            error=transition_error,
+        )
+        metadata = {
+            **dict(result.metadata),
+            "plan_transition_status": "blocked",
+            "plan_transition_evidence": str(_relative_to_repo(evidence, context)),
+        }
+        _rewrite_result_artifact(
+            runner_module,
+            step,
+            context,
+            step_dir,
+            status=StepStatus.BLOCKED,
+            error=transition_error,
+            metadata=metadata,
+        )
+        return replace(
+            result,
+            status=StepStatus.BLOCKED,
+            error=transition_error,
+            failure_kind=FailureKind.SCOPE_CONFLICT,
+            metadata=metadata,
+        )
+
+    basic_step_runner._run_agent = run_agent
+    basic_step_runner._plan_transition_policy_patch_applied = True
+
+
+def _active_plan_path(step, context) -> Path | None:
+    candidates = [context.active_plan_path, context.metadata.get("active_plan_path")]
+    candidates.extend((*step.inputs, *step.outputs))
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        path = Path(str(candidate))
+        if _is_active_plan_path(path):
+            return path
+
+    work_item_id = context.metadata.get("active_work_item_id")
+    if isinstance(work_item_id, str) and work_item_id:
+        return Path("docs/plans/active") / work_item_id / "plan.md"
+    return None
+
+
+def _is_active_plan_path(path: Path) -> bool:
+    return (
+        len(path.parts) == 5
+        and path.parts[:3] == ("docs", "plans", "active")
+        and path.name == "plan.md"
+    )
+
+
+def _completed_plan_path(active_path: Path) -> Path:
+    return Path("docs", "plans", "completed", active_path.parts[3], "plan.md")
+
+
+def _recover_plan_for_retry(active_path: Path, completed_path: Path) -> str | None:
+    active_exists = active_path.exists()
+    completed_exists = completed_path.exists()
+    if active_exists and completed_exists:
+        return (
+            "plan transition blocked: both active and completed plan paths exist; "
+            "retry state is ambiguous"
+        )
+    if not completed_exists:
+        return None
+    if completed_path.is_dir():
+        return f"plan transition blocked: completed plan path is not a file: {completed_path}"
+
+    active_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(completed_path), str(active_path))
+    return None
+
+
+def _capture_plan_location(
+    active_path: Path,
+    completed_path: Path,
+) -> _PlanLocationSnapshot:
+    return _PlanLocationSnapshot(
+        active_path=active_path,
+        completed_path=completed_path,
+        active_exists=active_path.exists(),
+        completed_exists=completed_path.exists(),
+        active_content=_file_content(active_path),
+        completed_content=_file_content(completed_path),
+    )
+
+
+def _file_content(path: Path) -> bytes | None:
+    return path.read_bytes() if path.is_file() else None
+
+
+def _plan_transition_error(step, before: _PlanLocationSnapshot, after: _PlanLocationSnapshot) -> str | None:
+    if after.completed_exists:
+        return (
+            f"plan transition blocked: `{step.id}` created or retained "
+            f"`{after.completed_path}`; only `complete-work-item-plan` may move a plan "
+            "to the completed path"
+        )
+    if before.active_exists and not after.active_exists:
+        return (
+            f"plan transition blocked: `{step.id}` removed `{before.active_path}`; "
+            "only `complete-work-item-plan` may remove the active plan"
+        )
+    if (
+        step.agent_id == "implementation_executor"
+        and before.active_content is not None
+        and after.active_content is not None
+        and before.active_content != after.active_content
+        and _executor_plan_content_changed_outside_owned_fields(
+            before.active_content.decode("utf-8"),
+            after.active_content.decode("utf-8"),
+        )
+    ):
+        return (
+            "executor plan mutation blocked: only existing checkbox state and the "
+            "`## 10. 검증 결과` / `## 10. Verification Results` section are executor-owned"
+        )
+    return None
+
+
+def _executor_plan_content_changed_outside_owned_fields(before: str, after: str) -> bool:
+    return _canonicalize_executor_plan(before) != _canonicalize_executor_plan(after)
+
+
+def _canonicalize_executor_plan(text: str) -> str:
+    lines: list[str] = []
+    in_verification_results = False
+    for line in text.splitlines(keepends=True):
+        heading = _PLAN_HEADING_RE.match(line)
+        if heading:
+            title = heading.group(1).strip().lower()
+            in_verification_results = (
+                "검증 결과" in title or "verification results" in title
+            )
+            lines.append(f"## {title}\n")
+            continue
+        if in_verification_results:
+            continue
+        lines.append(_CHECKBOX_RE.sub(r"\1[ ]", line))
+    return "".join(lines)
+
+
+def _restore_plan_location(before: _PlanLocationSnapshot) -> None:
+    if before.active_content is not None:
+        _write_file(before.active_path, before.active_content)
+    elif before.active_exists:
+        # A non-file active path is invalid, but avoid deleting it while reporting.
+        pass
+
+    if before.completed_content is not None:
+        _write_file(before.completed_path, before.completed_content)
+    elif not before.completed_exists:
+        _remove_path(before.completed_path)
+
+
+def _write_file(path: Path, content: bytes) -> None:
+    if path.exists() and path.is_dir():
+        shutil.rmtree(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        path.unlink()
+
+
+def _blocked_transition_result(runner_module, step, context, step_dir: Path, error: str, failure_kind):
+    evidence = _write_transition_evidence(
+        step_dir,
+        step_id=step.id,
+        active_path=_active_plan_path(step, context),
+        completed_path=(
+            _completed_plan_path(_active_plan_path(step, context))
+            if _active_plan_path(step, context) is not None
+            else None
+        ),
+        error=error,
+    )
+    result = runner_module._blocked_agent_result(step, context, step_dir, error)
+    return replace(
+        result,
+        failure_kind=failure_kind.SCOPE_CONFLICT,
+        metadata={
+            **dict(result.metadata),
+            "plan_transition_status": "blocked",
+            "plan_transition_evidence": str(_relative_to_repo(evidence, context)),
+        },
+    )
+
+
+def _write_transition_evidence(
+    step_dir: Path,
+    *,
+    step_id: str,
+    active_path: Path | None,
+    completed_path: Path | None,
+    error: str,
+) -> Path:
+    evidence = step_dir / "plan-transition.json"
+    evidence.write_text(
+        json.dumps(
+            {
+                "step_id": step_id,
+                "status": "blocked",
+                "active_plan_path": str(active_path) if active_path is not None else None,
+                "completed_plan_path": str(completed_path) if completed_path is not None else None,
+                "error": error,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return evidence
+
+
+def _rewrite_result_artifact(
+    runner_module,
+    step,
+    context,
+    step_dir: Path,
+    *,
+    status,
+    error: str,
+    metadata: dict,
+) -> None:
+    result_path = step_dir / "result.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "step_id": step.id,
+                "agent_id": step.agent_id,
+                "skill_id": runner_module._step_skill_id(step),
+                "status": status.value,
+                "exit_code": None,
+                "error": error,
+                "metadata": metadata,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runner_module._write_response_snapshot(context, step.id, result_path)
+
+
+def _relative_to_repo(path: Path, context) -> Path:
+    try:
+        return path.relative_to(context.repo_root)
+    except ValueError:
+        return path

--- a/harness_codex/runtime/work_item_plan_state_guard.py
+++ b/harness_codex/runtime/work_item_plan_state_guard.py
@@ -38,9 +38,11 @@ def apply_work_item_plan_state_guard() -> None:
         if active_path is None or step.id == _COMPLETION_STEP_ID:
             return original_run(self, step, context)
         completed_path = _completed_plan_path(active_path)
+        active_file = context.repo_root / active_path
+        completed_file = context.repo_root / completed_path
         step_dir = context.run_dir / "steps" / step.id
 
-        recovery_error = _recover_plan_for_retry(active_path, completed_path)
+        recovery_error = _recover_plan_for_retry(active_file, completed_file)
         if recovery_error is not None:
             return _blocked_result(
                 runner_module,
@@ -53,9 +55,9 @@ def apply_work_item_plan_state_guard() -> None:
                 StepStatus,
             )
 
-        before = _capture_plan_location(active_path, completed_path)
+        before = _capture_plan_location(active_file, completed_file)
         result = original_run(self, step, context)
-        after = _capture_plan_location(active_path, completed_path)
+        after = _capture_plan_location(active_file, completed_file)
         transition_error = _plan_transition_error(step, before, after)
         if transition_error is None:
             return result

--- a/harness_codex/runtime/work_item_plan_state_guard.py
+++ b/harness_codex/runtime/work_item_plan_state_guard.py
@@ -7,11 +7,12 @@ from dataclasses import replace
 from pathlib import Path
 
 
+_WORK_ITEM_WORKFLOW = "changeset-work-item-workflow"
 _COMPLETION_STEP_ID = "complete-work-item-plan"
 
 
 def apply_work_item_plan_state_guard() -> None:
-    """Guard active/completed plan state around every non-completion step."""
+    """Guard active/completed plan state around canonical non-completion steps."""
 
     from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
     from harness_codex.runtime.plan_transition_policy_patch import (
@@ -31,6 +32,8 @@ def apply_work_item_plan_state_guard() -> None:
     original_run = basic_step_runner.run
 
     def run(self, step, context):
+        if context.workflow_name != _WORK_ITEM_WORKFLOW:
+            return original_run(self, step, context)
         active_path = _active_plan_path(step, context)
         if active_path is None or step.id == _COMPLETION_STEP_ID:
             return original_run(self, step, context)

--- a/harness_codex/runtime/work_item_plan_state_guard.py
+++ b/harness_codex/runtime/work_item_plan_state_guard.py
@@ -1,0 +1,159 @@
+"""Runner-level plan state guard that survives agent-handler patch ordering."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+
+_COMPLETION_STEP_ID = "complete-work-item-plan"
+
+
+def apply_work_item_plan_state_guard() -> None:
+    """Guard active/completed plan state around every non-completion step."""
+
+    from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
+    from harness_codex.runtime.plan_transition_policy_patch import (
+        _active_plan_path,
+        _capture_plan_location,
+        _completed_plan_path,
+        _plan_transition_error,
+        _recover_plan_for_retry,
+        _restore_plan_location,
+    )
+    import harness_codex.runtime.runner as runner_module
+
+    basic_step_runner = runner_module.BasicStepRunner
+    if getattr(basic_step_runner, "_work_item_plan_state_guard_applied", False):
+        return
+
+    original_run = basic_step_runner.run
+
+    def run(self, step, context):
+        active_path = _active_plan_path(step, context)
+        if active_path is None or step.id == _COMPLETION_STEP_ID:
+            return original_run(self, step, context)
+        completed_path = _completed_plan_path(active_path)
+        step_dir = context.run_dir / "steps" / step.id
+
+        recovery_error = _recover_plan_for_retry(active_path, completed_path)
+        if recovery_error is not None:
+            return _blocked_result(
+                runner_module,
+                step,
+                context,
+                step_dir,
+                recovery_error,
+                FailureKind,
+                StepResult,
+                StepStatus,
+            )
+
+        before = _capture_plan_location(active_path, completed_path)
+        result = original_run(self, step, context)
+        after = _capture_plan_location(active_path, completed_path)
+        transition_error = _plan_transition_error(step, before, after)
+        if transition_error is None:
+            return result
+
+        _restore_plan_location(before)
+        evidence = _write_evidence(
+            step_dir,
+            step_id=step.id,
+            active_path=active_path,
+            completed_path=completed_path,
+            error=transition_error,
+        )
+        metadata = {
+            **dict(result.metadata),
+            "plan_transition_status": "blocked",
+            "plan_transition_evidence": str(_relative_to_repo(evidence, context)),
+        }
+        return replace(
+            result,
+            status=StepStatus.BLOCKED,
+            error=transition_error,
+            failure_kind=FailureKind.SCOPE_CONFLICT,
+            metadata=metadata,
+        )
+
+    basic_step_runner.run = run
+    basic_step_runner._work_item_plan_state_guard_applied = True
+
+
+def _blocked_result(
+    runner_module,
+    step,
+    context,
+    step_dir: Path,
+    error: str,
+    failure_kind,
+    step_result,
+    step_status,
+):
+    active_path = _active_path_for_evidence(step, context)
+    completed_path = (
+        Path("docs/plans/completed") / active_path.parts[3] / "plan.md"
+        if active_path is not None
+        else None
+    )
+    evidence = _write_evidence(
+        step_dir,
+        step_id=step.id,
+        active_path=active_path,
+        completed_path=completed_path,
+        error=error,
+    )
+    return step_result(
+        step_id=step.id,
+        status=step_status.BLOCKED,
+        output_path=runner_module._relative_to_repo(evidence, context),
+        error=error,
+        failure_kind=failure_kind.SCOPE_CONFLICT,
+        metadata={
+            "plan_transition_status": "blocked",
+            "plan_transition_evidence": str(_relative_to_repo(evidence, context)),
+        },
+    )
+
+
+def _active_path_for_evidence(step, context) -> Path | None:
+    from harness_codex.runtime.plan_transition_policy_patch import _active_plan_path
+
+    return _active_plan_path(step, context)
+
+
+def _write_evidence(
+    step_dir: Path,
+    *,
+    step_id: str,
+    active_path: Path | None,
+    completed_path: Path | None,
+    error: str,
+) -> Path:
+    step_dir.mkdir(parents=True, exist_ok=True)
+    evidence = step_dir / "plan-transition.json"
+    evidence.write_text(
+        json.dumps(
+            {
+                "step_id": step_id,
+                "status": "blocked",
+                "active_plan_path": str(active_path) if active_path is not None else None,
+                "completed_plan_path": str(completed_path) if completed_path is not None else None,
+                "error": error,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return evidence
+
+
+def _relative_to_repo(path: Path, context) -> Path:
+    try:
+        return path.relative_to(context.repo_root)
+    except ValueError:
+        return path

--- a/tests/runtime/test_plan_completion_boundary.py
+++ b/tests/runtime/test_plan_completion_boundary.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind, StepStatus
+from harness_codex.runtime.runner import BasicStepRunner
+
+
+def test_work_item_workflow_blocks_plan_move_from_non_completion_git_step(
+    tmp_path: Path,
+) -> None:
+    active = tmp_path / "docs/plans/active/UC-001/plan.md"
+    active.parent.mkdir(parents=True, exist_ok=True)
+    active.write_text("# Plan\n", encoding="utf-8")
+    completed = Path("docs/plans/completed/UC-001/plan.md")
+    context = RunContext(
+        run_id="run-001",
+        workflow_name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-001",
+    )
+    step = Step(
+        id="archive-plan-early",
+        kind=StepKind.GIT,
+        name="Archive plan early",
+        inputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        outputs=(completed,),
+    )
+
+    result = BasicStepRunner().run(step, context)
+
+    assert result.status == StepStatus.BLOCKED
+    assert "only `complete-work-item-plan` may move" in (result.error or "")
+    assert active.exists()
+    assert not (tmp_path / completed).exists()

--- a/tests/runtime/test_plan_state_guard_installation.py
+++ b/tests/runtime/test_plan_state_guard_installation.py
@@ -1,0 +1,7 @@
+from harness_codex.runtime.runner import BasicStepRunner
+
+
+def test_work_item_plan_state_guard_wraps_basic_step_runner() -> None:
+    assert BasicStepRunner.run.__module__ == (
+        "harness_codex.runtime.work_item_plan_state_guard"
+    )

--- a/tests/runtime/test_plan_transition_policy.py
+++ b/tests/runtime/test_plan_transition_policy.py
@@ -183,5 +183,7 @@ def test_retry_recovers_completed_plan_back_to_active_location(tmp_path: Path) -
     )
 
     assert result.status == StepStatus.SUCCEEDED
-    assert active.read_text(encoding="utf-8") == "# Recovered plan\n"
+    recovered = active.read_text(encoding="utf-8")
+    assert recovered.endswith("# Recovered plan\n")
+    assert "status: active" in recovered
     assert not completed.exists()

--- a/tests/runtime/test_plan_transition_policy.py
+++ b/tests/runtime/test_plan_transition_policy.py
@@ -1,0 +1,172 @@
+from pathlib import Path
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind, StepStatus
+from harness_codex.runtime.runner import AgentRunRequest, AgentRunResult, BasicStepRunner
+
+
+class MutatingAgent:
+    def __init__(self, mutation) -> None:
+        self._mutation = mutation
+
+    def run(self, request: AgentRunRequest) -> AgentRunResult:
+        self._mutation(request.context.repo_root)
+        return AgentRunResult(status=StepStatus.SUCCEEDED, exit_code=0)
+
+
+def _write_agent_config(repo_root: Path, agent_id: str) -> None:
+    agents_dir = repo_root / ".codex/agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / f"{agent_id}.toml").write_text(
+        "\n".join(
+            [
+                f'name = "{agent_id}"',
+                'description = "test agent"',
+                'model = "gpt-5.4"',
+                'sandbox_mode = "workspace-write"',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _context(repo_root: Path) -> RunContext:
+    return RunContext(
+        run_id="run-001",
+        workflow_name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=repo_root / ".harness/runs/run-001",
+        active_plan_path=Path("docs/plans/active/UC-001/plan.md"),
+        metadata={
+            "change_set_id": "CHG-001",
+            "active_work_item_id": "UC-001",
+            "active_plan_path": "docs/plans/active/UC-001/plan.md",
+        },
+    )
+
+
+def _step(agent_id: str = "implementation_executor") -> Step:
+    return Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute work item",
+        agent_id=agent_id,
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+    )
+
+
+def _active_plan(repo_root: Path) -> Path:
+    path = repo_root / "docs/plans/active/UC-001/plan.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "# Implementation Plan",
+                "",
+                "## 1. 구현 목표",
+                "- Original goal",
+                "",
+                "## 6. 구현 계획",
+                "- [ ] Implement the bounded change",
+                "",
+                "## 10. 검증 결과",
+                "- Tests: pending",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_runtime_blocks_and_restores_premature_plan_move(tmp_path: Path) -> None:
+    _write_agent_config(tmp_path, "implementation_executor")
+    active = _active_plan(tmp_path)
+    original = active.read_text(encoding="utf-8")
+    completed = tmp_path / "docs/plans/completed/UC-001/plan.md"
+
+    def move_plan(repo_root: Path) -> None:
+        completed.parent.mkdir(parents=True, exist_ok=True)
+        completed.write_text(active.read_text(encoding="utf-8"), encoding="utf-8")
+        active.unlink()
+
+    result = BasicStepRunner(agent_adapter=MutatingAgent(move_plan)).run(
+        _step(),
+        _context(tmp_path),
+    )
+
+    assert result.status == StepStatus.BLOCKED
+    assert "only `complete-work-item-plan` may move a plan" in (result.error or "")
+    assert active.read_text(encoding="utf-8") == original
+    assert not completed.exists()
+    assert (tmp_path / ".harness/runs/run-001/steps/execute-work-item/plan-transition.json").is_file()
+
+
+def test_executor_may_tick_existing_checkboxes_and_record_verification_results(
+    tmp_path: Path,
+) -> None:
+    _write_agent_config(tmp_path, "implementation_executor")
+    active = _active_plan(tmp_path)
+
+    def update_executor_owned_fields(_repo_root: Path) -> None:
+        active.write_text(
+            active.read_text(encoding="utf-8")
+            .replace("- [ ] Implement the bounded change", "- [x] Implement the bounded change")
+            .replace("- Tests: pending", "- Tests: PASS `python -m pytest tests/runtime`"),
+            encoding="utf-8",
+        )
+
+    result = BasicStepRunner(
+        agent_adapter=MutatingAgent(update_executor_owned_fields)
+    ).run(_step(), _context(tmp_path))
+
+    assert result.status == StepStatus.SUCCEEDED
+
+
+def test_runtime_blocks_and_restores_executor_mutation_outside_owned_fields(
+    tmp_path: Path,
+) -> None:
+    _write_agent_config(tmp_path, "implementation_executor")
+    active = _active_plan(tmp_path)
+    original = active.read_text(encoding="utf-8")
+
+    def rewrite_goal(_repo_root: Path) -> None:
+        active.write_text(
+            active.read_text(encoding="utf-8").replace("Original goal", "Changed goal"),
+            encoding="utf-8",
+        )
+
+    result = BasicStepRunner(agent_adapter=MutatingAgent(rewrite_goal)).run(
+        _step(),
+        _context(tmp_path),
+    )
+
+    assert result.status == StepStatus.BLOCKED
+    assert "executor plan mutation blocked" in (result.error or "")
+    assert active.read_text(encoding="utf-8") == original
+
+
+def test_retry_recovers_completed_plan_back_to_active_location(tmp_path: Path) -> None:
+    _write_agent_config(tmp_path, "implementation_planner")
+    completed = tmp_path / "docs/plans/completed/UC-001/plan.md"
+    completed.parent.mkdir(parents=True, exist_ok=True)
+    completed.write_text("# Recovered plan\n", encoding="utf-8")
+    active = tmp_path / "docs/plans/active/UC-001/plan.md"
+    step = Step(
+        id="plan-work-item",
+        kind=StepKind.AGENT,
+        name="Create plan",
+        agent_id="implementation_planner",
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+    )
+
+    result = BasicStepRunner(agent_adapter=MutatingAgent(lambda _repo_root: None)).run(
+        step,
+        _context(tmp_path),
+    )
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert active.read_text(encoding="utf-8") == "# Recovered plan\n"
+    assert not completed.exists()

--- a/tests/runtime/test_plan_transition_policy.py
+++ b/tests/runtime/test_plan_transition_policy.py
@@ -87,7 +87,7 @@ def test_runtime_blocks_and_restores_premature_plan_move(tmp_path: Path) -> None
     original = active.read_text(encoding="utf-8")
     completed = tmp_path / "docs/plans/completed/UC-001/plan.md"
 
-    def move_plan(repo_root: Path) -> None:
+    def move_plan(_repo_root: Path) -> None:
         completed.parent.mkdir(parents=True, exist_ok=True)
         completed.write_text(active.read_text(encoding="utf-8"), encoding="utf-8")
         active.unlink()
@@ -102,6 +102,21 @@ def test_runtime_blocks_and_restores_premature_plan_move(tmp_path: Path) -> None
     assert active.read_text(encoding="utf-8") == original
     assert not completed.exists()
     assert (tmp_path / ".harness/runs/run-001/steps/execute-work-item/plan-transition.json").is_file()
+
+
+def test_runtime_blocks_and_restores_active_plan_deletion(tmp_path: Path) -> None:
+    _write_agent_config(tmp_path, "implementation_executor")
+    active = _active_plan(tmp_path)
+    original = active.read_text(encoding="utf-8")
+
+    result = BasicStepRunner(agent_adapter=MutatingAgent(lambda _repo_root: active.unlink())).run(
+        _step(),
+        _context(tmp_path),
+    )
+
+    assert result.status == StepStatus.BLOCKED
+    assert "only `complete-work-item-plan` may remove the active plan" in (result.error or "")
+    assert active.read_text(encoding="utf-8") == original
 
 
 def test_executor_may_tick_existing_checkboxes_and_record_verification_results(

--- a/tests/runtime/test_work_item_plan_state_guard_contract.py
+++ b/tests/runtime/test_work_item_plan_state_guard_contract.py
@@ -1,0 +1,210 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind, StepStatus
+from harness_codex.runtime.runner import AgentRunRequest, AgentRunResult, BasicStepRunner
+
+
+class MutatingAgent:
+    def __init__(self, mutation) -> None:
+        self._mutation = mutation
+        self.calls = 0
+
+    def run(self, request: AgentRunRequest) -> AgentRunResult:
+        self.calls += 1
+        self._mutation(request.context.repo_root)
+        return AgentRunResult(status=StepStatus.SUCCEEDED, exit_code=0)
+
+
+def _context(repo_root: Path) -> RunContext:
+    return RunContext(
+        run_id="run-plan-state-guard",
+        workflow_name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=repo_root / ".harness/runs/run-plan-state-guard",
+        active_plan_path=Path("docs/plans/active/UC-100/plan.md"),
+        metadata={
+            "change_set_id": "CHG-100",
+            "active_work_item_id": "UC-100",
+            "active_plan_path": "docs/plans/active/UC-100/plan.md",
+        },
+    )
+
+
+def _write_agent_config(repo_root: Path, agent_id: str) -> None:
+    config_path = repo_root / ".codex/agents" / f"{agent_id}.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                f'name = "{agent_id}"',
+                'description = "contract test agent"',
+                'model = "gpt-5.4"',
+                'sandbox_mode = "workspace-write"',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _active_path(repo_root: Path) -> Path:
+    return repo_root / "docs/plans/active/UC-100/plan.md"
+
+
+def _completed_path(repo_root: Path) -> Path:
+    return repo_root / "docs/plans/completed/UC-100/plan.md"
+
+
+def _write_plan(path: Path, *, frontmatter: bool = False) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = "\n".join(
+        [
+            "# Implementation Plan",
+            "",
+            "## 1. 구현 목표",
+            "- Preserve workflow ownership",
+            "",
+            "## 6. 구현 계획",
+            "- [ ] Execute bounded change",
+            "",
+            "## 10. 검증 결과",
+            "- Tests: pending",
+            "",
+        ]
+    )
+    content = (
+        "---\ndoc_type: plan\ncontract_version: 1\nstatus: active\n---\n" + body
+        if frontmatter
+        else body
+    )
+    path.write_text(content, encoding="utf-8")
+    return content
+
+
+def _agent_step(
+    *,
+    step_id: str = "execute-work-item",
+    agent_id: str = "implementation_executor",
+) -> Step:
+    return Step(
+        id=step_id,
+        kind=StepKind.AGENT,
+        name=step_id,
+        agent_id=agent_id,
+        outputs=(Path("docs/plans/active/UC-100/plan.md"),),
+    )
+
+
+def test_executor_edit_with_runtime_frontmatter_keeps_allowed_changes(tmp_path: Path) -> None:
+    _write_agent_config(tmp_path, "implementation_executor")
+    active = _active_path(tmp_path)
+    _write_plan(active, frontmatter=True)
+
+    def update_owned_fields(_repo_root: Path) -> None:
+        active.write_text(
+            active.read_text(encoding="utf-8")
+            .replace("- [ ] Execute bounded change", "- [x] Execute bounded change")
+            .replace("- Tests: pending", "- Tests: PASS `pytest tests/runtime`"),
+            encoding="utf-8",
+        )
+
+    result = BasicStepRunner(agent_adapter=MutatingAgent(update_owned_fields)).run(
+        _agent_step(),
+        _context(tmp_path),
+    )
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert "- [x] Execute bounded change" in active.read_text(encoding="utf-8")
+
+
+def test_retained_completed_copy_is_blocked_and_evidence_is_structured(tmp_path: Path) -> None:
+    _write_agent_config(tmp_path, "implementation_executor")
+    active = _active_path(tmp_path)
+    original = _write_plan(active)
+    completed = _completed_path(tmp_path)
+
+    def copy_to_completed(_repo_root: Path) -> None:
+        completed.parent.mkdir(parents=True, exist_ok=True)
+        completed.write_text(active.read_text(encoding="utf-8"), encoding="utf-8")
+
+    result = BasicStepRunner(agent_adapter=MutatingAgent(copy_to_completed)).run(
+        _agent_step(),
+        _context(tmp_path),
+    )
+
+    evidence_path = (
+        tmp_path
+        / ".harness/runs/run-plan-state-guard/steps/execute-work-item/plan-transition.json"
+    )
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+
+    assert result.status == StepStatus.BLOCKED
+    assert active.read_text(encoding="utf-8") == original
+    assert not completed.exists()
+    assert evidence == {
+        "step_id": "execute-work-item",
+        "status": "blocked",
+        "active_plan_path": "docs/plans/active/UC-100/plan.md",
+        "completed_plan_path": "docs/plans/completed/UC-100/plan.md",
+        "error": result.error,
+    }
+
+
+def test_ambiguous_retry_blocks_before_the_agent_runs(tmp_path: Path) -> None:
+    _write_agent_config(tmp_path, "implementation_executor")
+    active = _active_path(tmp_path)
+    completed = _completed_path(tmp_path)
+    active_original = _write_plan(active)
+    completed.parent.mkdir(parents=True, exist_ok=True)
+    completed_original = "# Completed copy\n"
+    completed.write_text(completed_original, encoding="utf-8")
+    agent = MutatingAgent(lambda _repo_root: (_ for _ in ()).throw(AssertionError("must not run")))
+
+    result = BasicStepRunner(agent_adapter=agent).run(_agent_step(), _context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert "both active and completed plan paths exist" in (result.error or "")
+    assert agent.calls == 0
+    assert active.read_text(encoding="utf-8") == active_original
+    assert completed.read_text(encoding="utf-8") == completed_original
+
+
+def test_planner_can_create_a_missing_active_plan(tmp_path: Path) -> None:
+    _write_agent_config(tmp_path, "implementation_planner")
+    active = _active_path(tmp_path)
+
+    def create_active_plan(_repo_root: Path) -> None:
+        _write_plan(active)
+
+    result = BasicStepRunner(agent_adapter=MutatingAgent(create_active_plan)).run(
+        _agent_step(step_id="plan-work-item", agent_id="implementation_planner"),
+        _context(tmp_path),
+    )
+
+    assert result.status == StepStatus.SUCCEEDED
+    assert active.is_file()
+    assert not _completed_path(tmp_path).exists()
+
+
+def test_completion_step_reaches_its_own_validation_not_transition_guard(tmp_path: Path) -> None:
+    active = _active_path(tmp_path)
+    _write_plan(active)
+    context = _context(tmp_path)
+    step = Step(
+        id="complete-work-item-plan",
+        kind=StepKind.GIT,
+        name="Complete work-item plan",
+        inputs=(Path("docs/plans/active/UC-100/plan.md"),),
+        outputs=(Path("docs/plans/completed/UC-100/plan.md"),),
+    )
+
+    result = BasicStepRunner().run(step, context)
+
+    assert result.status == StepStatus.BLOCKED
+    assert (result.error or "").startswith("plan completion blocked:")
+    assert "plan transition blocked" not in (result.error or "")
+    assert active.exists()
+    assert not _completed_path(tmp_path).exists()


### PR DESCRIPTION
## 관련 이슈

- Closes #400

## 배경 및 문제

`changeset-work-item-workflow`는 검증·보안 게이트 통과 후 `complete-work-item-plan` git step이 active plan을 completed plan으로 이동하도록 설계되어 있습니다. 그러나 planner skill, detailed reference, agent instruction에는 planner가 완료 상태 전이를 수행할 수 있는 것처럼 읽히는 지시가 남아 있어 계획 작성 단계와 workflow completion 단계의 책임이 겹쳤습니다.

이 중복은 다음 문제를 만들 수 있습니다.

- planner 또는 executor가 workflow gate 이전에 plan 상태를 완료로 바꿀 수 있음
- completed plan 생성 또는 active plan 삭제로 retry/recovery의 재개 기준이 모호해짐
- executor가 plan 전체를 재작성해 planner가 정한 목표·범위·제약을 훼손할 수 있음
- workflow state와 파일 위치가 분리되어 완료·재시도 판단이 불일치할 수 있음

## 변경 사항

### 1. planner 책임을 active plan 작성·보완으로 단일화

- `implementation_planner` agent instruction, planner skill, detailed reference, invocation rule, plan rule, output template를 정리했습니다.
- planner의 쓰기 대상은 `docs/plans/active/<WORK-ITEM-ID>/plan.md`로 제한했습니다.
- completed 경로는 상태 계약을 위한 참조 경로로만 문서화했고, planner는 생성·삭제·이동하지 못하도록 명시했습니다.
- active → completed 상태 전이는 workflow의 `complete-work-item-plan` git step이 독점합니다.

### 2. executor-owned plan 필드 명시

executor가 active plan에서 수정할 수 있는 범위는 다음으로 한정했습니다.

- 이미 존재하는 markdown checkbox 상태: `- [ ]` → `- [x]`
- `## 10. 검증 결과` 또는 `## 10. Verification Results`의 명령·결과·근거

다음은 수정 금지입니다.

- 구현 목표·비목표
- 입력 문서·아키텍처 제약·범위 경계
- task wording·완료 정책
- completed plan 경로

runtime이 생성하는 plan metadata frontmatter는 executor 변경이 아닌 runtime-owned 산출물로 정규화했습니다.

### 3. runtime plan-state guard

canonical `changeset-work-item-workflow`의 runner 경계에서 active/completed 위치와 내용을 검사합니다.

- completion 이전 단계가 completed plan을 생성·유지하면 원상 복구 후 `BLOCKED`
- completion 이전 단계가 active plan을 삭제하면 원상 복구 후 `BLOCKED`
- executor가 허용 필드 외 본문을 변경하면 원상 복구 후 `BLOCKED`
- 차단 근거는 해당 step의 `plan-transition.json`에 기록
- handler patch 순서와 무관하도록 agent handler 내부가 아니라 `BasicStepRunner.run` 경계에서 검사

### 4. git step 우회 경로 차단

work-item workflow에서는 `complete-work-item-plan` 이외의 git step도 active → completed plan 이동을 수행할 수 없도록 차단했습니다.

### 5. retry/recovery 정합성 보장

retry 진입 시 active 경로가 없고 completed 경로에 plan만 남아 있으면 active 경로로 복구합니다. active와 completed plan이 동시에 존재하면 모호한 상태로 간주하고 `BLOCKED` 처리합니다.

## CI 실패 원인과 수정

초기 CI 실패는 다음 두 범주였습니다.

1. plan-state guard가 agent handler patch 순서에 영향을 받아 항상 적용되지 않음
   - runner-level guard로 이동하고 설치 여부를 검증하는 회귀 테스트를 추가했습니다.
2. runtime이 생성하는 plan metadata frontmatter를 executor의 비허용 plan 변경으로 오인함
   - runtime-owned metadata를 비교 전 정규화하고, recovery 테스트는 본문 보존·active 위치·active 상태를 검증하도록 수정했습니다.

## 테스트

추가·보강한 회귀 테스트:

- agent의 조기 active → completed 이동 차단 및 active plan 복구
- agent의 active plan 삭제 차단 및 복구
- executor의 checkbox·검증 결과 갱신 허용
- executor의 구현 목표 등 비소유 필드 변경 차단 및 복구
- retry 시 completed 경로에 남은 plan의 active 경로 복구
- `complete-work-item-plan` 외 git step의 plan 이동 차단
- runner-level plan-state guard 설치 확인

## 검증 결과

- GitHub Actions `Runtime document contracts` — **성공**
- Run #266: `runtime-contracts`의 전체 runtime/workflow 테스트 단계 성공

## 영향 및 롤백

- 영향 범위는 work-item plan의 상태 전이와 executor의 plan 갱신 경계입니다.
- 정상 `complete-work-item-plan`의 검증 및 이동 로직은 유지됩니다.
- 롤백이 필요하면 runtime guard와 planner/executor contract 변경을 함께 되돌리면 기존 동작으로 복귀합니다.