### PR TITLE
feat(cli): guide users to the next ChangeSet action

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,16 @@ flowchart TD
 대상 저장소의 루트에서 실행합니다. 설치된 대상 저장소에서는 `./harness`를 사용하고,
 harness-codex 자체를 로컬 개발할 때는 `python3 -m harness_codex`를 사용할 수 있습니다.
 
+먼저 `help`로 현재 저장소의 다음 안전한 행동을 확인합니다. 이 명령은 활성 ChangeSet 메타데이터만
+읽으며 agent, runner, RunState, 파일을 변경하지 않습니다.
+
 ```bash
+./harness help
 ./harness requirements-definition --title "변경 제목" --idea "짧은 제품 또는 엔지니어링 목표"
 ```
 
 이 명령은 활성 ChangeSet을 생성하거나 갱신합니다. 이후 단계에서는 생성된 ChangeSet ID를 사용합니다.
+세부 옵션은 `./harness help requirements-definition` 또는 `./harness help changes continue`에서 확인합니다.
 
 ## 공개 단계 워크플로우
 
@@ -144,10 +149,15 @@ ChangeSet은 active 상태로 남습니다.
 
 ## 재개와 상태 확인
 
+`./harness help`는 active ChangeSet이 하나면 먼저 `changes continue <CHG-ID> --plan`을 제안합니다.
+계획이 맞는지 확인한 뒤에만 `--apply`로 계속 진행합니다.
+
 ```bash
+./harness help
 ./harness changes list
 ./harness changes active
 ./harness changes show CHG-YYYYMMDD-001
+./harness changes continue CHG-YYYYMMDD-001 --plan
 ./harness changes continue CHG-YYYYMMDD-001 --apply
 ./harness stages list CHG-YYYYMMDD-001
 ./harness contracts validate CHG-YYYYMMDD-001

--- a/harness_codex/canonical_cli.py
+++ b/harness_codex/canonical_cli.py
@@ -15,7 +15,7 @@ from typing import Iterable, Sequence
 
 from harness_codex import cli as _stage_runtime
 from harness_codex.memory_cli import main as memory_main
-from harness_codex.runtime.changes import ChangeSetResolver
+from harness_codex.runtime.changes import ChangeSetResolver, NoActiveChangeSetsError
 
 _REMOVED_TOP_LEVEL_COMMANDS = frozenset({"ultrawork", "change-set-pr"})
 
@@ -268,6 +268,8 @@ def _format_guided_actions(repo_root: Path) -> str:
     lines = ["Next action:"]
     try:
         active_change_sets = tuple(ChangeSetResolver(repo_root).list_active())
+    except NoActiveChangeSetsError:
+        active_change_sets = ()
     except Exception as exc:  # Help must remain available for a damaged workspace.
         lines.extend(
             (
@@ -295,7 +297,7 @@ def _format_guided_actions(repo_root: Path) -> str:
         lines.extend(
             (
                 f"  Continue {change_set.change_set_id} [{status}]: {title}",
-                f"  Inspect: harness changes active",
+                "  Inspect: harness changes active",
                 f"  Safe plan: harness changes continue {change_set.change_set_id} --plan",
                 f"  Apply:     harness changes continue {change_set.change_set_id} --apply",
             )

--- a/harness_codex/canonical_cli.py
+++ b/harness_codex/canonical_cli.py
@@ -1,7 +1,7 @@
 """README-aligned public harness CLI.
 
 The public launcher owns the supported command boundary. The legacy stage runtime
-continues to implement the stage handlers, but commands that are intentionally not
+continues to implement stage handlers, but commands that are intentionally not
 part of the README workflow are rejected before they reach its parser.
 """
 
@@ -9,35 +9,175 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
 
 from harness_codex import cli as _stage_runtime
 from harness_codex.memory_cli import main as memory_main
+from harness_codex.runtime.changes import ChangeSetResolver
 
 _REMOVED_TOP_LEVEL_COMMANDS = frozenset({"ultrawork", "change-set-pr"})
 
-COMMAND_HELP: tuple[tuple[str, str], ...] = tuple(
-    (
-        ("memory", "List, search, or reindex reviewed ChangeSet-first memory.")
-        if item[0] == "memory"
-        else item
-    )
-    for item in _stage_runtime.COMMAND_HELP
-    if item[0] not in _REMOVED_TOP_LEVEL_COMMANDS
-)
-PUBLIC_COMMANDS = frozenset(command for command, _ in COMMAND_HELP)
-TOPIC_HELP = {
-    command: text
-    for command, text in _stage_runtime.TOPIC_HELP.items()
-    if command not in _REMOVED_TOP_LEVEL_COMMANDS
+
+@dataclass(frozen=True)
+class PublicCommand:
+    """One user-facing command entry shared by help and completion."""
+
+    name: str
+    summary: str
+    group: str
+    topic_help: str
+
+
+_COMMAND_GROUPS: dict[str, str] = {
+    "help": "Start and continue",
+    "init": "Setup and maintenance",
+    "agent-context": "Setup and maintenance",
+    "requirements-definition": "Start and continue",
+    "ubiquitous-language-definition": "Workflow stages",
+    "use-case-definition": "Workflow stages",
+    "event-storming": "Workflow stages",
+    "ddd-architecture-definition": "Workflow stages",
+    "technical-decisions": "Workflow stages",
+    "plan-writing": "Workflow stages",
+    "implementation": "Workflow stages",
+    "changes": "Inspect and resume",
+    "contracts": "Inspect and resume",
+    "stages": "Inspect and resume",
+    "artifacts": "Inspect and resume",
+    "resume": "Inspect and resume",
+    "report": "Inspect and resume",
+    "dashboard": "Inspect and resume",
+    "run": "Operations and advanced",
+    "completion": "Operations and advanced",
+    "ui-server": "Operations and advanced",
+    "memory": "Operations and advanced",
+    "evolution": "Operations and advanced",
+    "update": "Setup and maintenance",
+    "reset": "Setup and maintenance",
 }
-TOPIC_HELP["memory"] = (
-    "Usage: harness memory list [--kind KIND]\n"
-    "       harness memory search QUERY [--kind KIND] [--change-set ID] [--work-item ID] [--stage STAGE] [--limit N]\n"
-    "       harness memory reindex\n\n"
-    "Search reviewed ChangeSet-first memory under docs/memory. "
-    "Legacy score-based .harness/memory commands are retired."
+
+_TOPIC_HELP_OVERRIDES: dict[str, str] = {
+    "help": (
+        "Usage: harness help [COMMAND [SUBCOMMAND]]\n\n"
+        "Show workflow-aware guidance without running agents, mutating files, or "
+        "creating RunState. With no topic, help reads active ChangeSet metadata "
+        "and suggests the next safe command."
+    ),
+    "requirements-definition": (
+        "Usage: harness requirements-definition [CHG-ID] --title TEXT --idea TEXT [--force]\n\n"
+        "Start a ChangeSet from a product or engineering request. Omit CHG-ID to "
+        "create or finalize the current ChangeSet; provide one to update that "
+        "ChangeSet explicitly.\n\n"
+        "Writes: docs/design/요구사항.md and ChangeSet procedure-stage state.\n"
+        "Example:\n"
+        "  harness requirements-definition --title \"Add guided help\" "
+        "--idea \"Show the next safe runtime action\""
+    ),
+    "changes": (
+        "Usage: harness changes list|active\n"
+        "       harness changes show|delete|contents|continue CHG-ID [OPTIONS]\n"
+        "       harness changes document-delta CHG-ID --uc UC-ID --summary TEXT [OPTIONS]\n\n"
+        "Inspect and resume ChangeSets. Run `harness help changes continue` for "
+        "the recommended resume command and its execution modes."
+    ),
+    "implementation": (
+        "Usage: harness implementation CHG-ID [--force-verification] "
+        "[--rollback none|safe|git] --plan|--preview|--apply\n\n"
+        "Run every incomplete work item in one ChangeSet through planning, "
+        "implementation, verification, and delivery gates.\n\n"
+        "Modes: --plan describes work, --preview resolves the executable scope "
+        "without mutations, and --apply performs the run."
+    ),
+    "memory": (
+        "Usage: harness memory list [--kind KIND]\n"
+        "       harness memory search QUERY [--kind KIND] [--change-set ID] "
+        "[--work-item ID] [--stage STAGE] [--limit N]\n"
+        "       harness memory reindex\n\n"
+        "Search reviewed ChangeSet-first memory under docs/memory. Legacy "
+        "score-based .harness/memory commands are retired."
+    ),
+}
+
+_NESTED_TOPIC_HELP: dict[tuple[str, str], str] = {
+    ("changes", "continue"): (
+        "Usage: harness changes continue CHG-ID [--uc UC-ID] "
+        "[--blocker-resolution requirements|use-case] [--resolution-prompt TEXT] "
+        "[--force-verification] --plan|--preview|--apply\n\n"
+        "Resume the first incomplete or blocked stage of an active ChangeSet. "
+        "Use --plan before --apply to inspect the target stage without mutation. "
+        "When a use-case blocker requires an upstream choice, use "
+        "--blocker-resolution requirements, or --blocker-resolution use-case "
+        "with --resolution-prompt TEXT."
+    ),
+    ("changes", "active"): (
+        "Usage: harness changes active\n\n"
+        "Show each active ChangeSet with runtime readiness, work-item state, "
+        "plan path, verification goal, and latest run details. Read-only."
+    ),
+    ("changes", "show"): (
+        "Usage: harness changes show CHG-ID\n\n"
+        "Show the ChangeSet's intent, before/after summary, and affected work "
+        "items. Read-only."
+    ),
+    ("changes", "contents"): (
+        "Usage: harness changes contents CHG-ID [--raw]\n\n"
+        "Show structured ChangeSet content; use --raw to print its markdown "
+        "source. Read-only."
+    ),
+    ("contracts", "validate"): (
+        "Usage: harness contracts validate CHG-ID [--work-item ID] [--json]\n\n"
+        "Validate document handoff contracts before implementation or after an "
+        "upstream document change. Read-only."
+    ),
+    ("run", "app"): (
+        "Usage: harness run app [--timeout SECONDS] [-- SERVER_ARG ...]\n"
+        "       harness run app --foreground [-- APP_ARG ...]\n"
+        "       harness run app status|stop|attach infra|server\n\n"
+        "Start, inspect, attach to, or stop repository-local application sessions."
+    ),
+    ("run", "wiki"): (
+        "Usage: harness run wiki [serve|build|install] [--dev-addr HOST:PORT]\n\n"
+        "Run the repository MkDocs wiki command."
+    ),
+    ("completion", "install"): (
+        "Usage: harness completion install [--shell auto|zsh|bash|all]\n\n"
+        "Install bundled completion for the current shell."
+    ),
+}
+
+
+def _build_command_catalog() -> tuple[PublicCommand, ...]:
+    entries: list[PublicCommand] = []
+    for command, summary in _stage_runtime.COMMAND_HELP:
+        if command in _REMOVED_TOP_LEVEL_COMMANDS:
+            continue
+        public_summary = (
+            "List, search, or reindex reviewed ChangeSet-first memory."
+            if command == "memory"
+            else summary
+        )
+        entries.append(
+            PublicCommand(
+                name=command,
+                summary=public_summary,
+                group=_COMMAND_GROUPS.get(command, "Operations and advanced"),
+                topic_help=_TOPIC_HELP_OVERRIDES.get(
+                    command,
+                    _stage_runtime.TOPIC_HELP[command],
+                ),
+            )
+        )
+    return tuple(entries)
+
+
+COMMAND_CATALOG = _build_command_catalog()
+COMMAND_HELP: tuple[tuple[str, str], ...] = tuple(
+    (entry.name, entry.summary) for entry in COMMAND_CATALOG
 )
+PUBLIC_COMMANDS = frozenset(entry.name for entry in COMMAND_CATALOG)
+TOPIC_HELP = {entry.name: entry.topic_help for entry in COMMAND_CATALOG}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -45,14 +185,15 @@ def main(argv: list[str] | None = None) -> int:
 
     arguments = list(sys.argv[1:] if argv is None else argv)
     command, positional = _public_command(arguments)
+    repo_root = _repo_root_from_arguments(arguments)
 
     if command is None or command in {"-h", "--help"}:
-        print(help_command(None))
+        print(help_command(None, repo_root=repo_root))
         return 0
     if command == "help":
-        topic = positional[1] if len(positional) > 1 else None
+        topic: tuple[str, ...] = tuple(positional[1:])
         try:
-            print(help_command(topic))
+            print(help_command(topic or None, repo_root=repo_root))
         except ValueError as exc:
             print(str(exc), file=sys.stderr)
             return 2
@@ -87,12 +228,101 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def help_command(topic: str | None) -> str:
-    if not topic:
-        return "\n".join(("Harness runtime commands", "", _format_command_list()))
-    if topic not in TOPIC_HELP:
-        raise ValueError(f"unknown public harness command: {topic}")
-    return TOPIC_HELP[topic]
+def help_command(
+    topic: str | Sequence[str] | None,
+    *,
+    repo_root: Path | str = ".",
+) -> str:
+    """Render read-only overview or topic help for the public command catalog."""
+
+    topic_parts = _normalize_topic(topic)
+    if not topic_parts:
+        return "\n".join(
+            (
+                "Harness runtime guide",
+                "",
+                _format_guided_actions(Path(repo_root)),
+                "",
+                _format_command_list(),
+            )
+        )
+    if len(topic_parts) == 1 and topic_parts[0] in TOPIC_HELP:
+        return TOPIC_HELP[topic_parts[0]]
+    nested_help = _NESTED_TOPIC_HELP.get(topic_parts)
+    if nested_help:
+        return nested_help
+    raise ValueError(f"unknown public harness help topic: {' '.join(topic_parts)}")
+
+
+def _normalize_topic(topic: str | Sequence[str] | None) -> tuple[str, ...]:
+    if topic is None:
+        return ()
+    if isinstance(topic, str):
+        return tuple(part for part in topic.split() if part)
+    return tuple(str(part).strip() for part in topic if str(part).strip())
+
+
+def _format_guided_actions(repo_root: Path) -> str:
+    """Return repository-aware next steps without invoking runtime execution."""
+
+    lines = ["Next action:"]
+    try:
+        active_change_sets = tuple(ChangeSetResolver(repo_root).list_active())
+    except Exception as exc:  # Help must remain available for a damaged workspace.
+        lines.extend(
+            (
+                "  Workspace state could not be read.",
+                "  Inspect: harness changes list",
+                f"  Detail: {exc}",
+            )
+        )
+        return "\n".join(lines)
+
+    if not active_change_sets:
+        lines.extend(
+            (
+                "  Start a ChangeSet:",
+                "  harness requirements-definition --title \"Change title\" "
+                "--idea \"Product or engineering request\"",
+            )
+        )
+        return "\n".join(lines)
+
+    if len(active_change_sets) == 1:
+        change_set = active_change_sets[0]
+        title = change_set.title or change_set.intent_summary or "-"
+        status = change_set.status or "active"
+        lines.extend(
+            (
+                f"  Continue {change_set.change_set_id} [{status}]: {title}",
+                f"  Inspect: harness changes active",
+                f"  Safe plan: harness changes continue {change_set.change_set_id} --plan",
+                f"  Apply:     harness changes continue {change_set.change_set_id} --apply",
+            )
+        )
+        return "\n".join(lines)
+
+    lines.append("  Multiple active ChangeSets:")
+    for change_set in active_change_sets:
+        title = change_set.title or change_set.intent_summary or "-"
+        lines.append(f"  - {change_set.change_set_id}: {title}")
+    lines.extend(
+        (
+            "  Choose one: harness changes show CHG-ID",
+            "  Then plan: harness changes continue CHG-ID --plan",
+        )
+    )
+    return "\n".join(lines)
+
+
+def _repo_root_from_arguments(arguments: Iterable[str]) -> Path:
+    arguments_list = list(arguments)
+    for index, argument in enumerate(arguments_list):
+        if argument == "--repo-root" and index + 1 < len(arguments_list):
+            return Path(arguments_list[index + 1])
+        if argument.startswith("--repo-root="):
+            return Path(argument.partition("=")[2])
+    return Path(".")
 
 
 def _public_command(arguments: Iterable[str]) -> tuple[str | None, list[str]]:
@@ -128,10 +358,28 @@ def _memory_arguments(arguments: list[str]) -> list[str]:
 
 
 def _format_command_list() -> str:
-    width = max(len(command) for command, _ in COMMAND_HELP)
-    lines = ["Commands:"]
-    lines.extend(f"  {command.ljust(width)}  {summary}" for command, summary in COMMAND_HELP)
-    lines.append("")
-    lines.append("README.md defines the supported staged workflow.")
-    lines.append("Use `harness help <command>` for command usage.")
+    lines: list[str] = ["Commands:"]
+    groups = (
+        "Start and continue",
+        "Workflow stages",
+        "Inspect and resume",
+        "Operations and advanced",
+        "Setup and maintenance",
+    )
+    width = max(len(entry.name) for entry in COMMAND_CATALOG)
+    for group in groups:
+        entries = tuple(entry for entry in COMMAND_CATALOG if entry.group == group)
+        if not entries:
+            continue
+        lines.append(f"  {group}:")
+        lines.extend(
+            f"    {entry.name.ljust(width)}  {entry.summary}" for entry in entries
+        )
+    lines.extend(
+        (
+            "",
+            "README.md defines the supported staged workflow.",
+            "Use `harness help <command> [subcommand]` for command usage.",
+        )
+    )
     return "\n".join(lines)

--- a/tests/test_guided_help.py
+++ b/tests/test_guided_help.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_codex import canonical_cli
+from harness_codex import cli as stage_runtime
+
+
+ACTIVE_CHANGESET = """# ChangeSet CHG-001
+
+## 1. 메타데이터
+|항목|값|
+|---|---|
+|ChangeSet ID|`CHG-001`|
+|상태|active|
+|제목|Guided help|
+
+## 3. Before / After
+|구분|내용|
+|---|---|
+|Before|static command index|
+|After|guided workflow help|
+
+## 5. 영향 유스케이스
+|UC ID|유스케이스 이름|영향 유형|Slice 경로|상태|
+|---|---|---|---|---|
+|`UC-001`|Help 안내|update|`docs/use-cases/UC-001/`|planned|
+"""
+
+
+def _write_active_changeset(repo_root: Path, change_set_id: str = "CHG-001") -> None:
+    active_dir = repo_root / "docs/changes/active"
+    active_dir.mkdir(parents=True)
+    (active_dir / f"{change_set_id}.md").write_text(
+        ACTIVE_CHANGESET.replace("CHG-001", change_set_id),
+        encoding="utf-8",
+    )
+
+
+def test_help_guides_new_workspace_without_runtime_side_effects(tmp_path: Path, monkeypatch, capsys) -> None:
+    def fail_stage_runtime(_arguments: list[str]) -> int:
+        raise AssertionError("help must not delegate to the mutating stage runtime")
+
+    monkeypatch.setattr(canonical_cli._stage_runtime, "main", fail_stage_runtime)
+
+    assert canonical_cli.main(["--repo-root", str(tmp_path), "help"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Start a ChangeSet:" in output
+    assert "requirements-definition --title" in output
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_help_guides_single_active_changeset_to_safe_plan(tmp_path: Path, capsys) -> None:
+    _write_active_changeset(tmp_path)
+
+    assert canonical_cli.main(["--repo-root", str(tmp_path), "help"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Continue CHG-001" in output
+    assert "harness changes continue CHG-001 --plan" in output
+    assert "harness changes continue CHG-001 --apply" in output
+
+
+def test_help_supports_nested_changes_continue_topic(capsys) -> None:
+    assert canonical_cli.main(["help", "changes", "continue"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Usage: harness changes continue CHG-ID" in output
+    assert "--blocker-resolution requirements|use-case" in output
+    assert "--plan before --apply" in output
+
+
+def test_public_catalog_excludes_retired_commands_and_matches_stage_boundary() -> None:
+    expected = {
+        command
+        for command, _summary in stage_runtime.COMMAND_HELP
+        if command not in {"ultrawork", "change-set-pr"}
+    }
+
+    assert canonical_cli.PUBLIC_COMMANDS == expected
+    assert "ultrawork" not in canonical_cli.TOPIC_HELP
+    assert "change-set-pr" not in canonical_cli.TOPIC_HELP


### PR DESCRIPTION
## Summary

Closes #413.

- Adds a public command catalog used by the canonical CLI help surface and public parser catalog.
- Makes `harness help` read active ChangeSet metadata only and recommend a safe next action:
  - no active ChangeSet → start with `requirements-definition --title ... --idea ...`
  - one active ChangeSet → inspect, plan with `changes continue <CHG-ID> --plan`, then apply
  - multiple active ChangeSets → select and inspect one before continuing
- Adds nested help for high-frequency paths including `changes continue`, ChangeSet inspection, contract validation, app/wiki commands, and completion installation.
- Aligns `requirements-definition` and `implementation` help with their effective public usage and documents the guidance flow in README.

## Safety / compatibility

- Help is read-only: it does not invoke agents or the stage runtime, mutate files, or create RunState.
- The supported public command set remains the existing README-aligned boundary; retired commands remain excluded.

## Tests added

- new-workspace help guidance and no-side-effect contract
- one-active-ChangeSet safe plan/apply guidance
- nested `help changes continue` usage
- public catalog remains synchronized with the stage runtime boundary

## Validation

- Reviewed the changed CLI and test contracts.
- Local full test execution was not possible because this environment cannot resolve GitHub to clone the repository; CI should run the repository suite.