### PR TITLE
fix: 유스케이스 질문의 언어·Actor 책임 라우팅 강화

### DIFF
--- a/.codex/agents/references/harness_usecases.md
+++ b/.codex/agents/references/harness_usecases.md
@@ -41,6 +41,7 @@ Readiness and ambiguity routing:
 - If docs/design/요구사항.md is missing, return `blocked` and route to $harness-requirements.
 - If unresolved Business Policy Decisions remain, return `blocked` and route to $harness-requirements because use cases would encode unconfirmed behavior.
 - If Blocking Open Language Questions block a canonical noun, stable role label, state label, alias, or meaning boundary, return `blocked` and route to $harness-ubiquitous-language.
+- When runtime metadata includes `target_uc` or `uc_id` for `use-case-definition`, keep `docs/design/유스케이스.md` coherent but write or update only the matching `docs/use-cases/<UC-ID>/use-case.md` and `docs/use-cases/<UC-ID>/e2e-goal.md` slice. Preserve other use-case slice directories.
 - Foundational Technical Decisions may remain unresolved if actor goals, business policies, and language are clear.
 
 Ubiquitous language rules:

--- a/.codex/agents/references/harness_usecases.md
+++ b/.codex/agents/references/harness_usecases.md
@@ -30,25 +30,27 @@ Ownership:
 - Keep file writes limited to docs/design/유스케이스.md and docs/use-cases/<UC-ID>/ runtime slice docs.
 - If you cannot find or write the output documents, explain the reason and stop.
 
-Readiness:
+Readiness and ambiguity routing:
 - Read context.md before writing use cases.
 - Read docs/design/요구사항.md after context.md.
-- If context.md is missing or lacks a Ubiquitous Language section, stop and ask the user to run $harness-ubiquitous-language first.
-- If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
-- If unresolved Business Policy Decisions remain, stop because use cases would encode unconfirmed behavior.
-- If Blocking Open Language Questions block actor, goal, command, input, output, result, policy, or scope-boundary naming, stop because use cases would encode unconfirmed language.
-- Write or update the current use-case draft before asking questions.
-- Ask up to three focused Grill-Me questions only when confirmed requirements contain use-case-flow ambiguity. Route missing language/context to $harness-ubiquitous-language.
-- Include `Recommended answer:` with every blocking question.
-- When runtime metadata includes `target_uc` or `uc_id` for `use-case-definition`, keep `docs/design/유스케이스.md` coherent but write or update only that matching `docs/use-cases/<UC-ID>/use-case.md` and `docs/use-cases/<UC-ID>/e2e-goal.md` slice. Preserve other use-case slice directories.
+- Before asking a Grill-Me question, classify the ambiguity.
+- Missing or ambiguous canonical noun, role label, state label, alias, or meaning boundary: return `{"status":"blocked","questions":[],"changed_files":[],"blocker":"... Run $harness-ubiquitous-language ..."}`. Do not ask the user directly from the use-case stage, write a partial use-case draft, or invent the missing language.
+- Whether an external actor is distinct from an existing actor: return `{"status":"blocked","questions":[],"changed_files":[],"blocker":"... Run $harness-requirements ..."}`. Do not promote a role of an existing actor to a new actor unless requirements explicitly establish separate goals, authority, or interaction responsibilities.
+- Actor flow, precondition, observable success/failure, or single-goal decomposition ambiguity: ask up to three focused Grill-Me questions and return `needs_input`.
+- If context.md is missing or lacks a Ubiquitous Language section, return `blocked` and route to $harness-ubiquitous-language.
+- If docs/design/요구사항.md is missing, return `blocked` and route to $harness-requirements.
+- If unresolved Business Policy Decisions remain, return `blocked` and route to $harness-requirements because use cases would encode unconfirmed behavior.
+- If Blocking Open Language Questions block a canonical noun, stable role label, state label, alias, or meaning boundary, return `blocked` and route to $harness-ubiquitous-language.
 - Foundational Technical Decisions may remain unresolved if actor goals, business policies, and language are clear.
 
 Ubiquitous language rules:
-- Use only canonical terms from context.md for domain concepts.
+- Use only canonical terms from context.md for domain concepts, stable actor roles, state labels, and external systems.
 - Use the English column from context.md for code-facing command/event/policy candidate names when such candidates are included.
 - Do not introduce new actor names, goal names, state names, command names, event names, policy names, or external system names that conflict with context.md.
 - Do not use terms listed under Forbidden Terms.
-- If a needed term is missing or ambiguous, mark the related use case detail as Needs confirmation instead of inventing behavior.
+- Do not require every use-case verb, goal, command candidate, or title to become a canonical term. A use-case goal may combine a verb with confirmed canonical domain concepts.
+- Keep domain concepts, actor roles, state labels, and use-case actions distinct unless context.md explicitly confirms the same meaning boundary.
+- If a needed canonical term is missing or ambiguous, return `blocked` instead of asking a use-case Grill-Me question or inventing behavior.
 
 Use case rules:
 - Use cases are written from the perspective of external actors.
@@ -79,10 +81,10 @@ Runtime slice rules:
 
 Question loop:
 - In interactive runtime harvest, every turn must finish by returning only JSON.
-- Return `{"status":"needs_input","questions":[...],"changed_files":[],"blocker":""}` when user answers are required before use-case docs can be correct.
+- Return `{"status":"needs_input","questions":[...],"changed_files":[],"blocker":""}` only for actor-flow, precondition, observable success/failure, or single-goal decomposition ambiguity.
 - Return `{"status":"complete","questions":[],"changed_files":[...],"blocker":""}` only after writing docs/design/유스케이스.md and every matching docs/use-cases/<UC-ID>/use-case.md and docs/use-cases/<UC-ID>/e2e-goal.md.
-- Return `{"status":"blocked","questions":[],"changed_files":[],"blocker":"..."}` only when requirements or context.md are not ready and the use-case stage cannot resolve the blocker.
+- Return `{"status":"blocked","questions":[],"changed_files":[],"blocker":"..."}` when a required context or requirements decision belongs to an upstream stage and the use-case stage cannot resolve it.
 - Do not wait for interactive stdin. Ask by returning JSON and exiting.
-- Include `recommended` with every question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
+- Include `recommended` with every `needs_input` question. The recommendation must reflect the current evidence and should say whether it is based on local artifacts or your inference.
 - After the user answer appears in the use-case answer history, write docs/design/유스케이스.md and matching docs/use-cases/<UC-ID>/ slice docs when ready.
-- If a use case still has multiple user goals, mixed command/policy wording, multi-meaning event storming elements, non-canonical terms, Forbidden Terms, or invalid command/event/policy phrasing, either mark it as Needs confirmation in the docs or return up to three JSON needs_input questions before reporting readiness.
+- If a use case still has multiple user goals, mixed command/policy wording, multi-meaning event storming elements, non-canonical terms, Forbidden Terms, or invalid command/event/policy phrasing, either mark it as Needs confirmation in the docs or return up to three JSON needs_input questions before reporting readiness. Do not use `needs_input` to resolve missing language or actor-boundary decisions.

--- a/.codex/agents/references/ubiquitous_language_reviewer.md
+++ b/.codex/agents/references/ubiquitous_language_reviewer.md
@@ -14,9 +14,17 @@ Your job:
 
 Do not reopen requirements:
 - Do not ask broad actor, goal, success-condition, failure-policy, or hard-scope questions.
-- Do not ask whether a domain object, note type, source rule, MVP policy, actor goal, success condition, failure policy, or hard scope belongs in the product.
+- Do not ask whether a domain object, note type, source rule, MVP policy, actor goal, success condition, failure policy, hard scope, or independent external actor belongs in the product.
+- Whether a role of an existing actor is an independent external actor belongs to requirements. If the decision is missing, report an upstream requirements blocker and stop.
 - If requirements contradict each other or omit a decision that blocks language confirmation, report an upstream requirements blocker and stop.
 - Do not rewrite `docs/design/요구사항.md`.
