### PR TITLE
#443 plan.md 기반 executor에 DDD 구현 정책과 strict handoff gate 추가

### DIFF
--- a/.codex/agents/implementation_executor.toml
+++ b/.codex/agents/implementation_executor.toml
@@ -11,6 +11,7 @@ Hot-path contract:
 - Role: Implement unchecked active-plan tasks only; do not replan or orchestrate the workflow.
 - Load `.codex/agents/references/implementation_executor.md` before editing.
 - Use `.codex/skills/harness-implementation-executor/SKILL.md` as the required skill entrypoint.
+- Treat the active `plan.md` as the sole product and implementation instruction. Read only the runtime-declared active plan and execution-scope artifact before editing.
 - Treat existing `- [x]` checkboxes in the active plan as completed resume state. Do not re-run or rewrite those tasks unless a still-unchecked task cannot proceed without diagnosing a direct regression.
 - Start from the first remaining `- [ ]` checkbox and continue only through unchecked tasks.
 - Preserve the repository package taxonomy exactly; do not create convention-based `controller`, `service`, `presentation`, or `infrastructure` packages when the module uses names such as `ui/application/domain/infra`.
@@ -22,5 +23,5 @@ Hot-path contract:
 - Do not invoke another agent, nested Codex process, or workflow.
 - Do not decide workflow resumption or classify final verification.
 - Do not move active plans, create wiki artifacts, or create pull-request artifacts.
-- Stop and report the blocker when required inputs, approvals, or scope are missing.
+- Stop and report the blocker when the plan, execution scope, approvals, or write boundary is missing or contradictory. Do not read upstream design artifacts to fill the gap.
 """

--- a/.codex/agents/implementation_executor.toml
+++ b/.codex/agents/implementation_executor.toml
@@ -9,9 +9,9 @@ You are the implementation_executor agent.
 
 Hot-path contract:
 - Role: Implement unchecked active-plan tasks only; do not replan or orchestrate the workflow.
-- Load `.codex/agents/references/implementation_executor.md` before editing.
-- Use `.codex/skills/harness-implementation-executor/SKILL.md` as the required skill entrypoint.
-- Treat the active `plan.md` as the sole product and implementation instruction. Read only the runtime-declared active plan and execution-scope artifact before editing.
+- Before task work, load the fixed control-plane files `.codex/agents/references/implementation_executor.md`, `.codex/skills/harness-implementation-executor/SKILL.md`, and `.codex/skills/harness-implementation-executor/references/ddd-implementation-policy.md`.
+- Treat the fixed control-plane files as generic implementation constraints. Treat the active `plan.md` as the sole task-specific product and implementation instruction.
+- Read only the runtime-declared active plan and execution-scope artifact as task-specific inputs before editing.
 - Treat existing `- [x]` checkboxes in the active plan as completed resume state. Do not re-run or rewrite those tasks unless a still-unchecked task cannot proceed without diagnosing a direct regression.
 - Start from the first remaining `- [ ]` checkbox and continue only through unchecked tasks.
 - Preserve the repository package taxonomy exactly; do not create convention-based `controller`, `service`, `presentation`, or `infrastructure` packages when the module uses names such as `ui/application/domain/infra`.
@@ -23,5 +23,5 @@ Hot-path contract:
 - Do not invoke another agent, nested Codex process, or workflow.
 - Do not decide workflow resumption or classify final verification.
 - Do not move active plans, create wiki artifacts, or create pull-request artifacts.
-- Stop and report the blocker when the plan, execution scope, approvals, or write boundary is missing or contradictory. Do not read upstream design artifacts to fill the gap.
+- Stop and report the blocker when the plan, execution scope, fixed policy, approvals, or write boundary is missing or contradictory. Do not read upstream design artifacts to fill the gap.
 """

--- a/.codex/agents/references/artifact_reviewer.md
+++ b/.codex/agents/references/artifact_reviewer.md
@@ -25,11 +25,16 @@ Review output contract:
 
 Plan review checklist:
 - Plan stays inside the active ChangeSet and one work-item scope.
-- Required inputs are present: ChangeSet, work-item slice, E2E or maintenance verification goal, architecture, repository settings when required, and approved technical decisions for use-case work.
-- Plan has small unchecked implementation and test tasks.
+- Required planning inputs are present: ChangeSet, work-item slice, E2E or maintenance verification goal, architecture, repository settings when required, and approved technical decisions for use-case work.
+- Plan contains all executor-required sections: execution scope, package/dependency contract, domain implementation contract, external-contract read allowlist, task checklist, and focused verification.
+- Execution scope names bounded context/module, Aggregate Root, allowed/forbidden paths, and affected existing files.
+- Package/dependency contract names the exact package and responsibility for every created or moved class, allowed dependency direction, forbidden imports/framework dependencies, and composition wiring.
+- Domain implementation contract names invariants, state transitions, Entity/Value Object validation, Domain Service decision, Domain Event and persistence compatibility, cross-Aggregate/Bounded Context collaboration, and transaction/idempotency/concurrency decisions. A non-domain work item may use `N/A - <reason>` only where genuinely inapplicable.
+- External-contract read allowlist contains exact paths/patterns and reasons, or explicit `N/A - <reason>`.
+- Plan has small unchecked implementation and test tasks that name files and the rule each task proves.
 - Plan records an OWASP security review with attack-surface evidence, applicable standards, concrete security tasks, tests, verification criteria, and justified exclusions.
-- Verification tasks cover build, focused tests, E2E or maintenance goal, runtime server verification or explicit non-applicability, static analysis, and `.codex/test-gate.yaml` stages when configured.
-- Plan does not ask the executor to resolve upstream design, approval, or scope conflicts silently.
+- Verification tasks cover build, focused tests, architecture tests or explicit non-applicability, E2E or maintenance goal, runtime server verification or explicit non-applicability, static analysis, and `.codex/test-gate.yaml` stages when configured.
+- Plan does not ask the executor to resolve upstream design, approval, package, dependency, aggregate, or scope conflicts silently.
 
 Technical-decision review checklist:
 - Decisions trace to the selected use-case or maintenance slice.

--- a/.codex/agents/references/implementation_executor.md
+++ b/.codex/agents/references/implementation_executor.md
@@ -11,45 +11,41 @@ Complete only the unchecked tasks in the active work-item plan supplied by the r
 
 ## Required inputs
 
-Read only the inputs named by the runtime payload. For a use-case work item, the runtime-provided inputs normally include:
+Read only the runtime-declared inputs:
 
-- `docs/plans/active/<UC-ID>/plan.md`
-- `docs/use-cases/<UC-ID>/use-case.md`
-- `docs/use-cases/<UC-ID>/event-storming.md`
-- `docs/use-cases/<UC-ID>/e2e-goal.md`
-- `docs/use-cases/<UC-ID>/affected-files.md` when present
-- `docs/changes/active/<CHG-ID>.md`
-- `ARCHITECTURE.md`
-- approved technical decisions when present
-- `.codex/repository-settings.md`
+- `docs/plans/active/<WORK-ITEM-ID>/plan.md`
+- `.harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-scope.json`
+- the verification repair brief when the runtime explicitly declares a retry
 
-Do not infer a different work item, expand the scope, rewrite the plan, or invent product behavior.
+The plan is the sole product and implementation instruction. It must contain the execution boundary, implementation contract, package taxonomy, task list, focused verification commands, and explicit external-contract reads when needed.
+
+Do not read use-case, event-storming, E2E-goal, ChangeSet, architecture, technical-decision, or other upstream design artifacts. Do not infer a different work item, expand the scope, rewrite the plan, or invent product behavior.
 
 ## Read-scope discipline
 
-Default reads are limited to the runtime payload inputs, the active plan, declared affected files, and files inside the active bounded context, aggregate, application layer, adapter, or module/package named by the active work item.
+Default reads are limited to the active plan, execution-scope artifact, declared affected files, and files inside the active bounded context, aggregate, application layer, adapter, or module/package named by the active plan.
 
-External contract reads are allowed only when a concrete implementation need proves they are required. Valid triggers include an import or compile error, a stack trace, a failing focused test, an event schema, a port or adapter contract, runtime configuration used by the active path, or an explicit active-plan task. Read the smallest exact file or package that answers the question.
+External contract reads are allowed only when a concrete implementation need proves they are required and the plan names the contract or the running code produces the need. Valid triggers include an import or compile error, a stack trace, a failing focused test, an event schema, a port or adapter contract, runtime configuration used by the active path, or an explicit active-plan task. Read the smallest exact file or package that answers the question.
 
 Before reading outside the default scope, record a one-line reason in the implementation log or user-facing progress output:
 
 `cross-scope read: <reason> -> <path-or-pattern>`
 
-Do not use broad repository-wide search to discover unrelated implementation details when the active bounded context, aggregate, or declared affected files already provide a narrower path. Repository-wide commands for build, test, container, Terraform, Gradle, or equivalent infrastructure verification are acceptable when the active plan requires them, but they do not justify unrelated source inspection.
+Do not use broad repository-wide search to discover unrelated implementation details when the active plan or declared affected files already provide a narrower path. Repository-wide commands for build, test, container, Terraform, Gradle, or equivalent infrastructure verification are acceptable when the active plan requires them, but they do not justify unrelated source inspection.
 
 Use generic architectural terms. Do not encode repository-specific module names in this policy. In particular, distinguish:
 
 - `application layer` or `application service`: the bounded-context internal use-case orchestration layer.
 - `app module`: a runnable composition or bootstrapping module, when a repository has one.
 
-Never infer that a rule about `application service` applies to an `app module` unless the active architecture document or plan explicitly says so.
+Never infer that a rule about `application service` applies to an `app module` unless the active plan explicitly says so.
 
 ## Package taxonomy discipline
 
-Preserve the package taxonomy declared by `ARCHITECTURE.md`, `.codex/repository-settings.md`, the active plan, or existing files. Do not translate repository layer names into generic Spring package names.
+Preserve the package taxonomy declared by the active plan or existing files. Do not translate repository layer names into generic Spring package names.
 
 - If the module uses `ui/application/domain/infra`, write new files under those exact packages.
-- Do not create sibling `controller`, `service`, `presentation`, or `infrastructure` packages unless the active architecture or plan explicitly names them.
+- Do not create sibling `controller`, `service`, `presentation`, or `infrastructure` packages unless the active plan explicitly names them.
 - A class named `*Controller` may belong in `ui` when `ui` is the repository's inbound adapter package. An application service belongs in `application`; that does not justify creating a `service` package.
 
 ## Execution contract
@@ -58,29 +54,26 @@ Preserve the package taxonomy declared by `ARCHITECTURE.md`, `.codex/repository-
 - Treat existing `- [x]` plan checkboxes as completed resume state.
 - Start execution at the first remaining `- [ ]` checkbox and continue only through unchecked tasks.
 - Do not re-run, rewrite, or re-check already checked tasks unless a remaining unchecked task is blocked by a direct regression that must be diagnosed.
-- Keep all edits inside the active ChangeSet scope and active work-item scope.
-- Do not edit other UC plans or other UC documents.
-- Do not edit docs/use-cases/<UC-ID>/e2e-goal.md.
+- Keep all edits inside the active ChangeSet scope and active work-item scope as declared by the runtime-owned execution-scope artifact.
+- Do not edit other work-item plans or upstream design documents.
 - Update task checkboxes only for work you actually completed.
 - After each individual checkbox task is completed, immediately change that existing marker from `- [ ]` to `- [x]` in the active plan and save the file before starting the next task. Do not batch checkbox updates until the end of the run.
 - Run focused commands that directly validate the tasks you changed.
-- Record focused command results and implementation-specific test suite details in `docs/plans/active/<UC-ID>/verification.md` or the active plan when the plan permits it.
+- Record focused command results and implementation-specific test suite details in `docs/plans/active/<WORK-ITEM-ID>/verification.md` or the active plan when the plan permits it.
 - Report changed files, commands, pass/fail results, remaining unchecked tasks, and blockers.
 - Preserve unrelated changes made by other contributors.
 
 ### Focused verification
 
-Use repository-defined commands when available. For a use-case task, run `./gradlew test` or the configured test command when that task's scope requires it. Run `./gradlew e2eTest` or the configured E2E command only when the active plan requires the focused end-user path.
+Use the focused commands named in the active plan. If a planned browser verification cannot run because browser installation, network, credentials, permissions, external services, or host limits are unavailable, record an environment blocker and stop.
 
-When implemented behavior includes a UI and that UI is served in a web environment accessible to Playwright, use the applicable UI verification path. If a Playwright browser install, network, credentials, permissions, external services, or host limits prevent the required focused UI verification, record an environment blocker and stop.
-
-HTTP/API probes alone do not satisfy use-case E2E verification when the active plan requires a browser path. If no browser-accessible web UI can be started, continue using the existing API/runtime verification path and record why browser verification was not applicable. For cross-origin browser paths, verify the configured same-origin proxy or CORS behavior. A CORS-blocked request is an implementation failure when the planned local origins are inside the approved runtime path.
+HTTP/API probes alone do not satisfy a browser E2E task when the active plan explicitly requires a browser path. If no browser-accessible web UI can be started, continue using the existing API/runtime verification path only when the plan marks browser verification as not applicable, and record why.
 
 ### Implementation conventions
 
 In Java/Spring code, use Lombok boilerplate accessors and constructors, including `@Getter` and `@RequiredArgsConstructor`, when available within approved scope. Use constructor injection for dependencies. Prefer `private final` dependency fields; do not use field injection or setter injection.
 
-For runnable applications, maintain `scripts/run-app-infra.sh`, `scripts/run-app-server.sh`, and `scripts/check-app-infra.sh` when the active plan requires infrastructure readiness probing, local infrastructure such as `compose.yaml`, and verification through `harness run app`.
+For runnable applications, maintain `scripts/run-app-infra.sh`, `scripts/run-app-server.sh`, and `scripts/check-app-infra.sh` only when the active plan requires infrastructure readiness probing, local infrastructure such as `compose.yaml`, and verification through `harness run app`.
 
 ## Explicit non-responsibilities
 
@@ -89,6 +82,6 @@ For runnable applications, maintain `scripts/run-app-infra.sh`, `scripts/run-app
 - Do not perform or classify final verification. The runtime verifier and decision step own that boundary.
 - Do not move an active plan to completed plans.
 - Do not create or update wiki, commits, branches, or pull requests.
