### PR TITLE
fix(requirements): allow related UCs in ChangeSet MVP scope

### DIFF
--- a/.codex/agents/references/requirements_interviewer.md
+++ b/.codex/agents/references/requirements_interviewer.md
@@ -8,13 +8,15 @@ You are the requirements interviewer.
 Your job:
 - Start from the user's short initial idea.
 - Reduce ambiguity through a time-boxed grill-me loop, then write a useful requirements draft instead of pursuing perfect domain understanding.
-- For an empty project or broad request such as "build a calculator", first identify one MVP and ask only about the single MVP use case.
-- For an existing repository feature addition or modification, steer output toward a use-case-sized ChangeSet instead of a broad multi-use-case program.
-- Ask iterative Grill-Me clarification questions until actor, goal, success result, failure policy, hard scope boundary, and business policy decisions are specific enough for one use case.
+- For an empty project or broad request such as "build a calculator", first identify one coherent MVP delivery scope and ask only about the primary user outcome, included use cases, and required supporting work.
+- For an existing repository feature addition or modification, steer output toward a delivery-sized ChangeSet. Include multiple use cases only when they jointly deliver one user-visible outcome and share material dependencies.
+- Ask iterative Grill-Me clarification questions until the primary user outcome, actors, included use cases, success result, failure policy, hard scope boundary, and business policy decisions are specific enough for one coherent ChangeSet.
+- Do not force an arbitrary single use case when multiple related use cases are needed for a coherent first delivery.
+- Split independently valuable, independently verifiable, or unrelated use cases into separate ChangeSets.
 - Write or update the current requirements draft before asking questions.
 - Ask up to three focused questions per turn and include `Recommended answer:` with each question.
-- Do not ask technology-specific questions by default unless they directly change actor goal, user-visible result, user-visible failure policy, hard scope boundary, or one-ChangeSet fit.
-- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
+- Do not ask technology-specific questions by default unless they directly change the primary user outcome, user-visible result, user-visible failure policy, hard scope boundary, or one-ChangeSet fit.
+- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP delivery scope explicitly depends on that decision.
 - Do not own full ubiquitous language confirmation; route that work to `$harness-ubiquitous-language`.
 - Write or update exactly this output document:
   - docs/design/요구사항.md
@@ -36,13 +38,14 @@ Question loop:
 - Run at most 3 rounds.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
-- Stop when the information is sufficient to produce a useful requirements draft for one MVP use case.
+- Stop when the information is sufficient to produce a useful requirements draft for one coherent MVP delivery scope.
 - After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
 - If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Language Handoff Notes, or Post-DDD Technical Decision Candidates.
 
 Allowed question topics:
-- actor
-- goal
+- primary user outcome
+- actor or actors
+- included use cases and necessary supporting work
 - user-visible success condition
 - user-visible failure policy
 - hard scope boundary

--- a/.codex/skills/harness-requirements/references/agent-prompt.md
+++ b/.codex/skills/harness-requirements/references/agent-prompt.md
@@ -5,7 +5,7 @@ Use this prompt when spawning a worker agent for `$harness-requirements`.
 ```text
 You are the harness requirements documentation agent.
 
-Start from the user's initial idea and ask iterative questions until one MVP use case and its requirements are specific enough to document.
+Start from the user's initial idea and ask iterative questions until one coherent MVP delivery scope is specific enough to document. The scope may include multiple closely related use cases when they are jointly required to deliver one user-visible outcome within a single ChangeSet.
 Follow the ticketon-ddd style requirements standards embedded in the skill.
 Do not depend on external blog files or repo-local reference posts at runtime.
 
@@ -26,7 +26,7 @@ Rules:
 - Include `Recommended answer:` with every question.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
-- Stop when the information is sufficient to produce a useful draft for one MVP use case.
+- Stop when the information is sufficient to produce a useful draft for one coherent MVP delivery scope.
 - After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
 - If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Language Handoff Notes, or Post-DDD Technical Decision Candidates.
 - Do not own full ubiquitous language confirmation; route that work to `$harness-ubiquitous-language`.
@@ -35,8 +35,10 @@ Rules:
 - After the user answers, update docs/design/요구사항.md, then ask the next most important unresolved requirements decision within the question budget.
 - Split functional and non-functional requirements.
 - Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, and Language Handoff Notes.
-- Do not ask technology-specific questions by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
-- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
+- Ask about the primary user outcome, included use cases, and necessary supporting work. Do not force an arbitrary single use case when multiple related use cases are needed for one coherent delivery.
+- Split independently valuable, independently verifiable, or unrelated use cases into separate ChangeSets.
+- Do not ask technology-specific questions by default unless they directly change the primary user outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP delivery scope explicitly depends on that decision.
 - Do not write use cases.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```

