### PR TITLE
fix: ChangeSet 삭제 시 런타임 상태까지 정리

### DIFF
--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -30,7 +30,6 @@ def _install_changeset_execution_boundary() -> None:
         validation can still run over its empty test-step set without weakening the
         validation of production workflow definitions.
         """
-
         workflow = cli.load_named_workflow(*loader_args, **loader_kwargs)
         if not hasattr(workflow, "steps"):
             setattr(workflow, "steps", ())
@@ -87,6 +86,17 @@ def _install_canonical_procedure_stage_bridge() -> None:
     apply_dashboard_final_design_result_patch()
 
 
+def _install_changeset_deletion_cleanup() -> None:
+    """Install deletion cleanup after the legacy CLI module is fully defined."""
+
+    from harness_codex.runtime.changeset_deletion_runtime_patch import (
+        apply_changeset_deletion_runtime_cleanup_patch,
+    )
+
+    apply_changeset_deletion_runtime_cleanup_patch()
+
+
 _install_changeset_execution_boundary()
 _install_runtime_write_boundaries()
 _install_canonical_procedure_stage_bridge()
+_install_changeset_deletion_cleanup()

--- a/harness_codex/runtime/__init__.py
+++ b/harness_codex/runtime/__init__.py
@@ -149,6 +149,12 @@ apply_dashboard_runtime_state_patch()
 apply_dashboard_runtime_state_legacy_bridge()
 apply_dashboard_runtime_state_legacy_compat()
 
+from harness_codex.runtime.changeset_deletion_runtime_patch import (
+    apply_changeset_deletion_runtime_cleanup_patch,
+)
+
+apply_changeset_deletion_runtime_cleanup_patch()
+
 from harness_codex.runtime.verifier import (
     CommandCheck,
     RequiredStageCheck,

--- a/harness_codex/runtime/changeset_cleanup.py
+++ b/harness_codex/runtime/changeset_cleanup.py
@@ -1,0 +1,90 @@
+"""Cleanup for runtime artifacts owned by one deleted active ChangeSet."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_CHANGESET_ID_PATTERN = re.compile(r"CHG-[A-Za-z0-9-]+")
+
+
+def purge_changeset_runtime_artifacts(
+    repo_root: Path | str,
+    change_set_id: str,
+) -> tuple[Path, ...]:
+    """Remove disposable runtime state owned by a deleted ChangeSet.
+
+    Canonical design, use-case, and plan documents are intentionally not touched.
+    They can be reused or explicitly removed by a separate user action.  The cleanup
+    covers only resumable UI snapshots, persisted stage-rerun jobs, and run
+    directories whose JSON metadata identifies the deleted ChangeSet.
+    """
+
+    if not _CHANGESET_ID_PATTERN.fullmatch(change_set_id):
+        raise ValueError("invalid ChangeSet id")
+
+    root = Path(repo_root)
+    removed: list[Path] = []
+
+    _remove_path(
+        root / ".harness" / "ui" / "change-sets" / change_set_id,
+        removed,
+    )
+    _remove_path(
+        root / ".harness" / "ui" / "stage-rerun-jobs" / f"{change_set_id}.json",
+        removed,
+    )
+
+    runs_root = root / ".harness" / "runs"
+    if runs_root.is_dir():
+        for run_dir in runs_root.iterdir():
+            if run_dir.is_dir() and _run_directory_references_change_set(
+                run_dir, change_set_id
+            ):
+                _remove_path(run_dir, removed)
+
+    # The global harvest session is only safe to discard when deleting the last
+    # active ChangeSet.  With another active ChangeSet it may belong to that
+    # workflow, so its per-ChangeSet snapshot remains the source of truth.
+    active_dir = root / "docs" / "changes" / "active"
+    has_active_changesets = active_dir.is_dir() and any(active_dir.glob("CHG-*.md"))
+    if not has_active_changesets:
+        _remove_path(root / ".harness" / "ui" / "harvest-session.json", removed)
+
+    return tuple(removed)
+
+
+def _remove_path(path: Path, removed: list[Path]) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+        removed.append(path)
+    elif path.is_dir():
+        shutil.rmtree(path)
+        removed.append(path)
+
+
+def _run_directory_references_change_set(run_dir: Path, change_set_id: str) -> bool:
+    """Return whether durable JSON within one run identifies ``change_set_id``."""
+
+    for json_path in run_dir.rglob("*.json"):
+        try:
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            continue
+        if _json_references_change_set(payload, change_set_id):
+            return True
+    return False
+
+
+def _json_references_change_set(value: Any, change_set_id: str) -> bool:
+    if isinstance(value, Mapping):
+        if value.get("change_set_id") == change_set_id:
+            return True
+        return any(_json_references_change_set(item, change_set_id) for item in value.values())
+    if isinstance(value, list):
+        return any(_json_references_change_set(item, change_set_id) for item in value)
+    return False