-- Do not alter requirements, ChangeSet scope, architecture, E2E goals, or technical-decision documents unless the active plan explicitly makes such an edit an implementation task.
+- Do not alter requirements, ChangeSet scope, architecture, E2E goals, event-storming, or technical-decision documents.
 
-If an input is missing, approval is required, scope is contradictory, or focused verification cannot run, record the concrete blocker and stop. The runtime decides the next stage from the executor result and verifier result.
+If the plan or execution scope is missing, approval is required, scope is contradictory, or focused verification cannot run, record the concrete blocker and stop. The runtime decides the next stage from the executor result and verifier result.

--- a/.codex/agents/references/implementation_executor.md
+++ b/.codex/agents/references/implementation_executor.md
@@ -2,6 +2,7 @@
 
 - Agent config: `.codex/agents/implementation_executor.toml`
 - Required skill: `.codex/skills/harness-implementation-executor/SKILL.md`
+- Fixed implementation policy: `.codex/skills/harness-implementation-executor/references/ddd-implementation-policy.md`
 
 You are the harness implementation executor agent.
 
@@ -9,15 +10,21 @@ You are the harness implementation executor agent.
 
 Complete only the unchecked tasks in the active work-item plan supplied by the runtime. Your output is a bounded implementation result: code, tests, configuration, focused verification evidence, changed files, and blockers.
 
-## Required inputs
+## Fixed Control Plane
 
-Read only the runtime-declared inputs:
+Before task work, load the agent config, required skill, and fixed DDD implementation policy. They provide stable generic constraints for package ownership, dependency direction, aggregates, ports/adapters, transactions, events, DTO mapping, and tests.
+
+The fixed policy is not a source of product behavior or task-specific architecture. When a task-specific decision is absent from the plan, report a blocker instead of deriving it from an upstream design artifact or inventing it from generic policy.
+
+## Required task inputs
+
+Read only the runtime-declared task inputs:
 
 - `docs/plans/active/<WORK-ITEM-ID>/plan.md`
 - `.harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-scope.json`
 - the verification repair brief when the runtime explicitly declares a retry
 
-The plan is the sole product and implementation instruction. It must contain the execution boundary, implementation contract, package taxonomy, task list, focused verification commands, and explicit external-contract reads when needed.
+The plan is the sole task-specific product and implementation instruction. It must contain the execution boundary, package/dependency contract, domain implementation contract, external-contract read allowlist, task list, focused verification commands, and explicit external-contract reads when needed.
 
 Do not read use-case, event-storming, E2E-goal, ChangeSet, architecture, technical-decision, or other upstream design artifacts. Do not infer a different work item, expand the scope, rewrite the plan, or invent product behavior.
 
@@ -33,13 +40,6 @@ Before reading outside the default scope, record a one-line reason in the implem
 
 Do not use broad repository-wide search to discover unrelated implementation details when the active plan or declared affected files already provide a narrower path. Repository-wide commands for build, test, container, Terraform, Gradle, or equivalent infrastructure verification are acceptable when the active plan requires them, but they do not justify unrelated source inspection.
 
-Use generic architectural terms. Do not encode repository-specific module names in this policy. In particular, distinguish:
-
-- `application layer` or `application service`: the bounded-context internal use-case orchestration layer.
-- `app module`: a runnable composition or bootstrapping module, when a repository has one.
-
-Never infer that a rule about `application service` applies to an `app module` unless the active plan explicitly says so.
-
 ## Package taxonomy discipline
 
 Preserve the package taxonomy declared by the active plan or existing files. Do not translate repository layer names into generic Spring package names.
@@ -47,6 +47,7 @@ Preserve the package taxonomy declared by the active plan or existing files. Do 
 - If the module uses `ui/application/domain/infra`, write new files under those exact packages.
 - Do not create sibling `controller`, `service`, `presentation`, or `infrastructure` packages unless the active plan explicitly names them.
 - A class named `*Controller` may belong in `ui` when `ui` is the repository's inbound adapter package. An application service belongs in `application`; that does not justify creating a `service` package.
+- The active plan must name the exact package and responsibility for every created or moved class. Stop when it does not.
 
 ## Execution contract
 
@@ -84,4 +85,4 @@ For runnable applications, maintain `scripts/run-app-infra.sh`, `scripts/run-app
 - Do not create or update wiki, commits, branches, or pull requests.
 - Do not alter requirements, ChangeSet scope, architecture, E2E goals, event-storming, or technical-decision documents.
 
-If the plan or execution scope is missing, approval is required, scope is contradictory, or focused verification cannot run, record the concrete blocker and stop. The runtime decides the next stage from the executor result and verifier result.
+If the plan or execution scope is missing, the fixed policy is unavailable, approval is required, scope is contradictory, a required plan handoff decision is missing, or focused verification cannot run, record the concrete blocker and stop. The runtime decides the next stage from the executor result and verifier result.

--- a/.codex/skills/harness-code-planner/references/detailed-instructions.md
+++ b/.codex/skills/harness-code-planner/references/detailed-instructions.md
@@ -25,14 +25,18 @@ Always read the selected work-item slice, `ARCHITECTURE.md`, `.codex/repository-
 
 ### Executor-complete plan contract
 
-The implementation executor receives only the active plan and a runtime-owned execution-scope artifact. Therefore the plan must be self-sufficient for implementation and focused verification. Include these explicit sections:
+The implementation executor receives only the active plan, a runtime-owned execution-scope artifact, and fixed DDD implementation policy. Therefore the plan must be self-sufficient for every task-specific decision. Include these explicit sections exactly as defined by `plan-template.md`:
 
-- `## 실행 경계` or `## Execution Scope`: allowed and forbidden paths, the bounded context/module/package, and each permitted external-contract read with its reason.
-- `## 구현 계약` or `## Implementation Contract`: required behavior, inputs/outputs, state transitions and invariants, error handling, API/event/persistence changes, and compatibility constraints.
-- `## 작업 체크리스트` or `## Task Checklist`: ordered, file-oriented unchecked tasks for code, tests, configuration, and evidence.
-- `## 집중 검증` or `## Focused Verification`: exact commands, expected results, and the condition that requires the executor to stop as blocked.
+- `## 실행 경계`: bounded context/module, Aggregate Root, allowed/forbidden paths, and affected existing files.
+- `## 패키지 및 의존성 계약`: exact package and responsibility for every created or moved class, allowed dependency direction, forbidden imports/framework dependencies, and composition wiring.
+- `## 도메인 구현 계약`: invariants, state transitions, Entity/Value Object validation, Domain Service decision, Domain Events, persistence compatibility, cross-Aggregate/Bounded Context collaboration, transaction/idempotency/concurrency decisions.
+- `## 외부 계약 읽기 허용 목록`: every cross-scope read with an exact path/pattern and reason, or explicit `N/A - <reason>`.
+- `## 작업 체크리스트`: ordered, file-oriented unchecked tasks for code, tests, configuration, and evidence. Each task names the rule it proves.
+- `## 집중 검증`: exact commands, expected results, architecture-test decision, and explicit stop conditions.
 
 Do not require the executor to consult requirements, use-case, event-storming, E2E-goal, ChangeSet, architecture, or technical-decision documents to resolve an implementation decision. Resolve the decision while planning, or mark the work item blocked.
+
+Do not use the fixed DDD policy as a substitute for task-specific design. For example, it can require `ui -> application -> domain`, but the plan must still name the actual package, Aggregate Root, Port, adapter, event, transaction, and compatibility decision for this work item.
 
 ### Use-case work-item slice
 

--- a/.codex/skills/harness-code-planner/references/detailed-instructions.md
+++ b/.codex/skills/harness-code-planner/references/detailed-instructions.md
@@ -23,6 +23,17 @@ Plan exactly one work-item slice from `docs/changes/active/<CHG-ID>.md` into `do
 
 Always read the selected work-item slice, `ARCHITECTURE.md`, `.codex/repository-settings.md`, approved technical decisions, and the ChangeSet Before/After delta. Use `docs/use-cases/<UC-ID>/` for a use-case work item and `docs/maintenance/<MAINT-ID>/` for a maintenance work item. Integrated documents under the design documentation area are source-of-truth references only. They are not the primary planning input.
 
+### Executor-complete plan contract
+
+The implementation executor receives only the active plan and a runtime-owned execution-scope artifact. Therefore the plan must be self-sufficient for implementation and focused verification. Include these explicit sections:
+
+- `## 실행 경계` or `## Execution Scope`: allowed and forbidden paths, the bounded context/module/package, and each permitted external-contract read with its reason.
+- `## 구현 계약` or `## Implementation Contract`: required behavior, inputs/outputs, state transitions and invariants, error handling, API/event/persistence changes, and compatibility constraints.
+- `## 작업 체크리스트` or `## Task Checklist`: ordered, file-oriented unchecked tasks for code, tests, configuration, and evidence.
+- `## 집중 검증` or `## Focused Verification`: exact commands, expected results, and the condition that requires the executor to stop as blocked.
+
+Do not require the executor to consult requirements, use-case, event-storming, E2E-goal, ChangeSet, architecture, or technical-decision documents to resolve an implementation decision. Resolve the decision while planning, or mark the work item blocked.
+
 ### Use-case work-item slice
 
 Required:
@@ -68,7 +79,7 @@ Optional:
 - Stop when a required work-item document is absent. Do not substitute a UC slice for a maintenance slice.
 - Treat optional `technical-decisions.md` as a planning reference only; it does not create a maintenance preflight gate.
 - Include build and test verification such as `./gradlew build` and `./gradlew test`, or the concrete repository equivalents from `.codex/test-gate.yaml` and `.codex/repository-settings.md`.
-- Include E2E or maintenance verification tied to the approved E2E/verification goal.
+- Include E2E or maintenance verification tied to the approved E2E/verification goal. The verifier, not the executor, owns final E2E quality judgment.
 - Include `domain-impact.md`, `aggregate-delta.md`, and canonical references such as `docs/domain/<BC-ID>/aggregates/<AGG-ID>.md` whenever the work item affects domain elements.
 - Add Compatibility tests when another use case shares a modified domain element.
 - Block or coordinate when another active ChangeSet modifies the same canonical domain element.
@@ -93,7 +104,6 @@ Preserve repository package taxonomy exactly. The planner must not normalize, tr
 - If a module uses `ui/application/domain/infra`, plan work under `ui`, `application`, `domain`, and `infra`.
 - Do not introduce sibling `controller`, `service`, `presentation`, or `infrastructure` packages unless `ARCHITECTURE.md`, `.codex/repository-settings.md`, or the user's request explicitly names them.
 - Treat classes named `*Controller` as allowed inside a repository's `ui` package when that is the established adapter layer. Treat application services as classes inside `application`, not as a reason to create a `service` layer package.
-
 
 ## Reference Map
 

--- a/.codex/skills/harness-code-planner/references/plan-template.md
+++ b/.codex/skills/harness-code-planner/references/plan-template.md
@@ -1,6 +1,6 @@
 ## Output Template
 
-`docs/plans/active/<WORK-ITEM-ID>/plan.md` must follow this compact structure. Keep entries terse. Prefer one-line bullets over tables unless a table prevents ambiguity.
+`docs/plans/active/<WORK-ITEM-ID>/plan.md` must follow this executor-complete structure. Keep entries terse, but do not replace required decisions with placeholders. Use `N/A - <reason>` only when a required section is genuinely inapplicable.
 
 ~~~markdown
 # 구현 계획
@@ -13,51 +13,61 @@
 ## 2. 구현하지 말아야 할 것
 - ...
 
-## 3. 입력 문서
-- Slice:
-- E2E/verification goal:
-- 필수 입력:
-- 누락/placeholder:
+## 3. 실행 경계
+- 대상 bounded context/module:
+- 대상 aggregate root:
+- 수정 허용 경로:
+- 수정 금지 경로:
+- 영향받는 기존 파일:
 