+
+Vocabulary scope:
+- Canonical vocabulary covers domain concepts, stable roles, user-visible concepts, and state labels when needed.
+- Do not require every use-case verb, use-case goal, command candidate, or use-case title to become a canonical term.
+- A use-case goal may combine a verb with canonical domain concepts.
+- Keep domain concepts, actor-role labels, state labels, and use-case goals or actions distinct unless requirements and `context.md` explicitly establish the same meaning boundary.
+- A role label is not proof of a separate external actor.
 
 Allowed question topics:
 - canonical term
@@ -25,7 +33,6 @@ Allowed question topics:
 - aliases
 - forbidden terms
 - meaning boundary
-- use-case-facing command, input, output, result, policy, or scope-boundary terminology
 
 Deferred topics:
 - aggregate naming

--- a/.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md
+++ b/.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md
@@ -31,6 +31,7 @@ Requirements-definition owns:
 - hard scope boundary
 - business policy decisions
 - only MVP-blocking terms needed to understand the requirement
+- whether a role of an existing actor is an independent external actor with separate goals, authority, or interaction responsibilities
 
 Ubiquitous-language-definition owns:
 - canonical term
@@ -39,9 +40,19 @@ Ubiquitous-language-definition owns:
 - aliases
 - forbidden terms
 - meaning boundary
-- use-case-facing command, input, output, result, policy, and scope-boundary terminology
+- canonical vocabulary for domain concepts, stable roles, user-visible concepts, and state labels when needed
 
-Do not ask broad requirements questions unless a contradiction blocks language confirmation. Do not ask whether a domain object, note type, source rule, MVP policy, actor goal, success condition, failure policy, or hard scope belongs in the product. Those decisions belong upstream in requirements or use-case definition. If blocked, report an upstream requirements blocker and stop.
+Do not require every use-case verb, use-case goal, command candidate, or use-case title to become a canonical term. A use-case goal may combine a verb with canonical domain concepts.
+
+Keep the following categories distinct unless requirements and `context.md` explicitly establish the same meaning boundary:
+- domain concept
+- actor-role label
+- state label
+- use-case goal or action
+
+For example, a state label must not be confirmed as though it were a use-case action, and a role label must not be treated as a separate external actor without an explicit requirements decision.
+
+Do not ask broad requirements questions unless a contradiction blocks language confirmation. Do not ask whether a domain object, note type, source rule, MVP policy, actor goal, success condition, failure policy, hard scope, or independent external actor belongs in the product. Those decisions belong upstream in requirements. If blocked, report an upstream requirements blocker and stop.
 
 ## Deferred Naming
 

--- a/.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md
+++ b/.codex/skills/harness-ubiquitous-language/references/detailed-instructions.md
@@ -40,7 +40,7 @@ Ubiquitous-language-definition owns:
 - aliases
 - forbidden terms
 - meaning boundary
-- canonical vocabulary for domain concepts, stable roles, user-visible concepts, and state labels when needed
+- Canonical vocabulary covers domain concepts, stable roles, user-visible concepts, and state labels when needed
 
 Do not require every use-case verb, use-case goal, command candidate, or use-case title to become a canonical term. A use-case goal may combine a verb with canonical domain concepts.
 

--- a/.codex/skills/harness-usecases/references/invocation.md
+++ b/.codex/skills/harness-usecases/references/invocation.md
@@ -37,7 +37,7 @@ Rules:
 - Before asking a Grill-Me question, classify the ambiguity.
   - Missing or ambiguous canonical noun, role label, state label, alias, or meaning boundary: return `blocked` with no questions or changed files, and route to $harness-ubiquitous-language. Do not ask the user directly from the use-case stage or write a partial use-case draft.
   - Whether an external actor is distinct from an existing actor: return `blocked` with no questions or changed files, and route to $harness-requirements. Do not promote a role of an existing actor to a new actor unless requirements explicitly establish separate goals, authority, or interaction responsibilities.
-  - Actor flow, precondition, observable success/failure, or single-goal decomposition ambiguity: ask a focused use-case Grill-Me question and return `needs_input`.
+  - actor flow, precondition, observable success/failure, or single-goal decomposition ambiguity: ask a focused use-case Grill-Me question and return `needs_input`.
 - If context.md is missing or lacks Ubiquitous Language, return `blocked` and route to $harness-ubiquitous-language.
 - If docs/design/요구사항.md is missing, return `blocked` and route to $harness-requirements.
 - If unresolved Business Policy Decisions remain, return `blocked` and route to $harness-requirements because use cases would encode unconfirmed behavior.

