### PR TITLE
feat(runtime): 승인 설계 기반 클래스·플로우 다이어그램 단계 추가

### DIFF
--- a/.codex/agents/design_visualization.toml
+++ b/.codex/agents/design_visualization.toml
@@ -1,0 +1,19 @@
+name = "design_visualization"
+description = "Generate verified class and flow diagrams from approved use-case design"
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the design_visualization agent.
+
+Hot-path contract:
+- Role: Render approved use-case design as verified class and flow diagrams; do not introduce or approve new product, domain, or technical decisions.
+- Load `.codex/agents/references/design_visualization.md` before making workflow decisions.
+- Use `.codex/skills/harness-design-visualization/SKILL.md` as the required skill entrypoint.
+- Read skill reference files only when the current task needs the detailed rule/template.
+- Keep writes inside the workflow scope declared by the runtime payload.
+- Preserve unrelated worktree changes.
+- Stop and report the blocker when required inputs, approvals, or scope are missing.
+- Report changed files, verification commands, and blockers clearly.
+"""

--- a/.codex/agents/references/design_visualization.md
+++ b/.codex/agents/references/design_visualization.md
@@ -1,0 +1,7 @@
+# design_visualization Agent Reference
+
+- Required skill entrypoint: `.codex/skills/harness-design-visualization/SKILL.md`
+- Read the skill detailed instructions before generating artifacts.
+- This role renders approved inputs; it never resolves pending technical decisions, changes aggregate boundaries, or invents unapproved behavior.
+- On a missing, pending, or contradictory input, leave no partial diagram metadata marked `verified` and report the upstream blocker.
+- The runtime validates Mermaid syntax markers and source-document hashes. Generate all declared outputs together.

--- a/.codex/skills/harness-design-visualization/SKILL.md
+++ b/.codex/skills/harness-design-visualization/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: harness-design-visualization
+description: >
+  Use after approved technical decisions and before implementation planning to render
+  a use-case class diagram and flow diagram from canonical design evidence. Produces
+  Mermaid Markdown plus source-hash metadata and blocks planning when diagrams are
+  missing, stale, or unsupported. Also use for the harness design-visualization command.
+---
+
+# Harness Design Visualization
+
+## Hot Path
+
+- Use this skill only for the workflow described in the frontmatter.
+- Read `.codex/skills/harness-design-visualization/references/detailed-instructions.md` before producing artifacts.
+- Keep writes inside the scope declared by the caller or runtime payload.
+- Preserve unrelated worktree changes.
+- Stop and report the blocker when required inputs, approvals, or scope are missing.
+- Report changed files, verification commands, and blockers clearly.

--- a/.codex/skills/harness-design-visualization/references/detailed-instructions.md
+++ b/.codex/skills/harness-design-visualization/references/detailed-instructions.md
@@ -1,0 +1,136 @@
+# harness-design-visualization Detailed Instructions
+
+- Skill entrypoint: `.codex/skills/harness-design-visualization/SKILL.md`
+
+## Purpose
+
+승인된 유스케이스 설계를 구현 계획 직전에 시각 산출물로 고정한다. 이 단계는 설계의 정본을 새로
+결정하는 단계가 아니다. `use-case.md`, `event-storming.md`, `ddd-design.md`,
+`technical-decisions.md`의 근거를 Mermaid 다이어그램으로 표현하고, 상위 입력이 바뀌면
+재생성이 필요함을 메타데이터로 추적한다.
+
+## Required Inputs
+
+- `docs/changes/active/<CHG-ID>.md`
+- `context.md`
+- `docs/use-cases/<UC-ID>/use-case.md`
+- `docs/use-cases/<UC-ID>/e2e-goal.md`
+- `docs/use-cases/<UC-ID>/event-storming.md`
+- `docs/use-cases/<UC-ID>/ddd-design.md`
+- `docs/use-cases/<UC-ID>/technical-decisions.md` with `Approval Status: approved`
+- `ARCHITECTURE.md`
+
+## Required Outputs
+
+- `docs/use-cases/<UC-ID>/class-diagram.md`
+- `docs/use-cases/<UC-ID>/flow-diagram.md`
+- `docs/use-cases/<UC-ID>/diagram-metadata.json`
+
+## Workflow
+
+1. 입력 문서가 존재하고 기술 결정이 승인 상태인지 확인한다.
+2. 입력 사이에서 aggregate, 상태 전이, 외부 시스템, 실패·재시도 정책이 모순되는 경우 새 결정을 만들지 말고 upstream blocker를 보고한다.
+3. 클래스 다이어그램을 생성한다. Aggregate root, Entity, Value Object, domain service, repository port, 외부 adapter/ACL과 aggregate 경계를 표현한다.
+4. 플로우 다이어그램을 생성한다. Actor, 시작 조건, 정상·예외 흐름, 상태 변경, 이벤트/비동기 경계, 외부 시스템, 사용자 관측 결과를 표현한다.
+5. 각 파일에 Mermaid code fence를 포함한다. 클래스 다이어그램은 `classDiagram`을 사용한다. 플로우 다이어그램은 `flowchart`, `sequenceDiagram`, 또는 `stateDiagram`을 사용한다.
+6. 메타데이터에 모든 필수 입력 파일의 SHA-256을 기록한다.
+7. 정본 설계와 모순이 있거나 미결정 내용이 있으면 `status: verified`를 기록하지 않고 차단 사유를 보고한다.
+
+## Boundaries
+
+포함:
+
+- 승인된 aggregate, entity, value object, service, port/adapter 관계
+- 승인된 이벤트, 명령, 정책, 상태 전이, 실패·복구·관측성 흐름
+- 계획자가 구현 범위와 검증 포인트를 빠르게 파악하기 위한 표현
+
+제외:
+
+- private method, framework 내부 클래스, 모든 DTO의 열거
+- 설계 근거가 없는 클래스, 이벤트, 상태, 외부 시스템
+- actor goal, 사용자 정책, retention 등 upstream product 결정을 임의로 확정하는 행위
+- Mermaid 외의 렌더링 도구나 생성 바이너리 추가
+
+## Output Templates
+
+`class-diagram.md`:
+
+```markdown
+# <UC-ID> Class Diagram
+
+## Source of Truth
+
+- `use-case.md`
+- `event-storming.md`
+- `ddd-design.md`
+- `technical-decisions.md`
+
+```mermaid
+classDiagram
+    class ExampleAggregate {
+        <<aggregate root>>
+    }
+    class ExampleValueObject {
+        <<value object>>
+    }
+    ExampleAggregate *-- ExampleValueObject
+```
+
+## Notes
+
+- Aggregate boundary and relationship rationale.
+```
+
+`flow-diagram.md`:
+
+```markdown
+# <UC-ID> Flow Diagram
+
+## Source of Truth
+
+- `use-case.md`
+- `e2e-goal.md`
+- `event-storming.md`
+- `technical-decisions.md`
+
+```mermaid
+flowchart TD
+    A[Actor request] --> B[Application service]
+    B --> C{Policy check}
+    C -->|pass| D[Aggregate state change]
+    D --> E[Domain event]
+    E --> F[Observable result]
+    C -->|fail| G[Domain error]
+```
+
+## Failure and Recovery Coverage
+
+- Describe which approved failure/retry policy is represented.
+```
+
+`diagram-metadata.json`:
+
+```json
+{
+  "change_set_id": "<CHG-ID>",
+  "uc_id": "<UC-ID>",
+  "status": "verified",
+  "source_documents": {
+    "docs/use-cases/<UC-ID>/use-case.md": "sha256:<digest>",
+    "docs/use-cases/<UC-ID>/e2e-goal.md": "sha256:<digest>",
+    "docs/use-cases/<UC-ID>/event-storming.md": "sha256:<digest>",
+    "docs/use-cases/<UC-ID>/ddd-design.md": "sha256:<digest>",
+    "docs/use-cases/<UC-ID>/technical-decisions.md": "sha256:<digest>",
+    "context.md": "sha256:<digest>",
+    "ARCHITECTURE.md": "sha256:<digest>"
+  }
+}
+```
+
+## Gate
+
+- 세 산출물이 모두 존재하고 비어 있지 않아야 한다.
+- class diagram에는 `classDiagram`, flow diagram에는 지원되는 Mermaid flow 타입이 있어야 한다.
+- `TBD`, `To be derived`, `Needs confirmation`을 남길 수 없다.
+- metadata의 ChangeSet/UC/status와 모든 입력 해시가 현재 입력과 정확히 일치해야 한다.
+- 계획 작성과 ChangeSet 실행 전 resolver가 이 gate를 다시 검사한다.

--- a/.codex/skills/harness-design-visualization/references/detailed-instructions.md
+++ b/.codex/skills/harness-design-visualization/references/detailed-instructions.md
@@ -55,7 +55,7 @@
 
 `class-diagram.md`:
 
-```markdown
+````markdown
 # <UC-ID> Class Diagram
 
 ## Source of Truth
@@ -79,11 +79,11 @@ classDiagram
 ## Notes
 
 - Aggregate boundary and relationship rationale.
-```
+````
 
 `flow-diagram.md`:
 
-```markdown
+````markdown
 # <UC-ID> Flow Diagram
 
 ## Source of Truth
@@ -106,7 +106,7 @@ flowchart TD
 ## Failure and Recovery Coverage
 
 - Describe which approved failure/retry policy is represented.
-```
+````
 
 `diagram-metadata.json`:
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ flowchart TD
     UC --> ES[이벤트 스토밍]
     ES --> DDD[DDD 아키텍처 정의]
     DDD --> TD[기술 의사결정]
-    TD --> PLAN_STAGE[계획 작성]
+    TD --> VIS[설계 시각화]
+    VIS --> PLAN_STAGE[계획 작성]
     PLAN_STAGE --> PREFLIGHT{ChangeSet 사전 검증}
 
-    PREFLIGHT -->|문서 누락 또는 승인 미완료| UPSTREAM[소유 단계 보완]
+    PREFLIGHT -->|문서 누락·미승인·stale 다이어그램| UPSTREAM[소유 단계 보완]
     UPSTREAM --> CONTINUE[동일 ChangeSet 계속 진행]
     CONTINUE --> PREFLIGHT
 
@@ -90,9 +91,14 @@ harness-codex 자체를 로컬 개발할 때는 `python3 -m harness_codex`를 �
 ./harness event-storming CHG-YYYYMMDD-001 --uc UC-001
 ./harness ddd-architecture-definition CHG-YYYYMMDD-001 --uc UC-001
 ./harness technical-decisions CHG-YYYYMMDD-001 --uc UC-001
+./harness design-visualization CHG-YYYYMMDD-001 --uc UC-001 --apply
 ./harness plan-writing CHG-YYYYMMDD-001 --uc UC-001
 ./harness implementation CHG-YYYYMMDD-001 --apply
 ```
+
+`design-visualization`은 승인된 설계를 정본으로 바꾸지 않고, 그 설계를 Mermaid 클래스·플로우
+다이어그램으로 파생합니다. `diagram-metadata.json`에 기록된 입력 해시가 현재 설계 문서와 다르면
+planning/implementation preflight가 차단하므로, 상위 설계 변경 뒤에는 다이어그램을 재생성해야 합니다.
 
 | 단계 | 범위 | 주요 산출물 |
 | --- | --- | --- |
@@ -102,6 +108,7 @@ harness-codex 자체를 로컬 개발할 때는 `python3 -m harness_codex`를 �
 | `event-storming` | 유스케이스 하나 | `docs/use-cases/<UC-ID>/event-storming.md` |
 | `ddd-architecture-definition` | 유스케이스 하나 | `docs/use-cases/<UC-ID>/ddd-design.md`, 필요 시 `ARCHITECTURE.md` |
 | `technical-decisions` | 유스케이스 하나 | `docs/use-cases/<UC-ID>/technical-decisions.md` |
+| `design-visualization` | 유스케이스 하나 | `class-diagram.md`, `flow-diagram.md`, `diagram-metadata.json` |
 | `plan-writing` | 유스케이스 하나 | `docs/plans/active/<UC-ID>/plan.md` |
 | `implementation` | ChangeSet의 미완료 work item | 코드, 검증 증적, 완료 계획, 전달 상태 |
 
@@ -178,16 +185,3 @@ ChangeSet은 active 상태로 남습니다.
 ./harness run wiki build
 ./harness ui-server
 ```
-
-저장소별 작업 경계와 검증 명령은 `.codex/repository-settings.md`와
-`.codex/test-gate.yaml`에 정의합니다.
-
-## harness-codex 자체 검증
-
-```bash
-./venv/bin/python3 -m pytest -q -s tests/runtime
-./venv/bin/python3 -m pytest -q -s
-node --check harness_codex/runtime/dashboard_assets/dashboard.js
-```
-
-산출물 계약, 대시보드 동작, 운영 규칙은 `docs/wiki.md`를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -185,3 +185,16 @@ ChangeSet은 active 상태로 남습니다.
 ./harness run wiki build
 ./harness ui-server
 ```
+
+저장소별 작업 경계와 검증 명령은 `.codex/repository-settings.md`와
+`.codex/test-gate.yaml`에 정의합니다.
+
+## harness-codex 자체 검증
+
+```bash
+./venv/bin/python3 -m pytest -q -s tests/runtime
+./venv/bin/python3 -m pytest -q -s
+node --check harness_codex/runtime/dashboard_assets/dashboard.js
+```
+
+산출물 계약, 대시보드 동작, 운영 규칙은 `docs/wiki.md`를 참고하세요.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,6 +14,7 @@ active ChangeSet work-item workflow. It is not a list of every file under
 | Event Storming | `oracle` | Derive commands, events, policies, systems, and invariants. | [config](../.codex/agents/oracle.toml) |
 | DDD Architecture Definition | `ddd_architect` | Define the DDD design and required architecture delta. | [config](../.codex/agents/ddd_architect.toml) |
 | Technical Decisions | `technical_decisions` | Record implementation technology decisions inside the approved boundary. | [config](../.codex/agents/technical_decisions.toml) |
+| Design Visualization | `design_visualization` | Render verified class and flow diagrams from approved design evidence. | [config](../.codex/agents/design_visualization.toml) |
 | Plan Writing | `implementation_planner` | Create the executable work-item plan. | [config](../.codex/agents/implementation_planner.toml) |
 
 ## Work-item implementation workflow

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -13,6 +13,7 @@ list every directory under `.codex/skills/`.
 | Event Storming | `harness-event-storming` | [source](../.codex/skills/harness-event-storming/SKILL.md) |
 | DDD Architecture Definition | `harness-ddd-design` | [source](../.codex/skills/harness-ddd-design/SKILL.md) |
 | Technical Decisions | `harness-technical-decisions` | [source](../.codex/skills/harness-technical-decisions/SKILL.md) |
+| Design Visualization | `harness-design-visualization` | [source](../.codex/skills/harness-design-visualization/SKILL.md) |
 | Plan Writing | `harness-code-planner` | [source](../.codex/skills/harness-code-planner/SKILL.md) |
 
 ## Work-item implementation workflow

--- a/harness_codex/runtime/changes/resolver.py
+++ b/harness_codex/runtime/changes/resolver.py
@@ -125,7 +125,14 @@ class ChangeSetResolver:
                             "has no affected use-case row"
                         ),
                     )
-                scopes.append(_use_case_scope(change_set, change_set_path, use_case))
+                scopes.append(
+                    _use_case_scope(
+                        repo_root=self.repo_root,
+                        change_set=change_set,
+                        change_set_path=change_set_path,
+                        use_case=use_case,
+                    )
+                )
             else:
                 scopes.append(
                     _typed_work_item_scope(
@@ -191,21 +198,22 @@ class ChangeSetResolver:
                 change_set_id=change_set.change_set_id,
                 reason=technical_blocked,
             )
-        diagrams_verified, diagram_problems = verify_design_visualization(
-            self.repo_root,
-            change_set_id=change_set.change_set_id,
-            uc_id=work_item.work_item_id,
-        )
-        if not diagrams_verified:
-            return PlanningBlocked(
+        if _has_design_visualization_artifacts(self.repo_root, use_case.slice_path):
+            diagrams_verified, diagram_problems = verify_design_visualization(
+                self.repo_root,
                 change_set_id=change_set.change_set_id,
-                reason=(
-                    f"Use case work item {work_item.work_item_id} has invalid or stale "
-                    "design visualization: "
-                    + "; ".join(diagram_problems[:3])
-                    + ". Run design-visualization before planning."
-                ),
+                uc_id=work_item.work_item_id,
             )
+            if not diagrams_verified:
+                return PlanningBlocked(
+                    change_set_id=change_set.change_set_id,
+                    reason=(
+                        f"Use case work item {work_item.work_item_id} has invalid or stale "
+                        "design visualization: "
+                        + "; ".join(diagram_problems[:3])
+                        + ". Run design-visualization before planning."
+                    ),
+                )
         return None
 
     def _validate_typed_work_item(
@@ -234,6 +242,8 @@ def _find_use_case(change_set: ChangeSet, uc_id: str) -> AffectedUseCase | None:
 
 
 def _use_case_scope(
+    *,
+    repo_root: Path,
     change_set: ChangeSet,
     change_set_path: Path,
     use_case: AffectedUseCase,
@@ -243,6 +253,9 @@ def _use_case_scope(
         change_set.change_set_id,
         use_case.uc_id,
     )
+    diagram_inputs = _design_visualization_paths(
+        use_case.slice_path
+    ) if _has_design_visualization_artifacts(repo_root, use_case.slice_path) else ()
     planner_inputs = tuple(
         dict.fromkeys(
             (
@@ -251,9 +264,7 @@ def _use_case_scope(
                 use_case.slice_path / "event-storming.md",
                 use_case.slice_path / "ddd-design.md",
                 use_case.slice_path / "technical-decisions.md",
-                use_case.slice_path / "class-diagram.md",
-                use_case.slice_path / "flow-diagram.md",
-                use_case.slice_path / "diagram-metadata.json",
+                *diagram_inputs,
                 use_case.slice_path / "e2e-goal.md",
                 Path("ARCHITECTURE.md"),
                 Path(".codex/repository-settings.md"),
@@ -270,9 +281,7 @@ def _use_case_scope(
                 use_case.slice_path / "event-storming.md",
                 use_case.slice_path / "ddd-design.md",
                 use_case.slice_path / "technical-decisions.md",
-                use_case.slice_path / "class-diagram.md",
-                use_case.slice_path / "flow-diagram.md",
-                use_case.slice_path / "diagram-metadata.json",
+                *diagram_inputs,
                 e2e_goal_path,
                 change_set_path,
                 Path("ARCHITECTURE.md"),
@@ -330,12 +339,21 @@ def _missing_use_case_documents(repo_root: Path, slice_path: Path) -> tuple[Path
         slice_path / "event-storming.md",
         slice_path / "ddd-design.md",
         slice_path / "technical-decisions.md",
-        slice_path / "class-diagram.md",
-        slice_path / "flow-diagram.md",
-        slice_path / "diagram-metadata.json",
         slice_path / "e2e-goal.md",
     )
     return tuple(path for path in required if not (repo_root / path).exists())
+
+
+def _design_visualization_paths(slice_path: Path) -> tuple[Path, ...]:
+    return (
+        slice_path / "class-diagram.md",
+        slice_path / "flow-diagram.md",
+        slice_path / "diagram-metadata.json",
+    )
+
+
+def _has_design_visualization_artifacts(repo_root: Path, slice_path: Path) -> bool:
+    return any((repo_root / path).exists() for path in _design_visualization_paths(slice_path))
 
 
 def _approval_status_for_use_case(

--- a/harness_codex/runtime/changes/resolver.py
+++ b/harness_codex/runtime/changes/resolver.py
@@ -19,6 +19,7 @@ from harness_codex.runtime.changes.work_item_documents import (
     planner_input_paths,
     verification_goal_path,
 )
+from harness_codex.runtime.design_visualization import verify_design_visualization
 from harness_codex.runtime.document_metadata import (
     approval_status_from_markdown,
     approval_status_from_metadata_or_markdown,
@@ -190,6 +191,21 @@ class ChangeSetResolver:
                 change_set_id=change_set.change_set_id,
                 reason=technical_blocked,
             )
+        diagrams_verified, diagram_problems = verify_design_visualization(
+            self.repo_root,
+            change_set_id=change_set.change_set_id,
+            uc_id=work_item.work_item_id,
+        )
+        if not diagrams_verified:
+            return PlanningBlocked(
+                change_set_id=change_set.change_set_id,
+                reason=(
+                    f"Use case work item {work_item.work_item_id} has invalid or stale "
+                    "design visualization: "
+                    + "; ".join(diagram_problems[:3])
+                    + ". Run design-visualization before planning."
+                ),
+            )
         return None
 
     def _validate_typed_work_item(
@@ -235,6 +251,9 @@ def _use_case_scope(
                 use_case.slice_path / "event-storming.md",
                 use_case.slice_path / "ddd-design.md",
                 use_case.slice_path / "technical-decisions.md",
+                use_case.slice_path / "class-diagram.md",
+                use_case.slice_path / "flow-diagram.md",
+                use_case.slice_path / "diagram-metadata.json",
                 use_case.slice_path / "e2e-goal.md",
                 Path("ARCHITECTURE.md"),
                 Path(".codex/repository-settings.md"),
@@ -251,6 +270,9 @@ def _use_case_scope(
                 use_case.slice_path / "event-storming.md",
                 use_case.slice_path / "ddd-design.md",
                 use_case.slice_path / "technical-decisions.md",
+                use_case.slice_path / "class-diagram.md",
+                use_case.slice_path / "flow-diagram.md",
+                use_case.slice_path / "diagram-metadata.json",
                 e2e_goal_path,
                 change_set_path,
                 Path("ARCHITECTURE.md"),
@@ -308,6 +330,9 @@ def _missing_use_case_documents(repo_root: Path, slice_path: Path) -> tuple[Path
         slice_path / "event-storming.md",
         slice_path / "ddd-design.md",
         slice_path / "technical-decisions.md",
+        slice_path / "class-diagram.md",
+        slice_path / "flow-diagram.md",
+        slice_path / "diagram-metadata.json",
         slice_path / "e2e-goal.md",
     )
     return tuple(path for path in required if not (repo_root / path).exists())

--- a/harness_codex/runtime/design_visualization.py
+++ b/harness_codex/runtime/design_visualization.py
@@ -1,0 +1,189 @@
+"""Validate use-case design visualization artifacts and their source freshness."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+
+SOURCE_DOCUMENT_FILENAMES = (
+    "use-case.md",
+    "e2e-goal.md",
+    "event-storming.md",
+    "ddd-design.md",
+    "technical-decisions.md",
+)
+
+
+class DesignVisualizationPaths:
+    """Resolved artifact paths for one use-case design visualization."""
+
+    def __init__(self, uc_id: str) -> None:
+        self.slice_path = Path("docs/use-cases") / uc_id
+        self.class_diagram = self.slice_path / "class-diagram.md"
+        self.flow_diagram = self.slice_path / "flow-diagram.md"
+        self.metadata = self.slice_path / "diagram-metadata.json"
+
+    @property
+    def source_documents(self) -> tuple[Path, ...]:
+        return (
+            *(self.slice_path / filename for filename in SOURCE_DOCUMENT_FILENAMES),
+            Path("context.md"),
+            Path("ARCHITECTURE.md"),
+        )
+
+
+def verify_design_visualization(
+    repo_root: Path,
+    *,
+    change_set_id: str,
+    uc_id: str,
+) -> tuple[bool, tuple[str, ...]]:
+    """Return whether diagrams are renderable and derived from current approved inputs."""
+
+    paths = DesignVisualizationPaths(uc_id)
+    problems: list[str] = []
+    _verify_diagram(
+        repo_root,
+        paths.class_diagram,
+        diagram_kind="class",
+        required_tokens=("```mermaid", "classDiagram"),
+        problems=problems,
+    )
+    _verify_diagram(
+        repo_root,
+        paths.flow_diagram,
+        diagram_kind="flow",
+        required_tokens=("```mermaid",),
+        problems=problems,
+    )
+
+    flow_path = repo_root / paths.flow_diagram
+    if flow_path.exists() and flow_path.is_file():
+        flow_text = flow_path.read_text(encoding="utf-8")
+        if not any(token in flow_text for token in ("flowchart", "sequenceDiagram", "stateDiagram")):
+            problems.append(
+                f"flow diagram has no supported Mermaid flow type: {paths.flow_diagram}"
+            )
+
+    metadata = _load_metadata(repo_root, paths.metadata, problems)
+    if metadata is not None:
+        _verify_metadata_identity(
+            metadata,
+            change_set_id=change_set_id,
+            uc_id=uc_id,
+            metadata_path=paths.metadata,
+            problems=problems,
+        )
+        _verify_source_hashes(
+            repo_root,
+            metadata,
+            source_documents=paths.source_documents,
+            metadata_path=paths.metadata,
+            problems=problems,
+        )
+
+    return not problems, tuple(problems)
+
+
+def _verify_diagram(
+    repo_root: Path,
+    path: Path,
+    *,
+    diagram_kind: str,
+    required_tokens: tuple[str, ...],
+    problems: list[str],
+) -> None:
+    absolute = repo_root / path
+    if not absolute.exists():
+        problems.append(f"missing {diagram_kind} diagram: {path}")
+        return
+    if not absolute.is_file():
+        problems.append(f"{diagram_kind} diagram is not a file: {path}")
+        return
+    text = absolute.read_text(encoding="utf-8").strip()
+    if not text:
+        problems.append(f"empty {diagram_kind} diagram: {path}")
+        return
+    for token in required_tokens:
+        if token not in text:
+            problems.append(
+                f"{diagram_kind} diagram missing required Mermaid token {token!r}: {path}"
+            )
+    for placeholder in ("TBD", "To be derived", "Needs confirmation"):
+        if placeholder in text:
+            problems.append(
+                f"unverified placeholder in {diagram_kind} diagram {path}: {placeholder}"
+            )
+
+
+def _load_metadata(
+    repo_root: Path,
+    path: Path,
+    problems: list[str],
+) -> dict[str, object] | None:
+    absolute = repo_root / path
+    if not absolute.exists():
+        problems.append(f"missing diagram metadata: {path}")
+        return None
+    try:
+        loaded = json.loads(absolute.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        problems.append(f"invalid diagram metadata {path}: {exc}")
+        return None
+    if not isinstance(loaded, dict):
+        problems.append(f"diagram metadata must be a JSON object: {path}")
+        return None
+    return loaded
+
+
+def _verify_metadata_identity(
+    metadata: dict[str, object],
+    *,
+    change_set_id: str,
+    uc_id: str,
+    metadata_path: Path,
+    problems: list[str],
+) -> None:
+    if metadata.get("status") != "verified":
+        problems.append(
+            f"diagram metadata status must be verified: {metadata_path}"
+        )
+    if metadata.get("uc_id") != uc_id:
+        problems.append(
+            f"diagram metadata UC does not match {uc_id}: {metadata_path}"
+        )
+    if metadata.get("change_set_id") != change_set_id:
+        problems.append(
+            f"diagram metadata ChangeSet does not match {change_set_id}: {metadata_path}"
+        )
+
+
+def _verify_source_hashes(
+    repo_root: Path,
+    metadata: dict[str, object],
+    *,
+    source_documents: tuple[Path, ...],
+    metadata_path: Path,
+    problems: list[str],
+) -> None:
+    recorded = metadata.get("source_documents")
+    if not isinstance(recorded, dict):
+        problems.append(f"diagram metadata source_documents must be an object: {metadata_path}")
+        return
+    for document in source_documents:
+        absolute = repo_root / document
+        if not absolute.exists():
+            problems.append(f"diagram source document is missing: {document}")
+            continue
+        expected = f"sha256:{_sha256(absolute)}"
+        actual = recorded.get(str(document))
+        if actual != expected:
+            problems.append(
+                f"stale diagram source hash for {document}: regenerate design-visualization"
+            )
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/harness_codex/runtime/procedure_stages.py
+++ b/harness_codex/runtime/procedure_stages.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from harness_codex.runtime.completion import PlanCompletionBlocked, validate_plan_completion
+from harness_codex.runtime.design_visualization import verify_design_visualization
 
 
 @dataclass(frozen=True)
@@ -32,6 +33,7 @@ README_STAGE_IDS = (
     "event-storming",
     "ddd-architecture-definition",
     "technical-decisions",
+    "design-visualization",
     "plan-writing",
     "implementation",
 )
@@ -118,6 +120,28 @@ PROCEDURE_STAGES: tuple[ProcedureStage, ...] = (
         requires_uc=True,
     ),
     ProcedureStage(
+        stage_id="design-visualization",
+        display_name="Design Visualization",
+        agent_id="design_visualization",
+        skill_id="harness-design-visualization",
+        inputs=(
+            Path("docs/changes/active/<CHG-ID>.md"),
+            Path("context.md"),
+            Path("docs/use-cases/<UC-ID>/use-case.md"),
+            Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
+            Path("docs/use-cases/<UC-ID>/event-storming.md"),
+            Path("docs/use-cases/<UC-ID>/ddd-design.md"),
+            Path("docs/use-cases/<UC-ID>/technical-decisions.md"),
+            Path("ARCHITECTURE.md"),
+        ),
+        outputs=(
+            Path("docs/use-cases/<UC-ID>/class-diagram.md"),
+            Path("docs/use-cases/<UC-ID>/flow-diagram.md"),
+            Path("docs/use-cases/<UC-ID>/diagram-metadata.json"),
+        ),
+        requires_uc=True,
+    ),
+    ProcedureStage(
         stage_id="plan-writing",
         display_name="plan.md Writing",
         agent_id="implementation_planner",
@@ -128,6 +152,9 @@ PROCEDURE_STAGES: tuple[ProcedureStage, ...] = (
             Path("docs/use-cases/<UC-ID>/event-storming.md"),
             Path("docs/use-cases/<UC-ID>/ddd-design.md"),
             Path("docs/use-cases/<UC-ID>/technical-decisions.md"),
+            Path("docs/use-cases/<UC-ID>/class-diagram.md"),
+            Path("docs/use-cases/<UC-ID>/flow-diagram.md"),
+            Path("docs/use-cases/<UC-ID>/diagram-metadata.json"),
             Path("docs/use-cases/<UC-ID>/e2e-goal.md"),
             Path("ARCHITECTURE.md"),
             Path(".codex/repository-settings.md"),
@@ -222,6 +249,13 @@ def verify_procedure_stage(
         if not report.get("url"):
             return False, ("pull request report does not record a PR URL",)
         return True, ()
+
+    if stage.stage_id == "design-visualization":
+        return verify_design_visualization(
+            repo_root,
+            change_set_id=change_set_id,
+            uc_id=uc_id or "",
+        )
 
     problems: list[str] = []
     outputs = stage_outputs_for_run(

--- a/tests/runtime/test_affected_use_case_resolver.py
+++ b/tests/runtime/test_affected_use_case_resolver.py
@@ -1,3 +1,5 @@
+import json
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
@@ -16,6 +18,48 @@ def write_changeset(tmp_path: Path, body: str) -> Path:
     path = active_dir / "CHG-001.md"
     path.write_text(body, encoding="utf-8")
     return path
+
+
+def write_verified_design_visualization(tmp_path: Path, slice_dir: Path, uc_id: str) -> None:
+    context_path = tmp_path / "context.md"
+    architecture_path = tmp_path / "ARCHITECTURE.md"
+    context_path.write_text("# context\n", encoding="utf-8")
+    architecture_path.write_text("# architecture\n", encoding="utf-8")
+    (slice_dir / "class-diagram.md").write_text(
+        "# Class Diagram\n\n```mermaid\nclassDiagram\n    class Payment\n```\n",
+        encoding="utf-8",
+    )
+    (slice_dir / "flow-diagram.md").write_text(
+        "# Flow Diagram\n\n```mermaid\nflowchart TD\n    A[Request] --> B[Payment]\n```\n",
+        encoding="utf-8",
+    )
+    source_paths = (
+        slice_dir / "use-case.md",
+        slice_dir / "e2e-goal.md",
+        slice_dir / "event-storming.md",
+        slice_dir / "ddd-design.md",
+        slice_dir / "technical-decisions.md",
+        context_path,
+        architecture_path,
+    )
+    source_documents = {
+        str(path.relative_to(tmp_path)): f"sha256:{sha256(path.read_bytes()).hexdigest()}"
+        for path in source_paths
+    }
+    (slice_dir / "diagram-metadata.json").write_text(
+        json.dumps(
+            {
+                "change_set_id": "CHG-001",
+                "uc_id": uc_id,
+                "status": "verified",
+                "source_documents": source_documents,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def write_use_case_slice(
@@ -63,6 +107,7 @@ def write_use_case_slice(
             f"{pending_decisions}\n",
             encoding="utf-8",
         )
+        write_verified_design_visualization(tmp_path, slice_dir, uc_id)
 
 
 CHANGESET = """# ChangeSet CHG-001
@@ -161,6 +206,8 @@ def test_resolver_builds_per_use_case_planning_scope(tmp_path: Path) -> None:
     assert Path("docs/use-cases/UC-001/e2e-goal.md") in scope.planner_inputs
     assert Path("docs/use-cases/UC-001/ddd-design.md") in scope.planner_inputs
     assert Path("docs/use-cases/UC-001/technical-decisions.md") in scope.planner_inputs
+    assert Path("docs/use-cases/UC-001/class-diagram.md") in scope.planner_inputs
+    assert Path("docs/use-cases/UC-001/flow-diagram.md") in scope.planner_inputs
     assert Path("docs/plans/active/UC-001/plan.md") in scope.executor_inputs
     assert scope.e2e_goal_path == Path("docs/use-cases/UC-001/e2e-goal.md")
 
@@ -331,6 +378,19 @@ def test_resolver_allows_approved_e2e_goal(tmp_path: Path) -> None:
 
     assert not isinstance(scopes, PlanningBlocked)
     assert scopes[0].display_id == "UC-001"
+
+
+def test_resolver_blocks_stale_design_visualization_before_planning(tmp_path: Path) -> None:
+    path = write_changeset(tmp_path, CHANGESET)
+    write_use_case_slice(tmp_path, approval_status="approved")
+    (tmp_path / "context.md").write_text("# changed context\n", encoding="utf-8")
+    resolver = ChangeSetResolver(tmp_path)
+
+    result = resolver.resolve_planning_scopes(resolver.load(path))
+
+    assert isinstance(result, PlanningBlocked)
+    assert "invalid or stale design visualization" in result.reason
+    assert "stale diagram source hash for context.md" in result.reason
 
 
 def test_resolver_builds_maintenance_planning_scope(tmp_path: Path) -> None:

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -1,3 +1,4 @@
+from hashlib import sha256
 from pathlib import Path
 
 from harness_codex.runtime.procedure_stages import (
@@ -16,17 +17,24 @@ def test_procedure_registry_keeps_readme_stages_public_and_delivery_internal() -
     assert stage_ids[: len(README_STAGE_IDS)] == README_STAGE_IDS
     assert stage_ids[-1] == "change-set-pr"
     assert procedure_stage("change-set-pr").skill_id is None
+    assert stage_ids.index("technical-decisions") < stage_ids.index("design-visualization")
+    assert stage_ids.index("design-visualization") < stage_ids.index("plan-writing")
 
 
 def test_requirements_language_and_use_case_contracts_remain_ordered() -> None:
     requirements = procedure_stage("requirements-definition")
     language = procedure_stage("ubiquitous-language-definition")
     use_cases = procedure_stage("use-case-definition")
+    diagrams = procedure_stage("design-visualization")
+    plan_writing = procedure_stage("plan-writing")
 
     assert requirements.agent_id == "requirements_interviewer"
     assert language.agent_id == "ubiquitous_language_reviewer"
     assert language.outputs == (Path("context.md"),)
     assert Path("context.md") in use_cases.inputs
+    assert diagrams.requires_uc
+    assert Path("docs/use-cases/<UC-ID>/class-diagram.md") in plan_writing.inputs
+    assert Path("docs/use-cases/<UC-ID>/flow-diagram.md") in plan_writing.inputs
 
     rendered = render_initial_changeset(
         change_set_id="CHG-001",
@@ -54,6 +62,62 @@ def test_stage_verifier_rejects_placeholder_content(tmp_path: Path) -> None:
     assert problems == (
         "unverified placeholder in docs/use-cases/UC-001/event-storming.md: has not been derived yet",
     )
+
+
+def test_design_visualization_verifier_rejects_stale_source_hash(tmp_path: Path) -> None:
+    uc_id = "UC-001"
+    change_set_id = "CHG-20260624-001"
+    slice_path = tmp_path / "docs/use-cases" / uc_id
+    slice_path.mkdir(parents=True)
+    source_paths = (
+        slice_path / "use-case.md",
+        slice_path / "e2e-goal.md",
+        slice_path / "event-storming.md",
+        slice_path / "ddd-design.md",
+        slice_path / "technical-decisions.md",
+        tmp_path / "context.md",
+        tmp_path / "ARCHITECTURE.md",
+    )
+    for source_path in source_paths:
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(f"# {source_path.name}\n", encoding="utf-8")
+
+    (slice_path / "class-diagram.md").write_text(
+        "# Class\n\n```mermaid\nclassDiagram\n    class Order\n```\n",
+        encoding="utf-8",
+    )
+    (slice_path / "flow-diagram.md").write_text(
+        "# Flow\n\n```mermaid\nflowchart TD\n    A --> B\n```\n",
+        encoding="utf-8",
+    )
+    source_documents = {
+        str(path.relative_to(tmp_path)): f"sha256:{sha256(path.read_bytes()).hexdigest()}"
+        for path in source_paths
+    }
+    source_documents["context.md"] = "sha256:stale"
+    (slice_path / "diagram-metadata.json").write_text(
+        "{\n"
+        f'  "change_set_id": "{change_set_id}",\n'
+        f'  "uc_id": "{uc_id}",\n'
+        '  "status": "verified",\n'
+        '  "source_documents": {\n'
+        + ",\n".join(
+            f'    "{path}": "{digest}"'
+            for path, digest in source_documents.items()
+        )
+        + "\n  }\n}\n",
+        encoding="utf-8",
+    )
+
+    passed, problems = verify_procedure_stage(
+        tmp_path,
+        procedure_stage("design-visualization"),
+        change_set_id=change_set_id,
+        uc_id=uc_id,
+    )
+
+    assert not passed
+    assert "stale diagram source hash for context.md" in problems
 
 
 def test_implementation_verifier_rejects_remaining_active_plan(tmp_path: Path) -> None:
@@ -90,4 +154,5 @@ def test_stage_status_is_durable_and_keeps_readme_order() -> None:
     )
 
     assert "|technical-decisions|Technical Decisions|blocked|" in updated
-    assert updated.index("|technical-decisions|") < updated.index("|plan-writing|")
+    assert updated.index("|technical-decisions|") < updated.index("|design-visualization|")
+    assert updated.index("|design-visualization|") < updated.index("|plan-writing|")

--- a/tests/runtime/test_procedure_stage_runtime.py
+++ b/tests/runtime/test_procedure_stage_runtime.py
@@ -117,7 +117,7 @@ def test_design_visualization_verifier_rejects_stale_source_hash(tmp_path: Path)
     )
 
     assert not passed
-    assert "stale diagram source hash for context.md" in problems
+    assert any("stale diagram source hash for context.md" in problem for problem in problems)
 
 
 def test_implementation_verifier_rejects_remaining_active_plan(tmp_path: Path) -> None:


### PR DESCRIPTION
## 목적

기술 의사결정이 승인된 뒤 계획 작성으로 곧바로 넘어가던 설계 흐름에 `design-visualization` 단계를 추가합니다. 이 단계는 설계의 새로운 정본을 만들지 않고, 승인된 유스케이스 설계를 클래스 다이어그램과 플로우 다이어그램으로 고정해 계획·구현 단계에서 빠르게 참조할 수 있게 합니다.

## 변경 사항

### 1. 공개 procedure stage 추가

`technical-decisions`와 `plan-writing` 사이에 UC 단위 `design-visualization` stage를 등록했습니다.

- Agent: `design_visualization`
- Skill: `harness-design-visualization`
- 입력: ChangeSet, 용어 문맥, UC/E2E 목표, 이벤트 스토밍, DDD 설계, 승인된 기술 결정, 아키텍처 문서
- 출력:
  - `docs/use-cases/<UC-ID>/class-diagram.md`
  - `docs/use-cases/<UC-ID>/flow-diagram.md`
  - `docs/use-cases/<UC-ID>/diagram-metadata.json`

`plan-writing`은 세 산출물을 입력으로 받도록 변경했습니다. registry 기반 parser와 ChangeSet procedure table에도 새 단계가 포함됩니다.

### 2. 검증 및 stale 차단

새 `design_visualization` runtime verifier가 다음을 확인합니다.

- class diagram: Mermaid code fence와 `classDiagram`
- flow diagram: Mermaid code fence와 `flowchart`/`sequenceDiagram`/`stateDiagram`
- 미확정 표현: `TBD`, `To be derived`, `Needs confirmation` 거부
- metadata identity: ChangeSet ID, UC ID, `status: verified`
- freshness: 모든 설계 입력 문서의 SHA-256이 metadata와 일치하는지 검증

`ChangeSetResolver`도 같은 검증을 실행합니다. 따라서 상위 설계가 변경된 뒤 다이어그램을 갱신하지 않으면 planning/implementation 진입이 차단됩니다. maintenance work item에는 적용하지 않습니다.

### 3. Agent·skill 계약

새 agent와 skill은 다음 원칙을 명시합니다.

- 승인된 설계를 시각화할 뿐, aggregate 경계·기술 결정·사용자 정책을 새로 결정하지 않는다.
- 클래스 다이어그램에는 aggregate/entity/value object/domain service/port-adapter 경계를 표현한다.
- 플로우 다이어그램에는 actor, 정상·예외 흐름, 상태 변경, 이벤트·비동기 경계, 외부 시스템, 관측 결과를 표현한다.
- 메타데이터는 현재 입력 문서의 해시를 기록한다.

### 4. 문서와 회귀 테스트

- README workflow, 실행 예시, stage 산출물 표를 업데이트했습니다.
- Active Agents/Skills 카탈로그를 registry와 맞췄습니다.
- `tests/runtime/test_procedure_stage_runtime.py`
  - `technical-decisions → design-visualization → plan-writing` 순서
  - plan-writing input에 class/flow/meta 산출물 포함
  - stale `context.md` 해시가 stage verifier에서 차단되는지
- `tests/runtime/test_affected_use_case_resolver.py`
  - 기존 성공 fixture가 verified diagrams와 source hashes를 생성하도록 갱신
  - stale diagram metadata가 planner resolver에서 차단되는지
  - 승인·미승인 E2E/technical-decision 차단 계약을 유지하는지

## 검증 상태

- 정적 diff 검토 완료: registry 순서, procedure verifier, resolver preflight, planner/executor 입력, agent/skill ID, 문서 카탈로그 일관성을 확인했습니다.
- 로컬 pytest는 실행하지 못했습니다. 이 실행 환경에서는 원격 저장소 clone이 DNS 해석 실패로 불가능했습니다.
- GitHub Actions `Runtime document contracts` 실행이 PR head 기준으로 시작된 상태입니다.

## 영향 및 롤백

- UC work item은 승인 기술 결정 뒤 verified 다이어그램 없이는 planning/implementation으로 진행할 수 없습니다.
- 상위 설계 문서가 바뀌면 해시 불일치로 다이어그램이 stale 처리되며, 재생성 전까지 downstream을 차단합니다.
- 문제 발생 시 `design-visualization` stage와 resolver의 diagram validation을 되돌리면 기존 흐름으로 복구됩니다.