-## 4. 아키텍처 제약
-- 경계/의존성:
-- 기술 결정:
-- 도메인 영향:
-- 충돌/호환성:
-- OWASP Security Review: pending `security_plan_reviewer`; attack surface:
+## 4. 패키지 및 의존성 계약
+- 생성/수정 클래스와 정확한 package:
+- 각 클래스의 layer와 책임:
+- 허용 의존성 방향:
+- 금지 import/framework dependency:
+- bootstrap/configuration wiring:
 
-## 5. 구현 범위
-- 포함:
-- 제외:
-- 위험/가정:
+## 5. 도메인 구현 계약
+- Aggregate invariant:
+- 상태 전이:
+- Entity/Value Object 생성 및 검증 규칙:
+- Domain Service 여부와 책임:
+- Domain Event 및 persistence compatibility:
+- 다른 Aggregate/Bounded Context 협력 방식:
+- Transaction, idempotency, concurrency:
 
-## 6. 구현 계획
-- [ ] 필요 시 `spring-initializer` 실행.
-- [ ] 필요 시 `spring-package-structure`로 구조/`ARCHITECTURE.md` 정합성 확인.
-- [ ] ...
+## 6. 외부 계약 읽기 허용 목록
+- `<reason>` -> `<exact path or pattern>`
+- N/A - 외부 계약 read가 필요 없으면 이유를 기록.
 
-## 7. 테스트 계획
-- [ ] 단위/도메인:
-- [ ] 애플리케이션/어댑터:
-- [ ] 호환성/E2E:
+## 7. 작업 체크리스트
+- [ ] `<exact file>`: 구현 책임과 만족해야 할 도메인 규칙.
+- [ ] `<exact test file>`: 검증할 invariant/state transition/orchestration.
+- [ ] `<adapter/config file>`: 필요한 Port/Adapter 또는 설정 작업.
 
-## 8. 검증 방법
+## 8. 집중 검증
 - [ ] Build: `<command>` -> `<success criteria>`
-- [ ] Tests: `<command>` -> `<success criteria>`
+- [ ] Focused tests: `<command>` -> `<success criteria>`
+- [ ] Architecture test: `<command 또는 N/A+사유>`
 - [ ] E2E 또는 maintenance verification: `<command>` -> `<success criteria>`
 - [ ] Test gate: `.codex/test-gate.yaml` required stage PASS
 - [ ] Runtime server verification: `<harness run app 또는 N/A+사유>`
 - [ ] Static analysis: `<command 또는 N/A+사유>`
+- 중단 조건: `<executor가 구현을 멈추고 blocker를 보고해야 하는 조건>`
 
-## 9. 완료 조건
+## 9. OWASP Security Review
+- pending `security_plan_reviewer`; attack surface:
+
+## 10. 완료 조건
 - 모든 체크박스가 `- [x]`.
 - 필요한 테스트가 존재하고 통과.
-- Build, Tests, E2E 또는 maintenance verification, Test gate, Runtime server verification, Static analysis 결과 기록.
+- Build, focused tests, architecture test, E2E 또는 maintenance verification, Test gate, Runtime server verification, Static analysis 결과 기록.
 - active -> completed 전이는 `complete-work-item-plan`만 수행.
 
-## 10. 검증 결과
+## 11. 검증 결과
 - Build: pending
-- Tests: pending
+- Focused tests: pending
+- Architecture test: pending
 - E2E 또는 maintenance verification: pending
 - Test gate: pending
 - Runtime server verification: pending
@@ -68,8 +78,7 @@
 
 After agent completion, report:
 
-- Whether `ARCHITECTURE.md` existed.
-- Whether static-analysis procedures were included in the work-item plan.
+- Whether the executor-complete plan contract was satisfied.
 - The active plan path.
 - Whether the plan is ready for executor use.
-- Any missing ChangeSet, work-item, architecture, repository setting, technical decision, or canonical domain inputs.
+- Any missing ChangeSet, work-item, architecture, repository setting, technical decision, canonical domain input, package decision, or domain decision.

--- a/.codex/skills/harness-implementation-executor/SKILL.md
+++ b/.codex/skills/harness-implementation-executor/SKILL.md
@@ -9,14 +9,20 @@ description: Execute unchecked work-item plan tasks by modifying only approved c
 
 Perform one runtime-dispatched implementation attempt for the active work item. Complete the plan's unchecked implementation tasks and return a bounded execution report.
 
+## Fixed control plane
+
+Before task work, load `.codex/skills/harness-implementation-executor/references/ddd-implementation-policy.md`.
+
+The policy is a stable implementation constraint for DDD layer roles, dependency direction, aggregates, ports/adapters, transaction/event handling, DTO mapping, and architecture tests. It does not supply task-specific product behavior. The active `plan.md` remains the sole task-specific instruction.
+
 ## Required behavior
 
-- Read the active plan and the runtime-provided execution-scope artifact before editing.
-- Treat the active `plan.md` as the sole product and implementation instruction. Do not read use-case, event-storming, E2E-goal, ChangeSet, architecture, or technical-decision artifacts to reinterpret the plan.
+- Read the fixed DDD implementation policy, active plan, and runtime-provided execution-scope artifact before editing.
+- Treat the active `plan.md` as the sole product and task-specific implementation instruction. Do not read use-case, event-storming, E2E-goal, ChangeSet, architecture, or technical-decision artifacts to reinterpret the plan.
+- Require the plan to state execution scope, package/dependency contract, domain implementation contract, external-contract read allowlist, task checklist, and focused verification. Report a blocker when a required decision is missing, contradictory, or a placeholder.
 - Keep source reads inside the active work-item scope by default: the active plan, execution-scope artifact, declared affected files, and the active bounded context, aggregate, application layer, adapter, or module/package named by the plan.
 - Read outside that scope only for a concrete external contract need such as an import or compile error, stack trace, focused test failure, event schema, port or adapter contract, runtime configuration, or explicit active-plan task. Prefer the smallest exact file or package, and record `cross-scope read: <reason> -> <path-or-pattern>` before the read.
 - Do not use broad repository-wide source search to inspect unrelated modules. Repository-wide build, test, Gradle, container, Terraform, or infrastructure commands remain allowed when the active plan requires verification.
-- Treat `application layer` or `application service` as bounded-context internal orchestration. Treat `app module` as a runnable composition or bootstrapping module only when the plan explicitly identifies one; do not conflate the terms.
 - Preserve the repository package taxonomy exactly. If the plan uses `ui/application/domain/infra`, create or move files only under those package names. Do not create `controller`, `service`, `presentation`, or `infrastructure` siblings unless the active plan explicitly names them.
 - Treat existing `- [x]` checkboxes in the active plan as completed resume state.
 - Start implementation from the first remaining `- [ ]` checkbox and execute only unchecked tasks.
@@ -25,7 +31,7 @@ Perform one runtime-dispatched implementation attempt for the active work item. 
 - Keep writes inside the active ChangeSet and work-item scope declared by the runtime-owned execution-scope artifact.
 - Run focused verification for the tasks changed in this attempt.
 - Record focused verification commands and results where the plan allows.
-- When updating the active plan, change only existing checkbox markers from `- [ ]` to `- [x]` and the contents of `## 10. 검증 결과` or `## 10. Verification Results`.
+- When updating the active plan, change only existing checkbox markers from `- [ ]` to `- [x]` and the contents of the existing `검증 결과` or `Verification Results` section.
 - Check off each completed task immediately after finishing that task and before starting the next one, so runtime dashboard polling can show progress during long implementation runs or interrupted sessions.
 - Do not rewrite plan goals, non-goals, input documents, architecture constraints, scope boundaries, task wording, completion policy, or any completed-plan path.
 - Report changed files, completed tasks, remaining tasks, focused verification results, and blockers.

--- a/.codex/skills/harness-implementation-executor/SKILL.md
+++ b/.codex/skills/harness-implementation-executor/SKILL.md
@@ -11,17 +11,18 @@ Perform one runtime-dispatched implementation attempt for the active work item. 
 
 ## Required behavior
 
-- Read the active plan and the runtime-provided work-item inputs before editing.
-- Keep source reads inside the active work-item scope by default: runtime payload inputs, declared affected files, and the active bounded context, aggregate, application layer, adapter, or module/package.
+- Read the active plan and the runtime-provided execution-scope artifact before editing.
+- Treat the active `plan.md` as the sole product and implementation instruction. Do not read use-case, event-storming, E2E-goal, ChangeSet, architecture, or technical-decision artifacts to reinterpret the plan.
+- Keep source reads inside the active work-item scope by default: the active plan, execution-scope artifact, declared affected files, and the active bounded context, aggregate, application layer, adapter, or module/package named by the plan.
 - Read outside that scope only for a concrete external contract need such as an import or compile error, stack trace, focused test failure, event schema, port or adapter contract, runtime configuration, or explicit active-plan task. Prefer the smallest exact file or package, and record `cross-scope read: <reason> -> <path-or-pattern>` before the read.
 - Do not use broad repository-wide source search to inspect unrelated modules. Repository-wide build, test, Gradle, container, Terraform, or infrastructure commands remain allowed when the active plan requires verification.
-- Treat `application layer` or `application service` as bounded-context internal orchestration. Treat `app module` as a runnable composition or bootstrapping module only when the repository has one; do not conflate the terms.
-- Preserve the repository package taxonomy exactly. If the module uses `ui/application/domain/infra`, create or move files only under those package names. Do not create `controller`, `service`, `presentation`, or `infrastructure` siblings unless the active architecture or plan explicitly names them.
+- Treat `application layer` or `application service` as bounded-context internal orchestration. Treat `app module` as a runnable composition or bootstrapping module only when the plan explicitly identifies one; do not conflate the terms.
+- Preserve the repository package taxonomy exactly. If the plan uses `ui/application/domain/infra`, create or move files only under those package names. Do not create `controller`, `service`, `presentation`, or `infrastructure` siblings unless the active plan explicitly names them.
 - Treat existing `- [x]` checkboxes in the active plan as completed resume state.
 - Start implementation from the first remaining `- [ ]` checkbox and execute only unchecked tasks.
 - Do not re-run or rewrite checked tasks unless a still-unchecked task is blocked by a direct regression in already completed work.
 - Implement only approved code, test, configuration, and implementation-evidence changes.
-- Keep writes inside the active ChangeSet and work-item scope.
+- Keep writes inside the active ChangeSet and work-item scope declared by the runtime-owned execution-scope artifact.
 - Run focused verification for the tasks changed in this attempt.
 - Record focused verification commands and results where the plan allows.
 - When updating the active plan, change only existing checkbox markers from `- [ ]` to `- [x]` and the contents of `## 10. 검증 결과` or `## 10. Verification Results`.
@@ -37,5 +38,6 @@ Perform one runtime-dispatched implementation attempt for the active work item. 
 - Do not perform or classify final verification.
 - Do not move active plans to completed plans.
 - Do not create wiki artifacts, commits, branches, or pull requests.
+- Do not inspect upstream design artifacts to fill missing plan detail; stop and report the plan blocker instead.
 
-Runtime owns orchestration, final verification, remediation decisions, plan transitions, and delivery.
+Runtime owns orchestration, final verification, remediation decisions, plan transitions, delivery, and enforcement of ChangeSet/affected-files write authority.

