### PR TITLE
fix(harvest): bootstrap metadata와 단계별 output 계약 분리

### DIFF
--- a/.harness/workflows/harvest-workflow.yaml
+++ b/.harness/workflows/harvest-workflow.yaml
@@ -20,14 +20,6 @@ steps:
     metadata:
       stage: harvest
       scope: canonical_requirements
-      bootstrap_outputs:
-        - AGENTS.md
-        - docs/agent/context.md
-        - docs/agent/commands.md
-        - docs/agent/session-state.md
-        - docs/agent/codebase-artifacts.md
-        - docs/agent/design-conformance-report.md
-        - docs/agent/token-reduction-report.md
       output_gate:
         - docs/design/요구사항.md
 

--- a/docs/architecture/harvest-stage-output-contract.md
+++ b/docs/architecture/harvest-stage-output-contract.md
@@ -1,0 +1,48 @@
+# Harvest Stage Output Contract
+
+## Purpose
+
+Harvest stages have separate ownership boundaries. For every agent step, the
+workflow `outputs` field is the single source of write authorization. Runtime
+scope validation rejects writes outside those paths.
+
+## Stage Contracts
+
+| Stage | Owner | Declared outputs |
+| --- | --- | --- |
+| Bootstrap / init | `harness init` or `harness agent-context init` | `AGENTS.md` and `docs/agent/*` bootstrap context artifacts |
+| Requirements | `requirements_interviewer` | `docs/design/요구사항.md` |
+| Ubiquitous language | `ubiquitous_language_reviewer` | `context.md` |
+| Use cases | `harness_usecases` | `docs/design/유스케이스.md`, `docs/use-cases/**` |
+
+Bootstrap is not a harvest-agent responsibility. A harvest agent cannot gain
+additional permission through metadata such as `bootstrap_outputs`.
+
+## Bootstrap and Migration Compatibility
+
+Existing repositories do not need to delete, move, or regenerate already
+committed `AGENTS.md` or `docs/agent/*` files before running harvest. They remain
+available as read-only discovery context where a stage chooses to inspect them.
+
+For a new repository, or when bootstrap context should be regenerated, run one
+of the explicit commands before harvest:
+
+```bash
+python3 -m harness_codex init --description "<repository description>"
+# or
+python3 -m harness_codex agent-context init --description "<repository description>"
+```
+
+Custom workflow authors must remove `metadata.bootstrap_outputs` from agent
+steps. Runtime intentionally ignores that legacy key for write authorization, so
+it is safe to migrate workflows incrementally: explicit agent `outputs` must
+contain every artifact that the agent is permitted to write.
+
+## Boundary Examples
+
+- Requirements may not write `context.md` or `docs/use-cases/**`.
+- Ubiquitous-language review may not rewrite `docs/design/요구사항.md` or create
+  use-case slices.
+- Use-case harvest may not rewrite `context.md` or requirements.
+- Use-case harvest may write both its canonical index and its slice directory,
+  because both are declared outputs of the same step.

--- a/harness_codex/runtime/agent_write_scope_policy_patch.py
+++ b/harness_codex/runtime/agent_write_scope_policy_patch.py
@@ -146,11 +146,19 @@ def apply_agent_write_scope_policy_patch() -> None:
 
 
 def _declared_write_paths(step: Any) -> tuple[str, ...]:
-    values = [str(path) for path in getattr(step, "outputs", ())]
-    bootstrap_outputs = getattr(step, "metadata", {}).get("bootstrap_outputs", ())
-    if isinstance(bootstrap_outputs, (list, tuple)):
-        values.extend(str(path) for path in bootstrap_outputs)
-    return tuple(dict.fromkeys(value for value in values if value))
+    """Return the only non-runtime paths an agent may write.
+
+    ``metadata.bootstrap_outputs`` was a historical migration hint. It is no
+    longer an authorization source: bootstrap artifacts are produced only by
+    the explicit ``init`` / ``agent-context init`` commands, not by harvest
+    agents.
+    """
+
+    return tuple(
+        dict.fromkeys(
+            str(path) for path in getattr(step, "outputs", ()) if str(path)
+        )
+    )
 
 
 def _declares_directory(path: str) -> bool:

--- a/tests/runtime/test_agent_write_scope_policy.py
+++ b/tests/runtime/test_agent_write_scope_policy.py
@@ -205,8 +205,66 @@ def test_agent_write_scope_blocks_tracked_untracked_and_ignored_files(
     assert not (tmp_path / "ignored-outside.txt").exists()
 
 
+@pytest.mark.parametrize(
+    ("agent_id", "step_id", "declared_output", "forbidden_outputs"),
+    (
+        (
+            "requirements_interviewer",
+            "harvest-requirements",
+            "docs/design/요구사항.md",
+            ("context.md", "docs/use-cases/UC-001/use-case.md"),
+        ),
+        (
+            "ubiquitous_language_reviewer",
+            "harvest-ubiquitous-language",
+            "context.md",
+            ("docs/design/요구사항.md", "docs/use-cases/UC-001/use-case.md"),
+        ),
+        (
+            "harness_usecases",
+            "harvest-use-cases",
+            "docs/use-cases",
+            ("docs/design/요구사항.md", "context.md"),
+        ),
+    ),
+)
+def test_harvest_agents_block_cross_stage_output_writes(
+    tmp_path: Path,
+    agent_id: str,
+    step_id: str,
+    declared_output: str,
+    forbidden_outputs: tuple[str, ...],
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_agent_config(tmp_path, agent_id)
+    edits = {declared_output.rstrip("/") + "/.keep": "allowed\n"}
+    if Path(declared_output).suffix:
+        edits = {declared_output: "allowed\n"}
+    edits.update({path: "forbidden\n" for path in forbidden_outputs})
+    runner = BasicStepRunner(agent_adapter=EditingAgentAdapter(edits))
+    step = Step(
+        id=step_id,
+        kind=StepKind.AGENT,
+        name=step_id,
+        agent_id=agent_id,
+        outputs=(Path(declared_output),),
+    )
 
-def test_agent_write_scope_allows_declared_bootstrap_outputs(tmp_path: Path) -> None:
+    result = runner.run(step, _context(tmp_path))
+
+    assert result.status == StepStatus.BLOCKED
+    assert result.failure_kind == FailureKind.SCOPE_CONFLICT
+    report = json.loads(
+        (tmp_path / result.metadata["scope_diff_report_path"]).read_text(encoding="utf-8")
+    )
+    assert set(forbidden_outputs) <= {row["path"] for row in report["blocked"]}
+    for path in forbidden_outputs:
+        assert not (tmp_path / path).exists()
+
+
+def test_requirements_agent_blocks_legacy_bootstrap_metadata_outputs(
+    tmp_path: Path,
+) -> None:
     _init_git_repo(tmp_path)
     _write_agent_config(tmp_path, "requirements_interviewer")
     runner = BasicStepRunner(
@@ -228,8 +286,13 @@ def test_agent_write_scope_allows_declared_bootstrap_outputs(tmp_path: Path) -> 
 
     result = runner.run(step, _context(tmp_path))
 
-    assert result.status == StepStatus.SUCCEEDED
-    assert result.metadata["scope_diff_status"] == "passed"
+    assert result.status == StepStatus.BLOCKED
+    assert result.failure_kind == FailureKind.SCOPE_CONFLICT
+    report = json.loads(
+        (tmp_path / result.metadata["scope_diff_report_path"]).read_text(encoding="utf-8")
+    )
+    assert {"docs/agent/context.md"} <= {row["path"] for row in report["blocked"]}
+    assert not (tmp_path / "docs/agent/context.md").exists()
 
 
 def test_agent_write_scope_ignores_preexisting_dirty_worktree_changes(

--- a/tests/runtime/test_harvest_output_contract.py
+++ b/tests/runtime/test_harvest_output_contract.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from harness_codex.runtime.workflows import load_workflow_file
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARVEST_WORKFLOW_PATH = REPO_ROOT / ".harness/workflows/harvest-workflow.yaml"
+
+
+def test_harvest_agent_outputs_are_the_only_stage_write_contract() -> None:
+    workflow = load_workflow_file(HARVEST_WORKFLOW_PATH)
+    steps = {step.id: step for step in workflow.steps}
+
+    assert steps["harvest-requirements"].outputs == (
+        Path("docs/design/요구사항.md"),
+    )
+    assert steps["harvest-ubiquitous-language"].outputs == (Path("context.md"),)
+    assert steps["harvest-use-cases"].outputs == (
+        Path("docs/design/유스케이스.md"),
+        Path("docs/use-cases"),
+    )
+
+    for step_id in (
+        "harvest-requirements",
+        "harvest-ubiquitous-language",
+        "harvest-use-cases",
+    ):
+        assert "bootstrap_outputs" not in steps[step_id].metadata


### PR DESCRIPTION
## 닫는 사유

이 PR은 obsolete된 harvest workflow를 현재 경로로 잘못 판단해 작성되었습니다.

현재 런타임은 `requirement-decision`을 사용하므로, harvest requirements 및 그 연관 workflow/runtime/UI/test/documentation을 제거하는 별도 정리 PR로 대체합니다.

Closes #401