### PR TITLE
fix(ui): DDD Design Integration 재실행 모드와 상태 표시 정합성 수정

### DIFF
--- a/harness_codex/runtime/dashboard_ddd_integration_patch.py
+++ b/harness_codex/runtime/dashboard_ddd_integration_patch.py
@@ -43,6 +43,10 @@ def apply_dashboard_ddd_integration_patch() -> None:
     from harness_codex.runtime.dashboard_ddd_integration_ui_patch import (
         apply_dashboard_ddd_integration_ui_patch,
     )
+    from harness_codex.runtime.procedure_stage_runtime_state_preservation_patch import (
+        apply_procedure_stage_runtime_state_preservation_patch,
+    )
 
+    apply_procedure_stage_runtime_state_preservation_patch()
     apply_dashboard_ddd_integration_ui_patch()
     apply_dashboard_ddd_integration_rerun_patch()

--- a/harness_codex/runtime/dashboard_ddd_integration_patch.py
+++ b/harness_codex/runtime/dashboard_ddd_integration_patch.py
@@ -37,12 +37,12 @@ def apply_dashboard_ddd_integration_patch() -> None:
 
     # Dashboard state is ready now. The CLI bridge is installed later from the
     # package root, after `harness_codex.cli` has completed its own imports.
-    from harness_codex.runtime.procedure_stage_runtime_state_preservation_patch import (
-        apply_procedure_stage_runtime_state_preservation_patch,
+    from harness_codex.runtime.dashboard_ddd_integration_rerun_patch import (
+        apply_dashboard_ddd_integration_rerun_patch,
     )
     from harness_codex.runtime.dashboard_ddd_integration_ui_patch import (
         apply_dashboard_ddd_integration_ui_patch,
     )
 
-    apply_procedure_stage_runtime_state_preservation_patch()
     apply_dashboard_ddd_integration_ui_patch()
+    apply_dashboard_ddd_integration_rerun_patch()

--- a/harness_codex/runtime/dashboard_ddd_integration_rerun_patch.py
+++ b/harness_codex/runtime/dashboard_ddd_integration_rerun_patch.py
@@ -1,0 +1,105 @@
+"""Keep DDD integration reruns executable and canonically visible in the dashboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_DDD_INTEGRATION_STAGE_ID = "ddd-design-integration"
+_PATCHED_ATTR = "_harness_ddd_integration_rerun_patch_applied"
+
+
+def apply_dashboard_ddd_integration_rerun_patch() -> None:
+    """Add the explicit apply mode and canonical failure projection for integration reruns."""
+
+    from harness_codex.runtime import ui_server
+
+    if getattr(ui_server, _PATCHED_ATTR, False):
+        return
+
+    original_command = ui_server._rerun_design_stage_command
+    original_run_job = ui_server._run_rerun_design_stage_job
+
+    def command_with_ddd_integration_apply(
+        root: Path,
+        change_set_id: str,
+        stage_id: str,
+        user_prompt: str,
+        *,
+        uc_id: str,
+    ) -> list[str]:
+        command = original_command(
+            root,
+            change_set_id,
+            stage_id,
+            user_prompt,
+            uc_id=uc_id,
+        )
+        if stage_id == _DDD_INTEGRATION_STAGE_ID and "--apply" not in command:
+            command.append("--apply")
+        return command
+
+    def run_job_with_canonical_failure(
+        root: Path,
+        change_set_id: str,
+        stage_id: str,
+        user_prompt: str,
+        uc_id: str,
+        answers: list[dict[str, str]],
+        restart: bool,
+    ) -> None:
+        original_run_job(
+            root,
+            change_set_id,
+            stage_id,
+            user_prompt,
+            uc_id,
+            answers,
+            restart,
+        )
+        if stage_id != _DDD_INTEGRATION_STAGE_ID:
+            return
+
+        with ui_server._STAGE_RERUN_JOBS_LOCK:
+            job = ui_server._STAGE_RERUN_JOBS.get(change_set_id)
+            failed = bool(job and job.get("status") == "failed")
+            detail = str(job.get("error") or "stage rerun failed") if job else "stage rerun failed"
+        if not failed:
+            return
+
+        _record_failed_integration_stage(root, change_set_id, detail)
+        dashboard = ui_server.document_dashboard_state(root)
+        with ui_server._STAGE_RERUN_JOBS_LOCK:
+            current = ui_server._STAGE_RERUN_JOBS.get(change_set_id)
+            if current is not None:
+                current["dashboard"] = dashboard
+
+    ui_server._rerun_design_stage_command = command_with_ddd_integration_apply
+    ui_server._run_rerun_design_stage_job = run_job_with_canonical_failure
+    setattr(ui_server, _PATCHED_ATTR, True)
+
+
+def _record_failed_integration_stage(root: Path, change_set_id: str, detail: str) -> None:
+    """Make an asynchronous rerun failure visible through the canonical stage state."""
+
+    change_set_path = root / "docs/changes/active" / f"{change_set_id}.md"
+    if not change_set_path.exists():
+        return
+
+    from harness_codex import cli
+
+    cli._record_procedure_stage_status(
+        root,
+        change_set_path.relative_to(root),
+        ui_server_procedure_stage(),
+        "blocked",
+        f"DDD Design Integration rerun failed: {detail}",
+    )
+
+
+def ui_server_procedure_stage():
+    """Resolve the stage lazily after the canonical CLI bridge is installed."""
+
+    from harness_codex.runtime.procedure_stages import procedure_stage
+
+    return procedure_stage(_DDD_INTEGRATION_STAGE_ID)

--- a/harness_codex/runtime/dashboard_ddd_integration_rerun_patch.py
+++ b/harness_codex/runtime/dashboard_ddd_integration_rerun_patch.py
@@ -91,13 +91,13 @@ def _record_failed_integration_stage(root: Path, change_set_id: str, detail: str
     cli._record_procedure_stage_status(
         root,
         change_set_path.relative_to(root),
-        ui_server_procedure_stage(),
+        _integration_stage(),
         "blocked",
         f"DDD Design Integration rerun failed: {detail}",
     )
 
 
-def ui_server_procedure_stage():
+def _integration_stage():
     """Resolve the stage lazily after the canonical CLI bridge is installed."""
 
     from harness_codex.runtime.procedure_stages import procedure_stage

--- a/harness_codex/runtime/dashboard_ddd_integration_ui_patch.py
+++ b/harness_codex/runtime/dashboard_ddd_integration_ui_patch.py
@@ -92,6 +92,7 @@ function renderDddIntegrationWorkspace() {
     "DDD Design Integration",
     "",
     nextAction,
+    verified,
   );
   return `<section class="panel"><h3>DDD Design Integration</h3>
       <p><span class="pill ${escapeHtml(status)}">${escapeHtml(status)}</span></p>
@@ -103,6 +104,26 @@ function renderDddIntegrationWorkspace() {
 
 function technicalDecisionUseCases() {''',
         "DDD integration workspace",
+    )
+    patched = _replace_once(
+        patched,
+        '''function renderWorkflowRerunPanel(stageId, label, ucId = "", nextAction = "") {''',
+        '''function renderWorkflowRerunPanel(stageId, label, ucId = "", nextAction = "", complete = true) {''',
+        "rerun panel completion input",
+    )
+    patched = _replace_once(
+        patched,
+        '''  const buttonLabel = question ? "Submit answer and rerun" : "Rerun and verify";''',
+        '''  const buttonLabel = question ? "Submit answer and rerun" : complete ? "Rerun and verify" : "Run and verify";''',
+        "rerun panel action label",
+    )
+    patched = _replace_once(
+        patched,
+        '''    <p class="completion">${escapeHtml(label)} complete.</p>
+    <p class="small">Reruns this stage with <code>--force</code>, verifies output, and marks downstream design stale.</p>''',
+        '''    ${complete ? `<p class="completion">${escapeHtml(label)} complete.</p>` : '<p class="small">This stage is not verified yet.</p>'}
+    <p class="small">${complete ? "Reruns" : "Runs"} this stage with <code>--force</code>, verifies output, and marks downstream design stale.</p>''',
+        "rerun panel completion summary",
     )
     patched = _replace_once(
         patched,
@@ -158,6 +179,17 @@ function technicalDecisionUseCases() {''',
   if (job.stage_id === "ddd-design-integration") return "dddIntegration";
   if (job.stage_id === "technical-decisions") return "technicalDecisions";''',
         "rerun recovery tab",
+    )
+    patched = _replace_once(
+        patched,
+        '''    } else if (["failed", "blocked"].includes(result.job?.status)) {
+      app.error = result.job.error || "Stage rerun failed.";
+      clearBusy();''',
+        '''    } else if (["failed", "blocked"].includes(result.job?.status)) {
+      if (result.job.dashboard) app.state = result.job.dashboard;
+      app.error = result.job.error || "Stage rerun failed.";
+      clearBusy();''',
+        "rerun failure state refresh",
     )
     return patched
 

--- a/tests/runtime/test_dashboard_ddd_integration_ui_patch.py
+++ b/tests/runtime/test_dashboard_ddd_integration_ui_patch.py
@@ -25,7 +25,9 @@ def test_dashboard_script_exposes_ddd_integration_between_ddd_and_technical_deci
     assert 'complete ? "Rerun and verify" : "Run and verify"' in patched
     assert "This stage is not verified yet." in patched
     assert "nextAction,\n    verified,\n  );" in patched
-    assert "if (result.job.dashboard) app.state = result.job.dashboard;" in patched
+    assert '''    } else if (["failed", "blocked"].includes(result.job?.status)) {
+      if (result.job.dashboard) app.state = result.job.dashboard;
+      app.error = result.job.error || "Stage rerun failed.";''' in patched
 
     workspace = patched.split("function renderDddIntegrationWorkspace() {", 1)[1].split(
         "function technicalDecisionUseCases() {", 1

--- a/tests/runtime/test_dashboard_ddd_integration_ui_patch.py
+++ b/tests/runtime/test_dashboard_ddd_integration_ui_patch.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from harness_codex.runtime import dashboard_runtime_state as dashboard
 from harness_codex.runtime import ui_server
 from harness_codex.runtime.dashboard_ddd_integration_ui_patch import _patch_dashboard_script
+from harness_codex.runtime.procedure_stages import render_initial_changeset
 
 
 def test_dashboard_script_exposes_ddd_integration_between_ddd_and_technical_decisions() -> None:
@@ -19,9 +21,14 @@ def test_dashboard_script_exposes_ddd_integration_between_ddd_and_technical_deci
     assert 'data-stage-tab="technicalDecisions" ${!dddIntegrationDone || !technicalAvailable ? "disabled" : ""}' in patched
     assert 'data-stage-tab="dddIntegration">Open DDD Design Integration</button>' in patched
     assert 'if (job.stage_id === "ddd-design-integration") return "dddIntegration";' in patched
+    assert 'function renderWorkflowRerunPanel(stageId, label, ucId = "", nextAction = "", complete = true)' in patched
+    assert 'complete ? "Rerun and verify" : "Run and verify"' in patched
+    assert "This stage is not verified yet." in patched
+    assert "nextAction,\n    verified,\n  );" in patched
+    assert "if (result.job.dashboard) app.state = result.job.dashboard;" in patched
 
 
-def test_ddd_integration_rerun_is_change_set_scoped_without_use_case(tmp_path: Path) -> None:
+def test_ddd_integration_rerun_is_change_set_scoped_and_uses_apply_mode(tmp_path: Path) -> None:
     change_path = tmp_path / "docs/changes/active/CHG-001.md"
     change_path.parent.mkdir(parents=True)
     change_path.write_text("# CHG-001\n", encoding="utf-8")
@@ -34,5 +41,65 @@ def test_ddd_integration_rerun_is_change_set_scoped_without_use_case(tmp_path: P
         uc_id="",
     )
 
-    assert command[-3:] == ["ddd-design-integration", "CHG-001", "--force"]
+    assert command[-4:] == ["ddd-design-integration", "CHG-001", "--force", "--apply"]
     assert "--uc" not in command
+
+
+def test_failed_ddd_integration_rerun_blocks_canonical_stage(tmp_path: Path, monkeypatch) -> None:
+    change_set_id = "CHG-001"
+    change_path = tmp_path / "docs/changes/active" / f"{change_set_id}.md"
+    change_path.parent.mkdir(parents=True)
+    change_path.write_text(
+        render_initial_changeset(
+            change_set_id=change_set_id,
+            title="DDD integration rerun",
+            request_summary="Record a failed UI rerun in canonical state.",
+        ),
+        encoding="utf-8",
+    )
+
+    def raise_rerun_failure(*_args, **_kwargs):
+        raise ValueError("apply mode failed")
+
+    monkeypatch.setattr(ui_server, "rerun_design_stage", raise_rerun_failure)
+    job = {
+        "change_set_id": change_set_id,
+        "stage_id": "ddd-design-integration",
+        "uc_id": "",
+        "status": "running",
+        "started_at": "",
+        "started_at_epoch": 0.0,
+        "finished_at": "",
+        "finished_at_epoch": 0.0,
+        "returncode": None,
+        "output": "",
+        "error": "",
+        "pending_questions": [],
+    }
+
+    with ui_server._STAGE_RERUN_JOBS_LOCK:
+        ui_server._STAGE_RERUN_JOBS[change_set_id] = job
+    try:
+        ui_server._run_rerun_design_stage_job(
+            tmp_path,
+            change_set_id,
+            "ddd-design-integration",
+            "",
+            "",
+            [],
+            False,
+        )
+
+        state = dashboard.load_canonical_change_set_state(tmp_path, change_set_id)
+        assert state is not None
+        assert state.decision_results["procedure_stage_results"]["ddd-design-integration"] == {
+            "status": "blocked",
+            "notes": "DDD Design Integration rerun failed: apply mode failed",
+        }
+        with ui_server._STAGE_RERUN_JOBS_LOCK:
+            failed_job = ui_server._STAGE_RERUN_JOBS[change_set_id]
+            assert failed_job["status"] == "failed"
+            assert failed_job["dashboard"] is not None
+    finally:
+        with ui_server._STAGE_RERUN_JOBS_LOCK:
+            ui_server._STAGE_RERUN_JOBS.pop(change_set_id, None)

--- a/tests/runtime/test_dashboard_ddd_integration_ui_patch.py
+++ b/tests/runtime/test_dashboard_ddd_integration_ui_patch.py
@@ -27,6 +27,11 @@ def test_dashboard_script_exposes_ddd_integration_between_ddd_and_technical_deci
     assert "nextAction,\n    verified,\n  );" in patched
     assert "if (result.job.dashboard) app.state = result.job.dashboard;" in patched
 
+    workspace = patched.split("function renderDddIntegrationWorkspace() {", 1)[1].split(
+        "function technicalDecisionUseCases() {", 1
+    )[0]
+    assert "fetch(" not in workspace
+
 
 def test_ddd_integration_rerun_is_change_set_scoped_and_uses_apply_mode(tmp_path: Path) -> None:
     change_path = tmp_path / "docs/changes/active/CHG-001.md"


### PR DESCRIPTION
## 관련 이슈
Closes #431

## 문제 상황
ChangeSet Workflow의 **DDD Design Integration** 화면에서 재실행 경로가 `ddd-design-integration` 명령을 실행 모드 없이 조립하고 있었습니다. 해당 CLI는 `--plan`, `--preview`, `--apply` 중 하나를 요구하므로, 사용자가 화면에서 재실행을 시도하면 usage 오류가 발생할 수 있었습니다.

또한 화면은 단계 요약을 ChangeSet 상태에서 읽으면서도, 하단 재실행 패널은 상태와 무관하게 항상 `DDD Design Integration complete.`를 렌더링했습니다. 그래서 실제 실패 후에도 상단에는 `PENDING` 또는 오류가 보이고 하단에는 완료로 표시되는 모순이 발생했습니다.

## 원인
1. `ui_server._rerun_design_stage_command()`는 DDD Integration에도 공통적으로 `--force`만 추가했습니다.
2. DDD Integration은 일반 설계 단계와 달리 CLI에서 실행 모드를 명시해야 하는 단계라 `--apply`가 누락된 명령은 argparse usage 오류로 종료됩니다.
3. 비동기 재실행 실패는 job 상태에만 기록되고 ChangeSet의 canonical RunState에는 반영되지 않았습니다.
4. DDD Integration 전용 UI는 재실행 패널의 완료 문구를 조건 없이 사용했습니다.

## 변경 내용
### 1. DDD Integration 재실행 명령에 `--apply` 보장
- ChangeSet 범위의 `ddd-design-integration` 재실행 명령에만 `--apply`를 추가했습니다.
- `--uc`는 계속 전달하지 않아 ChangeSet 단위 통합이라는 기존 계약을 유지합니다.
- 결과 명령 형태: `harness ddd-design-integration <CHG-ID> --force --apply`

### 2. 실제 재실행 실패를 canonical RunState에 반영
- 비동기 DDD Integration 재실행 job이 실패하면 해당 절차 단계를 canonical state에서 `blocked`로 기록합니다.
- 실패 사유를 stage notes에 보존해 ChangeSet 요약과 상세 실행 결과가 같은 상태 원천을 보도록 했습니다.
- 갱신된 dashboard 상태를 job 응답에도 넣어 클라이언트가 즉시 최신 단계를 렌더링할 수 있게 했습니다.

### 3. 완료 문구를 canonical 단계 상태에 연동
- DDD Integration 탭의 `verified` 여부를 ChangeSet stage status에서 계산합니다.
- `verified`일 때만 `DDD Design Integration complete.`를 표시합니다.
- `pending`/`blocked`/`stale` 상태에서는 완료 문구 대신 미검증 상태를 표시하고 버튼도 `Run and verify`로 바뀝니다.
- 재실행 실패 후에는 클라이언트가 반환된 dashboard 상태를 적용한 뒤 오류를 표시합니다.

### 4. 기존 상태 보존 훅 유지
- DDD Integration dashboard patch에 이미 있던 `procedure_stage_runtime_state_preservation` 훅을 유지했습니다.
- 따라서 dashboard session 저장 과정이 기존 canonical procedure-stage 결정을 덮어쓰지 않습니다.

### 5. 회귀 테스트 추가
- DDD Integration 탭 렌더링이 `fetch`를 호출하지 않는 read-only 경로임을 검증했습니다.
- 재실행 명령에 `--force --apply`가 포함되고 `--uc`가 없는지 검증했습니다.
- 비동기 재실행 실패가 canonical RunState의 `ddd-design-integration=blocked`로 기록되는지 검증했습니다.
- 미검증 단계에서 완료 문구가 렌더링되지 않고 실패 후 dashboard 상태를 갱신하는 UI 패치가 포함되는지 검증했습니다.

## 기대 동작
- DDD Design Integration 탭 진입 자체는 read-only이며 실행 명령을 호출하지 않습니다.
- 완료된 ChangeSet은 상단 단계 상태와 하단 완료 문구가 모두 `verified` 기준으로 일치합니다.
- `Rerun and verify`는 유효한 `--apply` 모드로만 실행됩니다.
- 실제 실행 실패 시에는 오류와 `blocked` 상태가 함께 표시됩니다.

## 테스트
- GitHub Actions `Runtime document contracts` 실행 #568 통과
  - `Full runtime and workflow regression` 통과
  - `Public memory CLI end to end` 통과
  - `Memory schema and retrieval` 통과
  - `Memory prompt injection contract` 통과
  - `Evolution to memory integration` 통과
- 추가/수정 테스트: `tests/runtime/test_dashboard_ddd_integration_ui_patch.py`

## 리뷰 포인트
- DDD Integration만 실행 모드를 명시적으로 강제하고, 다른 단계의 기존 재실행 계약은 변경하지 않았습니다.
- 실패 상태를 `blocked`로 투영해 현재 canonical procedure-stage 상태 모델(`verified`/`pending`/`stale`/`blocked`)을 유지했습니다.
- 렌더링은 상태 조회만 수행하며, 실제 재실행은 사용자의 명시적 버튼 제출에서만 시작됩니다.