### PR TITLE
[codex] 손상된 venv pip 자동 복구

### DIFF
--- a/scripts/install-harness-codex.sh
+++ b/scripts/install-harness-codex.sh
@@ -292,6 +292,29 @@ ensure_harness_gitignore_entries() {
   fi
 }
 
+repair_venv_pip() {
+  local python_bin="$1"
+
+  echo "Repairing broken venv pip"
+  "$python_bin" - <<'PY'
+import ensurepip
+import runpy
+import sys
+
+with ensurepip._get_pip_whl_path_ctx() as pip_wheel:
+    sys.path.insert(0, str(pip_wheel))
+    sys.argv = [
+        "pip",
+        "install",
+        "--force-reinstall",
+        "--no-cache-dir",
+        "--no-index",
+        str(pip_wheel),
+    ]
+    runpy.run_module("pip", run_name="__main__")
+PY
+}
+
 install_runtime_files() {
 backup_preserved_paths
 
@@ -357,6 +380,9 @@ if [[ "$SKIP_VENV" -ne 1 ]]; then
     python3 -m venv "$TARGET_DIR/venv"
   else
     echo "skip existing: venv"
+  fi
+  if ! "$TARGET_DIR/venv/bin/python3" -m pip install --help >/dev/null 2>&1; then
+    repair_venv_pip "$TARGET_DIR/venv/bin/python3"
   fi
   "$TARGET_DIR/venv/bin/python3" -m pip install -U pip pytest pyyaml
 else

--- a/tests/runtime/test_install_update_preservation.py
+++ b/tests/runtime/test_install_update_preservation.py
@@ -133,3 +133,22 @@ def test_default_project_files_are_not_overwritten_by_force_update():
 
     assert 'if [[ -e "$dst" ]]' in body
     assert '"$FORCE"' not in body
+
+
+def test_installer_repairs_broken_existing_venv_pip_before_dependency_install():
+    repair_index = SCRIPT.index("repair_venv_pip() {")
+    health_check_index = SCRIPT.index(
+        'if ! "$TARGET_DIR/venv/bin/python3" -m pip install --help >/dev/null 2>&1'
+    )
+    repair_call_index = SCRIPT.index(
+        'repair_venv_pip "$TARGET_DIR/venv/bin/python3"',
+        health_check_index,
+    )
+    dependency_install_index = SCRIPT.index(
+        '"$TARGET_DIR/venv/bin/python3" -m pip install -U pip pytest pyyaml'
+    )
+
+    repair_body = SCRIPT[repair_index:health_check_index]
+    assert repair_index < health_check_index < repair_call_index < dependency_install_index
+    assert '"--force-reinstall"' in repair_body
+    assert "ensurepip._get_pip_whl_path_ctx()" in repair_body


### PR DESCRIPTION
## 구현 의도

기존 `venv`의 `pip` 패키지가 부분 손상된 경우에도 `harness update`가 중단되지 않게 한다.

## 구현 접근

- `pip install --help`로 install 명령 로딩 가능 여부를 검사한다.
- 실패 시 stdlib `ensurepip` 번들 wheel을 격리 로딩해 `pip`만 강제 재설치한다.
- 전체 `venv`는 재생성하지 않아 기존 프로젝트 의존성을 보존한다.

## 검증 방법

- `bash -n scripts/install-harness-codex.sh`
- `./venv/bin/python3 -m pytest -q tests/runtime/test_install_update_preservation.py tests/runtime/test_self_update.py` → 15 passed
- 임시 venv에서 `pip/_internal/operations/build` 삭제 후 자동 복구 및 `pip install --help` 성공 확인

## 위험 및 롤백

- 복구 경로는 Python stdlib의 `ensurepip` 내부 wheel 경로 API에 의존한다.
- 정상 `pip`에는 복구 로직이 실행되지 않는다.
- 문제 발생 시 커밋 `13bc4cc`를 revert하면 기존 동작으로 복귀한다.