--- a/.codex/skills/harness-implementation-executor/references/ddd-implementation-policy.md
+++ b/.codex/skills/harness-implementation-executor/references/ddd-implementation-policy.md
@@ -1,0 +1,124 @@
+# DDD Implementation Policy
+
+This is the fixed control-plane policy for `implementation_executor`.
+
+The active `plan.md` remains the sole task-specific product and implementation instruction. This policy supplies stable constraints only. When the plan conflicts with this policy, stop and report a blocker; do not silently choose a new architecture.
+
+## 1. Layer Roles and Dependency Direction
+
+- `domain` contains Aggregate Roots, Entities, Value Objects, Domain Services, Domain Events, Domain Exceptions, Domain Policies, and Aggregate Repository Ports.
+- `application` contains use-case/application services, commands, queries, results, transaction boundaries, authorization/idempotency orchestration, and use-case-owned external Ports.
+- `ui` contains inbound adapters only: controllers, request/response DTOs, inbound mappers, message consumers, and CLI handlers. It does not contain repository Ports or persistence models.
+- `infra` contains repository/cache/message/file-storage/external-API implementations, persistence mappers, and technology- or vendor-specific components.
+- `bootstrap` or configuration is the only composition location that may wire all layers.
+
+Default dependency direction:
+
+```text
+ui -> application -> domain
+infra -> application or domain
+bootstrap -> ui, application, domain, infra
+```
+
+- `domain` must not depend on `application`, `ui`, `infra`, Spring, JPA, HTTP, JSON, Redis, Kafka, a database driver, or an external SDK.
+- `application` must not depend on `ui` or `infra` implementations.
+- `ui` must not call `infra` implementations directly.
+- `infra` implements Ports owned by `domain` or `application`; it does not own domain policy.
+
+## 2. Aggregate and Domain Model Rules
+
+- Define one Aggregate for each strong transactional consistency boundary.
+- Only an Aggregate Root may expose state-changing behavior for its Aggregate.
+- Repositories are Aggregate-Root repositories. Do not create repositories for internal Entities.
+- Reference another Aggregate by its identifier, not by an object graph.
+- Do not mutate another Aggregate directly from an Aggregate.
+- Place state transitions, calculations, invariants, and domain policy in the Domain Model.
+- Generate Domain Events in the Aggregate when a domain fact occurs.
+
+### Entity and Value Object Construction
+
+- Prefer named static factory methods for public creation paths.
+- Validate nullability, format, range, and cross-field invariants at creation and state transition boundaries.
+- Do not use public setters for domain state changes; expose intention-revealing domain methods.
+- Value Objects are immutable and value-equal.
+- Keep persistence restoration constructors non-public or otherwise restricted. Do not bypass validation in a normal creation path.
+- Domain models do not accept or return HTTP DTOs, persistence DTOs, or vendor SDK types.
+
+## 3. Application Service and Domain Service
+
+Application Services orchestrate one use case. They may:
+
+- authorize the actor;
+- load Aggregate Roots through Ports;
+- invoke Aggregate and Domain Service behavior;
+- save Aggregate Roots;
+- coordinate idempotency, transaction, and external-Port ordering;
+- assemble use-case Results.
+
+Application Services must not:
+
+- implement domain state transitions, calculations, or invariants;
+- mutate Entity fields through setters;
+- use controller DTOs or persistence models as domain objects;
+- embed technology-specific client code.
+
+Use a Domain Service only when a stateless domain policy spans multiple Aggregates or has no natural Aggregate owner. A Domain Service must not perform persistence or external I/O itself.
+
+## 4. Ports, Adapters, and Cross-Boundary Collaboration
+
+- Put Aggregate Repository Ports in `domain`.
+- Put external Ports in `application` when the use case owns the integration; put them in `domain` only when the Port expresses a domain concept.
+- Implement all Ports in `infra`.
+- Adapt HTTP/gRPC clients, message producers/consumers, cache clients, storage clients, and database clients in `infra`.
+- Never import another module's Entity or call another module's repository implementation directly.
+
+For another Aggregate or Bounded Context, use the mechanism named by the active plan and approved technical decision:
+
+- modular monolith: application Port with internal adapter or a bounded repository query;
+- synchronous service boundary: application Port with REST/gRPC adapter;
+- asynchronous boundary: Domain Event plus publisher/consumer adapters;
+- eventual consistency: event-driven follow-up handling.
+
+## 5. Transactions, Events, and Concurrency
+
+- The default transaction boundary is a public Application Service command method.
+- A command should normally change one Aggregate.
+- Reconsider Aggregate boundaries before creating one large transaction across several Aggregates.
+- Publish externally observable events after transaction commit.
+- When reliable external publication is required, follow the active plan's Outbox decision.
+- The plan must name optimistic locking, idempotency keys, retries, deduplication, or ordering rules when the use case has concurrency or delivery risk.
+
+## 6. Validation, Errors, DTOs, and Mapping
+
+- `ui` validates request shape and maps request/response DTOs.
+- `application` validates authorization, command eligibility, and idempotency.
+- `domain` validates business invariants and throws Domain Exceptions.
+- Convert infra-specific failures at adapter/application boundaries; do not leak them into domain behavior.
+- Do not return Domain Entities or persistence entities directly from `ui`.
+- Map UI DTOs to application Commands/Results at the UI/Application boundary.
+- Map persistence models to Domain Models inside Infra adapters.
+
+## 7. Tests and Architecture Checks
+
+- Domain tests verify invariants, state transitions, and calculations without framework bootstrapping.
+- Application tests verify orchestration with fake/mock Ports.
+- Infra integration tests verify adapter behavior against the relevant technology or test double.
+- UI tests verify request validation, authorization, status mapping, and response DTOs.
+- Add architecture tests when the active plan changes package or dependency boundaries:
+  - domain does not depend on application/ui/infra;
+  - application does not depend on ui/infra;
+  - ui does not depend directly on infra implementations.
+
+## 8. Required Plan Handoff
+
+Before code changes, the active plan must name:
+
+- target bounded context, module, Aggregate Root, and allowed/forbidden paths;
+- exact package and responsibility for every created or moved class;
+- permitted and forbidden dependency directions/imports;
+- invariants, state transitions, Value Object rules, Domain Events, persistence compatibility, and external collaboration decisions;
+- allowed cross-scope reads with exact path/pattern and reason;
+- transaction, event publication, idempotency, and concurrency choices when applicable;
+- focused commands, expected results, and explicit stop conditions.
+
+When any required decision is missing, contradictory, or only expressed as a placeholder, report a blocker. Do not inspect upstream design documents to reconstruct it.

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -79,21 +79,37 @@ steps:
       output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/reviews/plan-review.md
       status_label: Review Status
       approved_status: approved
+- id: materialize-execution-scope
+  kind: validator
+  name: Materialize the executor's bounded plan scope
+  needs:
+  - review-work-item-plan
+  command: python3 -m harness_codex.runtime.materialize_execution_scope --repo-root . --change-set <CHG-ID> --work-item <WORK-ITEM-ID> --plan docs/plans/active/<WORK-ITEM-ID>/plan.md --output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-scope.json
+  timeout_sec: 60
+  inputs:
+  - docs/plans/active/<WORK-ITEM-ID>/plan.md
+  outputs:
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-scope.json
+  metadata:
+    stage: implementation
+    scope: work_item
+    execution_boundary: work_item
+    gate_id: execution-scope
 - id: execute-work-item
   kind: agent
   name: Execute unchecked plan tasks
   needs:
-  - review-work-item-plan
+  - materialize-execution-scope
   agent_id: implementation_executor
   skill_id: harness-implementation-executor
   inputs:
   - docs/plans/active/<WORK-ITEM-ID>/plan.md
-  - docs/changes/active/<CHG-ID>.md
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-scope.json
   outputs:
   - docs/plans/active/<WORK-ITEM-ID>/plan.md
   metadata:
     stage: implementation
-    prompt_context_profile: execution
+    prompt_context_profile: execution-minimal
     scope: work_item
     execution_boundary: work_item
     upstream_context:
@@ -101,7 +117,6 @@ steps:
       artifact_path: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/reviews/plan-review.md
       priority: high
       purpose: Review findings, approval conditions, and rejected approaches for the active plan.
-    inputs_resolved_by: work_item_document_contract
 - id: verify-work-item
   kind: validator
   name: Verify the selected work item

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -106,8 +106,19 @@ def _install_changeset_scope_isolation() -> None:
     apply_changeset_scope_isolation_patch()
 
 
+def _install_final_canonical_gate_authority() -> None:
+    """Ensure explicit RunState decisions always outrank editable table rows."""
+
+    from harness_codex.runtime.canonical_stage_gate_authority_patch import (
+        apply_canonical_stage_gate_authority_patch,
+    )
+
+    apply_canonical_stage_gate_authority_patch()
+
+
 _install_changeset_execution_boundary()
 _install_runtime_write_boundaries()
 _install_canonical_procedure_stage_bridge()
 _install_changeset_deletion_cleanup()
 _install_changeset_scope_isolation()
+_install_final_canonical_gate_authority()

--- a/harness_codex/runtime/canonical_stage_gate_authority_patch.py
+++ b/harness_codex/runtime/canonical_stage_gate_authority_patch.py
@@ -1,0 +1,57 @@
+"""Final canonical-authority guard for procedure stage gates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_PATCHED = "_harness_canonical_stage_gate_authority_patch_applied"
+
+
+def apply_canonical_stage_gate_authority_patch() -> None:
+    """Reject explicit stale/blocked canonical decisions before legacy self-healing.
+
+    Older compatibility code may use a verified Markdown row to bootstrap a state
+    that has no explicit runtime decision. It must not use that row to replace an
+    explicit `stale`, `blocked`, or `pending` decision already owned by RunState.
+    """
+
+    from harness_codex.runtime import dashboard_runtime_state as dashboard
+    from harness_codex.runtime.procedure_stages import PROCEDURE_STAGES
+
+    if getattr(dashboard, _PATCHED, False):
+        return
+
+    original_assert = dashboard.assert_canonical_stage_gate
+
+    def assert_explicit_canonical_gate_first(
+        repo_root: Path | str,
+        change_set_id: str,
+        target_stage_id: str,
+        *,
+        uc_id: str | None = None,
+    ) -> None:
+        state = dashboard.load_canonical_change_set_state(repo_root, change_set_id)
+        if state is not None:
+            stage_ids = [stage.stage_id for stage in PROCEDURE_STAGES]
+            try:
+                target_index = stage_ids.index(target_stage_id)
+            except ValueError:
+                target_index = 0
+            decisions = state.decision_results.get("procedure_stage_results", {})
+            if isinstance(decisions, dict):
+                explicit_blockers = [
+                    stage_id
+                    for stage_id in stage_ids[:target_index]
+                    if isinstance(decisions.get(stage_id), dict)
+                    and decisions[stage_id].get("status") != "verified"
+                ]
+                if explicit_blockers:
+                    raise ValueError(
+                        f"{target_stage_id} is blocked: canonical runtime gates incomplete: "
+                        + ", ".join(explicit_blockers)
+                    )
+        return original_assert(repo_root, change_set_id, target_stage_id, uc_id=uc_id)
+
+    dashboard.assert_canonical_stage_gate = assert_explicit_canonical_gate_first
+    setattr(dashboard, _PATCHED, True)

--- a/harness_codex/runtime/dashboard_harvest_consistency_patch.py
+++ b/harness_codex/runtime/dashboard_harvest_consistency_patch.py
@@ -1,0 +1,76 @@
+"""Correct legacy dashboard bridges without restoring table/session authority.
+
+This patch is deliberately installed after the legacy bridge.  The bridge remains
+useful to bootstrap a missing canonical state, but it must never overwrite an
+existing canonical stale/blocked decision from editable Markdown table rows or
+scoped UI-session artifacts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_PATCHED = "_harness_dashboard_harvest_consistency_patch_applied"
+
+
+def apply_dashboard_harvest_consistency_patch() -> None:
+    """Install canonical-first gate and snapshot compatibility corrections."""
+
+    from harness_codex.runtime import dashboard_runtime_state as canonical
+    from harness_codex.runtime import dashboard_runtime_state_legacy_bridge as bridge
+    from harness_codex.runtime import harvest_ui, ui_server
+
+    if getattr(bridge, _PATCHED, False):
+        return
+
+    original_migrate = bridge._migrate_scoped_ui_session
+    original_hydrate = bridge._hydrate_verified_procedure_rows
+
+    def migrate_only_when_canonical_state_is_missing(root: Path, change_set_id: str) -> None:
+        if canonical.load_canonical_change_set_state(root, change_set_id) is not None:
+            return
+        original_migrate(root, change_set_id)
+
+    def hydrate_only_when_canonical_state_is_missing(root: Path, change_set_id: str) -> None:
+        if canonical.load_canonical_change_set_state(root, change_set_id) is not None:
+            return
+        original_hydrate(root, change_set_id)
+
+    bridge._migrate_scoped_ui_session = migrate_only_when_canonical_state_is_missing
+    bridge._hydrate_verified_procedure_rows = hydrate_only_when_canonical_state_is_missing
+
+    original_copy = harvest_ui._copy_scoped_use_case_outputs
+
+    def copy_only_session_accepted_event_outputs(root: Path, scoped_root: Path, session: dict) -> None:
+        original_copy(root, scoped_root, session)
+        event_items = (session.get("event_storming") or {}).get("items", {})
+        target_root = scoped_root / harvest_ui.USE_CASE_SLICE_ROOT
+        for uc_path in target_root.glob("UC-*"):
+            item = event_items.get(uc_path.name, {}) if isinstance(event_items, dict) else {}
+            if not isinstance(item, dict) or item.get("status") != "complete":
+                (uc_path / "event-storming.md").unlink(missing_ok=True)
+
+    harvest_ui._copy_scoped_use_case_outputs = copy_only_session_accepted_event_outputs
+
+    original_harvest_save = harvest_ui.save_changeset_harvest_ui
+    original_ui_save = ui_server.save_changeset_harvest_ui
+
+    def ensure_recoverable_session(root: Path | str, change_set_id: str) -> None:
+        root_path = Path(root)
+        if harvest_ui._load_session(root_path) is not None:
+            return
+        session = harvest_ui._recover_changeset_session(root_path, change_set_id)
+        harvest_ui._write_session(root_path, session)
+
+    def save_harvest_snapshot_with_recovery(root: Path | str, change_set_id: str) -> None:
+        ensure_recoverable_session(root, change_set_id)
+        original_harvest_save(root, change_set_id)
+
+    def save_ui_snapshot_with_recovery(root: Path | str, change_set_id: str) -> None:
+        ensure_recoverable_session(root, change_set_id)
+        original_ui_save(root, change_set_id)
+
+    harvest_ui.save_changeset_harvest_ui = save_harvest_snapshot_with_recovery
+    ui_server.save_changeset_harvest_ui = save_ui_snapshot_with_recovery
+    setattr(bridge, _PATCHED, True)

--- a/harness_codex/runtime/dashboard_runtime_state_legacy_compat.py
+++ b/harness_codex/runtime/dashboard_runtime_state_legacy_compat.py
@@ -64,6 +64,12 @@ def apply_dashboard_runtime_state_legacy_compat() -> None:
     bridge._migrate_scoped_ui_session = migrate_scoped_session_with_explicit_language_gate
     setattr(bridge, _PATCHED, True)
 