--- a/harness_codex/runtime/changeset_deletion_runtime_patch.py
+++ b/harness_codex/runtime/changeset_deletion_runtime_patch.py
@@ -11,43 +11,48 @@ _PATCHED = "_harness_changeset_deletion_runtime_cleanup_applied"
 
 
 def apply_changeset_deletion_runtime_cleanup_patch() -> None:
-    """Make every active-ChangeSet unlink discard its resumable runtime state.
+    """Attach cleanup to the CLI and dashboard ChangeSet deletion boundaries."""
 
-    Both the legacy CLI and the document dashboard delete the active ChangeSet
-    markdown through ``Path.unlink``. Keeping the boundary here guarantees the
-    same cleanup semantics while those callers continue to share their existing
-    validation and response contracts.
-    """
+    _patch_dashboard_delete()
+    _patch_dashboard_run_projection()
+    _patch_cli_delete_when_available()
 
-    if getattr(Path, _PATCHED, False):
+
+def _patch_dashboard_delete() -> None:
+    from harness_codex.runtime import document_dashboard
+
+    original_delete = document_dashboard.delete_active_changeset
+    if getattr(original_delete, _PATCHED, False):
         return
 
-    original_unlink = Path.unlink
-
-    def unlink_with_changeset_runtime_cleanup(self: Path, missing_ok: bool = False) -> None:
-        cleanup_target = _active_changeset_target(self) if self.exists() else None
-        original_unlink(self, missing_ok=missing_ok)
-        if cleanup_target is None:
-            return
-        repo_root, change_set_id = cleanup_target
+    def delete_active_changeset_with_runtime_cleanup(
+        repo_root: Path | str,
+        change_set_id: str,
+    ) -> dict[str, str]:
+        result = original_delete(repo_root, change_set_id)
         purge_changeset_runtime_artifacts(repo_root, change_set_id)
+        return result
 
-    Path.unlink = unlink_with_changeset_runtime_cleanup
-    _patch_dashboard_run_projection()
-    setattr(Path, _PATCHED, True)
+    setattr(delete_active_changeset_with_runtime_cleanup, _PATCHED, True)
+    document_dashboard.delete_active_changeset = delete_active_changeset_with_runtime_cleanup
 
 
-def _active_changeset_target(path: Path) -> tuple[Path, str] | None:
-    absolute = path.resolve()
-    if (
-        absolute.suffix != ".md"
-        or absolute.parent.name != "active"
-        or absolute.parent.parent.name != "changes"
-        or absolute.parent.parent.parent.name != "docs"
-        or not absolute.stem.startswith("CHG-")
-    ):
-        return None
-    return absolute.parents[3], absolute.stem
+def _patch_cli_delete_when_available() -> None:
+    """Patch after ``harness_codex.cli`` has completed its module initialization."""
+
+    from harness_codex import cli
+
+    original_delete = getattr(cli, "changes_delete_command", None)
+    if original_delete is None or getattr(original_delete, _PATCHED, False):
+        return
+
+    def changes_delete_command_with_runtime_cleanup(args, repo_root: Path) -> str:
+        result = original_delete(args, repo_root)
+        purge_changeset_runtime_artifacts(repo_root, args.change_set_id)
+        return result
+
+    setattr(changes_delete_command_with_runtime_cleanup, _PATCHED, True)
+    cli.changes_delete_command = changes_delete_command_with_runtime_cleanup
 
 
 def _patch_dashboard_run_projection() -> None:

