### PR TITLE
[codex] 런타임 실행 이벤트 원장 및 단계별 성능 지표 도입

### DIFF
--- a/docs/runtime-observability.md
+++ b/docs/runtime-observability.md
@@ -1,0 +1,46 @@
+# Runtime Observability
+
+Harness records a local-first observability ledger for every normal runtime execution.
+
+## Artifacts
+
+Each run writes the following files below `.harness/runs/<RUN-ID>/`.
+
+```text
+.harness/runs/<RUN-ID>/
+  events.ndjson
+  metrics.json
+```
+
+`events.ndjson` is append-only and is the source artifact. `metrics.json` is a deterministic projection rebuilt from that ledger after every completed or raised step and after every workflow result.
+
+## Event boundary
+
+The runtime instruments these lifecycle events without changing the execution result:
+
+- `run.started`
+- `workflow.started`
+- `workflow.finished`
+- `workflow.raised`
+- `step.started`
+- `step.finished`
+- `step.raised`
+
+Every event is correlated by `run_id`, and where available also by `change_set_id`, `work_item_id`, workflow name, step id, step kind, and agent id.
+
+## Metrics
+
+`metrics.json` contains the following aggregate views:
+
+- event count and observed timestamps
+- status counts for completed steps
+- per-step count, total, average, p50, p95, and maximum duration
+- five highest-total-duration bottlenecks
+
+The projection intentionally uses local JSON rather than requiring an external collector. This keeps the first measurement loop available in local development, tests, and CI artifacts. A later exporter can consume the NDJSON ledger for OpenTelemetry or Prometheus-compatible infrastructure.
+
+## Data-safety boundary
+
+The ledger does not persist prompts, model outputs, source code, stdout, stderr, or arbitrary step metadata. It records only an allowlist of operational attributes such as provider, execution mode, retry attempt, termination reason, review-cache state, and gate status.
+
+Observability is best-effort: event or metric write failures are swallowed so disk, serialization, or permission errors cannot change a workflow outcome or hide the original failure.

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -75,6 +75,10 @@ from harness_codex.runtime.runner import (
     ConfigurableCliAgentAdapter,
     StepRunner,
 )
+from harness_codex.runtime.observability_patch import apply_observability_patch
+
+apply_observability_patch()
+
 from harness_codex.runtime.delivery_runner_patch import apply_delivery_runner_patch
 
 apply_delivery_runner_patch()

--- a/harness_codex/runtime/observability.py
+++ b/harness_codex/runtime/observability.py
@@ -81,7 +81,7 @@ class RunEventWriter:
                 payload["failure_kind"] = result.failure_kind.value if result.failure_kind else None
                 if isinstance(result, StepResult):
                     payload["exit_code"] = result.exit_code
-                if isinstance(result, RunResult) and result.failed_step_id:
+                elif result.failed_step_id:
                     payload["failed_step_id"] = result.failed_step_id
             if duration_ms is not None:
                 payload["duration_ms"] = round(max(duration_ms, 0.0), 3)
@@ -134,14 +134,9 @@ class ObservedStepRunner:
             _write_metrics_safely(context.repo_root, context.run_id)
             raise
 
-        result = _with_total_duration(result, _duration_ms(started_ns))
-        writer.emit(
-            "step.finished",
-            context,
-            step=step,
-            result=result,
-            duration_ms=result.metadata["phase_metrics"]["total_ms"],
-        )
+        duration_ms = _duration_ms(started_ns)
+        result = _with_observability_duration(result, duration_ms)
+        writer.emit("step.finished", context, step=step, result=result, duration_ms=duration_ms)
         _write_metrics_safely(context.repo_root, context.run_id)
         return result
 
@@ -289,22 +284,24 @@ def _percentile(values: list[float], percentile: float) -> float:
     return values[lower] + (values[upper] - values[lower]) * (rank - lower)
 
 
-def _with_total_duration(result: StepResult, duration_ms: float) -> StepResult:
-    existing = result.metadata.get("phase_metrics")
-    phase_metrics = dict(existing) if isinstance(existing, Mapping) else {}
-    phase_metrics["total_ms"] = round(max(duration_ms, 0.0), 3)
-    return replace(result, metadata={**dict(result.metadata), "phase_metrics": phase_metrics})
+def _with_observability_duration(result: StepResult, duration_ms: float) -> StepResult:
+    try:
+        existing = result.metadata.get("observability")
+        attributes = dict(existing) if isinstance(existing, Mapping) else {}
+        attributes["duration_ms"] = round(max(duration_ms, 0.0), 3)
+        return replace(result, metadata={**dict(result.metadata), "observability": attributes})
+    except (AttributeError, TypeError, ValueError):
+        return result
 
 
 def _safe_attributes(values: Mapping[str, Any] | None) -> dict[str, Any]:
     if not isinstance(values, Mapping):
         return {}
-    safe: dict[str, Any] = {}
-    for key in _SAFE_METADATA_KEYS:
-        value = values.get(key)
-        if isinstance(value, (str, int, float, bool)) and not isinstance(value, bool) or isinstance(value, bool):
-            safe[key] = value
-    return safe
+    return {
+        key: value
+        for key in _SAFE_METADATA_KEYS
+        if isinstance((value := values.get(key)), (str, int, float, bool))
+    }
 
 
 def _context_string(context: RunContext, key: str) -> str | None:

--- a/harness_codex/runtime/observability.py
+++ b/harness_codex/runtime/observability.py
@@ -1,0 +1,323 @@
+"""Local-first runtime observability for harness workflow executions."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from harness_codex.runtime.models import RunContext, Step, StepResult
+from harness_codex.runtime.runner import StepRunner
+
+OBSERVABILITY_SCHEMA_VERSION = 1
+_EVENT_FILE_NAME = "events.ndjson"
+_METRICS_FILE_NAME = "metrics.json"
+_SAFE_METADATA_KEYS = frozenset(
+    {
+        "execution_boundary",
+        "active_work_item_type",
+        "execution_mode",
+        "attempt",
+        "provider",
+        "termination_reason",
+        "review_cache_hit",
+        "scope_diff_status",
+        "review_gate_status",
+        "rollback_mode",
+    }
+)
+
+
+class RunEventWriter:
+    """Best-effort append-only writer for one run's observable events."""
+
+    def __init__(self, repo_root: Path | str, run_id: str) -> None:
+        self._repo_root = Path(repo_root)
+        self._run_id = run_id
+
+    @property
+    def path(self) -> Path:
+        return self._repo_root / ".harness" / "runs" / self._run_id / _EVENT_FILE_NAME
+
+    def start_run_if_absent(self, context: RunContext) -> bool:
+        if self.path.exists() and self.path.stat().st_size > 0:
+            return True
+        return self.emit("run.started", context)
+
+    def emit(
+        self,
+        event_type: str,
+        context: RunContext,
+        *,
+        step: Step | None = None,
+        result: StepResult | None = None,
+        duration_ms: float | None = None,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> bool:
+        payload: dict[str, Any] = {
+            "schema_version": OBSERVABILITY_SCHEMA_VERSION,
+            "event_type": event_type,
+            "occurred_at": _utc_now(),
+            "run_id": context.run_id,
+            "change_set_id": _context_string(context, "change_set_id"),
+            "work_item_id": _context_string(context, "active_work_item_id"),
+            "workflow_name": context.workflow_name,
+        }
+        if step is not None:
+            payload["step_id"] = step.id
+            payload["step_kind"] = step.kind.value
+            if step.agent_id:
+                payload["agent_id"] = step.agent_id
+        if result is not None:
+            payload["status"] = result.status.value
+            payload["failure_kind"] = result.failure_kind.value if result.failure_kind else None
+            payload["exit_code"] = result.exit_code
+        if duration_ms is not None:
+            payload["duration_ms"] = round(max(duration_ms, 0.0), 3)
+        safe_attributes = _safe_attributes(attributes)
+        if result is not None:
+            safe_attributes.update(_safe_attributes(result.metadata))
+        if safe_attributes:
+            payload["attributes"] = safe_attributes
+        return self._append(payload)
+
+    def _append(self, payload: Mapping[str, Any]) -> bool:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+                stream.flush()
+        except (OSError, TypeError, ValueError):
+            return False
+        return True
+
+
+class ObservedStepRunner:
+    """Decorate a step runner with durable, non-invasive timing events."""
+
+    def __init__(
+        self,
+        delegate: StepRunner,
+        writer_factory: Callable[[Path | str, str], RunEventWriter] = RunEventWriter,
+    ) -> None:
+        self._delegate = delegate
+        self._writer_factory = writer_factory
+
+    def run(self, step: Step, context: RunContext) -> StepResult:
+        writer = self._writer_factory(context.repo_root, context.run_id)
+        writer.start_run_if_absent(context)
+        writer.emit("step.started", context, step=step)
+        started_ns = time.perf_counter_ns()
+        try:
+            result = self._delegate.run(step, context)
+        except BaseException as exc:
+            duration_ms = _duration_ms(started_ns)
+            writer.emit(
+                "step.raised",
+                context,
+                step=step,
+                duration_ms=duration_ms,
+                attributes={"exception_type": type(exc).__name__},
+            )
+            _write_metrics_safely(context.repo_root, context.run_id)
+            raise
+
+        duration_ms = _duration_ms(started_ns)
+        result = _with_total_duration(result, duration_ms)
+        writer.emit("step.finished", context, step=step, result=result, duration_ms=duration_ms)
+        _write_metrics_safely(context.repo_root, context.run_id)
+        return result
+
+
+def write_run_metrics(repo_root: Path | str, run_id: str) -> Path:
+    """Build a deterministic metrics projection from the append-only event ledger."""
+
+    root = Path(repo_root)
+    run_dir = root / ".harness" / "runs" / run_id
+    events = read_run_events(root, run_id)
+    metrics = summarize_run_events(events, run_id=run_id)
+    path = run_dir / _METRICS_FILE_NAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(metrics, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def read_run_events(repo_root: Path | str, run_id: str) -> tuple[dict[str, Any], ...]:
+    """Read only valid JSON object lines from a run event ledger."""
+
+    path = Path(repo_root) / ".harness" / "runs" / run_id / _EVENT_FILE_NAME
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ()
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        try:
+            candidate = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict):
+            events.append(candidate)
+    return tuple(events)
+
+
+def summarize_run_events(
+    events: tuple[Mapping[str, Any], ...] | list[Mapping[str, Any]],
+    *,
+    run_id: str = "",
+) -> dict[str, Any]:
+    """Aggregate step timings and status distribution without retaining raw content."""
+
+    step_durations: dict[tuple[str, str], list[float]] = {}
+    step_statuses: dict[tuple[str, str], dict[str, int]] = {}
+    status_counts: dict[str, int] = {}
+    timestamps = [
+        str(event["occurred_at"])
+        for event in events
+        if isinstance(event.get("occurred_at"), str) and event.get("occurred_at")
+    ]
+
+    for event in events:
+        if event.get("event_type") != "step.finished":
+            continue
+        step_id = str(event.get("step_id") or "unknown")
+        step_kind = str(event.get("step_kind") or "unknown")
+        key = (step_id, step_kind)
+        duration = event.get("duration_ms")
+        if isinstance(duration, (int, float)) and not isinstance(duration, bool):
+            step_durations.setdefault(key, []).append(float(duration))
+        status = str(event.get("status") or "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        per_step = step_statuses.setdefault(key, {})
+        per_step[status] = per_step.get(status, 0) + 1
+
+    step_metrics = [
+        _step_metric(step_id, step_kind, values, step_statuses.get((step_id, step_kind), {}))
+        for (step_id, step_kind), values in step_durations.items()
+    ]
+    step_metrics.sort(key=lambda item: (-item["total_ms"], item["step_id"], item["step_kind"]))
+    started_at = min(timestamps) if timestamps else None
+    last_observed_at = max(timestamps) if timestamps else None
+    return {
+        "schema_version": OBSERVABILITY_SCHEMA_VERSION,
+        "run_id": run_id or _event_run_id(events),
+        "event_count": len(events),
+        "started_at": started_at,
+        "last_observed_at": last_observed_at,
+        "status_counts": dict(sorted(status_counts.items())),
+        "step_metrics": step_metrics,
+        "bottlenecks": step_metrics[:5],
+    }
+
+
+def render_run_metrics(metrics: Mapping[str, Any]) -> str:
+    """Render a concise human-readable local observability summary."""
+
+    lines = [
+        f"Run: {metrics.get('run_id') or '-'}",
+        f"Events: {metrics.get('event_count', 0)}",
+        f"Status counts: {json.dumps(metrics.get('status_counts', {}), ensure_ascii=False, sort_keys=True)}",
+        "Bottlenecks:",
+    ]
+    bottlenecks = metrics.get("bottlenecks", [])
+    if not isinstance(bottlenecks, list) or not bottlenecks:
+        lines.append("- none")
+        return "\n".join(lines)
+    for item in bottlenecks:
+        if not isinstance(item, Mapping):
+            continue
+        lines.append(
+            "- {step_id} ({step_kind}): total={total_ms:.3f}ms p95={p95_ms:.3f}ms count={count}".format(
+                step_id=item.get("step_id", "unknown"),
+                step_kind=item.get("step_kind", "unknown"),
+                total_ms=float(item.get("total_ms", 0.0)),
+                p95_ms=float(item.get("p95_ms", 0.0)),
+                count=int(item.get("count", 0)),
+            )
+        )
+    return "\n".join(lines)
+
+
+def _step_metric(
+    step_id: str,
+    step_kind: str,
+    durations: list[float],
+    statuses: Mapping[str, int],
+) -> dict[str, Any]:
+    ordered = sorted(durations)
+    total = sum(ordered)
+    return {
+        "step_id": step_id,
+        "step_kind": step_kind,
+        "count": len(ordered),
+        "total_ms": round(total, 3),
+        "average_ms": round(total / len(ordered), 3),
+        "p50_ms": round(_percentile(ordered, 0.50), 3),
+        "p95_ms": round(_percentile(ordered, 0.95), 3),
+        "max_ms": round(ordered[-1], 3),
+        "status_counts": dict(sorted(statuses.items())),
+    }
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    rank = (len(values) - 1) * percentile
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return values[lower]
+    return values[lower] + (values[upper] - values[lower]) * (rank - lower)
+
+
+def _with_total_duration(result: StepResult, duration_ms: float) -> StepResult:
+    existing = result.metadata.get("phase_metrics")
+    phase_metrics = dict(existing) if isinstance(existing, Mapping) else {}
+    phase_metrics["total_ms"] = round(max(duration_ms, 0.0), 3)
+    return replace(result, metadata={**dict(result.metadata), "phase_metrics": phase_metrics})
+
+
+def _safe_attributes(values: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(values, Mapping):
+        return {}
+    safe: dict[str, Any] = {}
+    for key in _SAFE_METADATA_KEYS:
+        value = values.get(key)
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            if value is not None:
+                safe[key] = value
+    return safe
+
+
+def _context_string(context: RunContext, key: str) -> str | None:
+    value = context.metadata.get(key)
+    return str(value) if value not in (None, "") else None
+
+
+def _duration_ms(started_ns: int) -> float:
+    return (time.perf_counter_ns() - started_ns) / 1_000_000
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _event_run_id(events: tuple[Mapping[str, Any], ...] | list[Mapping[str, Any]]) -> str:
+    for event in events:
+        run_id = event.get("run_id")
+        if isinstance(run_id, str) and run_id:
+            return run_id
+    return ""
+
+
+def _write_metrics_safely(repo_root: Path | str, run_id: str) -> None:
+    try:
+        write_run_metrics(repo_root, run_id)
+    except (OSError, TypeError, ValueError):
+        return

--- a/harness_codex/runtime/observability.py
+++ b/harness_codex/runtime/observability.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from harness_codex.runtime.models import RunContext, Step, StepResult
+from harness_codex.runtime.models import RunContext, RunResult, Step, StepResult
 from harness_codex.runtime.runner import StepRunner
 
 OBSERVABILITY_SCHEMA_VERSION = 1
@@ -44,8 +44,11 @@ class RunEventWriter:
         return self._repo_root / ".harness" / "runs" / self._run_id / _EVENT_FILE_NAME
 
     def start_run_if_absent(self, context: RunContext) -> bool:
-        if self.path.exists() and self.path.stat().st_size > 0:
-            return True
+        try:
+            if self.path.exists() and self.path.stat().st_size > 0:
+                return True
+        except OSError:
+            return False
         return self.emit("run.started", context)
 
     def emit(
@@ -54,36 +57,42 @@ class RunEventWriter:
         context: RunContext,
         *,
         step: Step | None = None,
-        result: StepResult | None = None,
+        result: StepResult | RunResult | None = None,
         duration_ms: float | None = None,
         attributes: Mapping[str, Any] | None = None,
     ) -> bool:
-        payload: dict[str, Any] = {
-            "schema_version": OBSERVABILITY_SCHEMA_VERSION,
-            "event_type": event_type,
-            "occurred_at": _utc_now(),
-            "run_id": context.run_id,
-            "change_set_id": _context_string(context, "change_set_id"),
-            "work_item_id": _context_string(context, "active_work_item_id"),
-            "workflow_name": context.workflow_name,
-        }
-        if step is not None:
-            payload["step_id"] = step.id
-            payload["step_kind"] = step.kind.value
-            if step.agent_id:
-                payload["agent_id"] = step.agent_id
-        if result is not None:
-            payload["status"] = result.status.value
-            payload["failure_kind"] = result.failure_kind.value if result.failure_kind else None
-            payload["exit_code"] = result.exit_code
-        if duration_ms is not None:
-            payload["duration_ms"] = round(max(duration_ms, 0.0), 3)
-        safe_attributes = _safe_attributes(attributes)
-        if result is not None:
-            safe_attributes.update(_safe_attributes(result.metadata))
-        if safe_attributes:
-            payload["attributes"] = safe_attributes
-        return self._append(payload)
+        try:
+            payload: dict[str, Any] = {
+                "schema_version": OBSERVABILITY_SCHEMA_VERSION,
+                "event_type": event_type,
+                "occurred_at": _utc_now(),
+                "run_id": context.run_id,
+                "change_set_id": _context_string(context, "change_set_id"),
+                "work_item_id": _context_string(context, "active_work_item_id"),
+                "workflow_name": context.workflow_name,
+            }
+            if step is not None:
+                payload["step_id"] = step.id
+                payload["step_kind"] = step.kind.value
+                if step.agent_id:
+                    payload["agent_id"] = step.agent_id
+            if result is not None:
+                payload["status"] = result.status.value
+                payload["failure_kind"] = result.failure_kind.value if result.failure_kind else None
+                if isinstance(result, StepResult):
+                    payload["exit_code"] = result.exit_code
+                if isinstance(result, RunResult) and result.failed_step_id:
+                    payload["failed_step_id"] = result.failed_step_id
+            if duration_ms is not None:
+                payload["duration_ms"] = round(max(duration_ms, 0.0), 3)
+            safe_attributes = _safe_attributes(attributes)
+            if result is not None:
+                safe_attributes.update(_safe_attributes(result.metadata))
+            if safe_attributes:
+                payload["attributes"] = safe_attributes
+            return self._append(payload)
+        except (AttributeError, OSError, TypeError, ValueError):
+            return False
 
     def _append(self, payload: Mapping[str, Any]) -> bool:
         try:
@@ -115,20 +124,24 @@ class ObservedStepRunner:
         try:
             result = self._delegate.run(step, context)
         except BaseException as exc:
-            duration_ms = _duration_ms(started_ns)
             writer.emit(
                 "step.raised",
                 context,
                 step=step,
-                duration_ms=duration_ms,
+                duration_ms=_duration_ms(started_ns),
                 attributes={"exception_type": type(exc).__name__},
             )
             _write_metrics_safely(context.repo_root, context.run_id)
             raise
 
-        duration_ms = _duration_ms(started_ns)
-        result = _with_total_duration(result, duration_ms)
-        writer.emit("step.finished", context, step=step, result=result, duration_ms=duration_ms)
+        result = _with_total_duration(result, _duration_ms(started_ns))
+        writer.emit(
+            "step.finished",
+            context,
+            step=step,
+            result=result,
+            duration_ms=result.metadata["phase_metrics"]["total_ms"],
+        )
         _write_metrics_safely(context.repo_root, context.run_id)
         return result
 
@@ -138,11 +151,13 @@ def write_run_metrics(repo_root: Path | str, run_id: str) -> Path:
 
     root = Path(repo_root)
     run_dir = root / ".harness" / "runs" / run_id
-    events = read_run_events(root, run_id)
-    metrics = summarize_run_events(events, run_id=run_id)
+    metrics = summarize_run_events(read_run_events(root, run_id), run_id=run_id)
     path = run_dir / _METRICS_FILE_NAME
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(metrics, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(metrics, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     return path
 
 
@@ -200,14 +215,12 @@ def summarize_run_events(
         for (step_id, step_kind), values in step_durations.items()
     ]
     step_metrics.sort(key=lambda item: (-item["total_ms"], item["step_id"], item["step_kind"]))
-    started_at = min(timestamps) if timestamps else None
-    last_observed_at = max(timestamps) if timestamps else None
     return {
         "schema_version": OBSERVABILITY_SCHEMA_VERSION,
         "run_id": run_id or _event_run_id(events),
         "event_count": len(events),
-        "started_at": started_at,
-        "last_observed_at": last_observed_at,
+        "started_at": min(timestamps) if timestamps else None,
+        "last_observed_at": max(timestamps) if timestamps else None,
         "status_counts": dict(sorted(status_counts.items())),
         "step_metrics": step_metrics,
         "bottlenecks": step_metrics[:5],
@@ -289,9 +302,8 @@ def _safe_attributes(values: Mapping[str, Any] | None) -> dict[str, Any]:
     safe: dict[str, Any] = {}
     for key in _SAFE_METADATA_KEYS:
         value = values.get(key)
-        if isinstance(value, (str, int, float, bool)) or value is None:
-            if value is not None:
-                safe[key] = value
+        if isinstance(value, (str, int, float, bool)) and not isinstance(value, bool) or isinstance(value, bool):
+            safe[key] = value
     return safe
 
 

--- a/harness_codex/runtime/observability_patch.py
+++ b/harness_codex/runtime/observability_patch.py
@@ -1,61 +1,28 @@
-"""Attach local-first observability without changing workflow semantics."""
+"""Attach local-first observability without replacing runtime step behavior."""
 
 from __future__ import annotations
 
 import time
-from dataclasses import replace
-from typing import Mapping
 
 
 def apply_observability_patch() -> None:
-    """Instrument RunnerEngine and BasicStepRunner on every normal runtime import.
+    """Instrument workflow runs and decorate their step runner at execution time.
 
-    Emission and metric projection are intentionally best-effort. A disk or JSON failure
-    must never change the workflow result or mask the original runtime exception.
+    The runtime applies several compatibility patches to ``BasicStepRunner`` during
+    import. Replacing its ``run`` method captures an unstable point in that patch
+    chain and can bypass rollback or completion guards. Decorating the runner only
+    while ``RunnerEngine`` executes keeps existing runner semantics intact.
     """
 
     import harness_codex.runtime.engine as engine_module
-    import harness_codex.runtime.runner as runner_module
-    from harness_codex.runtime.observability import RunEventWriter, _duration_ms, _write_metrics_safely
+    from harness_codex.runtime.observability import (
+        ObservedStepRunner,
+        RunEventWriter,
+        _duration_ms,
+        _write_metrics_safely,
+    )
 
-    BasicStepRunner = runner_module.BasicStepRunner
     RunnerEngine = engine_module.RunnerEngine
-
-    if not getattr(BasicStepRunner, "_observability_patch_applied", False):
-        original_step_run = BasicStepRunner.run
-
-        def observed_step_run(self, step, context):
-            writer = RunEventWriter(context.repo_root, context.run_id)
-            writer.start_run_if_absent(context)
-            writer.emit("step.started", context, step=step)
-            started_ns = time.perf_counter_ns()
-            try:
-                result = original_step_run(self, step, context)
-            except BaseException as exc:
-                writer.emit(
-                    "step.raised",
-                    context,
-                    step=step,
-                    duration_ms=_duration_ms(started_ns),
-                    attributes={"exception_type": type(exc).__name__},
-                )
-                _write_metrics_safely(context.repo_root, context.run_id)
-                raise
-            duration_ms = _duration_ms(started_ns)
-            existing = result.metadata.get("phase_metrics")
-            phase_metrics = dict(existing) if isinstance(existing, Mapping) else {}
-            phase_metrics["total_ms"] = round(max(duration_ms, 0.0), 3)
-            result = replace(
-                result,
-                metadata={**dict(result.metadata), "phase_metrics": phase_metrics},
-            )
-            writer.emit("step.finished", context, step=step, result=result, duration_ms=duration_ms)
-            _write_metrics_safely(context.repo_root, context.run_id)
-            return result
-
-        BasicStepRunner.run = observed_step_run
-        BasicStepRunner._observability_patch_applied = True
-
     if getattr(RunnerEngine, "_observability_patch_applied", False):
         return
 
@@ -65,6 +32,8 @@ def apply_observability_patch() -> None:
         writer = RunEventWriter(context.repo_root, context.run_id)
         writer.start_run_if_absent(context)
         writer.emit("workflow.started", context)
+        if not isinstance(self._step_runner, ObservedStepRunner):
+            self._step_runner = ObservedStepRunner(self._step_runner)
         started_ns = time.perf_counter_ns()
         try:
             result = original_workflow_run(self, workflow, context)
@@ -77,7 +46,12 @@ def apply_observability_patch() -> None:
             )
             _write_metrics_safely(context.repo_root, context.run_id)
             raise
-        writer.emit("workflow.finished", context, result=result, duration_ms=_duration_ms(started_ns))
+        writer.emit(
+            "workflow.finished",
+            context,
+            result=result,
+            duration_ms=_duration_ms(started_ns),
+        )
         _write_metrics_safely(context.repo_root, context.run_id)
         return result
 

--- a/harness_codex/runtime/observability_patch.py
+++ b/harness_codex/runtime/observability_patch.py
@@ -1,0 +1,85 @@
+"""Attach local-first observability without changing workflow semantics."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+from typing import Mapping
+
+
+def apply_observability_patch() -> None:
+    """Instrument RunnerEngine and BasicStepRunner on every normal runtime import.
+
+    Emission and metric projection are intentionally best-effort. A disk or JSON failure
+    must never change the workflow result or mask the original runtime exception.
+    """
+
+    import harness_codex.runtime.engine as engine_module
+    import harness_codex.runtime.runner as runner_module
+    from harness_codex.runtime.observability import RunEventWriter, _duration_ms, _write_metrics_safely
+
+    BasicStepRunner = runner_module.BasicStepRunner
+    RunnerEngine = engine_module.RunnerEngine
+
+    if not getattr(BasicStepRunner, "_observability_patch_applied", False):
+        original_step_run = BasicStepRunner.run
+
+        def observed_step_run(self, step, context):
+            writer = RunEventWriter(context.repo_root, context.run_id)
+            writer.start_run_if_absent(context)
+            writer.emit("step.started", context, step=step)
+            started_ns = time.perf_counter_ns()
+            try:
+                result = original_step_run(self, step, context)
+            except BaseException as exc:
+                writer.emit(
+                    "step.raised",
+                    context,
+                    step=step,
+                    duration_ms=_duration_ms(started_ns),
+                    attributes={"exception_type": type(exc).__name__},
+                )
+                _write_metrics_safely(context.repo_root, context.run_id)
+                raise
+            duration_ms = _duration_ms(started_ns)
+            existing = result.metadata.get("phase_metrics")
+            phase_metrics = dict(existing) if isinstance(existing, Mapping) else {}
+            phase_metrics["total_ms"] = round(max(duration_ms, 0.0), 3)
+            result = replace(
+                result,
+                metadata={**dict(result.metadata), "phase_metrics": phase_metrics},
+            )
+            writer.emit("step.finished", context, step=step, result=result, duration_ms=duration_ms)
+            _write_metrics_safely(context.repo_root, context.run_id)
+            return result
+
+        BasicStepRunner.run = observed_step_run
+        BasicStepRunner._observability_patch_applied = True
+
+    if getattr(RunnerEngine, "_observability_patch_applied", False):
+        return
+
+    original_workflow_run = RunnerEngine.run
+
+    def observed_workflow_run(self, workflow, context):
+        writer = RunEventWriter(context.repo_root, context.run_id)
+        writer.start_run_if_absent(context)
+        writer.emit("workflow.started", context)
+        started_ns = time.perf_counter_ns()
+        try:
+            result = original_workflow_run(self, workflow, context)
+        except BaseException as exc:
+            writer.emit(
+                "workflow.raised",
+                context,
+                duration_ms=_duration_ms(started_ns),
+                attributes={"exception_type": type(exc).__name__},
+            )
+            _write_metrics_safely(context.repo_root, context.run_id)
+            raise
+        writer.emit("workflow.finished", context, result=result, duration_ms=_duration_ms(started_ns))
+        _write_metrics_safely(context.repo_root, context.run_id)
+        return result
+
+    RunnerEngine.run = observed_workflow_run
+    RunnerEngine._observability_patch_applied = True

--- a/tests/runtime/test_observability.py
+++ b/tests/runtime/test_observability.py
@@ -50,7 +50,8 @@ def test_observed_step_runner_writes_safe_event_ledger_and_metrics(tmp_path):
 
     result = ObservedStepRunner(_SuccessfulRunner()).run(step, context)
 
-    assert result.metadata["phase_metrics"]["total_ms"] >= 0
+    assert result.metadata["observability"]["duration_ms"] >= 0
+    assert "phase_metrics" not in result.metadata
     events = read_run_events(tmp_path, "run-observe")
     assert [event["event_type"] for event in events] == [
         "run.started",

--- a/tests/runtime/test_observability.py
+++ b/tests/runtime/test_observability.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+
+from harness_codex.runtime.models import (
+    RunContext,
+    RunMode,
+    Step,
+    StepKind,
+    StepResult,
+    StepStatus,
+)
+from harness_codex.runtime.observability import (
+    ObservedStepRunner,
+    read_run_events,
+    render_run_metrics,
+    summarize_run_events,
+)
+
+
+class _SuccessfulRunner:
+    def run(self, step, context):
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.SUCCEEDED,
+            metadata={
+                "execution_mode": "fresh",
+                "provider": "codex",
+                "prompt": "must-not-be-persisted",
+                "stderr": "must-not-be-persisted",
+            },
+        )
+
+
+def test_observed_step_runner_writes_safe_event_ledger_and_metrics(tmp_path):
+    context = RunContext(
+        run_id="run-observe",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-observe/work-items/UC-001",
+        metadata={
+            "change_set_id": "CHG-001",
+            "active_work_item_id": "UC-001",
+            "active_work_item_type": "use_case",
+        },
+    )
+    step = Step(id="execute-work-item", kind=StepKind.AGENT, name="Execute", agent_id="executor")
+
+    result = ObservedStepRunner(_SuccessfulRunner()).run(step, context)
+
+    assert result.metadata["phase_metrics"]["total_ms"] >= 0
+    events = read_run_events(tmp_path, "run-observe")
+    assert [event["event_type"] for event in events] == [
+        "run.started",
+        "step.started",
+        "step.finished",
+    ]
+    finished = events[-1]
+    assert finished["change_set_id"] == "CHG-001"
+    assert finished["work_item_id"] == "UC-001"
+    assert finished["attributes"] == {"execution_mode": "fresh", "provider": "codex"}
+    assert "prompt" not in json.dumps(finished, ensure_ascii=False)
+    assert "stderr" not in json.dumps(finished, ensure_ascii=False)
+
+    metrics_path = tmp_path / ".harness/runs/run-observe/metrics.json"
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["status_counts"] == {"succeeded": 1}
+    assert metrics["bottlenecks"][0]["step_id"] == "execute-work-item"
+    assert "execute-work-item" in render_run_metrics(metrics)
+
+
+def test_summarize_run_events_orders_bottlenecks_and_calculates_percentiles():
+    metrics = summarize_run_events(
+        [
+            {
+                "event_type": "step.finished",
+                "run_id": "run-001",
+                "step_id": "fast",
+                "step_kind": "validator",
+                "status": "succeeded",
+                "duration_ms": 10,
+            },
+            {
+                "event_type": "step.finished",
+                "run_id": "run-001",
+                "step_id": "slow",
+                "step_kind": "agent",
+                "status": "failed",
+                "duration_ms": 100,
+            },
+            {
+                "event_type": "step.finished",
+                "run_id": "run-001",
+                "step_id": "slow",
+                "step_kind": "agent",
+                "status": "succeeded",
+                "duration_ms": 200,
+            },
+        ]
+    )
+
+    assert metrics["run_id"] == "run-001"
+    assert metrics["status_counts"] == {"failed": 1, "succeeded": 2}
+    assert metrics["bottlenecks"][0]["step_id"] == "slow"
+    assert metrics["bottlenecks"][0]["p50_ms"] == 150.0
+    assert metrics["bottlenecks"][0]["p95_ms"] == 195.0

--- a/tests/runtime/test_observability_patch.py
+++ b/tests/runtime/test_observability_patch.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from harness_codex.runtime import BasicStepRunner, RunnerEngine, RunContext, RunMode, Step, StepKind, Workflow
+from harness_codex.runtime.models import RunStatus
+from harness_codex.runtime.observability import read_run_events
+
+
+def test_runtime_import_instruments_engine_and_basic_step_runner(tmp_path):
+    workflow = Workflow(
+        name="observability-smoke",
+        mode=RunMode.APPLY,
+        steps=(Step(id="decision", kind=StepKind.DECISION, name="Decision"),),
+    )
+    context = RunContext(
+        run_id="run-patched",
+        workflow_name=workflow.name,
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-patched",
+        metadata={"change_set_id": "CHG-001", "active_work_item_id": "MAINT-001"},
+    )
+
+    result = RunnerEngine(BasicStepRunner()).run(workflow, context)
+
+    assert result.status is RunStatus.BLOCKED
+    assert [event["event_type"] for event in read_run_events(tmp_path, "run-patched")] == [
+        "run.started",
+        "workflow.started",
+        "step.started",
+        "step.finished",
+        "workflow.finished",
+    ]
+    assert (tmp_path / ".harness/runs/run-patched/metrics.json").exists()

--- a/tests/runtime/test_observability_workflow_result.py
+++ b/tests/runtime/test_observability_workflow_result.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from harness_codex.runtime.models import RunContext, RunMode, RunResult, RunStatus
+from harness_codex.runtime.observability import RunEventWriter, read_run_events
+
+
+def test_workflow_event_accepts_run_result_without_step_exit_code(tmp_path):
+    context = RunContext(
+        run_id="run-workflow-result",
+        workflow_name="changeset-use-case-workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-workflow-result",
+        metadata={"change_set_id": "CHG-001", "active_work_item_id": "UC-001"},
+    )
+    result = RunResult(
+        run_id=context.run_id,
+        status=RunStatus.BLOCKED,
+        step_results=(),
+        mode=RunMode.APPLY,
+        failed_step_id="verify-work-item",
+    )
+
+    assert RunEventWriter(tmp_path, context.run_id).emit(
+        "workflow.finished",
+        context,
+        result=result,
+        duration_ms=12.5,
+    )
+
+    event = read_run_events(tmp_path, context.run_id)[0]
+    assert event["status"] == "blocked"
+    assert event["failed_step_id"] == "verify-work-item"
+    assert "exit_code" not in event


### PR DESCRIPTION
## 구현 목적

하네스의 ChangeSet/work item/workflow/step 실행을 로컬에서도 재현 가능한 형태로 측정하고, 프롬프트·에이전트·검증 gate 개선의 근거로 사용할 수 있도록 런타임 관측성을 추가합니다.

외부 수집기나 SaaS를 먼저 강제하지 않고, 각 실행 디렉터리에 원본 이벤트와 집계 지표를 남기는 **local-first** 방식을 채택했습니다.

## 변경 사항

### 1. 실행 이벤트 원장

신규 `harness_codex.runtime.observability`가 다음 append-only 원장을 기록합니다.

```text
.harness/runs/<RUN-ID>/events.ndjson
```

기록 이벤트:

- `run.started`
- `workflow.started` / `workflow.finished` / `workflow.raised`
- `step.started` / `step.finished` / `step.raised`

모든 이벤트는 `run_id`를 기준으로 상관관계를 만들고, 가능하면 ChangeSet ID, work item ID, workflow, step ID/kind, agent ID, 상태, 실패 분류, 종료 코드, duration을 함께 기록합니다.

### 2. 기존 실행 의미론을 보존한 계측 경계

`RunnerEngine.run()`을 관측 경계로 사용합니다.

- workflow 시작·완료·예외를 기록합니다.
- 엔진이 실제 실행할 step runner를 `ObservedStepRunner`로 데코레이션해 모든 실행 step의 시작·완료·예외 및 wall-clock duration을 기록합니다.
- duration은 이벤트의 `duration_ms`와 step 결과의 독립된 `metadata.observability.duration_ms`에만 기록합니다.

중요하게도 `BasicStepRunner.run()` 자체와 기존 `phase_metrics` 계약은 변경하지 않습니다. 런타임에는 rollback, delivery, completion 등 여러 호환성 패치가 있으므로, 실행 메서드를 직접 monkey-patch하면 기존 patch chain을 우회할 수 있습니다. 엔진 경계의 runner 데코레이션 방식으로 이를 피했습니다.

### 3. 집계 지표 투영

원장에서 다음 파일을 매 step 완료/예외 및 workflow 완료/예외 시 재생성합니다.

```text
.harness/runs/<RUN-ID>/metrics.json
```

포함 내용:

- 완료 step 상태별 건수
- step ID/kind별 count, total, average, p50, p95, max duration
- 총 시간이 큰 상위 5개 병목 단계
- event count, 최초/최종 관측 시각

### 4. 데이터 경계 및 실패 격리

원장에는 프롬프트, 모델 응답, 소스 코드, stdout/stderr, 임의 metadata를 기록하지 않습니다.

허용 목록 기반으로 provider, execution mode, attempt, termination reason, review cache/gate 상태 등 운영 메타데이터만 기록합니다.

이벤트·metrics 쓰기는 best-effort입니다. 파일 시스템, 직렬화, 권한 문제로 관측 기록이 실패하더라도 원래 workflow 결과나 예외를 바꾸지 않습니다.

### 5. 테스트와 문서

- 이벤트 원장 생성 및 `metrics.json` 투영 검증
- prompt/stdout/stderr 성격의 metadata 비기록 검증
- 병목 정렬 및 p50/p95 계산 검증
- `RunResult` 기반 workflow 종료 이벤트가 step 전용 `exit_code`에 의존하지 않는 회귀 테스트
- 기존 `phase_metrics` 계약 유지 검증
- 일반 `RunnerEngine + BasicStepRunner` 경로의 자동 계측 smoke test
- `docs/runtime-observability.md` 추가

## 검증 및 자체 리뷰

초기 전체 회귀 실행에서 workflow 종료 이벤트에 `RunResult`를 전달하면서 `StepResult` 전용 `exit_code`를 읽는 결함을 확인했습니다. 이를 수정하고 `RunResult` 회귀 테스트를 추가했습니다.

이후 rollback 테스트가 깨지는 것을 확인해 원인을 추적했습니다. `BasicStepRunner.run()` 직접 래핑이 기존 rollback patch chain의 순서와 충돌한 문제였습니다. 계측을 `RunnerEngine`의 step-runner 데코레이터 방식으로 변경해 기존 runner 의미론을 보존했습니다.

마지막으로 기존 `phase_metrics` 구조에 관측 시간 필드를 삽입해 발생한 회귀를 수정했습니다. 관측 duration을 별도 `metadata.observability`로 분리했습니다.

최신 GitHub Actions `Runtime document contracts` run #361은 전체 성공했습니다. runtime/workflow 회귀, 메모리 계약, public CLI E2E, prompt-injection 경계 job이 모두 통과했습니다.

## 후속 확장 방향

이번 변경의 `events.ndjson`을 원본 계약으로 유지하면 후속 ChangeSet에서 CLI 대시보드 비교, CI artifact 업로드, OpenTelemetry 또는 Prometheus exporter를 런타임 의미 변경 없이 추가할 수 있습니다.