--- a/.codex/skills/harness-usecases/references/invocation.md
+++ b/.codex/skills/harness-usecases/references/invocation.md
@@ -34,11 +34,16 @@ Rules:
 - Do not revert existing user changes.
 - Read context.md first.
 - Read docs/design/요구사항.md after context.md.
-- If context.md is missing or lacks Ubiquitous Language, stop and ask the user to run $harness-ubiquitous-language first.
-- If docs/design/요구사항.md is missing, stop and ask the user to run $harness-requirements first.
-- If unresolved Business Policy Decisions remain, stop because use cases would encode unconfirmed behavior.
-- If Blocking Open Language Questions block actor, goal, command, input, output, result, policy, or scope-boundary naming, stop because use cases would encode unconfirmed language.
+- Before asking a Grill-Me question, classify the ambiguity.
+  - Missing or ambiguous canonical noun, role label, state label, alias, or meaning boundary: return `blocked` with no questions or changed files, and route to $harness-ubiquitous-language. Do not ask the user directly from the use-case stage or write a partial use-case draft.
+  - Whether an external actor is distinct from an existing actor: return `blocked` with no questions or changed files, and route to $harness-requirements. Do not promote a role of an existing actor to a new actor unless requirements explicitly establish separate goals, authority, or interaction responsibilities.
+  - Actor flow, precondition, observable success/failure, or single-goal decomposition ambiguity: ask a focused use-case Grill-Me question and return `needs_input`.
+- If context.md is missing or lacks Ubiquitous Language, return `blocked` and route to $harness-ubiquitous-language.
+- If docs/design/요구사항.md is missing, return `blocked` and route to $harness-requirements.
+- If unresolved Business Policy Decisions remain, return `blocked` and route to $harness-requirements because use cases would encode unconfirmed behavior.
+- If Blocking Open Language Questions block a canonical noun, stable role label, state label, alias, or meaning boundary needed to name a use case, return `blocked` and route to $harness-ubiquitous-language.
 - Use context.md canonical terms and avoid Forbidden Terms.
+- A use-case goal may combine a verb with confirmed canonical domain concepts; do not require every use-case goal, command candidate, or title to become a canonical term.
 - Write use cases around a single goal of an external actor.
 - Do not turn internal server/API flows into use cases.
 - Separate commands, events, and policies by meaning and sentence form.
@@ -51,17 +56,16 @@ Rules:
 ## Workflow
 
 1. **Inspect context language**
-   Read `context.md` first. Confirm that the Ubiquitous Language table exists and that required actor/goal/domain terms are present.
+   Read `context.md` first. Confirm that the Ubiquitous Language table exists and that required canonical domain concepts, stable role labels, state labels, aliases, and meaning boundaries are present.
 
 2. **Inspect requirements**
    Read `docs/design/요구사항.md` and any explicit user-provided decision record.
 
-3. **Check readiness**
-   Stop if requirements are missing, `context.md` is missing, unresolved business policy decisions remain, or open language questions block use-case naming. Route missing or unresolved `context.md` to `$harness-ubiquitous-language`.
-   Foundational technology decisions may remain unresolved if they do not affect actor goals.
+3. **Classify readiness and ambiguity**
+   Before creating or updating use-case documents, classify each blocker. Route missing or unresolved canonical language to `$harness-ubiquitous-language`; route the question of whether an actor is independent from an existing actor to `$harness-requirements`; ask Grill-Me questions only for actor-flow, precondition, observable outcome, or single-goal decomposition ambiguity. Foundational technology decisions may remain unresolved if they do not affect actor goals.
 
 4. **Derive actor goals**
-   Extract external actors and one goal per actor from confirmed functional requirements, using only canonical terms from `context.md`.
+   Extract external actors and one goal per actor from confirmed functional requirements, using only canonical terms from `context.md`. Do not infer an independent actor from a role label without an explicit requirements decision.
 
 5. **Assign stable use case IDs**
    Assign IDs in `UC-001` format. Preserve existing IDs when updating an existing `docs/design/유스케이스.md`.