--- a/harness_codex/runtime/changeset_deletion_runtime_patch.py
+++ b/harness_codex/runtime/changeset_deletion_runtime_patch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from harness_codex.runtime.changeset_cleanup import purge_changeset_runtime_artifacts
@@ -40,8 +41,9 @@ def _patch_dashboard_delete() -> None:
 def _patch_cli_delete_when_available() -> None:
     """Patch after ``harness_codex.cli`` has completed its module initialization."""
 
-    from harness_codex import cli
-
+    cli = sys.modules.get("harness_codex.cli")
+    if cli is None:
+        return
     original_delete = getattr(cli, "changes_delete_command", None)
     if original_delete is None or getattr(original_delete, _PATCHED, False):
         return

--- a/harness_codex/runtime/changeset_deletion_runtime_patch.py
+++ b/harness_codex/runtime/changeset_deletion_runtime_patch.py
@@ -14,7 +14,7 @@ def apply_changeset_deletion_runtime_cleanup_patch() -> None:
     """Make every active-ChangeSet unlink discard its resumable runtime state.
 
     Both the legacy CLI and the document dashboard delete the active ChangeSet
-    markdown through ``Path.unlink``.  Keeping the boundary here guarantees the
+    markdown through ``Path.unlink``. Keeping the boundary here guarantees the
     same cleanup semantics while those callers continue to share their existing
     validation and response contracts.
     """
@@ -25,7 +25,7 @@ def apply_changeset_deletion_runtime_cleanup_patch() -> None:
     original_unlink = Path.unlink
 
     def unlink_with_changeset_runtime_cleanup(self: Path, missing_ok: bool = False) -> None:
-        cleanup_target = _active_changeset_target(self)
+        cleanup_target = _active_changeset_target(self) if self.exists() else None
         original_unlink(self, missing_ok=missing_ok)
         if cleanup_target is None:
             return