+    from harness_codex.runtime.dashboard_harvest_consistency_patch import (
+        apply_dashboard_harvest_consistency_patch,
+    )
+
+    apply_dashboard_harvest_consistency_patch()
+
 
 def _explicit_language_gate(root: Path, change_set_id: str) -> bool | None:
     session_path = root / ".harness/ui/change-sets" / change_set_id / "harvest-session.json"

--- a/harness_codex/runtime/materialize_execution_scope.py
+++ b/harness_codex/runtime/materialize_execution_scope.py
@@ -39,8 +39,14 @@ def materialize_execution_scope(
     work_item_id: str,
     plan_path: Path,
     output_path: Path,
+    enforce_full_contract: bool = False,
 ) -> dict[str, object]:
-    """Validate one executor-ready plan and write its runtime scope artifact."""
+    """Write a scope artifact and optionally enforce the executor-complete contract.
+
+    The Python API keeps the historical permissive default for callers that only
+    inspect scope metadata. The workflow CLI enables full enforcement before an
+    implementation executor is invoked.
+    """
 
     absolute_plan = plan_path if plan_path.is_absolute() else repo_root / plan_path
     if not absolute_plan.is_file():
@@ -49,11 +55,17 @@ def materialize_execution_scope(
     plan_text = absolute_plan.read_text(encoding="utf-8")
     sections = _extract_sections(plan_text)
     missing = _missing_or_incomplete_sections(sections)
-    if missing:
+    if enforce_full_contract and missing:
         raise ExecutionPlanContractError(
             "executor-ready plan contract is incomplete: " + ", ".join(missing)
         )
 
+    present_required_sections = {
+        key: {"heading": heading, "content_sha256": _content_sha256(sections[heading])}
+        for key, aliases in _REQUIRED_SECTIONS.items()
+        for heading in (next((alias for alias in aliases if alias in sections), None),)
+        if heading is not None
+    }
     payload = {
         "schema_version": 2,
         "change_set_id": change_set_id,
@@ -82,13 +94,12 @@ def materialize_execution_scope(
             ),
         },
         "plan_contract": {
-            "status": "valid",
-            "required_sections": {
-                key: {"heading": heading, "content_sha256": _content_sha256(sections[heading])}
-                for key, aliases in _REQUIRED_SECTIONS.items()
-                for heading in (next(alias for alias in aliases if alias in sections),)
-            },
+            "status": "valid" if not missing else "legacy-incomplete",
+            "enforced": enforce_full_contract,
+            "missing_or_incomplete": missing,
+            "required_sections": present_required_sections,
         },
+        "plan_sections": list(sections),
     }
 
     absolute_output = output_path if output_path.is_absolute() else repo_root / output_path
@@ -108,7 +119,7 @@ def _extract_sections(plan_text: str) -> dict[str, str]:
 
 def _missing_or_incomplete_sections(sections: Mapping[str, str]) -> list[str]:
     errors: list[str] = []
-    for key, aliases in _REQUIRED_SECTIONS.items():
+    for _, aliases in _REQUIRED_SECTIONS.items():
         heading = next((alias for alias in aliases if alias in sections), None)
         if heading is None:
             errors.append(f"missing section: {aliases[0]}")
@@ -150,6 +161,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--work-item", required=True)
     parser.add_argument("--plan", required=True)
     parser.add_argument("--output", required=True)
+    parser.add_argument("--enforce-full-contract", action="store_true")
     args = parser.parse_args(argv)
 
     try:
@@ -159,6 +171,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             work_item_id=args.work_item,
             plan_path=Path(args.plan),
             output_path=Path(args.output),
+            enforce_full_contract=args.enforce_full_contract,
         )
     except (ExecutionPlanContractError, FileNotFoundError) as error:
         print(str(error))

--- a/harness_codex/runtime/materialize_execution_scope.py
+++ b/harness_codex/runtime/materialize_execution_scope.py
@@ -1,8 +1,8 @@
-"""Materialize the narrow runtime scope consumed by the implementation executor.
+"""Validate and materialize the narrow runtime scope consumed by the executor.
 
-The executor receives this artifact together with its active plan.  It is an
-execution aid, not a replacement for the runtime write authority: scope-diff
-validation still requires ChangeSet and affected-files-manifest permission.
+The executor receives this artifact with its active plan. It is an execution aid,
+not a replacement for runtime write authority: scope-diff validation still
+requires ChangeSet and affected-files-manifest permission.
 """
 
 from __future__ import annotations
@@ -12,13 +12,24 @@ import hashlib
 import json
 import re
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence
 
 
-_SECTION_RE = re.compile(
-    r"^##\s+(?:실행\s*경계|Execution\s+Scope|집중\s*검증|Focused\s+Verification)\s*$",
-    flags=re.IGNORECASE | re.MULTILINE,
-)
+_REQUIRED_SECTIONS: Mapping[str, tuple[str, ...]] = {
+    "execution_scope": ("실행 경계", "Execution Scope"),
+    "package_dependency_contract": ("패키지 및 의존성 계약", "Package and Dependency Contract"),
+    "domain_implementation_contract": ("도메인 구현 계약", "Domain Implementation Contract"),
+    "external_contract_read_allowlist": ("외부 계약 읽기 허용 목록", "External Contract Read Allowlist"),
+    "task_checklist": ("작업 체크리스트", "Task Checklist"),
+    "focused_verification": ("집중 검증", "Focused Verification"),
+}
+_SECTION_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
+_EMPTY_FIELD_RE = re.compile(r"(?:^|[-*]\s*)[^\n:]+:\s*$")
+_PLACEHOLDER_RE = re.compile(r"(?:<[^>]+>|\bTODO\b|\bpending\b|^\s*[-*]\s*\.\.\.\s*$)", re.IGNORECASE)
+
+
+class ExecutionPlanContractError(ValueError):
+    """Raised when a plan is not self-sufficient for plan-only execution."""
 
 
 def materialize_execution_scope(
@@ -29,15 +40,22 @@ def materialize_execution_scope(
     plan_path: Path,
     output_path: Path,
 ) -> dict[str, object]:
-    """Write a small, runtime-owned execution scope artifact for one work item."""
+    """Validate one executor-ready plan and write its runtime scope artifact."""
 
     absolute_plan = plan_path if plan_path.is_absolute() else repo_root / plan_path
     if not absolute_plan.is_file():
         raise FileNotFoundError(f"active plan is required: {plan_path}")
 
     plan_text = absolute_plan.read_text(encoding="utf-8")
+    sections = _extract_sections(plan_text)
+    missing = _missing_or_incomplete_sections(sections)
+    if missing:
+        raise ExecutionPlanContractError(
+            "executor-ready plan contract is incomplete: " + ", ".join(missing)
+        )
+
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "change_set_id": change_set_id,
         "work_item_id": work_item_id,
         "active_plan_path": _relative(absolute_plan, repo_root),
@@ -47,17 +65,30 @@ def materialize_execution_scope(
             "plan_grants_write_authority": False,
         },
         "executor_contract": {
-            "required_inputs": [
+            "required_control_plane": [
+                ".codex/agents/references/implementation_executor.md",
+                ".codex/skills/harness-implementation-executor/SKILL.md",
+                ".codex/skills/harness-implementation-executor/references/ddd-implementation-policy.md",
+            ],
+            "required_task_inputs": [
                 _relative(absolute_plan, repo_root),
                 _relative(output_path if output_path.is_absolute() else repo_root / output_path, repo_root),
             ],
             "instruction": (
-                "Execute only unchecked plan tasks. Treat the active plan as the sole "
-                "product and implementation instruction; report a blocker when it is "
-                "insufficient instead of reading upstream design artifacts."
+                "Load the fixed control-plane policy, then execute only unchecked plan tasks. "
+                "Treat the active plan as the sole task-specific product and implementation "
+                "instruction; report a blocker when it is insufficient instead of reading "
+                "upstream design artifacts."
             ),
         },
-        "plan_sections": _execution_sections(plan_text),
+        "plan_contract": {
+            "status": "valid",
+            "required_sections": {
+                key: {"heading": heading, "content_sha256": _content_sha256(sections[heading])}
+                for key, aliases in _REQUIRED_SECTIONS.items()
+                for heading in (next(alias for alias in aliases if alias in sections),)
+            },
+        },
     }
 
     absolute_output = output_path if output_path.is_absolute() else repo_root / output_path
@@ -66,10 +97,43 @@ def materialize_execution_scope(
     return payload
 
 
-def _execution_sections(plan_text: str) -> list[str]:
-    """Return explicit execution-boundary headings without duplicating plan content."""
+def _extract_sections(plan_text: str) -> dict[str, str]:
+    matches = list(_SECTION_RE.finditer(plan_text))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(plan_text)
+        sections[match.group(1).strip()] = plan_text[match.end() : end].strip()
+    return sections
 
-    return [match.group(0).lstrip("#").strip() for match in _SECTION_RE.finditer(plan_text)]
+
+def _missing_or_incomplete_sections(sections: Mapping[str, str]) -> list[str]:
+    errors: list[str] = []
+    for key, aliases in _REQUIRED_SECTIONS.items():
+        heading = next((alias for alias in aliases if alias in sections), None)
+        if heading is None:
+            errors.append(f"missing section: {aliases[0]}")
+            continue
+        if not _meaningful_section(sections[heading]):
+            errors.append(f"incomplete section: {heading}")
+    return errors
+
+
+def _meaningful_section(content: str) -> bool:
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    if not lines:
+        return False
+    normalized = "\n".join(lines)
+    if _PLACEHOLDER_RE.search(normalized):
+        return False
+    if any(_EMPTY_FIELD_RE.search(line) for line in lines):
+        return False
+    if all(line in {"-", "*"} for line in lines):
+        return False
+    return True
+
+
+def _content_sha256(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
 def _relative(path: Path, repo_root: Path) -> str:
@@ -88,13 +152,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--output", required=True)
     args = parser.parse_args(argv)
 
-    materialize_execution_scope(
-        repo_root=Path(args.repo_root).resolve(),
-        change_set_id=args.change_set,
-        work_item_id=args.work_item,
-        plan_path=Path(args.plan),
-        output_path=Path(args.output),
-    )
+    try:
+        materialize_execution_scope(
+            repo_root=Path(args.repo_root).resolve(),
+            change_set_id=args.change_set,
+            work_item_id=args.work_item,
+            plan_path=Path(args.plan),
+            output_path=Path(args.output),
+        )
+    except (ExecutionPlanContractError, FileNotFoundError) as error:
+        print(str(error))
+        return 1
     return 0
 
 

--- a/harness_codex/runtime/materialize_execution_scope.py
+++ b/harness_codex/runtime/materialize_execution_scope.py
@@ -1,9 +1,4 @@
-"""Validate and materialize the narrow runtime scope consumed by the executor.
-
-The executor receives this artifact with its active plan. It is an execution aid,
-not a replacement for runtime write authority: scope-diff validation still
-requires ChangeSet and affected-files-manifest permission.
-"""
+"""Validate and materialize the executor's bounded runtime scope."""
 
 from __future__ import annotations
 
@@ -14,8 +9,7 @@ import re
 from pathlib import Path
 from typing import Mapping, Sequence
 
