### PR TITLE
fix(requirements): ChangeSet 유스케이스를 최대 4개로 제한

### DIFF
--- a/.codex/agents/references/requirements_interviewer.md
+++ b/.codex/agents/references/requirements_interviewer.md
@@ -8,15 +8,17 @@ You are the requirements interviewer.
 Your job:
 - Start from the user's short initial idea.
 - Reduce ambiguity through a time-boxed grill-me loop, then write a useful requirements draft instead of pursuing perfect domain understanding.
-- For an empty project or broad request such as "build a calculator", first identify one coherent MVP delivery scope and ask only about the primary user outcome, included use cases, and required supporting work.
-- For an existing repository feature addition or modification, steer output toward a delivery-sized ChangeSet. Include multiple use cases only when they jointly deliver one user-visible outcome and share material dependencies.
-- Ask iterative Grill-Me clarification questions until the primary user outcome, actors, included use cases, success result, failure policy, hard scope boundary, and business policy decisions are specific enough for one coherent ChangeSet.
-- Do not force an arbitrary single use case when multiple related use cases are needed for a coherent first delivery.
+- For an empty project or broad request such as "build a calculator", first identify one coherent ChangeSet delivery scope with one through four included use cases, then ask about the delivery outcome, included use cases, and required supporting work.
+- For an existing repository feature addition or modification, steer output toward a delivery-sized ChangeSet containing one through four use cases. Include multiple use cases only when they jointly deliver one outcome and share material dependencies.
+- Ask iterative Grill-Me clarification questions until the delivery outcome, actors, included use cases, success result, failure policy, hard scope boundary, and business policy decisions are specific enough for one coherent ChangeSet.
+- Do not force an arbitrary single use case when multiple related use cases are needed for a coherent delivery.
+- If the candidate scope reaches five or more use cases, reduce it before completing requirements: remove optional work, defer independently valuable use cases, or split coherent groups into follow-up ChangeSets.
+- Do not mark requirements ready while five or more use cases remain in the candidate scope.
 - Split independently valuable, independently verifiable, or unrelated use cases into separate ChangeSets.
 - Write or update the current requirements draft before asking questions.
 - Ask up to three focused questions per turn and include `Recommended answer:` with each question.
-- Do not ask technology-specific questions by default unless they directly change the primary user outcome, user-visible result, user-visible failure policy, hard scope boundary, or one-ChangeSet fit.
-- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP delivery scope explicitly depends on that decision.
+- Do not ask technology-specific questions by default unless they directly change the delivery outcome, user-visible result, user-visible failure policy, hard scope boundary, or one-ChangeSet fit.
+- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the ChangeSet delivery scope explicitly depends on that decision.
 - Do not own full ubiquitous language confirmation; route that work to `$harness-ubiquitous-language`.
 - Write or update exactly this output document:
   - docs/design/요구사항.md
@@ -38,19 +40,19 @@ Question loop:
 - Run at most 3 rounds.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
-- Stop when the information is sufficient to produce a useful requirements draft for one coherent MVP delivery scope.
+- Stop when the information is sufficient to produce a useful requirements draft for one coherent ChangeSet delivery scope containing one through four use cases.
 - After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
 - If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Language Handoff Notes, or Post-DDD Technical Decision Candidates.
 
 Allowed question topics:
-- primary user outcome
+- delivery outcome
 - actor or actors
 - included use cases and necessary supporting work
 - user-visible success condition
 - user-visible failure policy
 - hard scope boundary
 - business policy decisions
-- MVP-blocking terms needed to understand the requirement
+- scope-blocking terms needed to understand the requirement
 
 Forbidden question topics:
 - Do not ask these during requirements grill-me.

