### PR TITLE
feat: 산출 문서와 Grill-Me 질문의 기본 언어를 한국어로 전환

### DIFF
--- a/.codex/agents/requirements_interviewer.toml
+++ b/.codex/agents/requirements_interviewer.toml
@@ -7,6 +7,11 @@ sandbox_mode = "workspace-write"
 developer_instructions = """
 You are the requirements_interviewer agent.
 
+Language contract:
+- Write every user-facing Grill-Me question, recommended answer, summary, and Markdown artifact in Korean.
+- Preserve JSON field names, source paths, command names, code identifiers, and established canonical terms required by contracts.
+- Use Korean for prose that explains a preserved identifier.
+
 Hot-path contract:
 - Role: Derive functional and non-functional requirements only. Confirm only MVP-blocking terms needed to understand the requirement.
 - Load `.codex/agents/references/requirements_interviewer.md` before making workflow decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Context
 
-Write all agent input/output and user-facing output in English.
+Write all agent input/output and user-facing output in Korean. Preserve code identifiers, file paths, JSON keys, CLI commands, protocol names, and previously approved canonical terms when compatibility requires their original form.
 
 This repo is a Python Codex harness for ChangeSet/use-case workflows with a bundled runtime dashboard.
 
@@ -15,7 +15,8 @@ Read only the smallest relevant context file. Prefer `rg`, targeted file reads, 
 
 ## Hard Rules
 - PR bodies, commit messages, and code comments must be written in Korean.
-- Documents created or updated under `docs/` must be written in English.
+- Documents created or updated under `docs/` must use Korean for titles, headings, prose, table labels, statuses, findings, and user-visible examples.
+- Grill-Me, use-case, event-storming, DDD, technical-decision, planning, verification, and review questions plus recommended answers must be written in Korean.
 - Use `python3` for Python commands.
 - Manage dependencies with the repository-root `venv`.
 - Preserve existing ChangeSet, use-case, maintenance, and plan workflow boundaries.


### PR DESCRIPTION
## 구현 의도
ChangeSet 워크플로우가 생성하는 산출 문서와 Grill-Me 질문이 사용자에게 영어로 노출되는 문제를 해결합니다. 코드·JSON·CLI 계약은 유지하면서 사용자용 문장과 Markdown 산출물의 기본 언어를 한국어로 전환합니다.

## 구현 방식
- 루트 `AGENTS.md`에 문서 제목·본문·표 라벨·상태·검토 결과와 각 설계 단계의 질문·권장 답변을 한국어로 작성하도록 공통 언어 계약을 추가했습니다.
- `requirements_interviewer` 에이전트에 Grill-Me 질문, 권장 답변, 요약, 요구사항 Markdown을 한국어로 생성하도록 직접 규칙을 추가했습니다.
- JSON 키, 경로, 명령, 코드 식별자, 기존 계약상 canonical term은 유지하도록 예외를 명시했습니다.

## 검증
- `main...feat/korean-artifact-language` 비교에서 변경 범위가 언어 지침 파일 두 개로 제한됨을 확인했습니다.
- 브랜치의 `AGENTS.md`와 `requirements_interviewer.toml`을 다시 읽어 한국어 출력 규칙이 반영되었음을 확인했습니다.
- 이 환경에는 리포지토리 작업 트리가 없어 테스트 명령은 실행하지 못했습니다. 변경은 Markdown/TOML 지침뿐이며, CI에서 기존 테스트 전체가 실행되어야 합니다.

## 위험 및 롤백
- 기존 영문 구조를 전제로 한 프롬프트나 스냅샷 테스트가 있다면 결과 문자열이 바뀔 수 있습니다.
- 문제 발생 시 이 PR의 두 커밋을 되돌리면 이전 언어 정책으로 복구됩니다.