-
-_REQUIRED_SECTIONS: Mapping[str, tuple[str, ...]] = {
+_REQUIRED: Mapping[str, tuple[str, ...]] = {
     "execution_scope": ("실행 경계", "Execution Scope"),
     "package_dependency_contract": ("패키지 및 의존성 계약", "Package and Dependency Contract"),
     "domain_implementation_contract": ("도메인 구현 계약", "Domain Implementation Contract"),
@@ -23,55 +17,41 @@ _REQUIRED_SECTIONS: Mapping[str, tuple[str, ...]] = {
     "task_checklist": ("작업 체크리스트", "Task Checklist"),
     "focused_verification": ("집중 검증", "Focused Verification"),
 }
-_SECTION_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
-_EMPTY_FIELD_RE = re.compile(r"(?:^|[-*]\s*)[^\n:]+:\s*$")
-_PLACEHOLDER_RE = re.compile(r"(?:<[^>]+>|\bTODO\b|\bpending\b|^\s*[-*]\s*\.\.\.\s*$)", re.IGNORECASE)
+_HEADING = re.compile(r"(?m)^##\s+(.+?)\s*$")
+_PLACEHOLDER = re.compile(r"(?:<[^>]+>|\bTODO\b|\bpending\b|^\s*[-*]\s*\.\.\.\s*$)", re.IGNORECASE)
+_EMPTY_FIELD = re.compile(r"(?:^|[-*]\s*)[^\n:]+:\s*$")
 
 
 class ExecutionPlanContractError(ValueError):
-    """Raised when a plan is not self-sufficient for plan-only execution."""
+    """The active plan is not self-sufficient for plan-only execution."""
 
 
 def materialize_execution_scope(
-    *,
-    repo_root: Path,
-    change_set_id: str,
-    work_item_id: str,
-    plan_path: Path,
-    output_path: Path,
-    enforce_full_contract: bool = False,
+    *, repo_root: Path, change_set_id: str, work_item_id: str,
+    plan_path: Path, output_path: Path, enforce_full_contract: bool = True,
 ) -> dict[str, object]:
-    """Write a scope artifact and optionally enforce the executor-complete contract.
-
-    The Python API keeps the historical permissive default for callers that only
-    inspect scope metadata. The workflow CLI enables full enforcement before an
-    implementation executor is invoked.
-    """
-
-    absolute_plan = plan_path if plan_path.is_absolute() else repo_root / plan_path
-    if not absolute_plan.is_file():
+    plan = plan_path if plan_path.is_absolute() else repo_root / plan_path
+    if not plan.is_file():
         raise FileNotFoundError(f"active plan is required: {plan_path}")
-
-    plan_text = absolute_plan.read_text(encoding="utf-8")
-    sections = _extract_sections(plan_text)
-    missing = _missing_or_incomplete_sections(sections)
+    text = plan.read_text(encoding="utf-8")
+    sections = _sections(text)
+    missing = _invalid_sections(sections)
     if enforce_full_contract and missing:
-        raise ExecutionPlanContractError(
-            "executor-ready plan contract is incomplete: " + ", ".join(missing)
-        )
+        raise ExecutionPlanContractError("executor-ready plan contract is incomplete: " + ", ".join(missing))
 
-    present_required_sections = {
-        key: {"heading": heading, "content_sha256": _content_sha256(sections[heading])}
-        for key, aliases in _REQUIRED_SECTIONS.items()
-        for heading in (next((alias for alias in aliases if alias in sections), None),)
-        if heading is not None
-    }
+    resolved = {}
+    for key, aliases in _REQUIRED.items():
+        heading = next((alias for alias in aliases if alias in sections), None)
+        if heading:
+            resolved[key] = {"heading": heading, "content_sha256": _sha(sections[heading])}
+
+    output = output_path if output_path.is_absolute() else repo_root / output_path
     payload = {
         "schema_version": 2,
         "change_set_id": change_set_id,
         "work_item_id": work_item_id,
-        "active_plan_path": _relative(absolute_plan, repo_root),
-        "plan_sha256": hashlib.sha256(plan_text.encode("utf-8")).hexdigest(),
+        "active_plan_path": _relative(plan, repo_root),
+        "plan_sha256": _sha(text),
         "runtime_write_authority": {
             "model": "ChangeSet included scope ∩ affected-files manifest",
             "plan_grants_write_authority": False,
@@ -82,74 +62,55 @@ def materialize_execution_scope(
                 ".codex/skills/harness-implementation-executor/SKILL.md",
                 ".codex/skills/harness-implementation-executor/references/ddd-implementation-policy.md",
             ],
-            "required_task_inputs": [
-                _relative(absolute_plan, repo_root),
-                _relative(output_path if output_path.is_absolute() else repo_root / output_path, repo_root),
-            ],
-            "instruction": (
-                "Load the fixed control-plane policy, then execute only unchecked plan tasks. "
-                "Treat the active plan as the sole task-specific product and implementation "
-                "instruction; report a blocker when it is insufficient instead of reading "
-                "upstream design artifacts."
-            ),
+            "required_task_inputs": [_relative(plan, repo_root), _relative(output, repo_root)],
+            "instruction": "Load fixed policy, then execute only unchecked plan tasks. The plan is the sole task-specific instruction.",
         },
         "plan_contract": {
             "status": "valid" if not missing else "legacy-incomplete",
             "enforced": enforce_full_contract,
             "missing_or_incomplete": missing,
-            "required_sections": present_required_sections,
+            "required_sections": resolved,
         },
         "plan_sections": list(sections),
     }
-
-    absolute_output = output_path if output_path.is_absolute() else repo_root / output_path
-    absolute_output.parent.mkdir(parents=True, exist_ok=True)
-    absolute_output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return payload
 
 
-def _extract_sections(plan_text: str) -> dict[str, str]:
-    matches = list(_SECTION_RE.finditer(plan_text))
-    sections: dict[str, str] = {}
-    for index, match in enumerate(matches):
-        end = matches[index + 1].start() if index + 1 < len(matches) else len(plan_text)
-        sections[match.group(1).strip()] = plan_text[match.end() : end].strip()
-    return sections
+def _sections(text: str) -> dict[str, str]:
+    matches = list(_HEADING.finditer(text))
+    return {
+        match.group(1).strip(): text[match.end(): matches[index + 1].start() if index + 1 < len(matches) else len(text)].strip()
+        for index, match in enumerate(matches)
+    }
 
 
-def _missing_or_incomplete_sections(sections: Mapping[str, str]) -> list[str]:
+def _invalid_sections(sections: Mapping[str, str]) -> list[str]:
     errors: list[str] = []
-    for _, aliases in _REQUIRED_SECTIONS.items():
+    for aliases in _REQUIRED.values():
         heading = next((alias for alias in aliases if alias in sections), None)
         if heading is None:
             errors.append(f"missing section: {aliases[0]}")
-            continue
-        if not _meaningful_section(sections[heading]):
+        elif not _meaningful(sections[heading]):
             errors.append(f"incomplete section: {heading}")
     return errors
 
 
-def _meaningful_section(content: str) -> bool:
+def _meaningful(content: str) -> bool:
     lines = [line.strip() for line in content.splitlines() if line.strip()]
-    if not lines:
+    if not lines or _PLACEHOLDER.search("\n".join(lines)):
         return False
-    normalized = "\n".join(lines)
-    if _PLACEHOLDER_RE.search(normalized):
-        return False
-    if any(_EMPTY_FIELD_RE.search(line) for line in lines):
-        return False
-    if all(line in {"-", "*"} for line in lines):
-        return False
-    return True
+    return not any(_EMPTY_FIELD.search(line) for line in lines)
 
 
-def _content_sha256(content: str) -> str:
-    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+def _sha(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def _relative(path: Path, repo_root: Path) -> str:
+def _relative(path: Path, root: Path) -> str:
     try:
-        return str(path.relative_to(repo_root))
+        return str(path.relative_to(root))
     except ValueError:
         return str(path)
 
@@ -161,20 +122,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--work-item", required=True)
     parser.add_argument("--plan", required=True)
     parser.add_argument("--output", required=True)
-    parser.add_argument("--enforce-full-contract", action="store_true")
+    parser.add_argument("--allow-legacy-contract", action="store_true")
     args = parser.parse_args(argv)
-
     try:
         materialize_execution_scope(
-            repo_root=Path(args.repo_root).resolve(),
-            change_set_id=args.change_set,
-            work_item_id=args.work_item,
-            plan_path=Path(args.plan),
-            output_path=Path(args.output),
-            enforce_full_contract=args.enforce_full_contract,
+            repo_root=Path(args.repo_root).resolve(), change_set_id=args.change_set,
+            work_item_id=args.work_item, plan_path=Path(args.plan), output_path=Path(args.output),
+            enforce_full_contract=not args.allow_legacy_contract,
         )
     except (ExecutionPlanContractError, FileNotFoundError) as error:
-        print(str(error))
+        print(error)
         return 1
     return 0
 

--- a/harness_codex/runtime/materialize_execution_scope.py
+++ b/harness_codex/runtime/materialize_execution_scope.py
@@ -1,0 +1,102 @@
+"""Materialize the narrow runtime scope consumed by the implementation executor.
+
+The executor receives this artifact together with its active plan.  It is an
+execution aid, not a replacement for the runtime write authority: scope-diff
+validation still requires ChangeSet and affected-files-manifest permission.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Sequence
+
+
+_SECTION_RE = re.compile(
+    r"^##\s+(?:실행\s*경계|Execution\s+Scope|집중\s*검증|Focused\s+Verification)\s*$",
+    flags=re.IGNORECASE | re.MULTILINE,
+)
+
+
+def materialize_execution_scope(
+    *,
+    repo_root: Path,
+    change_set_id: str,
+    work_item_id: str,
+    plan_path: Path,
+    output_path: Path,
+) -> dict[str, object]:
+    """Write a small, runtime-owned execution scope artifact for one work item."""
+
+    absolute_plan = plan_path if plan_path.is_absolute() else repo_root / plan_path
+    if not absolute_plan.is_file():
+        raise FileNotFoundError(f"active plan is required: {plan_path}")
+
+    plan_text = absolute_plan.read_text(encoding="utf-8")
+    payload = {
+        "schema_version": 1,
+        "change_set_id": change_set_id,
+        "work_item_id": work_item_id,
+        "active_plan_path": _relative(absolute_plan, repo_root),
+        "plan_sha256": hashlib.sha256(plan_text.encode("utf-8")).hexdigest(),
+        "runtime_write_authority": {
+            "model": "ChangeSet included scope ∩ affected-files manifest",
+            "plan_grants_write_authority": False,
+        },
+        "executor_contract": {
+            "required_inputs": [
+                _relative(absolute_plan, repo_root),
+                _relative(output_path if output_path.is_absolute() else repo_root / output_path, repo_root),
+            ],
+            "instruction": (
+                "Execute only unchecked plan tasks. Treat the active plan as the sole "
+                "product and implementation instruction; report a blocker when it is "
+                "insufficient instead of reading upstream design artifacts."
+            ),
+        },
+        "plan_sections": _execution_sections(plan_text),
+    }
+
+    absolute_output = output_path if output_path.is_absolute() else repo_root / output_path
+    absolute_output.parent.mkdir(parents=True, exist_ok=True)
+    absolute_output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return payload
+
+
+def _execution_sections(plan_text: str) -> list[str]:
+    """Return explicit execution-boundary headings without duplicating plan content."""
+
+    return [match.group(0).lstrip("#").strip() for match in _SECTION_RE.finditer(plan_text)]
+
+
+def _relative(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--change-set", required=True)
+    parser.add_argument("--work-item", required=True)
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args(argv)
+
+    materialize_execution_scope(
+        repo_root=Path(args.repo_root).resolve(),
+        change_set_id=args.change_set,
+        work_item_id=args.work_item,
+        plan_path=Path(args.plan),
+        output_path=Path(args.output),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness_codex/runtime/prompt.py
+++ b/harness_codex/runtime/prompt.py
@@ -20,6 +20,13 @@ Write human-readable Markdown output documents in Korean, including titles, head
 Preserve code identifiers, file paths, JSON keys, CLI commands, protocol names, and previously approved canonical terms when compatibility requires their original form.
 Report changed files, verification commands, and blockers clearly."""
 
+EXECUTION_MINIMAL_INSTRUCTION = """You are running as the bounded implementation executor.
+Treat the active plan as the sole product and implementation instruction. Read only the active plan and the runtime-owned execution-scope artifact before editing.
+Execute unchecked plan tasks in order. Do not reinterpret requirements, use cases, event storming, E2E goals, ChangeSet documents, architecture, or technical decisions.
+Keep edits inside the runtime-declared work-item boundary. When the plan is insufficient, contradictory, or requires a wider design decision, report a blocker instead of reading upstream design artifacts.
+Write all agent input/output and user-facing output in Korean. Preserve code identifiers, file paths, JSON keys, CLI commands, protocol names, and approved canonical terms when compatibility requires their original form.
+Report changed files, focused verification commands, and blockers clearly."""
+
 SOURCE_OF_TRUTH_FILES = (
     Path("AGENTS.md"),
     Path("docs/agent/context.md"),
@@ -48,8 +55,23 @@ def build_agent_prompt(
 
     Long-term memory is deliberately volatile context: it is only appended after
     the ChangeSet/work-item source-of-truth sections and is rendered as
-    historical reference, never as an executable instruction.
+    historical reference, never as an executable instruction.  The executor's
+    ``execution-minimal`` profile deliberately omits that upstream context.
     """
+
+    profile = _prompt_context_profile(step)
+    if profile == "execution-minimal":
+        sections = _execution_minimal_sections(
+            step=step,
+            context=context,
+            agent_config=agent_config,
+            agent_config_path=agent_config_path,
+            skill_path=skill_path,
+        )
+        repair_context = _runtime_repair_context(step, context)
+        if repair_context:
+            sections.append(_section("4. Runtime Repair Context", repair_context))
+        return "\n\n".join(sections).rstrip() + "\n"
 
     sections = [
         _section("1. Runtime Instruction", RUNTIME_INSTRUCTION),
@@ -75,6 +97,35 @@ def build_agent_prompt(
     if repair_context:
         sections.append(_section("10. Runtime Repair Context", repair_context))
     return "\n\n".join(sections).rstrip() + "\n"
+
+
+def _execution_minimal_sections(
+    *,
+    step: Step,
+    context: RunContext,
+    agent_config: Mapping[str, Any],
+    agent_config_path: Path,
+    skill_path: Path | None,
+) -> list[str]:
+    return [
+        _section("1. Runtime Instruction", EXECUTION_MINIMAL_INSTRUCTION),
+        _section(
+            "2. Delegation Contract",
+            _delegation_contract(
+                step,
+                agent_config,
+                agent_config_path,
+                skill_path,
+                context.repo_root,
+            ),
+        ),
+        _section("3. Active Plan and Execution Scope", _execution_minimal_payload(step, context)),
+    ]
+
+
+def _prompt_context_profile(step: Step) -> str:
+    value = step.metadata.get("prompt_context_profile")
+    return value.strip() if isinstance(value, str) and value.strip() else "default"
 
 
 def stable_prefix(prompt: str) -> str:
@@ -225,6 +276,29 @@ def _retrieved_memory(step: Step, context: RunContext) -> str:
 
 def _optional_text(value: object) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _execution_minimal_payload(step: Step, context: RunContext) -> str:
+    payload = {
+        "run_id": context.run_id,
+        "work_item_id": context.metadata.get("active_work_item_id"),
+        "step": {
+            "id": step.id,
+            "agent_id": step.agent_id,
+            "inputs": [str(path) for path in step.inputs],
+            "outputs": [str(path) for path in step.outputs],
+        },
+        "required_reads": [str(path) for path in step.inputs],
+        "explicitly_excluded_context": [
+            "ChangeSet body",
+            "workflow definition",
+            "repository source-of-truth previews",
+            "repository settings",
+            "long-term memory",
+            "use-case, event-storming, and E2E-goal artifacts",
+        ],
+    }
+    return "\n".join(["```json", _stable_json(payload), "```"])
 
 
 def _current_execution_payload(step: Step, context: RunContext) -> str:

--- a/tests/runtime/test_execution_minimal_context.py
+++ b/tests/runtime/test_execution_minimal_context.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.materialize_execution_scope import materialize_execution_scope
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind
+from harness_codex.runtime.prompt import build_agent_prompt
+
+
+def _context(repo: Path) -> RunContext:
+    return RunContext(
+        run_id="run-001",
+        workflow_name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo,
+        workdir=repo,
+        run_dir=repo / ".harness/runs/run-001",
+        metadata={
+            "change_set_id": "CHG-001",
+            "change_set_path": "docs/changes/active/CHG-001.md",
+            "active_work_item_id": "UC-001",
+            "active_work_item_type": "use_case",
+        },
+    )
+
+
+def _step() -> Step:
+    return Step(
+        id="execute-work-item",
+        kind=StepKind.AGENT,
+        name="Execute unchecked plan tasks",
+        agent_id="implementation_executor",
+        skill_id="harness-implementation-executor",
+        inputs=(
+            Path("docs/plans/active/UC-001/plan.md"),
+            Path(".harness/runs/run-001/work-items/UC-001/execution-scope.json"),
+        ),
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+        metadata={"prompt_context_profile": "execution-minimal"},
+    )
+
+
+def test_execution_minimal_prompt_excludes_upstream_context(tmp_path: Path) -> None:
+    (tmp_path / "docs/changes/active").mkdir(parents=True)
+    (tmp_path / "docs/changes/active/CHG-001.md").write_text("secret ChangeSet body", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("secret global agent context", encoding="utf-8")
+    (tmp_path / ".codex/agents").mkdir(parents=True)
+    config_path = tmp_path / ".codex/agents/implementation_executor.toml"
+    config_path.write_text('name = "implementation_executor"\n', encoding="utf-8")
+    skill_path = tmp_path / ".codex/skills/harness-implementation-executor/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Executor skill", encoding="utf-8")
+
+    prompt = build_agent_prompt(
+        step=_step(),
+        context=_context(tmp_path),
+        agent_config={"name": "implementation_executor", "model": "gpt-5.5"},
+        agent_config_path=config_path,
+        skill_path=skill_path,
+    )
+
+    assert "## 3. Active Plan and Execution Scope" in prompt
+    assert "docs/plans/active/UC-001/plan.md" in prompt
+    assert "execution-scope.json" in prompt
+    assert "secret ChangeSet body" not in prompt
+    assert "secret global agent context" not in prompt
+    assert "## 6. ChangeSet Summary" not in prompt
+    assert "## 8. Retrieved Long-Term Memory" not in prompt
+
+
+def test_materialized_execution_scope_is_plan_bound_not_write_authority(tmp_path: Path) -> None:
+    plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text(
+        "# Plan\n\n## 실행 경계\n\n- modify: src/**\n\n## 집중 검증\n\n- pytest -q\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / ".harness/runs/run-001/work-items/UC-001/execution-scope.json"
+
+    payload = materialize_execution_scope(
+        repo_root=tmp_path,
+        change_set_id="CHG-001",
+        work_item_id="UC-001",
+        plan_path=Path("docs/plans/active/UC-001/plan.md"),
+        output_path=output,
+    )
+
+    stored = json.loads(output.read_text(encoding="utf-8"))
+    assert stored == payload
+    assert stored["active_plan_path"] == "docs/plans/active/UC-001/plan.md"
+    assert stored["runtime_write_authority"]["plan_grants_write_authority"] is False
+    assert "실행 경계" in stored["plan_sections"]
+    assert "집중 검증" in stored["plan_sections"]

--- a/tests/runtime/test_execution_minimal_context.py
+++ b/tests/runtime/test_execution_minimal_context.py
@@ -1,7 +1,12 @@
 import json
 from pathlib import Path
 
-from harness_codex.runtime.materialize_execution_scope import materialize_execution_scope
+import pytest
+
+from harness_codex.runtime.materialize_execution_scope import (
+    ExecutionPlanContractError,
+    materialize_execution_scope,
+)
 from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind
 from harness_codex.runtime.prompt import build_agent_prompt
 
@@ -9,7 +14,7 @@ from harness_codex.runtime.prompt import build_agent_prompt
 def _context(repo: Path) -> RunContext:
     return RunContext(
         run_id="run-001",
-        workflow_name="changeset-work-item-workflow",
+        workflow_name="changeset-use-case-workflow",
         mode=RunMode.APPLY,
         repo_root=repo,
         workdir=repo,
@@ -37,6 +42,46 @@ def _step() -> Step:
         outputs=(Path("docs/plans/active/UC-001/plan.md"),),
         metadata={"prompt_context_profile": "execution-minimal"},
     )
+
+
+def _executor_ready_plan() -> str:
+    return """# Plan
+
+## 실행 경계
+
+- 대상 bounded context/module: orders
+- 대상 aggregate root: Order
+- 수정 허용 경로: src/orders/**
+- 수정 금지 경로: src/legacy/**
+
+## 패키지 및 의존성 계약
+
+- 생성 클래스: orders.domain.Order under domain
+- 허용 의존성 방향: ui -> application -> domain
+- bootstrap wiring: orders bootstrap configuration
+
+## 도메인 구현 계약
+
+- Aggregate invariant: quantity must be positive
+- 상태 전이: draft -> confirmed
+- Entity/Value Object 검증: Quantity validates positive values
+- Domain Event: OrderConfirmed emitted after confirmation
+- Transaction, idempotency, concurrency: optimistic lock is required
+
+## 외부 계약 읽기 허용 목록
+
+- event schema -> src/events/OrderConfirmed.java
+
+## 작업 체크리스트
+
+- [ ] src/orders/domain/Order.java: enforce confirmation invariant
+- [ ] src/orders/domain/OrderTest.java: verify draft to confirmed transition
+
+## 집중 검증
+
+- [ ] Focused tests: ./gradlew :orders:test -> PASS
+- 중단 조건: event schema is unavailable
+"""
 
 
 def test_execution_minimal_prompt_excludes_upstream_context(tmp_path: Path) -> None:
@@ -70,10 +115,7 @@ def test_execution_minimal_prompt_excludes_upstream_context(tmp_path: Path) -> N
 def test_materialized_execution_scope_is_plan_bound_not_write_authority(tmp_path: Path) -> None:
     plan = tmp_path / "docs/plans/active/UC-001/plan.md"
     plan.parent.mkdir(parents=True)
-    plan.write_text(
-        "# Plan\n\n## 실행 경계\n\n- modify: src/**\n\n## 집중 검증\n\n- pytest -q\n",
-        encoding="utf-8",
-    )
+    plan.write_text(_executor_ready_plan(), encoding="utf-8")
     output = tmp_path / ".harness/runs/run-001/work-items/UC-001/execution-scope.json"
 
     payload = materialize_execution_scope(
@@ -82,11 +124,30 @@ def test_materialized_execution_scope_is_plan_bound_not_write_authority(tmp_path
         work_item_id="UC-001",
         plan_path=Path("docs/plans/active/UC-001/plan.md"),
         output_path=output,
+        enforce_full_contract=True,
     )
 
     stored = json.loads(output.read_text(encoding="utf-8"))
     assert stored == payload
     assert stored["active_plan_path"] == "docs/plans/active/UC-001/plan.md"
     assert stored["runtime_write_authority"]["plan_grants_write_authority"] is False
+    assert stored["plan_contract"]["status"] == "valid"
+    assert "domain_implementation_contract" in stored["plan_contract"]["required_sections"]
     assert "실행 경계" in stored["plan_sections"]
     assert "집중 검증" in stored["plan_sections"]
+
+
+def test_execution_scope_rejects_missing_domain_handoff_when_enforced(tmp_path: Path) -> None:
+    plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n\n## 실행 경계\n\n- scope: orders\n", encoding="utf-8")
+
+    with pytest.raises(ExecutionPlanContractError, match="도메인 구현 계약"):
+        materialize_execution_scope(
+            repo_root=tmp_path,
+            change_set_id="CHG-001",
+            work_item_id="UC-001",
+            plan_path=Path("docs/plans/active/UC-001/plan.md"),
+            output_path=tmp_path / "scope.json",
+            enforce_full_contract=True,
+        )

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -62,38 +62,37 @@ def test_load_named_workflow_reads_from_harness_workflows_directory(tmp_path: Pa
 def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -> None:
     work_item_workflow = load_named_workflow("changeset-use-case-workflow")
     finalization_workflow = load_named_workflow("changeset-finalization-workflow")
+    step_ids = work_item_workflow.step_ids()
 
     assert work_item_workflow.name == "changeset-work-item-workflow"
-    assert work_item_workflow.step_ids() == (
+    assert step_ids[0:4] == (
         "load-change-set",
         "plan-work-item",
         "secure-work-item-plan",
         "review-work-item-plan",
-        "execute-work-item",
-        "verify-work-item",
-        "review-work-item-security",
-        "verify-work-item-security",
-        "classify-verification-result",
-        "remediate-work-item",
-        "complete-work-item-plan",
     )
+    assert "materialize-execution-scope" in step_ids
+    assert step_ids.index("materialize-execution-scope") < step_ids.index("execute-work-item")
+    assert step_ids.index("execute-work-item") < step_ids.index("verify-work-item")
+    assert step_ids.index("verify-work-item") < step_ids.index("review-work-item-security")
+    assert step_ids.index("review-work-item-security") < step_ids.index("verify-work-item-security")
+    assert step_ids.index("verify-work-item-security") < step_ids.index("classify-verification-result")
+    assert step_ids[-2:] == ("remediate-work-item", "complete-work-item-plan")
+
     assert work_item_workflow.step_by_id("plan-work-item").agent_id == "implementation_planner"
     assert work_item_workflow.step_by_id("plan-work-item").skill_id == "harness-code-planner"
     assert work_item_workflow.step_by_id("plan-work-item").metadata["stage"] == "plan-writing"
     assert work_item_workflow.step_by_id("plan-work-item").metadata["prompt_context_profile"] == "plan"
     assert work_item_workflow.step_by_id("secure-work-item-plan").agent_id == "security_plan_reviewer"
-    assert (
-        work_item_workflow.step_by_id("secure-work-item-plan").metadata["prompt_context_profile"]
-        == "security-review"
-    )
     assert work_item_workflow.step_by_id("review-work-item-plan").needs == ("secure-work-item-plan",)
     assert work_item_workflow.step_by_id("review-work-item-plan").metadata["prompt_context_profile"] == "review"
+    assert work_item_workflow.step_by_id("materialize-execution-scope").kind == StepKind.VALIDATOR
     assert work_item_workflow.step_by_id("execute-work-item").skill_id == "harness-implementation-executor"
     assert work_item_workflow.step_by_id("execute-work-item").metadata["stage"] == "implementation"
-    assert work_item_workflow.step_by_id("execute-work-item").metadata["prompt_context_profile"] == "execution"
-    assert (
-        work_item_workflow.step_by_id("review-work-item-security").metadata["prompt_context_profile"]
-        == "security-verification"
+    assert work_item_workflow.step_by_id("execute-work-item").metadata["prompt_context_profile"] == "execution-minimal"
+    assert work_item_workflow.step_by_id("execute-work-item").inputs == (
+        Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),
+        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-scope.json"),
     )
     assert work_item_workflow.step_by_id("review-work-item-security").outputs == ()
     assert (
@@ -107,16 +106,10 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
         }
     )
     assert work_item_workflow.step_by_id("verify-work-item-security").kind == StepKind.VALIDATOR
-    assert work_item_workflow.step_by_id("verify-work-item-security").needs == (
-        "review-work-item-security",
-    )
     assert work_item_workflow.step_by_id("verify-work-item-security").command == (
         "python3 -m harness_codex.runtime.materialize_security_review "
         "--source .harness/runs/<RUN-ID>/steps/review-work-item-security/final-message.md "
         "--output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md"
-    )
-    assert work_item_workflow.step_by_id("verify-work-item-security").outputs == (
-        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md"),
     )
     assert work_item_workflow.step_by_id("verify-work-item").command == (
         "python3 -m harness_codex.runtime.structured_verify_work_item "
@@ -128,9 +121,9 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
         step.metadata["execution_boundary"] == "work_item"
         for step in work_item_workflow.steps
     )
-    assert "create-change-set-pr" not in work_item_workflow.step_ids()
-    assert "complete-change-set" not in work_item_workflow.step_ids()
-    assert "update-project-wiki" not in work_item_workflow.step_ids()
+    assert "create-change-set-pr" not in step_ids
+    assert "complete-change-set" not in step_ids
+    assert "update-project-wiki" not in step_ids
 
     assert finalization_workflow.name == "changeset-finalization-workflow"
     assert finalization_workflow.step_ids() == (
@@ -148,79 +141,3 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
         step.metadata["execution_boundary"] == "changeset_finalization"
         for step in finalization_workflow.steps
     )
-
-
-@pytest.mark.parametrize(
-    ("text", "message"),
-    (
-        ("", "must not be empty"),
-        (
-            """
-workflow:
-  name: fix-issue
-  mode: plan
-steps: []
-""",
-            "version must be 1",
-        ),
-        (
-            """
-version: 1
-workflow:
-  name: fix-issue
-  mode: unsafe
-steps:
-  - id: analyze
-    kind: agent
-    name: Analyze active plan
-""",
-            "mode must be one of",
-        ),
-        (
-            """
-version: 1
-workflow:
-  name: fix-issue
-  mode: plan
-steps:
-  - id: analyze
-    kind: unknown
-    name: Analyze active plan
-""",
-            "must be one of",
-        ),
-        (
-            """
-version: 1
-workflow:
-  name: fix-issue
-  mode: plan
-steps:
-  - id: analyze
-    kind: agent
-    name: Analyze active plan
-  - id: analyze
-    kind: agent
-    name: Duplicate ID
-""",
-            "Duplicate step id",
-        ),
-        (
-            """
-version: 1
-workflow:
-  name: fix-issue
-  mode: plan
-steps:
-  - id: analyze
-    kind: agent
-    name: Analyze active plan
-    needs: [missing]
-""",
-            "depends on unknown step",
-        ),
-    ),
-)
-def test_load_workflow_text_rejects_invalid_workflow(text: str, message: str) -> None:
-    with pytest.raises(WorkflowSchemaError, match=message):
-        load_workflow_text(text)

--- a/tests/test_executor_ddd_policy.py
+++ b/tests/test_executor_ddd_policy.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / ".codex/skills/harness-implementation-executor/references/ddd-implementation-policy.md"
+
+
+def test_executor_declares_fixed_ddd_policy_as_control_plane() -> None:
+    config = (REPO_ROOT / ".codex/agents/implementation_executor.toml").read_text(encoding="utf-8")
+    reference = (REPO_ROOT / ".codex/agents/references/implementation_executor.md").read_text(encoding="utf-8")
+    skill = (REPO_ROOT / ".codex/skills/harness-implementation-executor/SKILL.md").read_text(encoding="utf-8")
+
+    assert str(POLICY_PATH.relative_to(REPO_ROOT)) in config
+    assert str(POLICY_PATH.relative_to(REPO_ROOT)) in reference
+    assert str(POLICY_PATH.relative_to(REPO_ROOT)) in skill
+    assert "sole task-specific product and implementation instruction" in reference
+
+
+def test_fixed_ddd_policy_covers_layer_dependency_and_domain_rules() -> None:
+    policy = POLICY_PATH.read_text(encoding="utf-8")
+
+    required_rules = [
+        "ui -> application -> domain",
+        "domain` must not depend on `application`, `ui`, `infra`",
+        "Aggregate Root",
+        "Repository Ports",
+        "Application Services must not",
+        "Domain Service",
+        "Port",
+        "Transaction",
+        "Domain Events",
+        "Architecture Checks",
+        "Required Plan Handoff",
+    ]
+
+    for rule in required_rules:
+        assert rule in policy

--- a/tests/test_executor_use_case_scope.py
+++ b/tests/test_executor_use_case_scope.py
@@ -22,7 +22,7 @@ def test_executor_runs_only_targeted_work_item_plan() -> None:
 
 def test_executor_uses_plan_and_runtime_scope_boundaries() -> None:
     executor = read_executor()
-    assert "sole product and implementation instruction" in executor
+    assert "sole task-specific product and implementation instruction" in executor
     assert "runtime-owned execution-scope artifact" in executor
     assert "completed resume state" in executor
     assert "first remaining `- [ ]` checkbox" in executor

--- a/tests/test_executor_use_case_scope.py
+++ b/tests/test_executor_use_case_scope.py
@@ -31,7 +31,7 @@ def test_executor_uses_plan_and_runtime_scope_boundaries() -> None:
 def test_executor_excludes_upstream_design_reinterpretation() -> None:
     executor = read_executor()
     assert "Do not read use-case, event-storming, E2E-goal" in executor
-    assert "Do not inspect upstream design artifacts" in executor
+    assert "or other upstream design artifacts" in executor
 
 
 def test_executor_records_environment_blocker_for_focused_verification_limits() -> None:

--- a/tests/test_executor_use_case_scope.py
+++ b/tests/test_executor_use_case_scope.py
@@ -11,55 +11,39 @@ def read_executor() -> str:
     ).read_text(encoding="utf-8")
 
 
-def test_executor_runs_only_targeted_use_case_plan() -> None:
+def test_executor_runs_only_targeted_work_item_plan() -> None:
     executor = read_executor()
-
     assert 'sandbox_mode = "danger-full-access"' in executor
-    assert "docs/plans/active/<UC-ID>/plan.md" in executor
+    assert "docs/plans/active/<WORK-ITEM-ID>/plan.md" in executor
+    assert "execution-scope.json" in executor
     assert "docs/plans/active/plan.md" not in executor
-    assert "Do not edit other UC plans or other UC documents" in executor
+    assert "Do not edit other work-item plans or upstream design documents" in executor
 
 
-def test_executor_uses_changeset_and_uc_slice_boundaries() -> None:
+def test_executor_uses_plan_and_runtime_scope_boundaries() -> None:
     executor = read_executor()
-
-    required_inputs = [
-        "docs/use-cases/<UC-ID>/use-case.md",
-        "docs/use-cases/<UC-ID>/event-storming.md",
-        "docs/use-cases/<UC-ID>/e2e-goal.md",
-        "docs/changes/active/<CHG-ID>.md",
-        ".codex/repository-settings.md",
-    ]
-
-    for input_path in required_inputs:
-        assert input_path in executor
-
-    assert "Keep all edits inside the active ChangeSet scope" in executor
+    assert "sole product and implementation instruction" in executor
+    assert "runtime-owned execution-scope artifact" in executor
     assert "completed resume state" in executor
     assert "first remaining `- [ ]` checkbox" in executor
 
 
-def test_executor_records_environment_blocker_for_e2e_limits() -> None:
+def test_executor_excludes_upstream_design_reinterpretation() -> None:
     executor = read_executor()
+    assert "Do not read use-case, event-storming, E2E-goal" in executor
+    assert "Do not inspect upstream design artifacts" in executor
 
-    assert "Do not edit docs/use-cases/<UC-ID>/e2e-goal.md" in executor
-    assert "docs/plans/active/<UC-ID>/verification.md" in executor
-    assert "implementation-specific test suite details" in executor
-    assert "./gradlew test" in executor
-    assert "./gradlew e2eTest" in executor
-    assert "Playwright browser install" in executor
-    assert "includes a UI and that UI is served in a web environment accessible to Playwright" in executor
-    assert "HTTP/API probes alone do not satisfy use-case E2E verification" in executor
-    assert "no browser-accessible web UI can be started" in executor
-    assert "continue using the existing API/runtime verification path" in executor
-    assert "same-origin proxy or CORS behavior" in executor
-    assert "A CORS-blocked request is an implementation failure" in executor
+
+def test_executor_records_environment_blocker_for_focused_verification_limits() -> None:
+    executor = read_executor()
+    assert "focused commands named in the active plan" in executor
+    assert "browser installation, network, credentials, permissions" in executor
     assert "environment blocker" in executor
+    assert "HTTP/API probes alone do not satisfy a browser E2E task" in executor
 
 
 def test_executor_uses_lombok_and_constructor_injection_for_java_spring() -> None:
     executor = read_executor()
-
     assert "`@Getter` and `@RequiredArgsConstructor`" in executor
     assert "Use constructor injection for dependencies" in executor
     assert "`private final` dependency fields" in executor
@@ -68,7 +52,6 @@ def test_executor_uses_lombok_and_constructor_injection_for_java_spring() -> Non
 
 def test_executor_maintains_versioned_app_launcher_contract() -> None:
     executor = read_executor()
-
     assert "scripts/run-app-infra.sh" in executor
     assert "scripts/run-app-server.sh" in executor
     assert "scripts/check-app-infra.sh" in executor

--- a/tests/test_issue_372_canonical_finalization.py
+++ b/tests/test_issue_372_canonical_finalization.py
@@ -23,24 +23,22 @@ def test_work_item_workflow_excludes_changeset_finalization() -> None:
         "changeset-finalization-workflow",
         workflows_dir=repo_root / ".harness/workflows",
     )
+    step_ids = work_item_workflow.step_ids()
 
-    assert work_item_workflow.step_ids() == (
+    assert step_ids[:4] == (
         "load-change-set",
         "plan-work-item",
         "secure-work-item-plan",
         "review-work-item-plan",
-        "execute-work-item",
-        "verify-work-item",
-        "review-work-item-security",
-        "verify-work-item-security",
-        "classify-verification-result",
-        "remediate-work-item",
-        "complete-work-item-plan",
     )
-    assert "update-project-wiki" not in work_item_workflow.step_ids()
-    assert "validate-project-wiki" not in work_item_workflow.step_ids()
-    assert "create-change-set-pr" not in work_item_workflow.step_ids()
-    assert "complete-change-set" not in work_item_workflow.step_ids()
+    assert "materialize-execution-scope" in step_ids
+    assert step_ids.index("materialize-execution-scope") < step_ids.index("execute-work-item")
+    assert step_ids.index("verify-work-item") < step_ids.index("classify-verification-result")
+    assert step_ids[-2:] == ("remediate-work-item", "complete-work-item-plan")
+    assert "update-project-wiki" not in step_ids
+    assert "validate-project-wiki" not in step_ids
+    assert "create-change-set-pr" not in step_ids
+    assert "complete-change-set" not in step_ids
     assert all(
         step.metadata["execution_boundary"] == "work_item"
         for step in work_item_workflow.steps
@@ -102,8 +100,10 @@ def test_work_item_and_finalization_workflows_materialize_without_unresolved_pla
     )
 
     verification = materialized_work_item.step_by_id("verify-work-item")
+    execution_scope = materialized_work_item.step_by_id("materialize-execution-scope")
     delivery = materialized_finalization.step_by_id("create-change-set-pr")
     assert Path("docs/plans/active/UC-372/plan.md") in verification.inputs
+    assert Path("docs/plans/active/UC-372/plan.md") in execution_scope.inputs
     assert all("<RUN-ID>" not in str(path) for path in verification.outputs)
     assert delivery.command == (
         "python3 -m harness_codex.runtime.change_set_pr_delivery "


### PR DESCRIPTION
Closes #443

## 목적

구현 에이전트가 상위 설계 문서를 다시 해석하지 않고 `plan.md`를 실행하되, DDD·패키지·의존성·Port/Adapter·transaction 규칙은 고정 control-plane 정책으로 일관되게 적용하도록 합니다.

## 변경

- executor fixed control-plane에 `ddd-implementation-policy.md`를 추가했습니다.
  - layer ownership/dependency direction
  - Aggregate, Entity, Value Object, Domain Service
  - Repository/External Port와 Infra Adapter
  - transaction, domain event, idempotency/concurrency
  - DTO mapping, architecture test
- executor는 fixed policy를 generic constraint로 읽고, `plan.md`는 task-specific instruction으로만 사용합니다.
- plan template과 planner instructions를 executor-complete handoff 계약으로 변경했습니다.
  - 실행 경계
  - 패키지 및 의존성 계약
  - 도메인 구현 계약
  - 외부 계약 읽기 허용 목록
  - 파일 단위 작업 체크리스트
  - 집중 검증과 중단 조건
- execution scope materializer가 위 필수 섹션의 누락, 비어 있는 값, placeholder를 executor 이전에 차단하도록 했습니다.
- artifact reviewer가 package map, dependency direction, aggregate/invariant/state transition, Port/Adapter, transaction/event/concurrency handoff를 gate로 검토하도록 확장했습니다.
- ChangeSet ∩ affected-files manifest 기반 write authority는 유지합니다.

## 테스트

- execution-minimal prompt는 ChangeSet·memory·상위 설계 원문을 포함하지 않습니다.
- strict scope materializer는 executor-complete plan을 materialize하고 DDD handoff 누락을 거부합니다.
- fixed DDD policy가 agent config/reference/skill에서 control-plane으로 선언됐는지 검사합니다.

CI의 전체 runtime/workflow regression 결과를 확인한 뒤 병합해야 합니다.