### PR TITLE
fix(ui): 접힌 워크플로우 패널에서도 Continue 액션 유지

### DIFF
--- a/harness_codex/runtime/dashboard_assets/dashboard.html
+++ b/harness_codex/runtime/dashboard_assets/dashboard.html
@@ -134,5 +134,54 @@
       })();
     </script>
     <script type="module" src="/assets/dashboard.js"></script>
+    <script>
+      (() => {
+        const actionClass = "grill-panel-collapsed-action";
+        const placeholderClass = "grill-panel-collapsed-action-placeholder";
+        const actionSelector = ".grill-panel-body .next-stage";
+        const style = document.createElement("style");
+        style.textContent = `
+          .grill-panel-collapsed-action { display: none; }
+          .grill-panel.collapsed .grill-panel-collapsed-action {
+            display: block;
+            margin-top: 12px;
+          }
+        `;
+        document.head.append(style);
+
+        function moveCollapsedContinueActions() {
+          document.querySelectorAll(".grill-panel").forEach((panel) => {
+            const body = panel.querySelector(".grill-panel-body");
+            const container = panel.querySelector(`.${actionClass}`);
+            const movedAction = container?.querySelector(".next-stage");
+            const placeholder = body?.querySelector(`.${placeholderClass}`);
+
+            if (!body) return;
+            if (!panel.classList.contains("collapsed")) {
+              if (movedAction && placeholder) placeholder.replaceWith(movedAction);
+              container?.remove();
+              return;
+            }
+
+            const nextAction = movedAction || body.querySelector(actionSelector);
+            if (!nextAction || movedAction) return;
+
+            const marker = document.createElement("span");
+            marker.className = placeholderClass;
+            nextAction.before(marker);
+            const actionContainer = container || document.createElement("div");
+            actionContainer.className = actionClass;
+            if (!container) panel.querySelector(".grill-panel-header")?.after(actionContainer);
+            actionContainer.append(nextAction);
+          });
+        }
+
+        new MutationObserver(moveCollapsedContinueActions).observe(document.body, {
+          childList: true,
+          subtree: true,
+        });
+        moveCollapsedContinueActions();
+      })();
+    </script>
   </body>
 </html>

--- a/tests/runtime/test_dashboard_collapsed_continue_action.py
+++ b/tests/runtime/test_dashboard_collapsed_continue_action.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+DASHBOARD_HTML = (
+    Path(__file__).resolve().parents[2]
+    / "harness_codex/runtime/dashboard_assets/dashboard.html"
+)
+
+
+def test_collapsed_workflow_panel_moves_and_restores_the_original_next_stage_action() -> None:
+    page = DASHBOARD_HTML.read_text(encoding="utf-8")
+
+    assert 'const actionClass = "grill-panel-collapsed-action";' in page
+    assert 'const placeholderClass = "grill-panel-collapsed-action-placeholder";' in page
+    assert 'const actionSelector = ".grill-panel-body .next-stage";' in page
+    assert "nextAction.before(marker);" in page
+    assert "actionContainer.append(nextAction);" in page
+    assert "placeholder.replaceWith(movedAction);" in page
+    assert "cloneNode" not in page
+    assert "outerHTML" not in page


### PR DESCRIPTION
## 개요

ChangeSet 워크플로우 화면에서 grill panel을 접으면 다음 단계로 진행하는 `Continue` 액션도 함께 숨겨져, 사용자가 패널을 다시 펼치기 전에는 진행할 수 없는 문제를 해결합니다.

이 PR은 현재 `main` 기준으로 브랜치를 다시 구성했습니다. 오래된 커밋을 포함하지 않으며, `main` 대비 `behind 0` 상태입니다.

## 변경 사항

- 접힌 `.grill-panel`에서 `.next-stage` 버튼을 헤더 아래의 전용 컨테이너로 이동합니다.
- 패널을 다시 펼치면 placeholder 위치로 같은 버튼 노드를 원복합니다.
- 버튼을 복제하거나 HTML 문자열로 새로 만들지 않습니다.
  - 기존 클릭 이벤트 핸들러가 그대로 유지됩니다.
  - 런타임 진행 중 disabled 상태가 그대로 유지됩니다.
  - UI가 별도 액션이나 별도 gate 상태를 만들지 않습니다.

## Gate 정본화와의 관계

#426에서 UI, CLI, 런타임이 동일한 canonical `RunState`와 gate 결과를 사용하도록 통합한 변경은 이미 `main`에 반영되어 있습니다.

이 PR은 해당 정본 상태를 우회하거나 새 상태를 만들지 않습니다. 접힌 상태에서 보이는 버튼도 기존 `.next-stage` 원본 노드 하나이므로, 같은 런타임 핸들러와 canonical gate 결과를 그대로 사용합니다.

## 테스트

추가한 회귀 테스트:

- `tests/runtime/test_dashboard_collapsed_continue_action.py`
  - 접힘 시 원본 버튼을 이동하는지 확인
  - 펼침 시 원래 위치로 복원하는지 확인
  - `cloneNode` 및 `outerHTML` 기반 재생성을 사용하지 않는지 확인

기존 gate 정본화 테스트:

- `tests/runtime/test_dashboard_runtime_state.py`
  - Dashboard 진행 상태가 canonical `RunState`로 저장되는지 확인
  - ChangeSet 절차 표가 canonical 상태로 동기화되는지 확인
  - UI-local flag만으로 verified 단계가 표시되지 않는지 확인
  - canonical `RunState` 없이 Plan Writing gate를 통과할 수 없는지 확인

## 검증 상태

- PR 브랜치: 현재 `main` 기준 `behind 0`
- PR 변경: dashboard HTML 1건, 회귀 테스트 1건
- PR 워크플로우 실행 결과는 갱신 시점에 아직 보고되지 않았습니다.