@@ -78,5 +82,4 @@ Rules:
    If runtime metadata includes `target_uc` or `uc_id`, write or update only that matching runtime slice while keeping `docs/design/유스케이스.md` coherent and preserving other slice directories.
 
 8. **Confirm completion**
-   If any use case still has multiple goals, mixed command/policy wording, multi-meaning event-storming candidates, non-canonical language, or Forbidden Terms, mark it as `Needs confirmation`.
-   If ambiguity blocks correctness, write or update the current use-case draft before asking questions, then ask up to three focused Grill-Me questions and include `Recommended answer:` for each.
+   If any use case still has multiple goals, mixed command/policy wording, multi-meaning event-storming candidates, non-canonical language, or Forbidden Terms, mark it as `Needs confirmation`. For a confirmed use-case-flow ambiguity, write or update the current use-case draft, then ask up to three focused Grill-Me questions and include `Recommended answer:` for each. Do not ask Grill-Me questions for language or actor-boundary blockers; return `blocked` and route them to their owning upstream stage.

--- a/.codex/skills/harness-usecases/references/standards.md
+++ b/.codex/skills/harness-usecases/references/standards.md
@@ -10,7 +10,7 @@ Use the following standards as the source of truth for the instructions.
 - Use the table's `English` names for code-facing command/event/policy candidates when such candidates are included.
 - Do not introduce new actor names, goal names, domain concepts, state names, command names, event names, policy names, or external system names that conflict with `context.md`.
 - Do not use terms listed under `Forbidden Terms`.
-- If a needed MVP term is missing or ambiguous, stop or mark the related use case detail as `Needs confirmation`; record the missing term as a `Blocking Open Language Question` instead of inventing behavior.
+- If a canonical noun, role label, state label, alias, or meaning boundary needed to name a use case is missing or ambiguous, return `blocked` and route to `$harness-ubiquitous-language` instead of writing or updating use-case documents.
 
 ### Ambiguity Routing Standards
 

--- a/.codex/skills/harness-usecases/references/standards.md
+++ b/.codex/skills/harness-usecases/references/standards.md
@@ -18,7 +18,7 @@ Before asking a Grill-Me question, classify the ambiguity.
 
 - Missing or ambiguous canonical noun, role label, state label, alias, or meaning boundary: return `blocked` and route to `$harness-ubiquitous-language`. Do not ask the user directly from the use-case stage, write a partial use-case draft, or invent the missing language.
 - Whether an external actor is distinct from an existing actor: return `blocked` and route to `$harness-requirements`. Do not promote a role of an existing actor to a new actor unless requirements explicitly establish separate goals, authority, or interaction responsibilities.
-- Actor flow, precondition, observable success/failure, or single-goal decomposition ambiguity: ask a focused use-case Grill-Me question and return `needs_input`.
+- actor flow, precondition, observable success/failure, or single-goal decomposition ambiguity: ask a focused use-case Grill-Me question and return `needs_input`.
 - Do not require every use-case verb, goal, or title to become a canonical term. A use-case goal may combine a verb with confirmed canonical domain concepts. Keep a domain concept, an actor role, a state label, and a use-case action distinct unless `context.md` explicitly confirms the same meaning boundary.
 
 ### Use Case Standards

--- a/.codex/skills/harness-usecases/references/standards.md
+++ b/.codex/skills/harness-usecases/references/standards.md
@@ -12,6 +12,15 @@ Use the following standards as the source of truth for the instructions.
 - Do not use terms listed under `Forbidden Terms`.
 - If a needed MVP term is missing or ambiguous, stop or mark the related use case detail as `Needs confirmation`; record the missing term as a `Blocking Open Language Question` instead of inventing behavior.
 