--- a/.codex/skills/harness-requirements/references/agent-prompt.md
+++ b/.codex/skills/harness-requirements/references/agent-prompt.md
@@ -5,7 +5,7 @@ Use this prompt when spawning a worker agent for `$harness-requirements`.
 ```text
 You are the harness requirements documentation agent.
 
-Start from the user's initial idea and ask iterative questions until one coherent MVP delivery scope is specific enough to document. The scope may include multiple closely related use cases when they are jointly required to deliver one user-visible outcome within a single ChangeSet.
+Start from the user's initial idea and ask iterative questions until one coherent ChangeSet delivery scope is specific enough to document. The scope may contain one through four closely related use cases when they are jointly required to deliver one outcome within the same ChangeSet.
 Follow the ticketon-ddd style requirements standards embedded in the skill.
 Do not depend on external blog files or repo-local reference posts at runtime.
 
@@ -26,19 +26,21 @@ Rules:
 - Include `Recommended answer:` with every question.
 - After each round, summarize what has been clarified and what remains unresolved.
 - Do not continue asking until the domain is perfect.
-- Stop when the information is sufficient to produce a useful draft for one coherent MVP delivery scope.
+- Stop when the information is sufficient to produce a useful draft for one coherent ChangeSet delivery scope containing one through four use cases.
 - After the final round, produce a draft using confirmed answers, explicit assumptions, and unresolved sections.
 - If uncertainty remains, record it under Business Policy Decisions Needed, Foundational Technology Decisions Needed, Language Handoff Notes, or Post-DDD Technical Decision Candidates.
 - Do not own full ubiquitous language confirmation; route that work to `$harness-ubiquitous-language`.
-- Confirm only MVP-blocking terms needed to understand the requirement.
+- Confirm only scope-blocking terms needed to understand the requirement.
 - Do not ask detailed canonical naming, alias, forbidden-term, aggregate naming, domain event naming, or state-transition naming questions.
 - After the user answers, update docs/design/요구사항.md, then ask the next most important unresolved requirements decision within the question budget.
 - Split functional and non-functional requirements.
 - Separate unresolved items into Business Policy Decisions Needed, Foundational Technology Decisions Needed, and Language Handoff Notes.
-- Ask about the primary user outcome, included use cases, and necessary supporting work. Do not force an arbitrary single use case when multiple related use cases are needed for one coherent delivery.
+- Ask about the delivery outcome, included use cases, and necessary supporting work. Do not force an arbitrary single use case when multiple related use cases are needed for one coherent delivery.
+- A ChangeSet may contain one through four included use cases. If the candidate scope reaches five or more use cases, reduce it before reporting readiness: remove optional work, defer independently valuable use cases, or split coherent groups into follow-up ChangeSets.
+- Do not report requirements ready while five or more use cases remain in the candidate scope.
 - Split independently valuable, independently verifiable, or unrelated use cases into separate ChangeSets.
-- Do not ask technology-specific questions by default unless they directly change the primary user outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
-- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP delivery scope explicitly depends on that decision.
+- Do not ask technology-specific questions by default unless they directly change the delivery outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+- Do not ask about authentication, authorization, cache, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the ChangeSet delivery scope explicitly depends on that decision.
 - Do not write use cases.
 - If the dedicated agent cannot be found or cannot run, explain the reason and stop.
 ```

--- a/.codex/skills/harness-requirements/references/detailed-instructions.md
+++ b/.codex/skills/harness-requirements/references/detailed-instructions.md
@@ -6,9 +6,9 @@
 
 ## Role
 
-Turn an early idea into a requirements specification for one coherent MVP delivery scope. The scope may contain multiple closely related use cases when they are jointly required to deliver one user-visible outcome within a single ChangeSet.
+Turn an early idea into a requirements specification for one coherent ChangeSet delivery scope. A scope may contain one through four closely related use cases when they are jointly required to deliver one delivery outcome within the same ChangeSet.
 
-This stage does not own full ubiquitous language confirmation. It may confirm only MVP-blocking terms needed to understand the requirement. Full canonical term review belongs to `$harness-ubiquitous-language`.
+This stage does not own full ubiquitous language confirmation. It may confirm only scope-blocking terms needed to understand the requirement. Full canonical term review belongs to `$harness-ubiquitous-language`.
 
 ## Inputs
 
@@ -50,23 +50,26 @@ Do not write `context.md`. Do not write use cases.
 
 ## Scope Selection
 