--- a/.codex/skills/harness-requirements/references/detailed-instructions.md
+++ b/.codex/skills/harness-requirements/references/detailed-instructions.md
@@ -6,7 +6,7 @@
 
 ## Role
 
-Turn an early idea into a requirements specification for one MVP use case.
+Turn an early idea into a requirements specification for one coherent MVP delivery scope. The scope may contain multiple closely related use cases when they are jointly required to deliver one user-visible outcome within a single ChangeSet.
 
 This stage does not own full ubiquitous language confirmation. It may confirm only MVP-blocking terms needed to understand the requirement. Full canonical term review belongs to `$harness-ubiquitous-language`.
 
@@ -48,11 +48,20 @@ Do not write `context.md`. Do not write use cases.
 - The recommendation must reflect current evidence and should say whether it is based on local artifacts or inference.
 - When invoked by runtime, return only JSON with keys `status`, `questions`, `changed_files`, and `blocker`.
 
+## Scope Selection
+
+- Define one coherent MVP delivery scope for the current ChangeSet; do not force it into one arbitrary use case.
+- A scope may include multiple use cases only when they are jointly necessary to produce one primary user-visible outcome, share material domain or implementation dependencies, and can be verified as one delivery.
+- Mark the primary user outcome and distinguish primary use cases from supporting or prerequisite work items.
+- Split work into separate ChangeSets when a use case has independent user value, can be delivered and verified independently, or would make the scope lack a clear delivery boundary.
+- Do not use a broad program, roadmap, or unrelated feature bundle as an MVP delivery scope.
+
 ## Allowed Requirement Questions
 
 Requirements grill-me should clarify:
-- actor
-- goal
+- primary user outcome
+- actor or actors
+- included use cases and necessary supporting work
 - success condition
 - failure policy
 - hard scope boundary
@@ -71,9 +80,9 @@ Requirements grill-me must not ask:
 - DDD design terminology
 - implementation strategy
 
-Do not ask technology-specific questions by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+Do not ask technology-specific questions by default unless they directly change the primary user outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
 
-Do not ask about authentication, authorization, cache, Redis, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP use case explicitly depends on that decision.
+Do not ask about authentication, authorization, cache, Redis, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP delivery scope explicitly depends on that decision.
 
 ## Requirements Rules
 
@@ -81,7 +90,7 @@ Do not ask about authentication, authorization, cache, Redis, messaging, events,
 - Split functional requirements and non-functional requirements.
 - Classify unresolved decisions as either Business Policy Decisions Needed, Foundational Technology Decisions Needed, or Language Handoff Notes.
 - Business Policy Decisions are product/domain rules: success/failure outcomes, validation rules, compensation, permissions, and user-visible behavior.
-- Foundational Technical Decisions are large technology choices that shape the whole program. During harvest, defer them by default unless they directly change the actor goal, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+- Foundational Technical Decisions are large technology choices that shape the whole program. During harvest, defer them by default unless they directly change the primary user outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
 - Do not decide detailed implementation strategies during requirements elicitation. Polling vs push, circuit breaker, retry/backoff, outbox/inbox, detailed transaction propagation, cache TTL/invalidation, and observability fields belong after DDD design in the technical-decision stage.
 - Business Policy Decisions must be resolved before ubiquitous language confirmation can pass.
 - Foundational Technical Decisions may remain unresolved after requirements, but must be clearly separated for DDD and technical-decision gates.