+### Ambiguity Routing Standards
+
+Before asking a Grill-Me question, classify the ambiguity.
+
+- Missing or ambiguous canonical noun, role label, state label, alias, or meaning boundary: return `blocked` and route to `$harness-ubiquitous-language`. Do not ask the user directly from the use-case stage, write a partial use-case draft, or invent the missing language.
+- Whether an external actor is distinct from an existing actor: return `blocked` and route to `$harness-requirements`. Do not promote a role of an existing actor to a new actor unless requirements explicitly establish separate goals, authority, or interaction responsibilities.
+- Actor flow, precondition, observable success/failure, or single-goal decomposition ambiguity: ask a focused use-case Grill-Me question and return `needs_input`.
+- Do not require every use-case verb, goal, or title to become a canonical term. A use-case goal may combine a verb with confirmed canonical domain concepts. Keep a domain concept, an actor role, a state label, and a use-case action distinct unless `context.md` explicitly confirms the same meaning boundary.
+
 ### Use Case Standards
 
 - Write use cases around the goals of external actors.
@@ -46,4 +55,3 @@ Rules:
 - `docs/use-cases/<UC-ID>/e2e-goal.md` must define the end-to-end verification goal for that same use case.
 - If the use case is not fully confirmed, still create both slice documents and mark ambiguous sections as `Needs confirmation`.
 - Do not leave a harvested use case only in `docs/design/유스케이스.md`; it must have matching runtime slice documents.
-

--- a/tests/test_usecase_ambiguity_routing_instructions.py
+++ b/tests/test_usecase_ambiguity_routing_instructions.py
@@ -21,7 +21,7 @@ def test_usecase_ambiguity_is_routed_before_questions() -> None:
         assert "$harness-ubiquitous-language" in contract
         assert "$harness-requirements" in contract
         assert "Do not promote a role of an existing actor to a new actor" in contract
-        assert "actor flow, precondition, observable success/failure, or single-goal decomposition" in contract
+        assert "single-goal decomposition ambiguity" in contract
 
 
 def test_usecase_contract_has_blocked_and_input_routes() -> None:

--- a/tests/test_usecase_ambiguity_routing_instructions.py
+++ b/tests/test_usecase_ambiguity_routing_instructions.py
@@ -6,3 +6,18 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def read_text(path: str) -> str:
     return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_usecase_ambiguity_is_routed_before_questions() -> None:
+    contracts = (
+        read_text(".codex/skills/harness-usecases/references/standards.md"),
+        read_text(".codex/skills/harness-usecases/references/invocation.md"),
+        read_text(".codex/agents/references/harness_usecases.md"),
+    )
+
+    for contract in contracts:
+        assert "Before asking a Grill-Me question, classify the ambiguity." in contract
+        assert "canonical noun, role label, state label, alias, or meaning boundary" in contract
+        assert "$harness-ubiquitous-language" in contract
+        assert "$harness-requirements" in contract
+        assert "Do not promote a role of an existing actor to a new actor" in contract

--- a/tests/test_usecase_ambiguity_routing_instructions.py
+++ b/tests/test_usecase_ambiguity_routing_instructions.py
@@ -24,6 +24,13 @@ def test_usecase_ambiguity_is_routed_before_questions() -> None:
         assert "actor flow, precondition, observable success/failure, or single-goal decomposition" in contract
 
 