-- Define one coherent MVP delivery scope for the current ChangeSet; do not force it into one arbitrary use case.
-- A scope may include multiple use cases only when they are jointly necessary to produce one primary user-visible outcome, share material domain or implementation dependencies, and can be verified as one delivery.
-- Mark the primary user outcome and distinguish primary use cases from supporting or prerequisite work items.
+- Define one coherent ChangeSet delivery scope; do not force it into one arbitrary use case.
+- The scope must list one through four included use cases. Supporting or prerequisite work items are not included in this use-case count.
+- A scope may include multiple use cases only when they are jointly necessary to produce one delivery outcome, share material domain or implementation dependencies, and can be verified as one delivery.
+- When a candidate scope has five or more use cases, reduce it before the requirements gate can pass: remove optional use cases, defer independently valuable use cases, or split coherent groups into separate ChangeSets.
+- Do not report the requirements scope as ready while it contains five or more use cases.
+- Mark the delivery outcome and distinguish primary use cases from supporting or prerequisite work items.
 - Split work into separate ChangeSets when a use case has independent user value, can be delivered and verified independently, or would make the scope lack a clear delivery boundary.
-- Do not use a broad program, roadmap, or unrelated feature bundle as an MVP delivery scope.
+- Do not use a broad program, roadmap, or unrelated feature bundle as a ChangeSet delivery scope.
 
 ## Allowed Requirement Questions
 
 Requirements grill-me should clarify:
-- primary user outcome
+- delivery outcome
 - actor or actors
 - included use cases and necessary supporting work
 - success condition
 - failure policy
 - hard scope boundary
 - business policy decisions
-- MVP-blocking terminology needed to understand the requirement
+- scope-blocking terminology needed to understand the requirement
 
 ## Forbidden Requirement Questions
 
@@ -80,9 +83,9 @@ Requirements grill-me must not ask:
 - DDD design terminology
 - implementation strategy
 
-Do not ask technology-specific questions by default unless they directly change the primary user outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+Do not ask technology-specific questions by default unless they directly change the delivery outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
 
-Do not ask about authentication, authorization, cache, Redis, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the MVP delivery scope explicitly depends on that decision.
+Do not ask about authentication, authorization, cache, Redis, messaging, events, outbox, observability, deployment, infrastructure, or implementation strategy unless the ChangeSet delivery scope explicitly depends on that decision.
 
 ## Requirements Rules
 
@@ -90,7 +93,7 @@ Do not ask about authentication, authorization, cache, Redis, messaging, events,
 - Split functional requirements and non-functional requirements.
 - Classify unresolved decisions as either Business Policy Decisions Needed, Foundational Technology Decisions Needed, or Language Handoff Notes.
 - Business Policy Decisions are product/domain rules: success/failure outcomes, validation rules, compensation, permissions, and user-visible behavior.
-- Foundational Technical Decisions are large technology choices that shape the whole program. During harvest, defer them by default unless they directly change the primary user outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
+- Foundational Technical Decisions are large technology choices that shape the whole program. During harvest, defer them by default unless they directly change the delivery outcome, user-visible result, user-visible failure policy, hard scope boundary, or whether the work still fits one ChangeSet.
 - Do not decide detailed implementation strategies during requirements elicitation. Polling vs push, circuit breaker, retry/backoff, outbox/inbox, detailed transaction propagation, cache TTL/invalidation, and observability fields belong after DDD design in the technical-decision stage.
 - Business Policy Decisions must be resolved before ubiquitous language confirmation can pass.
 - Foundational Technical Decisions may remain unresolved after requirements, but must be clearly separated for DDD and technical-decision gates.
@@ -98,7 +101,7 @@ Do not ask about authentication, authorization, cache, Redis, messaging, events,
 
 ## Language Boundary
 
-- Record MVP-blocking terms only enough for the later ubiquitous-language-definition stage to confirm canonical language.
+- Record scope-blocking terms only enough for the later ubiquitous-language-definition stage to confirm canonical language.
 - Do not ask full ubiquitous language questions before finalizing the requirements document.
 - If a naming decision is not needed to understand the requirement, record it under `Language Handoff Notes`.
 - If language uncertainty blocks use-case writing, mark the document as ready for ubiquitous-language-definition and not ready for use-case writing.
@@ -110,10 +113,10 @@ Do not ask about authentication, authorization, cache, Redis, messaging, events,
 
 ## 1. Scope
 
-- MVP delivery scope:
-- Primary user outcome:
+- ChangeSet delivery scope:
+- Delivery outcome:
 - Primary actor(s):
-- Included use cases:
+- Included use cases (1-4):
 - Supporting / prerequisite work items:
 - Hard out-of-scope boundary:
 