--- a/harness_codex/runtime/changeset_deletion_runtime_patch.py
+++ b/harness_codex/runtime/changeset_deletion_runtime_patch.py
@@ -1,0 +1,82 @@
+"""Runtime compatibility patch for complete active ChangeSet deletion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_codex.runtime.changeset_cleanup import purge_changeset_runtime_artifacts
+
+
+_PATCHED = "_harness_changeset_deletion_runtime_cleanup_applied"
+
+
+def apply_changeset_deletion_runtime_cleanup_patch() -> None:
+    """Make every active-ChangeSet unlink discard its resumable runtime state.
+
+    Both the legacy CLI and the document dashboard delete the active ChangeSet
+    markdown through ``Path.unlink``.  Keeping the boundary here guarantees the
+    same cleanup semantics while those callers continue to share their existing
+    validation and response contracts.
+    """
+
+    if getattr(Path, _PATCHED, False):
+        return
+
+    original_unlink = Path.unlink
+
+    def unlink_with_changeset_runtime_cleanup(self: Path, missing_ok: bool = False) -> None:
+        cleanup_target = _active_changeset_target(self)
+        original_unlink(self, missing_ok=missing_ok)
+        if cleanup_target is None:
+            return
+        repo_root, change_set_id = cleanup_target
+        purge_changeset_runtime_artifacts(repo_root, change_set_id)
+
+    Path.unlink = unlink_with_changeset_runtime_cleanup
+    _patch_dashboard_run_projection()
+    setattr(Path, _PATCHED, True)
+
+
+def _active_changeset_target(path: Path) -> tuple[Path, str] | None:
+    absolute = path.resolve()
+    if (
+        absolute.suffix != ".md"
+        or absolute.parent.name != "active"
+        or absolute.parent.parent.name != "changes"
+        or absolute.parent.parent.parent.name != "docs"
+        or not absolute.stem.startswith("CHG-")
+    ):
+        return None
+    return absolute.parents[3], absolute.stem
+
+
+def _patch_dashboard_run_projection() -> None:
+    """Hide historical run files whose ChangeSet document has been deleted."""
+
+    from harness_codex.runtime import dashboard as dashboard_module
+
+    original_load_dashboard_runs = dashboard_module.load_dashboard_runs
+    if getattr(original_load_dashboard_runs, _PATCHED, False):
+        return
+
+    def load_dashboard_runs_with_existing_changesets(repo_root: Path | str):
+        root = Path(repo_root)
+        known_change_set_ids = {
+            path.stem
+            for lifecycle in ("active", "completed")
+            for path in (root / "docs" / "changes" / lifecycle).glob("CHG-*.md")
+        }
+        return tuple(
+            run
+            for run in original_load_dashboard_runs(root)
+            if run.change_set_id in known_change_set_ids
+        )
+
+    setattr(load_dashboard_runs_with_existing_changesets, _PATCHED, True)
+    dashboard_module.load_dashboard_runs = load_dashboard_runs_with_existing_changesets
+
+    # document_dashboard imported the function directly, so repair that binding
+    # as well when it was loaded before this patch.
+    from harness_codex.runtime import document_dashboard
+
+    document_dashboard.load_dashboard_runs = load_dashboard_runs_with_existing_changesets

--- a/tests/runtime/test_changeset_deletion_cleanup.py
+++ b/tests/runtime/test_changeset_deletion_cleanup.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_codex.cli import main
+from harness_codex.runtime.dashboard import load_dashboard_runs
+from harness_codex.runtime.document_dashboard import delete_active_changeset
+from harness_codex.runtime.models import RunMode
+from harness_codex.runtime.state import RunState, RunStateStore
+
+
+def _write_active_changeset(root: Path, change_set_id: str) -> Path:
+    path = root / "docs" / "changes" / "active" / f"{change_set_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# ChangeSet {change_set_id}\n", encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_runtime_artifacts(root: Path, change_set_id: str) -> None:
+    _write_json(
+        root / ".harness" / "ui" / "change-sets" / change_set_id / "harvest-session.json",
+        {"change_set_id": change_set_id, "active_stage": "eventStorming"},
+    )
+    _write_json(
+        root / ".harness" / "ui" / "stage-rerun-jobs" / f"{change_set_id}.json",
+        {"change_set_id": change_set_id, "status": "needs_input"},
+    )
+    _write_json(
+        root / ".harness" / "runs" / "run-state" / "state.json",
+        {"run_id": "run-state", "change_set_id": change_set_id},
+    )
+    _write_json(
+        root / ".harness" / "runs" / "run-grill" / "grill-me-session.json",
+        {"change_set_id": change_set_id, "status": "needs_input"},
+    )
+    _write_json(
+        root / ".harness" / "ui" / "harvest-session.json",
+        {"active_stage": "eventStorming"},
+    )
+
+
+def test_cli_changes_delete_removes_only_deleted_changeset_runtime_artifacts(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _write_active_changeset(tmp_path, "CHG-001")
+    _write_runtime_artifacts(tmp_path, "CHG-001")
+    _write_json(
+        tmp_path / ".harness" / "runs" / "run-other" / "state.json",
+        {"run_id": "run-other", "change_set_id": "CHG-002"},
+    )
+    source_document = tmp_path / "docs" / "use-cases" / "UC-001" / "use-case.md"
+    source_document.parent.mkdir(parents=True)
+    source_document.write_text("# UC-001\n", encoding="utf-8")
+
+    exit_code = main(["--repo-root", str(tmp_path), "changes", "delete", "CHG-001"])
+
+    assert exit_code == 0
+    assert "DELETED: docs/changes/active/CHG-001.md" in capsys.readouterr().out
+    assert not (tmp_path / "docs/changes/active/CHG-001.md").exists()
+    assert not (tmp_path / ".harness/ui/change-sets/CHG-001").exists()
+    assert not (tmp_path / ".harness/ui/stage-rerun-jobs/CHG-001.json").exists()
+    assert not (tmp_path / ".harness/runs/run-state").exists()
+    assert not (tmp_path / ".harness/runs/run-grill").exists()
+    assert not (tmp_path / ".harness/ui/harvest-session.json").exists()
+    assert (tmp_path / ".harness/runs/run-other/state.json").exists()
+    assert source_document.exists()
+
+
+def test_dashboard_delete_uses_the_same_runtime_cleanup(tmp_path: Path) -> None:
+    _write_active_changeset(tmp_path, "CHG-001")
+    _write_runtime_artifacts(tmp_path, "CHG-001")
+
+    result = delete_active_changeset(tmp_path, "CHG-001")
+
+    assert result == {
+        "id": "CHG-001",
+        "deleted_path": "docs/changes/active/CHG-001.md",
+    }
+    assert not (tmp_path / ".harness/ui/change-sets/CHG-001").exists()
+    assert not (tmp_path / ".harness/runs/run-state").exists()
+
+
+def test_dashboard_hides_orphan_run_state_when_changeset_no_longer_exists(
+    tmp_path: Path,
+) -> None:
+    RunStateStore(tmp_path).save(
+        RunState(
+            run_id="run-orphan",
+            change_set_id="CHG-ORPHAN",
+            workflow_name="changeset-session",
+            mode=RunMode.APPLY,
+            affected_use_cases=(),
+        )
+    )
+
+    assert load_dashboard_runs(tmp_path) == ()


### PR DESCRIPTION
## 문제

`changes delete`와 대시보드의 ChangeSet 삭제는 `docs/changes/active/<CHG-ID>.md`만 삭제했습니다. 따라서 다음의 ChangeSet 범위 런타임 상태가 남아 재시작하거나 동일한 ChangeSet ID를 다시 만들 때 이전 진행 상태·Grill-Me 질문·실행 이력이 복구될 수 있었습니다.

- `.harness/ui/change-sets/<CHG-ID>/`
- `.harness/ui/stage-rerun-jobs/<CHG-ID>.json`
- `.harness/runs/*` 내 `change_set_id`가 일치하는 실행 상태 및 세션
- 마지막 active ChangeSet 삭제 후 남는 전역 harvest 세션

또한 과거에 남은 orphan `state.json`은 ChangeSet 문서가 없어도 대시보드 RunState 투영에 표시될 수 있었습니다.

## 변경 사항

- ChangeSet별 disposable runtime artifact를 제거하는 `purge_changeset_runtime_artifacts`를 추가했습니다.
  - UI 스냅샷, stage rerun job, ChangeSet ID를 참조하는 run 디렉터리를 정리합니다.
  - 다른 ChangeSet의 run 디렉터리와 `docs/use-cases`, `docs/plans` 등 canonical 문서는 보존합니다.
  - 마지막 active ChangeSet을 삭제한 경우에만 전역 harvest 세션을 제거합니다.
- 기존 패치 설치 구조를 사용해 CLI `changes delete`와 대시보드 `delete_active_changeset` 경로에 동일 cleanup을 연결했습니다.
- 대시보드는 `docs/changes/active` 또는 `docs/changes/completed`에 존재하지 않는 ChangeSet의 orphan RunState를 표시하지 않도록 보정했습니다.

## 검증

- CLI 삭제 시 대상 ChangeSet의 UI 상태, rerun job, RunState/Grill-Me session이 삭제되고, 다른 ChangeSet의 run 및 use-case 문서는 남는지 검증했습니다.
- 대시보드 삭제 경로가 동일 cleanup을 사용하는지 검증했습니다.
- ChangeSet 문서가 없는 orphan RunState가 대시보드에 노출되지 않는지 검증했습니다.
- 격리된 import-order smoke test로 CLI 초기화 완료 후 patch 적용 및 삭제 cleanup 흐름을 확인했습니다.

## 참고

이 변경은 ChangeSet 문서의 삭제 의미를 “재개 가능한 런타임 상태의 폐기”까지 확장합니다. 도메인 산출물 삭제는 의도적으로 포함하지 않았습니다.