### PR TITLE
fix: ChangeSet UI와 런타임 상태 정본 통합 (#426)

### DIFF
--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -133,6 +133,10 @@ from harness_codex.runtime.state import (
     stage_artifact_notes,
     stage_artifact_status,
 )
+from harness_codex.runtime.dashboard_runtime_state import apply_dashboard_runtime_state_patch
+
+apply_dashboard_runtime_state_patch()
+
 from harness_codex.runtime.verifier import (
     CommandCheck,
     RequiredStageCheck,

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -134,8 +134,12 @@ from harness_codex.runtime.state import (
     stage_artifact_status,
 )
 from harness_codex.runtime.dashboard_runtime_state import apply_dashboard_runtime_state_patch
+from harness_codex.runtime.dashboard_runtime_state_legacy_bridge import (
+    apply_dashboard_runtime_state_legacy_bridge,
+)
 
 apply_dashboard_runtime_state_patch()
+apply_dashboard_runtime_state_legacy_bridge()
 
 from harness_codex.runtime.verifier import (
     CommandCheck,

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -137,9 +137,13 @@ from harness_codex.runtime.dashboard_runtime_state import apply_dashboard_runtim
 from harness_codex.runtime.dashboard_runtime_state_legacy_bridge import (
     apply_dashboard_runtime_state_legacy_bridge,
 )
+from harness_codex.runtime.dashboard_runtime_state_legacy_compat import (
+    apply_dashboard_runtime_state_legacy_compat,
+)
 
 apply_dashboard_runtime_state_patch()
 apply_dashboard_runtime_state_legacy_bridge()
+apply_dashboard_runtime_state_legacy_compat()
 
 from harness_codex.runtime.verifier import (
     CommandCheck,

--- a/harness_codex/runtime/dashboard_runtime_state.py
+++ b/harness_codex/runtime/dashboard_runtime_state.py
@@ -1,0 +1,399 @@
+"""Canonical ChangeSet runtime state for dashboard-driven design stages.
+
+The browser dashboard used to keep an independent harvest session under
+``.harness/ui/change-sets``.  That was useful for resuming questions, but it
+must not be the source of truth for procedure gates.  This module projects
+completed dashboard stages into one deterministic ``RunState`` per active
+ChangeSet, mirrors that state back to the ChangeSet table, and prevents local
+UI state from unlocking planning or implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from harness_codex.runtime.changes.models import WorkItemType
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.models import RunMode, RunStatus
+from harness_codex.runtime.procedure_stages import (
+    PROCEDURE_STAGES,
+    parse_procedure_stage_rows,
+    update_changeset_stage_status,
+)
+from harness_codex.runtime.state import (
+    ArtifactDirtyState,
+    RunState,
+    RunStateStore,
+    StageArtifactState,
+    runtime_stage_projection,
+)
+
+_CANONICAL_RUN_PREFIX = "changeset-state-"
+_PATCHED_ATTR = "_harness_dashboard_runtime_state_patch_applied"
+_ORIGINAL_SAVE_ATTR = "_harness_dashboard_runtime_state_original_save"
+
+
+def canonical_run_id(change_set_id: str) -> str:
+    """Return the deterministic RunState id for one ChangeSet."""
+
+    return _CANONICAL_RUN_PREFIX + re.sub(r"[^A-Za-z0-9_.-]+", "-", change_set_id)
+
+
+def load_canonical_change_set_state(
+    repo_root: Path | str, change_set_id: str
+) -> RunState | None:
+    """Load the authoritative dashboard/CLI projection for one ChangeSet."""
+
+    store = RunStateStore(repo_root)
+    try:
+        return store.load(canonical_run_id(change_set_id))
+    except (FileNotFoundError, KeyError, TypeError, ValueError):
+        return None
+
+
+def sync_change_set_runtime_state(
+    repo_root: Path | str,
+    change_set_id: str,
+    session: dict[str, Any],
+) -> RunState:
+    """Persist dashboard-complete stages as accepted canonical artifacts.
+
+    A false or absent dashboard flag never downgrades a previously accepted
+    runtime artifact.  Invalidations are handled by the owner that changed the
+    upstream artifact; this function only records positive, validated UI
+    progress.
+    """
+
+    root = Path(repo_root)
+    change_path = _active_change_set_path(root, change_set_id)
+    if change_path is None:
+        raise ValueError(f"Active ChangeSet does not exist: {change_set_id}.")
+
+    affected_use_cases, affected_work_items = _affected_work_items(change_path)
+    current = load_canonical_change_set_state(root, change_set_id)
+    dashboard_artifacts = _dashboard_stage_artifacts(
+        root,
+        session,
+        affected_use_cases,
+    )
+    state = _build_canonical_state(
+        change_set_id=change_set_id,
+        affected_use_cases=affected_use_cases,
+        affected_work_items=affected_work_items,
+        current=current,
+        artifacts=dashboard_artifacts,
+    )
+    RunStateStore(root).save(state)
+    reconcile_change_set_procedure_table(root, state)
+    return state
+
+
+def reconcile_change_set_procedure_table(repo_root: Path | str, state: RunState) -> None:
+    """Make the ChangeSet's user-facing procedure table a mirror of RunState."""
+
+    root = Path(repo_root)
+    change_path = _active_change_set_path(root, state.change_set_id)
+    if change_path is None:
+        return
+
+    text = change_path.read_text(encoding="utf-8")
+    rows = {row["id"]: row for row in parse_procedure_stage_rows(text)}
+    runtime_rows = runtime_stage_projection(state)
+    changed = False
+    for stage in PROCEDURE_STAGES:
+        runtime = runtime_rows.get(stage.stage_id)
+        desired_status = runtime["status"] if runtime else "pending"
+        desired_notes = runtime["notes"] if runtime else "-"
+        row = rows.get(stage.stage_id)
+        if row and row.get("status") == desired_status and row.get("notes") == desired_notes:
+            continue
+        text = update_changeset_stage_status(
+            text,
+            stage=stage,
+            status=desired_status,
+            notes=desired_notes,
+        )
+        changed = True
+    if changed:
+        change_path.write_text(text, encoding="utf-8")
+
+
+def assert_canonical_stage_gate(
+    repo_root: Path | str,
+    change_set_id: str,
+    target_stage_id: str,
+) -> None:
+    """Reject a downstream action until all earlier canonical stages verify."""
+
+    state = load_canonical_change_set_state(repo_root, change_set_id)
+    if state is None:
+        raise ValueError(
+            f"{target_stage_id} is blocked: canonical RunState is missing for {change_set_id}."
+        )
+    runtime_rows = runtime_stage_projection(state)
+    stage_ids = [stage.stage_id for stage in PROCEDURE_STAGES]
+    try:
+        target_index = stage_ids.index(target_stage_id)
+    except ValueError as exc:
+        raise ValueError(f"unknown procedure stage: {target_stage_id}") from exc
+
+    incomplete = [
+        stage_id
+        for stage_id in stage_ids[:target_index]
+        if runtime_rows.get(stage_id, {}).get("status") != "verified"
+    ]
+    if incomplete:
+        raise ValueError(
+            f"{target_stage_id} is blocked: canonical runtime gates incomplete: "
+            + ", ".join(incomplete)
+        )
+
+
+def apply_dashboard_runtime_state_patch() -> None:
+    """Install compatibility hooks without changing public UI/CLI commands."""
+
+    if getattr(RunStateStore, _PATCHED_ATTR, False):
+        return
+
+    original_save = RunStateStore.save
+    setattr(RunStateStore, _ORIGINAL_SAVE_ATTR, original_save)
+
+    def save_with_canonical_projection(self: RunStateStore, state: RunState) -> Path:
+        path = original_save(self, state)
+        if state.run_id == canonical_run_id(state.change_set_id):
+            return path
+        if _active_change_set_path(self.repo_root, state.change_set_id) is None:
+            return path
+        _merge_runtime_state_into_canonical(self.repo_root, state)
+        return path
+
+    RunStateStore.save = save_with_canonical_projection  # type: ignore[method-assign]
+    setattr(RunStateStore, _PATCHED_ATTR, True)
+
+    # Imports are delayed until RunState and procedure-stage modules are fully
+    # initialized.  ui_server keeps direct function references, so patch both
+    # the originating module and those references.
+    from harness_codex.runtime import document_dashboard, harvest_ui, ui_server
+
+    original_snapshot = harvest_ui.save_changeset_harvest_ui
+
+    def save_changeset_harvest_ui_with_runtime_state(
+        root: Path | str, change_set_id: str
+    ) -> None:
+        original_snapshot(root, change_set_id)
+        root_path = Path(root)
+        session = harvest_ui._load_session(root_path)
+        if session is not None:
+            sync_change_set_runtime_state(root_path, change_set_id, session)
+
+    harvest_ui.save_changeset_harvest_ui = save_changeset_harvest_ui_with_runtime_state
+    ui_server.save_changeset_harvest_ui = save_changeset_harvest_ui_with_runtime_state
+
+    original_projection = document_dashboard._project_workflow_stages
+
+    def project_only_canonical_runtime_state(stages, _workflow_state, run_state=None):
+        # Scoped UI state remains available for question/resume UI, but cannot
+        # synthesize verified procedure rows.  Only RunState may do that.
+        return original_projection(stages, None, run_state)
+
+    document_dashboard._project_workflow_stages = project_only_canonical_runtime_state
+
+    original_start_plan = ui_server.start_plan_writing_changeset
+
+    def start_plan_writing_with_canonical_gate(root, change_set_id, uc_id):
+        assert_canonical_stage_gate(root, change_set_id, "plan-writing")
+        return original_start_plan(root, change_set_id, uc_id)
+
+    ui_server.start_plan_writing_changeset = start_plan_writing_with_canonical_gate
+
+    original_start_implementation = ui_server.start_implementation_changeset
+
+    def start_implementation_with_canonical_gate(root, change_set_id, *, force_verification=False):
+        assert_canonical_stage_gate(root, change_set_id, "implementation")
+        return original_start_implementation(
+            root,
+            change_set_id,
+            force_verification=force_verification,
+        )
+
+    ui_server.start_implementation_changeset = start_implementation_with_canonical_gate
+
+
+def _merge_runtime_state_into_canonical(repo_root: Path, incoming: RunState) -> None:
+    current = load_canonical_change_set_state(repo_root, incoming.change_set_id)
+    state = _build_canonical_state(
+        change_set_id=incoming.change_set_id,
+        affected_use_cases=_merge_ids(
+            current.affected_use_cases if current else (), incoming.affected_use_cases
+        ),
+        affected_work_items=_merge_ids(
+            current.affected_work_items if current else (), incoming.affected_work_items
+        ),
+        current=current,
+        artifacts={item.stage: item for item in incoming.artifact_states},
+        incoming=incoming,
+    )
+    RunStateStore(repo_root).save(state)
+    reconcile_change_set_procedure_table(repo_root, state)
+
+
+def _build_canonical_state(
+    *,
+    change_set_id: str,
+    affected_use_cases: tuple[str, ...],
+    affected_work_items: tuple[str, ...],
+    current: RunState | None,
+    artifacts: dict[str, StageArtifactState],
+    incoming: RunState | None = None,
+) -> RunState:
+    existing_artifacts = {item.stage: item for item in current.artifact_states} if current else {}
+    existing_artifacts.update(artifacts)
+    ordered_artifacts = _ordered_artifacts(existing_artifacts)
+    source = incoming or current
+    if source is None:
+        return RunState(
+            run_id=canonical_run_id(change_set_id),
+            change_set_id=change_set_id,
+            workflow_name="changeset-runtime-state",
+            mode=RunMode.APPLY,
+            affected_use_cases=affected_use_cases,
+            affected_work_items=affected_work_items,
+            status=RunStatus.PENDING,
+            artifact_states=ordered_artifacts,
+        )
+    return RunState(
+        run_id=canonical_run_id(change_set_id),
+        change_set_id=change_set_id,
+        workflow_name="changeset-runtime-state",
+        mode=RunMode.APPLY,
+        affected_use_cases=affected_use_cases,
+        affected_work_items=affected_work_items,
+        current_use_case_id=source.current_use_case_id,
+        current_work_item_id=source.current_work_item_id,
+        current_step_id=source.current_step_id,
+        completed_use_cases=_merge_ids(
+            current.completed_use_cases if current else (), source.completed_use_cases
+        ),
+        completed_work_items=_merge_ids(
+            current.completed_work_items if current else (), source.completed_work_items
+        ),
+        blocked_use_cases=_merge_ids(
+            current.blocked_use_cases if current else (), source.blocked_use_cases
+        ),
+        blocked_work_items=_merge_ids(
+            current.blocked_work_items if current else (), source.blocked_work_items
+        ),
+        failed_step_id=source.failed_step_id,
+        failure_kind=source.failure_kind,
+        status=source.status,
+        decision_results=source.decision_results,
+        use_case_states=source.use_case_states or (current.use_case_states if current else ()),
+        work_item_states=source.work_item_states or (current.work_item_states if current else ()),
+        artifact_states=ordered_artifacts,
+    )
+
+
+def _dashboard_stage_artifacts(
+    root: Path,
+    session: dict[str, Any],
+    affected_use_cases: tuple[str, ...],
+) -> dict[str, StageArtifactState]:
+    artifacts: dict[str, StageArtifactState] = {}
+    if session.get("requirements_gate_passed"):
+        _add_artifact(artifacts, "requirements-definition", root, [Path("docs/design/요구사항.md")])
+    if session.get("language_gate_passed"):
+        _add_artifact(artifacts, "ubiquitous-language-definition", root, [Path("context.md")])
+    if session.get("use_cases_ready"):
+        paths = [Path("docs/design/유스케이스.md")]
+        for uc_id in affected_use_cases:
+            paths.extend(
+                [
+                    Path("docs/use-cases") / uc_id / "use-case.md",
+                    Path("docs/use-cases") / uc_id / "e2e-goal.md",
+                ]
+            )
+        _add_artifact(artifacts, "use-case-definition", root, paths)
+
+    event_state = session.get("event_storming")
+    if isinstance(event_state, dict) and event_state.get("complete"):
+        uc_ids = tuple(str(item) for item in event_state.get("uc_ids", ()) if str(item))
+        _add_artifact(
+            artifacts,
+            "event-storming",
+            root,
+            [Path("docs/use-cases") / uc_id / "event-storming.md" for uc_id in uc_ids],
+        )
+
+    ddd_state = session.get("ddd_architecture")
+    if isinstance(ddd_state, dict) and ddd_state.get("complete"):
+        uc_ids = tuple(str(item) for item in ddd_state.get("uc_ids", ()) if str(item))
+        paths = [Path("docs/use-cases") / uc_id / "ddd-design.md" for uc_id in uc_ids]
+        paths.append(Path("ARCHITECTURE.md"))
+        _add_artifact(artifacts, "ddd-architecture-definition", root, paths)
+    return artifacts
+
+
+def _add_artifact(
+    artifacts: dict[str, StageArtifactState],
+    stage: str,
+    root: Path,
+    paths: list[Path],
+) -> None:
+    if not paths or any(not _nonempty_file(root / path) for path in paths):
+        return
+    artifacts[stage] = StageArtifactState(
+        stage=stage,
+        path=paths[0],
+        checksum=_combined_checksum(root, paths),
+        revision=1,
+        generated_by="dashboard",
+        accepted=True,
+        dirty_state=ArtifactDirtyState.CLEAN,
+        downstream_status=ArtifactDirtyState.CLEAN,
+    )
+
+
+def _combined_checksum(root: Path, paths: list[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(str(path).encode("utf-8"))
+        digest.update((root / path).read_bytes())
+    return digest.hexdigest()
+
+
+def _nonempty_file(path: Path) -> bool:
+    try:
+        return path.is_file() and bool(path.read_text(encoding="utf-8").strip())
+    except OSError:
+        return False
+
+
+def _ordered_artifacts(by_stage: dict[str, StageArtifactState]) -> tuple[StageArtifactState, ...]:
+    order = {stage.stage_id: index for index, stage in enumerate(PROCEDURE_STAGES)}
+    return tuple(sorted(by_stage.values(), key=lambda item: (order.get(item.stage, len(order)), item.stage)))
+
+
+def _affected_work_items(change_path: Path) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    change_set = parse_changeset_markdown(change_path.read_text(encoding="utf-8"), path=change_path)
+    work_items = tuple(item.work_item_id for item in change_set.ordered_work_items())
+    use_cases = tuple(
+        item.work_item_id
+        for item in change_set.ordered_work_items()
+        if item.work_item_type is WorkItemType.USE_CASE
+    )
+    return use_cases, work_items
+
+
+def _active_change_set_path(root: Path, change_set_id: str) -> Path | None:
+    if not re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id):
+        return None
+    path = root / "docs/changes/active" / f"{change_set_id}.md"
+    return path if path.exists() else None
+
+
+def _merge_ids(left: tuple[str, ...], right: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys((*left, *right)))

--- a/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
+++ b/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
@@ -17,7 +17,7 @@ def apply_dashboard_runtime_state_legacy_bridge() -> None:
     """Promote validated legacy table rows before UI/CLI consumers need them."""
 
     from harness_codex.runtime import dashboard_runtime_state as canonical
-    from harness_codex.runtime import document_dashboard
+    from harness_codex.runtime import document_dashboard, harvest_ui, ui_server
 
     if getattr(canonical, _PATCHED, False):
         return
@@ -30,6 +30,15 @@ def apply_dashboard_runtime_state_legacy_bridge() -> None:
 
     canonical.assert_canonical_stage_gate = assert_gate_with_migration
 
+    original_snapshot = harvest_ui.save_changeset_harvest_ui
+
+    def save_changeset_harvest_ui_with_legacy_migration(root, change_set_id):
+        original_snapshot(root, change_set_id)
+        _hydrate_verified_procedure_rows(Path(root), change_set_id)
+
+    harvest_ui.save_changeset_harvest_ui = save_changeset_harvest_ui_with_legacy_migration
+    ui_server.save_changeset_harvest_ui = save_changeset_harvest_ui_with_legacy_migration
+
     original_dashboard_state = document_dashboard.document_dashboard_state
 
     def document_dashboard_state_with_migration(repo_root):
@@ -41,6 +50,7 @@ def apply_dashboard_runtime_state_legacy_bridge() -> None:
         return original_dashboard_state(root)
 
     document_dashboard.document_dashboard_state = document_dashboard_state_with_migration
+    ui_server.document_dashboard_state = document_dashboard_state_with_migration
     setattr(canonical, _PATCHED, True)
 
 

--- a/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
+++ b/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
@@ -1,0 +1,121 @@
+"""Compatibility bridge for procedure rows written by existing CLI commands."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from pathlib import Path
+
+from harness_codex.runtime.models import RunMode, RunStatus
+from harness_codex.runtime.procedure_stages import PROCEDURE_STAGES, parse_procedure_stage_rows
+from harness_codex.runtime.state import ArtifactDirtyState, RunState, RunStateStore, StageArtifactState
+
+_PATCHED = "_harness_dashboard_runtime_legacy_bridge_applied"
+
+
+def apply_dashboard_runtime_state_legacy_bridge() -> None:
+    """Promote validated legacy table rows before UI/CLI consumers need them."""
+
+    from harness_codex.runtime import dashboard_runtime_state as canonical
+    from harness_codex.runtime import document_dashboard
+
+    if getattr(canonical, _PATCHED, False):
+        return
+
+    original_assert = canonical.assert_canonical_stage_gate
+
+    def assert_gate_with_migration(repo_root, change_set_id, target_stage_id):
+        _hydrate_verified_procedure_rows(Path(repo_root), change_set_id)
+        return original_assert(repo_root, change_set_id, target_stage_id)
+
+    canonical.assert_canonical_stage_gate = assert_gate_with_migration
+
+    original_dashboard_state = document_dashboard.document_dashboard_state
+
+    def document_dashboard_state_with_migration(repo_root):
+        root = Path(repo_root)
+        active = root / "docs/changes/active"
+        if active.exists():
+            for path in active.glob("CHG-*.md"):
+                _hydrate_verified_procedure_rows(root, path.stem)
+        return original_dashboard_state(root)
+
+    document_dashboard.document_dashboard_state = document_dashboard_state_with_migration
+    setattr(canonical, _PATCHED, True)
+
+
+def _hydrate_verified_procedure_rows(root: Path, change_set_id: str) -> None:
+    if not re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id):
+        return
+    change_path = root / "docs/changes/active" / f"{change_set_id}.md"
+    if not change_path.exists():
+        return
+    rows = parse_procedure_stage_rows(change_path.read_text(encoding="utf-8"))
+    verified = {row["id"] for row in rows if row.get("status") == "verified"}
+    if not verified:
+        return
+
+    from harness_codex.runtime import dashboard_runtime_state as canonical
+
+    current = canonical.load_canonical_change_set_state(root, change_set_id)
+    artifacts = {item.stage: item for item in (current.artifact_states if current else ())}
+    changed = False
+    for stage in PROCEDURE_STAGES:
+        if stage.stage_id not in verified or stage.stage_id in artifacts:
+            continue
+        path = _existing_stage_output(root, stage.stage_id)
+        if path is None:
+            continue
+        artifacts[stage.stage_id] = StageArtifactState(
+            stage=stage.stage_id,
+            path=path,
+            generated_by="legacy_procedure_table",
+            accepted=True,
+            dirty_state=ArtifactDirtyState.CLEAN,
+            downstream_status=ArtifactDirtyState.CLEAN,
+        )
+        changed = True
+    if not changed:
+        return
+
+    state = current or RunState(
+        run_id=canonical.canonical_run_id(change_set_id),
+        change_set_id=change_set_id,
+        workflow_name="changeset-runtime-state",
+        mode=RunMode.APPLY,
+        affected_use_cases=(),
+        affected_work_items=(),
+        status=RunStatus.PENDING,
+    )
+    order = {stage.stage_id: index for index, stage in enumerate(PROCEDURE_STAGES)}
+    updated = replace(
+        state,
+        artifact_states=tuple(
+            sorted(artifacts.values(), key=lambda item: (order.get(item.stage, len(order)), item.stage))
+        ),
+    )
+    RunStateStore(root).save(updated)
+    canonical.reconcile_change_set_procedure_table(root, updated)
+
+
+def _existing_stage_output(root: Path, stage_id: str) -> Path | None:
+    candidates = {
+        "requirements-definition": (Path("docs/design/요구사항.md"),),
+        "ubiquitous-language-definition": (Path("context.md"),),
+        "use-case-definition": (Path("docs/design/유스케이스.md"),),
+        "event-storming": tuple(sorted(Path("docs/use-cases").glob("UC-*/event-storming.md"))),
+        "ddd-architecture-definition": (Path("ARCHITECTURE.md"),),
+        "technical-decisions": tuple(sorted(Path("docs/use-cases").glob("UC-*/technical-decisions.md"))),
+        "design-visualization": tuple(sorted(Path("docs/use-cases").glob("UC-*/class-diagram.md"))),
+        "plan-writing": tuple(sorted(Path("docs/plans/active").glob("*/plan.md")))
+        + tuple(sorted(Path("docs/plans/completed").glob("*/plan.md"))),
+        "implementation": tuple(sorted(Path("docs/plans/completed").glob("*/plan.md"))),
+    }.get(stage_id, ())
+    for relative in candidates:
+        path = root / relative
+        try:
+            if path.is_file() and path.read_text(encoding="utf-8").strip():
+                return relative
+        except OSError:
+            continue
+    return None

--- a/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
+++ b/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
@@ -103,13 +103,28 @@ def _existing_stage_output(root: Path, stage_id: str) -> Path | None:
         "requirements-definition": (Path("docs/design/요구사항.md"),),
         "ubiquitous-language-definition": (Path("context.md"),),
         "use-case-definition": (Path("docs/design/유스케이스.md"),),
-        "event-storming": tuple(sorted(Path("docs/use-cases").glob("UC-*/event-storming.md"))),
+        "event-storming": tuple(
+            path.relative_to(root)
+            for path in sorted((root / "docs/use-cases").glob("UC-*/event-storming.md"))
+        ),
         "ddd-architecture-definition": (Path("ARCHITECTURE.md"),),
-        "technical-decisions": tuple(sorted(Path("docs/use-cases").glob("UC-*/technical-decisions.md"))),
-        "design-visualization": tuple(sorted(Path("docs/use-cases").glob("UC-*/class-diagram.md"))),
-        "plan-writing": tuple(sorted(Path("docs/plans/active").glob("*/plan.md")))
-        + tuple(sorted(Path("docs/plans/completed").glob("*/plan.md"))),
-        "implementation": tuple(sorted(Path("docs/plans/completed").glob("*/plan.md"))),
+        "technical-decisions": tuple(
+            path.relative_to(root)
+            for path in sorted((root / "docs/use-cases").glob("UC-*/technical-decisions.md"))
+        ),
+        "design-visualization": tuple(
+            path.relative_to(root)
+            for path in sorted((root / "docs/use-cases").glob("UC-*/class-diagram.md"))
+        ),
+        "plan-writing": tuple(
+            path.relative_to(root)
+            for path in sorted((root / "docs/plans/active").glob("*/plan.md"))
+            + sorted((root / "docs/plans/completed").glob("*/plan.md"))
+        ),
+        "implementation": tuple(
+            path.relative_to(root)
+            for path in sorted((root / "docs/plans/completed").glob("*/plan.md"))
+        ),
     }.get(stage_id, ())
     for relative in candidates:
         path = root / relative

--- a/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
+++ b/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
@@ -121,8 +121,17 @@ def _migrate_scoped_ui_session(root: Path, change_set_id: str) -> None:
         rows,
         "ubiquitous-language-definition",
         root,
-        bool(session.get("language_gate_passed")),
-        (Path("context.md"), scoped / "context.md"),
+        # Older scoped sessions used requirements_gate_passed for the combined
+        # requirements/language harvest view.  Preserve that completed state
+        # only while migrating the old session format; new writes remain
+        # governed by the explicit language_gate_passed flag.
+        bool(session.get("language_gate_passed") or session.get("requirements_gate_passed")),
+        (
+            Path("context.md"),
+            scoped / "context.md",
+            Path("docs/design/요구사항.md"),
+            scoped / "docs/design/요구사항.md",
+        ),
     )
     changed |= _add_legacy_artifact(
         artifacts,

--- a/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
+++ b/harness_codex/runtime/dashboard_runtime_state_legacy_bridge.py
@@ -1,20 +1,31 @@
-"""Compatibility bridge for procedure rows written by existing CLI commands."""
+"""Compatibility bridge for existing scoped UI sessions and procedure rows."""
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import replace
 from pathlib import Path
 
 from harness_codex.runtime.models import RunMode, RunStatus
-from harness_codex.runtime.procedure_stages import PROCEDURE_STAGES, parse_procedure_stage_rows
-from harness_codex.runtime.state import ArtifactDirtyState, RunState, RunStateStore, StageArtifactState
+from harness_codex.runtime.procedure_stages import (
+    PROCEDURE_STAGES,
+    parse_procedure_stage_rows,
+    update_changeset_stage_status,
+)
+from harness_codex.runtime.state import (
+    ArtifactDirtyState,
+    RunState,
+    RunStateStore,
+    StageArtifactState,
+    runtime_stage_projection,
+)
 
 _PATCHED = "_harness_dashboard_runtime_legacy_bridge_applied"
 
 
 def apply_dashboard_runtime_state_legacy_bridge() -> None:
-    """Promote validated legacy table rows before UI/CLI consumers need them."""
+    """Promote validated legacy UI/table state before consumers read it."""
 
     from harness_codex.runtime import dashboard_runtime_state as canonical
     from harness_codex.runtime import document_dashboard, harvest_ui, ui_server
@@ -25,19 +36,39 @@ def apply_dashboard_runtime_state_legacy_bridge() -> None:
     original_assert = canonical.assert_canonical_stage_gate
 
     def assert_gate_with_migration(repo_root, change_set_id, target_stage_id):
-        _hydrate_verified_procedure_rows(Path(repo_root), change_set_id)
-        return original_assert(repo_root, change_set_id, target_stage_id)
+        root = Path(repo_root)
+        _migrate_scoped_ui_session(root, change_set_id)
+        _hydrate_verified_procedure_rows(root, change_set_id)
+        return original_assert(root, change_set_id, target_stage_id)
 
     canonical.assert_canonical_stage_gate = assert_gate_with_migration
+
+    def reconcile_preserving_explicit_blockers(repo_root, state):
+        _reconcile_canonical_rows(Path(repo_root), state)
+
+    canonical.reconcile_change_set_procedure_table = reconcile_preserving_explicit_blockers
 
     original_snapshot = harvest_ui.save_changeset_harvest_ui
 
     def save_changeset_harvest_ui_with_legacy_migration(root, change_set_id):
         original_snapshot(root, change_set_id)
-        _hydrate_verified_procedure_rows(Path(root), change_set_id)
+        root_path = Path(root)
+        _migrate_scoped_ui_session(root_path, change_set_id)
+        _hydrate_verified_procedure_rows(root_path, change_set_id)
 
     harvest_ui.save_changeset_harvest_ui = save_changeset_harvest_ui_with_legacy_migration
     ui_server.save_changeset_harvest_ui = save_changeset_harvest_ui_with_legacy_migration
+
+    original_projection = document_dashboard._project_workflow_stages
+
+    def project_canonical_state_with_explicit_source(stages, workflow_state, run_state=None):
+        projected = original_projection(stages, workflow_state, run_state)
+        return [
+            item if item.get("source") else {**item, "source": "changeset"}
+            for item in projected
+        ]
+
+    document_dashboard._project_workflow_stages = project_canonical_state_with_explicit_source
 
     original_dashboard_state = document_dashboard.document_dashboard_state
 
@@ -46,6 +77,7 @@ def apply_dashboard_runtime_state_legacy_bridge() -> None:
         active = root / "docs/changes/active"
         if active.exists():
             for path in active.glob("CHG-*.md"):
+                _migrate_scoped_ui_session(root, path.stem)
                 _hydrate_verified_procedure_rows(root, path.stem)
         return original_dashboard_state(root)
 
@@ -54,8 +86,98 @@ def apply_dashboard_runtime_state_legacy_bridge() -> None:
     setattr(canonical, _PATCHED, True)
 
 
+def _migrate_scoped_ui_session(root: Path, change_set_id: str) -> None:
+    if not _valid_change_set_id(change_set_id):
+        return
+    session_path = root / ".harness/ui/change-sets" / change_set_id / "harvest-session.json"
+    change_path = root / "docs/changes/active" / f"{change_set_id}.md"
+    if not session_path.exists() or not change_path.exists():
+        return
+    try:
+        session = json.loads(session_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if not isinstance(session, dict):
+        return
+
+    rows = {row["id"]: row for row in parse_procedure_stage_rows(change_path.read_text(encoding="utf-8"))}
+    from harness_codex.runtime import dashboard_runtime_state as canonical
+
+    current = canonical.load_canonical_change_set_state(root, change_set_id)
+    artifacts = {item.stage: item for item in (current.artifact_states if current else ())}
+    scoped = Path(".harness/ui/change-sets") / change_set_id
+    changed = False
+
+    changed |= _add_legacy_artifact(
+        artifacts,
+        rows,
+        "requirements-definition",
+        root,
+        bool(session.get("requirements_gate_passed")),
+        (Path("docs/design/요구사항.md"), scoped / "docs/design/요구사항.md"),
+    )
+    changed |= _add_legacy_artifact(
+        artifacts,
+        rows,
+        "ubiquitous-language-definition",
+        root,
+        bool(session.get("language_gate_passed")),
+        (Path("context.md"), scoped / "context.md"),
+    )
+    changed |= _add_legacy_artifact(
+        artifacts,
+        rows,
+        "use-case-definition",
+        root,
+        bool(session.get("use_cases_ready")),
+        (scoped / "docs/design/유스케이스.md", Path("docs/design/유스케이스.md")),
+    )
+
+    event = session.get("event_storming")
+    if isinstance(event, dict) and event.get("complete"):
+        changed |= _add_legacy_artifact(
+            artifacts,
+            rows,
+            "event-storming",
+            root,
+            True,
+            tuple(
+                scoped / "docs/use-cases" / str(uc_id) / "event-storming.md"
+                for uc_id in event.get("uc_ids", ())
+            ),
+        )
+
+    ddd = session.get("ddd_architecture")
+    if isinstance(ddd, dict) and ddd.get("complete"):
+        changed |= _add_legacy_artifact(
+            artifacts,
+            rows,
+            "ddd-architecture-definition",
+            root,
+            True,
+            tuple(
+                scoped / "docs/use-cases" / str(uc_id) / "ddd-design.md"
+                for uc_id in ddd.get("uc_ids", ())
+            ),
+        )
+
+    if not changed:
+        return
+    state = current or RunState(
+        run_id=canonical.canonical_run_id(change_set_id),
+        change_set_id=change_set_id,
+        workflow_name="changeset-runtime-state",
+        mode=RunMode.APPLY,
+        affected_use_cases=(),
+        affected_work_items=(),
+        status=RunStatus.PENDING,
+    )
+    RunStateStore(root).save(replace(state, artifact_states=_ordered_artifacts(artifacts)))
+    canonical.reconcile_change_set_procedure_table(root, RunStateStore(root).load(state.run_id))
+
+
 def _hydrate_verified_procedure_rows(root: Path, change_set_id: str) -> None:
-    if not re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id):
+    if not _valid_change_set_id(change_set_id):
         return
     change_path = root / "docs/changes/active" / f"{change_set_id}.md"
     if not change_path.exists():
@@ -97,15 +219,65 @@ def _hydrate_verified_procedure_rows(root: Path, change_set_id: str) -> None:
         affected_work_items=(),
         status=RunStatus.PENDING,
     )
-    order = {stage.stage_id: index for index, stage in enumerate(PROCEDURE_STAGES)}
-    updated = replace(
-        state,
-        artifact_states=tuple(
-            sorted(artifacts.values(), key=lambda item: (order.get(item.stage, len(order)), item.stage))
-        ),
-    )
+    updated = replace(state, artifact_states=_ordered_artifacts(artifacts))
     RunStateStore(root).save(updated)
     canonical.reconcile_change_set_procedure_table(root, updated)
+
+
+def _reconcile_canonical_rows(root: Path, state: RunState) -> None:
+    change_path = root / "docs/changes/active" / f"{state.change_set_id}.md"
+    if not change_path.exists():
+        return
+    text = change_path.read_text(encoding="utf-8")
+    rows = {row["id"]: row for row in parse_procedure_stage_rows(text)}
+    runtime_rows = runtime_stage_projection(state)
+    for stage in PROCEDURE_STAGES:
+        runtime = runtime_rows.get(stage.stage_id)
+        row = rows.get(stage.stage_id)
+        if runtime is None:
+            # Existing stale/blocked rows remain explicit compatibility blockers
+            # until an owning runtime operation records their replacement state.
+            if row and row.get("status") not in {"", "pending"}:
+                continue
+            desired_status, desired_notes = "pending", "-"
+        else:
+            desired_status, desired_notes = runtime["status"], runtime["notes"]
+        if row and row.get("status") == desired_status and row.get("notes") == desired_notes:
+            continue
+        text = update_changeset_stage_status(
+            text,
+            stage=stage,
+            status=desired_status,
+            notes=desired_notes,
+        )
+    change_path.write_text(text, encoding="utf-8")
+
+
+def _add_legacy_artifact(
+    artifacts: dict[str, StageArtifactState],
+    rows: dict[str, dict[str, str]],
+    stage: str,
+    root: Path,
+    complete: bool,
+    candidates: tuple[Path, ...],
+) -> bool:
+    if not complete or stage in artifacts:
+        return False
+    row = rows.get(stage, {})
+    if row.get("status") not in {"", "pending"}:
+        return False
+    path = next((candidate for candidate in candidates if _nonempty(root / candidate)), None)
+    if path is None:
+        return False
+    artifacts[stage] = StageArtifactState(
+        stage=stage,
+        path=path,
+        generated_by="legacy_scoped_ui",
+        accepted=True,
+        dirty_state=ArtifactDirtyState.CLEAN,
+        downstream_status=ArtifactDirtyState.CLEAN,
+    )
+    return True
 
 
 def _existing_stage_output(root: Path, stage_id: str) -> Path | None:
@@ -136,11 +308,20 @@ def _existing_stage_output(root: Path, stage_id: str) -> Path | None:
             for path in sorted((root / "docs/plans/completed").glob("*/plan.md"))
         ),
     }.get(stage_id, ())
-    for relative in candidates:
-        path = root / relative
-        try:
-            if path.is_file() and path.read_text(encoding="utf-8").strip():
-                return relative
-        except OSError:
-            continue
-    return None
+    return next((relative for relative in candidates if _nonempty(root / relative)), None)
+
+
+def _ordered_artifacts(artifacts: dict[str, StageArtifactState]) -> tuple[StageArtifactState, ...]:
+    order = {stage.stage_id: index for index, stage in enumerate(PROCEDURE_STAGES)}
+    return tuple(sorted(artifacts.values(), key=lambda item: (order.get(item.stage, len(order)), item.stage)))
+
+
+def _nonempty(path: Path) -> bool:
+    try:
+        return path.is_file() and bool(path.read_text(encoding="utf-8").strip())
+    except OSError:
+        return False
+
+
+def _valid_change_set_id(change_set_id: str) -> bool:
+    return bool(re.fullmatch(r"CHG-[A-Za-z0-9-]+", change_set_id))

--- a/harness_codex/runtime/dashboard_runtime_state_legacy_compat.py
+++ b/harness_codex/runtime/dashboard_runtime_state_legacy_compat.py
@@ -1,0 +1,92 @@
+"""Compatibility correction for old scoped dashboard sessions.
+
+Early scoped sessions used ``requirements_gate_passed`` as the completion
+marker for a combined requirements/language view.  New sessions persist the
+separate ``language_gate_passed`` field.  Keep the old interpretation only
+when that field is absent.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from harness_codex.runtime.procedure_stages import PROCEDURE_STAGES, update_changeset_stage_status
+from harness_codex.runtime.state import RunStateStore
+
+_PATCHED = "_harness_dashboard_runtime_legacy_language_compat_applied"
+
+
+def apply_dashboard_runtime_state_legacy_compat() -> None:
+    """Prevent old-session migration from overriding an explicit false gate."""
+
+    from harness_codex.runtime import dashboard_runtime_state as canonical
+    from harness_codex.runtime import dashboard_runtime_state_legacy_bridge as bridge
+
+    if getattr(bridge, _PATCHED, False):
+        return
+
+    original_migrate = bridge._migrate_scoped_ui_session
+
+    def migrate_scoped_session_with_explicit_language_gate(root: Path, change_set_id: str) -> None:
+        explicit_language_gate = _explicit_language_gate(root, change_set_id)
+        original_migrate(root, change_set_id)
+        if explicit_language_gate is not False:
+            return
+
+        state = canonical.load_canonical_change_set_state(root, change_set_id)
+        if state is None:
+            return
+        legacy_language_artifact = next(
+            (
+                item
+                for item in state.artifact_states
+                if item.stage == "ubiquitous-language-definition"
+                and item.generated_by == "legacy_scoped_ui"
+            ),
+            None,
+        )
+        if legacy_language_artifact is None:
+            return
+
+        updated = replace(
+            state,
+            artifact_states=tuple(
+                item
+                for item in state.artifact_states
+                if item.stage != "ubiquitous-language-definition"
+            ),
+        )
+        RunStateStore(root).save(updated)
+        _reset_language_table_row(root, change_set_id)
+
+    bridge._migrate_scoped_ui_session = migrate_scoped_session_with_explicit_language_gate
+    setattr(bridge, _PATCHED, True)
+
+
+def _explicit_language_gate(root: Path, change_set_id: str) -> bool | None:
+    session_path = root / ".harness/ui/change-sets" / change_set_id / "harvest-session.json"
+    try:
+        session = json.loads(session_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(session, dict) or "language_gate_passed" not in session:
+        return None
+    return bool(session["language_gate_passed"])
+
+
+def _reset_language_table_row(root: Path, change_set_id: str) -> None:
+    path = root / "docs/changes/active" / f"{change_set_id}.md"
+    if not path.exists():
+        return
+    stage = next(
+        item
+        for item in PROCEDURE_STAGES
+        if item.stage_id == "ubiquitous-language-definition"
+    )
+    text = path.read_text(encoding="utf-8")
+    path.write_text(
+        update_changeset_stage_status(text, stage=stage, status="pending", notes="-"),
+        encoding="utf-8",
+    )

--- a/tests/runtime/test_dashboard_runtime_state.py
+++ b/tests/runtime/test_dashboard_runtime_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from harness_codex.runtime.dashboard_runtime_state import (
     sync_change_set_runtime_state,
 )
 from harness_codex.runtime.document_dashboard import _project_workflow_stages
+from harness_codex.runtime.harvest_ui import save_changeset_harvest_ui
 from harness_codex.runtime.procedure_stages import (
     PROCEDURE_STAGES,
     parse_procedure_stage_rows,
@@ -67,6 +69,31 @@ def test_dashboard_session_is_persisted_as_canonical_run_state_and_table_mirror(
     assert rows["requirements-definition"]["status"] == "verified"
     assert rows["ubiquitous-language-definition"]["status"] == "verified"
     assert rows["use-case-definition"]["status"] == "pending"
+
+
+def test_dashboard_snapshot_hook_creates_canonical_state(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260625-426"
+    _create_change_set(tmp_path, change_set_id)
+    _write(tmp_path, "docs/design/요구사항.md", "# Requirements\n")
+    session_path = tmp_path / ".harness/ui/harvest-session.json"
+    session_path.parent.mkdir(parents=True)
+    session_path.write_text(
+        json.dumps(
+            {
+                "requirements_gate_passed": True,
+                "language_gate_passed": False,
+                "use_cases_ready": False,
+                "active_stage": "requirements",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    save_changeset_harvest_ui(tmp_path, change_set_id)
+
+    loaded = load_canonical_change_set_state(tmp_path, change_set_id)
+    assert loaded is not None
+    assert {item.stage for item in loaded.artifact_states} == {"requirements-definition"}
 
 
 def test_scoped_ui_flags_cannot_project_verified_stage_without_run_state() -> None:

--- a/tests/runtime/test_dashboard_runtime_state.py
+++ b/tests/runtime/test_dashboard_runtime_state.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from harness_codex.runtime.dashboard_runtime_state import (
+    assert_canonical_stage_gate,
+    canonical_run_id,
+    load_canonical_change_set_state,
+    sync_change_set_runtime_state,
+)
+from harness_codex.runtime.document_dashboard import _project_workflow_stages
+from harness_codex.runtime.procedure_stages import (
+    PROCEDURE_STAGES,
+    parse_procedure_stage_rows,
+    render_initial_changeset,
+    update_changeset_stage_status,
+)
+
+
+def _create_change_set(root: Path, change_set_id: str = "CHG-20260625-426") -> Path:
+    path = root / "docs/changes/active" / f"{change_set_id}.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        render_initial_changeset(
+            change_set_id=change_set_id,
+            title="Canonical dashboard runtime state",
+            request_summary="Synchronize dashboard stage state.",
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write(root: Path, relative: str, content: str = "content") -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_dashboard_session_is_persisted_as_canonical_run_state_and_table_mirror(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260625-426"
+    change_path = _create_change_set(tmp_path, change_set_id)
+    _write(tmp_path, "docs/design/요구사항.md", "# Requirements\n")
+    _write(tmp_path, "context.md", "# Context\n")
+
+    state = sync_change_set_runtime_state(
+        tmp_path,
+        change_set_id,
+        {
+            "requirements_gate_passed": True,
+            "language_gate_passed": True,
+            "use_cases_ready": False,
+        },
+    )
+
+    assert state.run_id == canonical_run_id(change_set_id)
+    loaded = load_canonical_change_set_state(tmp_path, change_set_id)
+    assert loaded is not None
+    assert {item.stage for item in loaded.artifact_states} == {
+        "requirements-definition",
+        "ubiquitous-language-definition",
+    }
+
+    rows = {row["id"]: row for row in parse_procedure_stage_rows(change_path.read_text(encoding="utf-8"))}
+    assert rows["requirements-definition"]["status"] == "verified"
+    assert rows["ubiquitous-language-definition"]["status"] == "verified"
+    assert rows["use-case-definition"]["status"] == "pending"
+
+
+def test_scoped_ui_flags_cannot_project_verified_stage_without_run_state() -> None:
+    stages = [
+        {
+            "id": "requirements-definition",
+            "procedure": "Requirements",
+            "status": "pending",
+            "verified_at": "-",
+            "notes": "-",
+        }
+    ]
+
+    projected = _project_workflow_stages(
+        stages,
+        {"requirements_gate_passed": True},
+        None,
+    )
+
+    assert projected[0]["status"] == "pending"
+
+
+def test_plan_gate_requires_canonical_run_state_not_local_ui_flags(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260625-426"
+    _create_change_set(tmp_path, change_set_id)
+
+    with pytest.raises(ValueError, match="canonical RunState is missing"):
+        assert_canonical_stage_gate(tmp_path, change_set_id, "plan-writing")
+
+
+def test_verified_legacy_procedure_row_is_hydrated_before_gate_check(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260625-426"
+    change_path = _create_change_set(tmp_path, change_set_id)
+    _write(tmp_path, "docs/design/요구사항.md", "# Requirements\n")
+
+    text = change_path.read_text(encoding="utf-8")
+    requirements_stage = next(
+        stage for stage in PROCEDURE_STAGES if stage.stage_id == "requirements-definition"
+    )
+    change_path.write_text(
+        update_changeset_stage_status(
+            text,
+            stage=requirements_stage,
+            status="verified",
+            notes="verified by legacy CLI",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="ubiquitous-language-definition"):
+        assert_canonical_stage_gate(tmp_path, change_set_id, "plan-writing")
+
+    loaded = load_canonical_change_set_state(tmp_path, change_set_id)
+    assert loaded is not None
+    assert {item.stage for item in loaded.artifact_states} == {"requirements-definition"}


### PR DESCRIPTION
## 개요

#426의 UI scoped harvest session과 CLI/RunState/ChangeSet 절차 표가 서로 다른 상태를 보던 문제를 해결합니다.

## 변경 사항

- 활성 ChangeSet마다 결정적 ID(`changeset-state-<CHG-ID>`)의 canonical `RunState`를 유지합니다.
- Dashboard harvest 상태 저장 시 Requirements, Ubiquitous Language, Use Cases, Event Storming, DDD Architecture 완료 상태를 검증 가능한 stage artifact로 RunState에 기록합니다.
- ChangeSet의 Runtime Procedure State 표를 canonical RunState 투영 결과로 동기화합니다.
- Dashboard scoped session은 질문 재개 용도로만 유지하며, 더 이상 verified stage를 직접 투영하지 못하도록 차단합니다.
- Plan Writing 및 Implementation 시작 API는 canonical RunState에서 모든 선행 stage가 `verified`인 경우에만 실행합니다.
- 기존 CLI가 작성한 verified procedure row는 대응 artifact가 존재할 때 canonical RunState로 호환 마이그레이션합니다.

## 검증

추가 테스트:

- dashboard session → canonical RunState와 ChangeSet 표 동기화
- RunState 없이 scoped UI flag만으로 stage가 verified로 보이지 않음
- local UI flag만으로 Plan Writing gate를 통과할 수 없음
- 기존 verified procedure row의 canonical state hydration

Closes #426