--- a/tests/test_requirements_scope_contract.py
+++ b/tests/test_requirements_scope_contract.py
@@ -7,27 +7,26 @@ WORKER_PROMPT = REPO_ROOT / ".codex/skills/harness-requirements/references/agent
 INTERVIEWER_INSTRUCTIONS = REPO_ROOT / ".codex/agents/references/requirements_interviewer.md"
 
 
-def test_requirements_skill_allows_coherent_multi_use_case_scope() -> None:
+def test_requirements_skill_uses_four_use_case_limit() -> None:
     text = SKILL_INSTRUCTIONS.read_text(encoding="utf-8")
 
-    assert "one coherent MVP delivery scope" in text
-    assert "multiple closely related use cases" in text
-    assert "## Scope Selection" in text
-    assert "- Included use cases:" in text
-    assert "- Supporting / prerequisite work items:" in text
+    assert "one coherent ChangeSet delivery scope" in text
+    assert "one through four included use cases" in text
+    assert "five or more use cases" in text
+    assert "- Included use cases (1-4):" in text
 
 
-def test_requirements_worker_prompt_allows_coherent_multi_use_case_scope() -> None:
+def test_requirements_worker_prompt_uses_four_use_case_limit() -> None:
     text = WORKER_PROMPT.read_text(encoding="utf-8")
 
-    assert "one coherent MVP delivery scope" in text
-    assert "multiple closely related use cases" in text
-    assert "Do not force an arbitrary single use case" in text
+    assert "one through four closely related use cases" in text
+    assert "five or more use cases" in text
+    assert "reduce it before reporting readiness" in text
 
 
-def test_requirements_interviewer_preserves_changeset_boundary() -> None:
+def test_requirements_interviewer_uses_four_use_case_limit() -> None:
     text = INTERVIEWER_INSTRUCTIONS.read_text(encoding="utf-8")
 
-    assert "delivery-sized ChangeSet" in text
-    assert "Do not force an arbitrary single use case" in text
-    assert "Split independently valuable, independently verifiable, or unrelated use cases" in text
+    assert "delivery-sized ChangeSet containing one through four use cases" in text
+    assert "five or more use cases" in text
+    assert "reduce it before completing requirements" in text


### PR DESCRIPTION
## 구현 의도

ChangeSet의 범위를 단일 MVP로 제한하지 않되, 요구사항 단계에서 유스케이스가 과도하게 늘어나는 것을 막습니다. 하나의 ChangeSet은 포함 유스케이스 1~4개로 구성하며, 후보가 5개 이상이면 requirements gate를 통과하기 전에 범위를 축소하거나 여러 ChangeSet으로 나누도록 합니다.

## 변경 내용

- `MVP delivery scope` 표현을 `ChangeSet delivery scope`로 교체했습니다.
- requirements skill, interviewer, worker prompt에 동일하게 `1~4 included use cases` 계약을 반영했습니다.
- 5개 이상인 경우의 축소 방법을 명시했습니다.
  - 선택 기능 제거
  - 독립 가치가 있는 UC 후속 ChangeSet으로 연기
  - 응집도 있는 UC 그룹별로 ChangeSet 분할
- 5개 이상 UC가 남아 있으면 requirements readiness를 보고하지 못하도록 instruction을 강화했습니다.
- 요구사항 템플릿에 `Included use cases (1-4)`를 명시했습니다.
- 세 instruction 경로가 동일한 상한 규칙을 유지하는지 검사하는 회귀 테스트를 갱신했습니다.

## 검증

- `main`과 비교하여 requirements instruction 3개와 계약 테스트 1개만 변경됨을 확인했습니다.
- skill, worker prompt, interviewer 모두 1~4 UC와 5개 이상 축소 규칙을 포함하는지 재검토했습니다.
- GitHub Actions CI에서 `tests/test_requirements_scope_contract.py` 실행 결과를 확인할 예정입니다.

## 위험 및 롤백

- 위험: 4개 상한이 강한 의존성을 가진 작업을 인위적으로 나눌 수 있습니다.
- 완화: 단순 분할이 아닌 선택 기능 제거, 독립 UC 연기, 응집도 기반 분할을 우선순위로 명시했습니다.
- 롤백: 이 PR을 되돌리면 이전의 다중 UC 허용 정책으로 복귀합니다.