+def test_usecase_contract_has_blocked_and_input_routes() -> None:
+    agent_contract = read_text(".codex/agents/references/harness_usecases.md")
+
+    assert "return `blocked`" in agent_contract
+    assert "return `needs_input`" in agent_contract
+
+
 def test_ubiquitous_language_keeps_actions_and_state_labels_distinct() -> None:
     contracts = (
         read_text(".codex/skills/harness-ubiquitous-language/references/detailed-instructions.md"),

--- a/tests/test_usecase_ambiguity_routing_instructions.py
+++ b/tests/test_usecase_ambiguity_routing_instructions.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_text(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")

--- a/tests/test_usecase_ambiguity_routing_instructions.py
+++ b/tests/test_usecase_ambiguity_routing_instructions.py
@@ -21,3 +21,16 @@ def test_usecase_ambiguity_is_routed_before_questions() -> None:
         assert "$harness-ubiquitous-language" in contract
         assert "$harness-requirements" in contract
         assert "Do not promote a role of an existing actor to a new actor" in contract
+        assert "actor flow, precondition, observable success/failure, or single-goal decomposition" in contract
+
+
+def test_ubiquitous_language_keeps_actions_and_state_labels_distinct() -> None:
+    contracts = (
+        read_text(".codex/skills/harness-ubiquitous-language/references/detailed-instructions.md"),
+        read_text(".codex/agents/references/ubiquitous_language_reviewer.md"),
+    )
+
+    for contract in contracts:
+        assert "Canonical vocabulary covers domain concepts, stable roles, user-visible concepts, and state labels" in contract
+        assert "Do not require every use-case verb" in contract
+        assert "A use-case goal may combine a verb with canonical domain concepts." in contract


### PR DESCRIPTION
## 관련 이슈

Closes #421

## 문제

유스케이스 단계가 `context.md`에 없는 canonical vocabulary나 기존 Actor와 역할의 분리 여부를 직접 Grill-Me 질문으로 만들 수 있었습니다. 이 경우 유스케이스 단계가 유비쿼터스 언어 또는 요구사항의 책임을 침범하고, 역할 label을 독립 external actor로 성급하게 승격할 위험이 있습니다.

또한 UL 단계의 범위가 use-case-facing command·input·output 등까지 넓게 표현되어, domain concept·actor role·state label·use-case action의 의미 경계가 흐려질 수 있었습니다.

## 변경 사항

### 1. 유스케이스 단계에 질문 전 ambiguity 분류를 강제했습니다

유스케이스 에이전트 표준·invocation·agent reference에 동일한 분류 규칙을 추가했습니다.

| 모호성 종류 | 유스케이스 단계 처리 |
|---|---|
| canonical noun, role label, state label, alias, meaning boundary의 부재·모호성 | `blocked` 반환 후 `$harness-ubiquitous-language`로 라우팅 |
| 기존 actor와 분리된 external actor인지 여부 | `blocked` 반환 후 `$harness-requirements`로 라우팅 |
| actor flow, precondition, observable success/failure, single-goal decomposition | `needs_input`으로 Grill-Me 질문 |

언어 또는 actor-boundary blocker는 질문·변경 파일 없이 상위 단계로 반환하며, use-case 초안을 부분 생성하지 않도록 명시했습니다.

### 2. Actor 역할을 독립 Actor로 자동 승격하지 않도록 일반화했습니다

특정 도메인이나 예시에 의존하지 않고, 기존 actor의 role은 요구사항이 별도 goal·authority·interaction responsibility를 명시한 경우에만 독립 external actor가 될 수 있도록 규정했습니다.

### 3. UL 단계의 vocabulary 범위를 명확히 했습니다

UL은 domain concept, stable role, user-visible concept, state label의 canonical vocabulary와 label·alias·forbidden term·meaning boundary를 담당합니다.

반면 모든 use-case verb, goal, command candidate, title을 canonical term으로 만들지 않으며, use-case goal은 canonical domain concept과 동사를 조합할 수 있습니다. domain concept, actor-role label, state label, use-case action은 명시적 의미 경계가 없으면 서로 다른 분류로 유지합니다.

### 4. 회귀 테스트를 추가했습니다

`tests/test_usecase_ambiguity_routing_instructions.py`에서 다음 계약을 검사합니다.

- 질문 전 ambiguity 분류 규칙과 upstream routing 존재 여부
- 역할 label의 독립 actor 자동 승격 금지 규칙
- `blocked`와 `needs_input` 경로의 분리
- UL 단계가 use-case action과 state label을 구별하는 규칙

## 검증

- 추가한 정적 계약 테스트의 assertion 대상과 변경 파일을 교차 검토했습니다.
- 이 실행 환경에서는 GitHub 저장소 clone 시 DNS 해석이 실패해 로컬 `pytest` 전체 실행은 수행하지 못했습니다. PR CI에서 실제 checkout 기준으로 검증하도록 했습니다.

## 리뷰 포인트

- actor 분리 판단을 특정 사례가 아닌 `separate goals / authority / interaction responsibilities`라는 일반 기준으로 둔 점
- language blocker는 use-case 단계에서 `needs_input`으로 묻지 않고 반드시 `blocked`로 반환하는 점
- UL 단계가 action과 state를 동일한 canonical vocabulary 분류로 합치지 않도록 한 점