@@ -101,9 +110,11 @@ Do not ask about authentication, authorization, cache, Redis, messaging, events,
 
 ## 1. Scope
 
-- MVP use case:
-- Actor:
-- Goal:
+- MVP delivery scope:
+- Primary user outcome:
+- Primary actor(s):
+- Included use cases:
+- Supporting / prerequisite work items:
 - Hard out-of-scope boundary:
 
 ## 2. Functional Requirements

--- a/tests/test_requirements_scope_contract.py
+++ b/tests/test_requirements_scope_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_INSTRUCTIONS = REPO_ROOT / ".codex/skills/harness-requirements/references/detailed-instructions.md"
+INTERVIEWER_INSTRUCTIONS = REPO_ROOT / ".codex/agents/references/requirements_interviewer.md"
+
+
+def test_requirements_skill_allows_coherent_multi_use_case_scope() -> None:
+    text = SKILL_INSTRUCTIONS.read_text(encoding="utf-8")
+
+    assert "one coherent MVP delivery scope" in text
+    assert "multiple closely related use cases" in text
+    assert "## Scope Selection" in text
+    assert "- Included use cases:" in text
+    assert "- Supporting / prerequisite work items:" in text
+
+
+def test_requirements_interviewer_preserves_changeset_boundary() -> None:
+    text = INTERVIEWER_INSTRUCTIONS.read_text(encoding="utf-8")
+
+    assert "delivery-sized ChangeSet" in text
+    assert "Do not force an arbitrary single use case" in text
+    assert "Split independently valuable, independently verifiable, or unrelated use cases" in text

--- a/tests/test_requirements_scope_contract.py
+++ b/tests/test_requirements_scope_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL_INSTRUCTIONS = REPO_ROOT / ".codex/skills/harness-requirements/references/detailed-instructions.md"
+WORKER_PROMPT = REPO_ROOT / ".codex/skills/harness-requirements/references/agent-prompt.md"
 INTERVIEWER_INSTRUCTIONS = REPO_ROOT / ".codex/agents/references/requirements_interviewer.md"
 
 
@@ -14,6 +15,14 @@ def test_requirements_skill_allows_coherent_multi_use_case_scope() -> None:
     assert "## Scope Selection" in text
     assert "- Included use cases:" in text
     assert "- Supporting / prerequisite work items:" in text
+
+
+def test_requirements_worker_prompt_allows_coherent_multi_use_case_scope() -> None:
+    text = WORKER_PROMPT.read_text(encoding="utf-8")
+
+    assert "one coherent MVP delivery scope" in text
+    assert "multiple closely related use cases" in text
+    assert "Do not force an arbitrary single use case" in text
 
 
 def test_requirements_interviewer_preserves_changeset_boundary() -> None:


### PR DESCRIPTION
목적: requirements-definition을 임의의 단일 유스케이스가 아니라 하나의 일관된 MVP 전달 범위와 ChangeSet 단위로 정렬합니다. 동일한 사용자 결과를 위해 함께 필요한 여러 UC와 선행 작업을 포함할 수 있도록 합니다.

변경: requirements skill, interviewer instruction, worker prompt에 같은 범위 규칙을 적용했습니다. 다중 UC는 단일 사용자 결과, 공유 의존성, 하나의 전달 검증이 모두 성립할 때만 허용하며, 독립 가치나 독립 검증이 가능한 UC는 별도 ChangeSet으로 분리합니다. 요구사항 Scope 템플릿에는 전달 범위, 사용자 결과, 포함 UC, 선행 작업 필드를 추가했습니다.

검증: Scope Selection, 문서 템플릿, interviewer, worker prompt의 계약을 검사하는 회귀 테스트를 추가했습니다. GitHub Actions의 Runtime document contracts 워크플로 run #580이 성공했습니다.

위험과 롤백: 다중 UC 허용이 넓은 기능 묶음으로 해석되지 않도록 명시적인 분리 기준을 추가했습니다. 문제가 발생하면 이 PR을 되돌려 기존 정책으로 복구할 수 있습니다.