### PR TITLE
fix: deleted ChangeSet 상태와 UC 작업공간 격리

### DIFF
--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -96,7 +96,18 @@ def _install_changeset_deletion_cleanup() -> None:
     apply_changeset_deletion_runtime_cleanup_patch()
 
 
+def _install_changeset_scope_isolation() -> None:
+    """Keep global harvest artifacts scoped to the currently active ChangeSet."""
+
+    from harness_codex.runtime.changeset_scope_isolation_patch import (
+        apply_changeset_scope_isolation_patch,
+    )
+
+    apply_changeset_scope_isolation_patch()
+
+
 _install_changeset_execution_boundary()
 _install_runtime_write_boundaries()
 _install_canonical_procedure_stage_bridge()
 _install_changeset_deletion_cleanup()
+_install_changeset_scope_isolation()

--- a/harness_codex/runtime/changeset_cleanup.py
+++ b/harness_codex/runtime/changeset_cleanup.py
@@ -19,7 +19,7 @@ def purge_changeset_runtime_artifacts(
     """Remove disposable runtime state owned by a deleted ChangeSet.
 
     Canonical design, use-case, and plan documents are intentionally not touched.
-    They can be reused or explicitly removed by a separate user action.  The cleanup
+    They can be reused or explicitly removed by a separate user action. The cleanup
     covers only resumable UI snapshots, persisted stage-rerun jobs, and run
     directories whose JSON metadata identifies the deleted ChangeSet.
     """
@@ -47,13 +47,10 @@ def purge_changeset_runtime_artifacts(
             ):
                 _remove_path(run_dir, removed)
 
-    # The global harvest session is only safe to discard when deleting the last
-    # active ChangeSet.  With another active ChangeSet it may belong to that
-    # workflow, so its per-ChangeSet snapshot remains the source of truth.
-    active_dir = root / "docs" / "changes" / "active"
-    has_active_changesets = active_dir.is_dir() and any(active_dir.glob("CHG-*.md"))
-    if not has_active_changesets:
-        _remove_path(root / ".harness" / "ui" / "harvest-session.json", removed)
+    # This is a materialized working copy, not durable ChangeSet state. Every
+    # active ChangeSet owns a scoped snapshot, so retaining this unscoped file
+    # after deleting any ChangeSet can resurrect the deleted workflow.
+    _remove_path(root / ".harness" / "ui" / "harvest-session.json", removed)
 
     return tuple(removed)
 

--- a/harness_codex/runtime/changeset_scope_isolation_patch.py
+++ b/harness_codex/runtime/changeset_scope_isolation_patch.py
@@ -1,0 +1,46 @@
+"""Ensure activating one ChangeSet cannot inherit another ChangeSet's UC slices."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_PATCHED = "_harness_changeset_scope_isolation_patch_applied"
+
+
+def apply_changeset_scope_isolation_patch() -> None:
+    """Replace the global UC worktree from the selected ChangeSet snapshot.
+
+    ``activate_changeset_harvest_ui`` used to copy scoped UC documents with
+    ``replace=False``. A newly created ChangeSet has no scoped UC tree yet, so
+    stale ``docs/use-cases`` directories from a deleted ChangeSet survived and
+    could be considered by subsequent agent runs. The global worktree is only a
+    materialized view of the active ChangeSet snapshot; it must be replaced, not
+    merged.
+    """
+
+    from harness_codex.runtime import harvest_ui
+
+    original_activate = harvest_ui.activate_changeset_harvest_ui
+    if getattr(original_activate, _PATCHED, False):
+        return
+
+    def activate_changeset_harvest_ui_with_isolated_use_cases(
+        root: Path | str,
+        change_set_id: str,
+    ) -> None:
+        root_path = Path(root)
+        original_activate(root_path, change_set_id)
+
+        scoped_root = root_path / harvest_ui.CHANGESET_SESSION_ROOT / change_set_id
+        scoped_slices = scoped_root / harvest_ui.USE_CASE_SLICE_ROOT
+        active_slices = root_path / harvest_ui.USE_CASE_SLICE_ROOT
+        harvest_ui._copy_optional_tree(scoped_slices, active_slices, replace=True)
+
+    setattr(activate_changeset_harvest_ui_with_isolated_use_cases, _PATCHED, True)
+    harvest_ui.activate_changeset_harvest_ui = activate_changeset_harvest_ui_with_isolated_use_cases
+
+    # ui_server holds a direct import, so repair that binding too.
+    from harness_codex.runtime import ui_server
+
+    ui_server.activate_changeset_harvest_ui = activate_changeset_harvest_ui_with_isolated_use_cases

--- a/tests/runtime/test_changeset_scope_isolation.py
+++ b/tests/runtime/test_changeset_scope_isolation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_codex.runtime.document_dashboard import delete_active_changeset
+from harness_codex.runtime.harvest_ui import activate_changeset_harvest_ui
+
+
+def _write_active_changeset(root: Path, change_set_id: str) -> None:
+    path = root / "docs" / "changes" / "active" / f"{change_set_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# ChangeSet {change_set_id}\n", encoding="utf-8")
+
+
+def _new_session() -> dict[str, object]:
+    return {
+        "initial_prompt": "new scoped request",
+        "clarifications": [],
+        "current_question": None,
+        "current_questions": [],
+        "pending_questions": [],
+        "requirements_gate_passed": False,
+        "language_gate_passed": False,
+        "active_stage": "requirements",
+        "use_cases_ready": False,
+        "runtime_error": "",
+    }
+
+
+def test_delete_clears_global_harvest_state_even_when_another_changeset_is_active(
+    tmp_path: Path,
+) -> None:
+    _write_active_changeset(tmp_path, "CHG-001")
+    _write_active_changeset(tmp_path, "CHG-002")
+    state_path = tmp_path / ".harness" / "ui" / "harvest-session.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps(_new_session()), encoding="utf-8")
+
+    delete_active_changeset(tmp_path, "CHG-001")
+
+    assert not state_path.exists()
+    assert (tmp_path / "docs/changes/active/CHG-002.md").exists()
+
+
+def test_activate_new_changeset_replaces_stale_global_use_case_slices(tmp_path: Path) -> None:
+    _write_active_changeset(tmp_path, "CHG-NEW")
+    scoped_session = (
+        tmp_path
+        / ".harness"
+        / "ui"
+        / "change-sets"
+        / "CHG-NEW"
+        / "harvest-session.json"
+    )
+    scoped_session.parent.mkdir(parents=True)
+    scoped_session.write_text(json.dumps(_new_session()), encoding="utf-8")
+
+    stale_canonical = tmp_path / "docs" / "design" / "유스케이스.md"
+    stale_canonical.parent.mkdir(parents=True)
+    stale_canonical.write_text("- UC-001. stale use case\n", encoding="utf-8")
+    stale_slice = tmp_path / "docs" / "use-cases" / "UC-001" / "use-case.md"
+    stale_slice.parent.mkdir(parents=True)
+    stale_slice.write_text("# stale\n", encoding="utf-8")
+
+    activate_changeset_harvest_ui(tmp_path, "CHG-NEW")
+
+    assert not stale_canonical.exists()
+    assert not (tmp_path / "docs" / "use-cases").exists()


### PR DESCRIPTION
## 문제

ChangeSet을 삭제한 뒤에도 전역 harvest state와 `docs/use-cases` 작업공간이 남아, 새 ChangeSet이 이전 ChangeSet에서 생성한 UC를 읽을 수 있었습니다.

두 누수 경로가 있었습니다.

1. 다른 active ChangeSet이 존재하면 `.harness/ui/harvest-session.json`을 보존했습니다. 이 파일은 ChangeSet 소유 정보가 없는 전역 working copy라서 삭제한 ChangeSet의 진행 상태를 다시 노출할 수 있습니다.
2. `activate_changeset_harvest_ui`가 scoped `docs/use-cases`를 전역 작업공간으로 `replace=False`로 병합했습니다. 새 ChangeSet의 snapshot에 UC 트리가 아직 없으면 이전 UC 디렉터리가 그대로 남아 이후 agent 입력으로 사용될 수 있었습니다.

## 변경 사항

- ChangeSet 삭제 시 전역 harvest session을 active ChangeSet 개수와 관계없이 항상 제거합니다.
  - 각 active ChangeSet의 durable state는 이미 `.harness/ui/change-sets/<CHG-ID>/`에 저장되어 있으므로, 전역 working copy를 보존할 이유가 없습니다.
- ChangeSet 활성화 시 `docs/use-cases`를 해당 ChangeSet snapshot으로 **교체**합니다.
  - snapshot에 UC 산출물이 없으면 전역 UC tree를 제거합니다.
  - snapshot에 산출물이 있으면 해당 scope의 UC tree만 materialize합니다.
- UI 서버가 직접 import한 activation 함수를 함께 보정해 API 요청에도 동일한 격리가 적용됩니다.

## 회귀 테스트

- 다른 active ChangeSet이 남아 있어도 삭제한 ChangeSet 뒤 전역 harvest session이 남지 않는지 검증
- 새 ChangeSet 활성화 시 이전 전역 `docs/design/유스케이스.md`와 `docs/use-cases/UC-*`가 제거되는지 검증

이 변경은 `docs/use-cases`를 공유 canonical 저장소가 아니라 현재 활성 ChangeSet snapshot의 materialized working copy로 명확히 취급합니다.