### PR TITLE
#444 보안 리뷰 입력을 profile·diff bundle로 경량화

### DIFF
--- a/.codex/agents/security_implementation_reviewer.toml
+++ b/.codex/agents/security_implementation_reviewer.toml
@@ -7,11 +7,12 @@ developer_instructions = """
 You are the security_implementation_reviewer agent.
 
 Hot-path contract:
-- Role: Independently review one implemented ChangeSet work item after product verification and before completion.
+- Role: Independently review one implemented work item after product verification and before completion.
 - Use `.codex/skills/harness-security-implementation-reviewer/SKILL.md` as the required skill entrypoint.
-- Read only runtime-declared inputs, focused verification evidence, applicable pinned OWASP controls, and the repository diff relevant to the active work item.
+- Read only the runtime-declared security review bundle: changed files, scoped implementation diff, security profile, selected controls, security plan tasks, and verification evidence.
+- Do not read the ChangeSet, repository settings, full OWASP standards source, or upstream design artifacts.
 - Do not edit implementation code, plans, ChangeSet documents, upstream artifacts, or runtime output files.
 - Preserve unrelated worktree changes.
-- Stop and report the blocker when required inputs, read scope, verification evidence, or security-relevant decisions are missing.
+- Stop and report the blocker when required bundle inputs, read scope, verification evidence, or security-relevant decisions are missing.
 - Return exactly one Markdown report with the required security review status, reviewed inputs, findings, remediation target, and evidence.
 """

--- a/.codex/agents/security_plan_reviewer.toml
+++ b/.codex/agents/security_plan_reviewer.toml
@@ -8,13 +8,13 @@ developer_instructions = """
 You are the security_plan_reviewer agent.
 
 Hot-path contract:
-- Role: Review one active work-item plan against applicable OWASP standards and add missing security implementation, test, and verification tasks.
+- Role: Review one active work-item plan against runtime-selected applicable OWASP controls and add missing security implementation, test, and verification tasks.
 - Load `.codex/agents/references/security_plan_reviewer.md` before making workflow decisions.
 - Use `.codex/skills/harness-security-plan-reviewer/SKILL.md` as the required skill entrypoint.
-- Read only the workflow-declared plan and its declared ChangeSet, work-item slice, architecture, repository settings, and technical decisions.
+- Read only the workflow-declared active plan, `security-profile.json`, and `selected-controls.json`. Do not read the ChangeSet, work-item slice, architecture, repository settings, or the full OWASP standards source.
 - Keep writes limited to the runtime-declared active plan path.
 - Preserve unrelated worktree changes.
 - Do not implement production or test code.
-- Stop and report the blocker when required inputs, write scope, or security-relevant decisions are missing.
-- Report applicable standards, added plan tasks, changed files, and blockers clearly.
+- Stop and report the blocker when required bundle inputs, write scope, or security-relevant decisions are missing.
+- Report applicable controls, added plan tasks, changed files, and blockers clearly.
 """

--- a/.codex/skills/harness-security-implementation-reviewer/SKILL.md
+++ b/.codex/skills/harness-security-implementation-reviewer/SKILL.md
@@ -1,35 +1,15 @@
 ---
 name: harness-security-implementation-reviewer
-description: Independently review one implemented ChangeSet work item after product verification and before completion. Inspect the implemented diff, active plan, verification evidence, and applicable OWASP controls. Use this as a blocking delivery gate.
+description: Independently review one implemented work item from a runtime-generated security bundle.
 ---
 
-# Harness Security Implementation Reviewer
+# Security Implementation Reviewer
 
-## Scope
+- Read only `security-review-bundle/` inputs: changed files, scoped diff, profile, selected controls, plan tasks, and verification evidence.
+- Do not read ChangeSet, active-plan, repository settings, full standards, or upstream design artifacts.
+- Do not edit implementation code, plans, or runtime output files.
+- Return exactly one Markdown report.
 
-- Read only runtime-declared inputs and the repository diff relevant to the active work item.
-- Do not edit implementation code, plans, ChangeSet documents, upstream artifacts, or runtime output files.
-- Return exactly one Markdown report as the final response. The runtime materializes that final response at the workflow-declared security review output path.
-
-## Review Flow
-
-1. Derive the implemented attack surface from the active ChangeSet, work-item documents, active plan, verification evidence, and changed files.
-2. Review applicable controls against the pinned OWASP sources in `.codex/security/`.
-3. Check that security plan tasks are implemented and supported by focused evidence.
-4. Return the report headings below in the final response only.
-
-## Report Contract
-
-The first non-heading status line must be exactly one of:
-
-- `Security Review Status: approved`
-- `Security Review Status: rejected`
-
-The report must contain:
-
-- `## Reviewed Inputs`
-- `## Security Findings`
-- `## Remediation Target`
-- `## Evidence`
-
-For an approved review, `## Remediation Target` is `none`. A rejected review blocks delivery and must state whether the owner is `plan` or `implementation`.
+The first non-heading status line is exactly `Security Review Status: approved` or `Security Review Status: rejected`.
+The report contains `## Reviewed Inputs`, `## Security Findings`, `## Remediation Target`, and `## Evidence`.
+For approval, remediation target is `none`; rejection names `plan` or `implementation`.

--- a/.codex/skills/harness-security-plan-reviewer/SKILL.md
+++ b/.codex/skills/harness-security-plan-reviewer/SKILL.md
@@ -1,58 +1,15 @@
 ---
 name: harness-security-plan-reviewer
-description: Review one active ChangeSet work-item implementation plan against applicable OWASP standards and add missing security implementation, test, and verification tasks before executor use. Use after harness-code-planner creates or updates an active work-item plan and before artifact review or implementation execution.
+description: Review one active plan against runtime-selected security controls and add focused tasks.
 ---
 
-# Harness Security Plan Reviewer
+# Security Plan Reviewer
 
-## Hot Path
+- Read only the runtime-declared active plan, `security-profile.json`, and `selected-controls.json`.
+- Do not read the ChangeSet, upstream design artifacts, repository settings, or the complete standards source.
+- Edit only the declared active plan; preserve unrelated content and checkbox state.
+- Convert each selected control into concrete implementation, test, and verification tasks.
+- Record exclusions with rationale and stop when the profile or plan cannot support a security decision.
+- Do not implement code or create a separate report.
 
-- Read `.codex/agents/references/security_plan_reviewer.md`.
-- Read `references/owasp-baseline.md`.
-- Read `.codex/security/owasp-standards.json` and use its pinned versions.
-- Read only inputs declared by the runtime payload.
-- Edit only the declared active work-item `plan.md`.
-- Preserve existing content and checkbox state.
-- Add risk-specific, testable security tasks. Do not add generic security boilerplate.
-- Do not implement code or change upstream artifacts.
-- Report blockers when security-relevant decisions are unresolved.
-
-## Review Flow
-
-1. Identify attack surface from feature scope, data, actors, trust boundaries, protocols, dependencies, and deployment shape.
-2. Select applicable standards:
-   - OWASP ASVS 5.0.0 for web applications and services.
-   - OWASP Top 10:2025 for risk coverage.
-   - OWASP API Security Top 10:2023 for API scope.
-   - OWASP MASVS 2.1.0 for native mobile scope.
-3. Map each applicable risk to an implementation control, focused test, verification procedure, and success criterion.
-4. Add an `OWASP Security Review` section to the plan.
-5. Add checkboxes near relevant implementation, test, and verification sections.
-6. Record excluded standards or controls with rationale.
-7. Stop when a security-critical decision cannot be derived from approved inputs.
-
-## Task Quality
-
-- Name protected asset and threat.
-- Name enforcement layer and expected behavior.
-- Include success, denied, malformed, boundary, and replay or idempotency cases when applicable.
-- Prefer existing repository security tools and commands.
-- When tooling is absent, add a scoped setup task only when required by the identified risk.
-- Treat SAST, dependency scanning, secret scanning, and DAST as evidence sources, not substitutes for behavior tests.
-
-## Output Contract
-
-Add or update:
-
-- Security applicability and attack-surface summary.
-- OWASP source and version mapping.
-- Security implementation checkboxes.
-- Security test checkboxes.
-- Security verification checkboxes and success criteria.
-- Security assumptions, exclusions, and unresolved blockers.
-
-Do not create a separate report. The updated active plan is the workflow artifact consumed by the independent artifact reviewer.
-
-Return/apply only a minimal delta. The final response must list changed plan
-sections, unresolved blocking findings, and whether the plan was approved for
-artifact review. Do not rewrite the full plan or include unchanged plan content.
+The final response lists changed plan sections, blockers, and readiness for artifact review.

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -33,27 +33,44 @@ steps:
     scope: work_item
     execution_boundary: work_item
     inputs_resolved_by: work_item_document_contract
+- id: materialize-security-profile
+  kind: validator
+  name: Materialize focused security profile and applicable controls
+  needs:
+  - plan-work-item
+  command: python3 -m harness_codex.runtime.security_review_bundle profile --repo-root . --plan docs/plans/active/<WORK-ITEM-ID>/plan.md --profile-output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json --controls-output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
+  timeout_sec: 60
+  inputs:
+  - docs/plans/active/<WORK-ITEM-ID>/plan.md
+  - .codex/security/owasp-standards.json
+  outputs:
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
+  metadata:
+    stage: plan-writing
+    scope: work_item
+    execution_boundary: work_item
+    gate_id: security-profile
 - id: secure-work-item-plan
   kind: agent
   name: Add applicable security controls to the selected work item plan
   needs:
-  - plan-work-item
+  - materialize-security-profile
   agent_id: security_plan_reviewer
   skill_id: harness-security-plan-reviewer
   inputs:
-  - docs/changes/active/<CHG-ID>.md
   - docs/plans/active/<WORK-ITEM-ID>/plan.md
-  - .codex/repository-settings.md
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
   outputs:
   - docs/plans/active/<WORK-ITEM-ID>/plan.md
   metadata:
     stage: plan-writing
-    prompt_context_profile: security-review
+    prompt_context_profile: review-bundle-minimal
     scope: work_item
     execution_boundary: work_item
     gate_id: security-review
     baseline: OWASP ASVS 5.0.0
-    inputs_resolved_by: work_item_document_contract
 - id: review-work-item-plan
   kind: agent
   name: Review the work item implementation plan before execution
@@ -143,28 +160,56 @@ steps:
     - static-analysis
     inputs_resolved_by: work_item_document_contract
     test_gate: .codex/test-gate.yaml required stages must PASS when applicable
+- id: materialize-security-review-bundle
+  kind: validator
+  name: Materialize scoped implementation diff and security evidence bundle
+  needs:
+  - verify-work-item
+  command: python3 -m harness_codex.runtime.security_review_bundle bundle --repo-root . --run-id <RUN-ID> --work-item <WORK-ITEM-ID> --plan docs/plans/active/<WORK-ITEM-ID>/plan.md --profile .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json --controls .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json --verification-report .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json --verification-markdown .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/verification.md --output-dir .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle
+  timeout_sec: 60
+  inputs:
+  - docs/plans/active/<WORK-ITEM-ID>/plan.md
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/verification.md
+  outputs:
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/manifest.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/changed-files.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/implementation.diff
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-profile.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/selected-controls.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-plan-tasks.md
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/verification-summary.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/focused-test-summary.md
+  metadata:
+    stage: implementation
+    scope: work_item
+    execution_boundary: work_item
+    gate_id: security-review-bundle
 - id: review-work-item-security
   kind: agent
   name: Independently review the implemented work item for security findings
   needs:
-  - verify-work-item
+  - materialize-security-review-bundle
   agent_id: security_implementation_reviewer
   skill_id: harness-security-implementation-reviewer
   inputs:
-  - docs/changes/active/<CHG-ID>.md
-  - docs/plans/active/<WORK-ITEM-ID>/plan.md
-  - .codex/repository-settings.md
-  - .codex/security/owasp-standards.json
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/verification.md
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/manifest.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/changed-files.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/implementation.diff
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-profile.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/selected-controls.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-plan-tasks.md
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/verification-summary.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/focused-test-summary.md
   metadata:
     stage: implementation
-    prompt_context_profile: security-verification
+    prompt_context_profile: review-bundle-minimal
     scope: work_item
     execution_boundary: work_item
     gate_id: security-review
     baseline: OWASP ASVS 5.0.0
-    inputs_resolved_by: work_item_document_contract
     final_response_contract:
       channel: final-message
       format: markdown

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -116,9 +116,20 @@ def _install_final_canonical_gate_authority() -> None:
     apply_canonical_stage_gate_authority_patch()
 
 
+def _install_security_review_bundle_prompt_profile() -> None:
+    """Install minimal prompt handling for bundle-scoped security reviewers."""
+
+    from harness_codex.runtime.security_review_prompt_patch import (
+        apply_security_review_prompt_patch,
+    )
+
+    apply_security_review_prompt_patch()
+
+
 _install_changeset_execution_boundary()
 _install_runtime_write_boundaries()
 _install_canonical_procedure_stage_bridge()
 _install_changeset_deletion_cleanup()
 _install_changeset_scope_isolation()
 _install_final_canonical_gate_authority()
+_install_security_review_bundle_prompt_profile()

--- a/harness_codex/runtime/security_review_bundle.py
+++ b/harness_codex/runtime/security_review_bundle.py
@@ -1,0 +1,211 @@
+"""Create small, durable security-review artifacts for one work item."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+_SIGNAL_PATTERNS: dict[str, tuple[str, ...]] = {
+    "public_http_endpoint": ("endpoint", "controller", "route", "rest", "http", "api"),
+    "authentication_changed": ("authentication", "authenticate", "login", "jwt", "session", "token", "인증", "로그인"),
+    "authorization_changed": ("authorization", "permission", "role", "access control", "권한", "인가"),
+    "personal_data": ("personal data", "pii", "email", "phone", "profile", "개인정보", "회원"),
+    "external_network_call": ("webhook", "webclient", "resttemplate", "http client", "external api", "third party"),
+    "file_upload": ("upload", "multipart", "attachment", "file input"),
+    "deserialization": ("deserialize", "serialization", "yaml", "pickle"),
+    "tenant_boundary": ("tenant", "multi-tenant", "multitenant"),
+    "dynamic_query": ("dynamic query", "criteria", "native sql", "search query", "filter expression"),
+    "secret_or_token": ("secret", "api key", "password", "credential", "refresh token"),
+    "payment": ("payment", "결제", "invoice", "refund"),
+}
+
+_CONTROL_MAP: dict[str, tuple[dict[str, str], ...]] = {
+    "public_http_endpoint": ({"id": "ASVS-V4", "title": "Input validation", "requirement": "Reject malformed and boundary-invalid input."},),
+    "authentication_changed": ({"id": "ASVS-V2", "title": "Authentication", "requirement": "Protected behavior rejects failed authentication."},),
+    "authorization_changed": ({"id": "ASVS-V4.2", "title": "Authorization", "requirement": "Denied principals cannot access another resource."},),
+    "personal_data": ({"id": "ASVS-V8", "title": "Data protection", "requirement": "Do not expose personal data beyond the response contract."},),
+    "external_network_call": ({"id": "ASVS-V9", "title": "Communications", "requirement": "Constrain outbound destinations and failures."},),
+    "file_upload": ({"id": "ASVS-V12", "title": "File handling", "requirement": "Validate type, size, storage path, and authorization."},),
+    "deserialization": ({"id": "ASVS-V5", "title": "Secure coding", "requirement": "Avoid unsafe untrusted deserialization."},),
+    "tenant_boundary": ({"id": "API1:2023", "title": "Object authorization", "requirement": "Verify tenant and object ownership."},),
+    "dynamic_query": ({"id": "ASVS-V5.3", "title": "Injection prevention", "requirement": "Bind values and validate query operators."},),
+    "secret_or_token": ({"id": "ASVS-V6", "title": "Stored secrets", "requirement": "Do not expose secrets or tokens."},),
+    "payment": ({"id": "ASVS-V11", "title": "Business logic", "requirement": "Verify authorization, idempotency, and state invariants."},),
+}
+_HIGH_RISK = frozenset(_SIGNAL_PATTERNS) - {"public_http_endpoint"}
+
+
+def materialize_security_profile(
+    *, repo_root: Path, plan_path: Path, profile_output: Path,
+    controls_output: Path, standards_path: Path = Path(".codex/security/owasp-standards.json"),
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    plan = _absolute(repo_root, plan_path)
+    if not plan.is_file():
+        raise FileNotFoundError(f"active plan is required: {plan_path}")
+    text = plan.read_text(encoding="utf-8").lower()
+    signals = {key: any(token.lower() in text for token in needles) for key, needles in _SIGNAL_PATTERNS.items()}
+    applicable = [key for key, enabled in signals.items() if enabled]
+    controls = _dedupe(control for signal in applicable for control in _CONTROL_MAP.get(signal, ()))
+    profile = {
+        "schema_version": 1,
+        "source_plan": _relative(plan, repo_root),
+        "signals": signals,
+        "applicable_signals": applicable,
+        "review_required": any(signals[key] for key in _HIGH_RISK),
+        "routing": "independent-review" if any(signals[key] for key in _HIGH_RISK) else "static-profile-only",
+    }
+    selected = {
+        "schema_version": 1,
+        "source": "runtime security profile",
+        "pinned_standards": _pinned_standards(_absolute(repo_root, standards_path)),
+        "selected_controls": controls,
+    }
+    _write_json(_absolute(repo_root, profile_output), profile)
+    _write_json(_absolute(repo_root, controls_output), selected)
+    return profile, selected
+
+
+def materialize_security_review_bundle(
+    *, repo_root: Path, run_id: str, work_item_id: str, plan_path: Path,
+    profile_path: Path, controls_path: Path, verification_report_path: Path,
+    verification_markdown_path: Path, output_dir: Path,
+) -> dict[str, Any]:
+    target = _absolute(repo_root, output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    files = _changed_files_from_scope_report(repo_root, run_id)
+    if not files:
+        files = _git_changed_files(repo_root)
+    _write_json(target / "changed-files.json", {"files": files})
+    (target / "implementation.diff").write_text(_git_diff(repo_root, files), encoding="utf-8")
+    _write_json(target / "security-profile.json", _read_json(_absolute(repo_root, profile_path)))
+    _write_json(target / "selected-controls.json", _read_json(_absolute(repo_root, controls_path)))
+    (target / "security-plan-tasks.md").write_text(_security_plan_section(_read_text(_absolute(repo_root, plan_path))), encoding="utf-8")
+    _write_json(target / "verification-summary.json", _read_json(_absolute(repo_root, verification_report_path)))
+    (target / "focused-test-summary.md").write_text(_read_text(_absolute(repo_root, verification_markdown_path)), encoding="utf-8")
+    manifest = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "work_item_id": work_item_id,
+        "files": [
+            "changed-files.json", "implementation.diff", "security-profile.json",
+            "selected-controls.json", "security-plan-tasks.md", "verification-summary.json",
+            "focused-test-summary.md",
+        ],
+    }
+    _write_json(target / "manifest.json", manifest)
+    return manifest
+
+
+def _changed_files_from_scope_report(repo_root: Path, run_id: str) -> list[dict[str, str]]:
+    payload = _read_json(repo_root / ".harness/runs" / run_id / "steps" / "execute-work-item" / "scope-diff-report.json")
+    allowed = payload.get("allowed")
+    if not isinstance(allowed, list):
+        return []
+    return [
+        {"path": str(row["path"]), "operation": str(row.get("operation") or "modify")}
+        for row in allowed if isinstance(row, Mapping) and row.get("path")
+    ]
+
+
+def _git_changed_files(repo_root: Path) -> list[dict[str, str]]:
+    result = subprocess.run(["git", "diff", "--name-only", "HEAD"], cwd=repo_root, text=True, capture_output=True, check=False)
+    return [{"path": line, "operation": "modify"} for line in result.stdout.splitlines() if line] if result.returncode == 0 else []
+
+
+def _git_diff(repo_root: Path, files: Sequence[Mapping[str, str]]) -> str:
+    paths = [str(row["path"]) for row in files if row.get("path")]
+    if not paths:
+        return "# No scoped implementation diff was available.\n"
+    result = subprocess.run(["git", "diff", "--binary", "HEAD", "--", *paths], cwd=repo_root, text=True, capture_output=True, check=False)
+    if result.returncode:
+        return f"# Unable to materialize scoped diff\n\n{result.stderr}\n"
+    return result.stdout or "# No tracked scoped implementation diff was available.\n"
+
+
+def _security_plan_section(text: str) -> str:
+    match = re.search(r"(?ims)^##\s+(?:OWASP\s+Security\s+Review|보안\s+검토)\s*$.*?(?=^##\s|\Z)", text)
+    return match.group(0).strip() + "\n" if match else "# No dedicated security-plan section was found.\n"
+
+
+def _pinned_standards(path: Path) -> list[dict[str, str]]:
+    values = _read_json(path).get("standards")
+    if not isinstance(values, list):
+        return []
+    return [
+        {"id": str(item["id"]), "version": str(item["expected_version"]), "name": str(item.get("name") or item["id"])}
+        for item in values if isinstance(item, Mapping) and item.get("id") and item.get("expected_version")
+    ]
+
+
+def _dedupe(values: Any) -> list[dict[str, str]]:
+    result: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in values:
+        if item["id"] not in seen:
+            seen.add(item["id"])
+            result.append(dict(item))
+    return result
+
+
+def _absolute(root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else root / path
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    profile = subparsers.add_parser("profile")
+    profile.add_argument("--repo-root", default=".")
+    profile.add_argument("--plan", required=True)
+    profile.add_argument("--profile-output", required=True)
+    profile.add_argument("--controls-output", required=True)
+    profile.add_argument("--standards", default=".codex/security/owasp-standards.json")
+    bundle = subparsers.add_parser("bundle")
+    bundle.add_argument("--repo-root", default=".")
+    bundle.add_argument("--run-id", required=True)
+    bundle.add_argument("--work-item", required=True)
+    bundle.add_argument("--plan", required=True)
+    bundle.add_argument("--profile", required=True)
+    bundle.add_argument("--controls", required=True)
+    bundle.add_argument("--verification-report", required=True)
+    bundle.add_argument("--verification-markdown", required=True)
+    bundle.add_argument("--output-dir", required=True)
+    args = parser.parse_args(argv)
+    root = Path(args.repo_root).resolve()
+    if args.command == "profile":
+        materialize_security_profile(repo_root=root, plan_path=Path(args.plan), profile_output=Path(args.profile_output), controls_output=Path(args.controls_output), standards_path=Path(args.standards))
+    else:
+        materialize_security_review_bundle(repo_root=root, run_id=args.run_id, work_item_id=args.work_item, plan_path=Path(args.plan), profile_path=Path(args.profile), controls_path=Path(args.controls), verification_report_path=Path(args.verification_report), verification_markdown_path=Path(args.verification_markdown), output_dir=Path(args.output_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness_codex/runtime/security_review_prompt_patch.py
+++ b/harness_codex/runtime/security_review_prompt_patch.py
@@ -1,0 +1,92 @@
+"""Install a minimal prompt profile for bundle-scoped security reviewers."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+_PATCHED = "_harness_security_review_prompt_profile_applied"
+
+_REVIEW_BUNDLE_INSTRUCTION = """You are running as a bounded reviewer.
+Read only the runtime-declared review bundle. Treat its focused diff, evidence, security profile, and selected controls as the review authority.
+Do not read ChangeSet documents, repository settings, full standards sources, long-term memory, or upstream design artifacts. Report a blocker when the bundle is insufficient rather than widening the read scope.
+Write all agent input/output and user-facing output in Korean. Preserve code identifiers, file paths, JSON keys, CLI commands, protocol names, and approved canonical terms when compatibility requires their original form.
+Report findings, evidence, and blockers clearly."""
+
+
+def apply_security_review_prompt_patch() -> None:
+    """Route `review-bundle-minimal` through a bounded prompt assembly path."""
+
+    from harness_codex.runtime import prompt
+
+    if getattr(prompt, _PATCHED, False):
+        return
+
+    original = prompt.build_agent_prompt
+
+    def build_agent_prompt(
+        *,
+        step,
+        context,
+        agent_config: Mapping[str, Any],
+        agent_config_path,
+        skill_path=None,
+        skill_body=None,
+    ) -> str:
+        if prompt._prompt_context_profile(step) != "review-bundle-minimal":
+            return original(
+                step=step,
+                context=context,
+                agent_config=agent_config,
+                agent_config_path=agent_config_path,
+                skill_path=skill_path,
+                skill_body=skill_body,
+            )
+        payload = {
+            "run_id": context.run_id,
+            "work_item_id": context.metadata.get("active_work_item_id"),
+            "step": {
+                "id": step.id,
+                "agent_id": step.agent_id,
+                "inputs": [str(path) for path in step.inputs],
+                "outputs": [str(path) for path in step.outputs],
+            },
+            "required_reads": [str(path) for path in step.inputs],
+            "explicitly_excluded_context": [
+                "ChangeSet body",
+                "workflow definition",
+                "repository source-of-truth previews",
+                "repository settings",
+                "full OWASP standards source",
+                "long-term memory",
+                "upstream design artifacts",
+            ],
+        }
+        sections = [
+            prompt._section("1. Runtime Instruction", _REVIEW_BUNDLE_INSTRUCTION),
+            prompt._section(
+                "2. Delegation Contract",
+                prompt._delegation_contract(
+                    step,
+                    agent_config,
+                    agent_config_path,
+                    skill_path,
+                    context.repo_root,
+                ),
+            ),
+            prompt._section(
+                "3. Focused Review Bundle",
+                "\n".join(["```json", prompt._stable_json(payload), "```"]),
+            ),
+        ]
+        return "\n\n".join(sections).rstrip() + "\n"
+
+    prompt.build_agent_prompt = build_agent_prompt
+    try:
+        from harness_codex.runtime import runner
+
+        if getattr(runner, "build_agent_prompt", None) is original:
+            runner.build_agent_prompt = build_agent_prompt
+    except ImportError:
+        pass
+    setattr(prompt, _PATCHED, True)

--- a/tests/runtime/test_security_review_bundle.py
+++ b/tests/runtime/test_security_review_bundle.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.security_review_bundle import (
+    materialize_security_profile,
+    materialize_security_review_bundle,
+)
+
+
+def test_security_profile_selects_signaled_controls(tmp_path: Path) -> None:
+    standards = tmp_path / ".codex/security/owasp-standards.json"
+    standards.parent.mkdir(parents=True)
+    standards.write_text(json.dumps({"standards": [{"id": "asvs", "name": "ASVS", "expected_version": "5.0.0"}]}), encoding="utf-8")
+    plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n\nImplement JWT authentication for a public API endpoint.\n", encoding="utf-8")
+
+    profile, controls = materialize_security_profile(
+        repo_root=tmp_path,
+        plan_path=plan,
+        profile_output=tmp_path / "profile.json",
+        controls_output=tmp_path / "controls.json",
+    )
+
+    assert profile["signals"]["authentication_changed"] is True
+    assert profile["signals"]["public_http_endpoint"] is True
+    assert profile["routing"] == "independent-review"
+    assert {item["id"] for item in controls["selected_controls"]} >= {"ASVS-V2", "ASVS-V4"}
+
+
+def test_security_bundle_uses_scope_diff_paths(tmp_path: Path, monkeypatch) -> None:
+    run_id = "run-001"
+    scope = tmp_path / ".harness/runs" / run_id / "steps/execute-work-item/scope-diff-report.json"
+    scope.parent.mkdir(parents=True)
+    scope.write_text(json.dumps({"allowed": [{"path": "src/App.py", "operation": "modify"}]}), encoding="utf-8")
+    plan = tmp_path / "plan.md"
+    plan.write_text("## OWASP Security Review\n\n- [ ] validate input\n", encoding="utf-8")
+    profile = tmp_path / "profile.json"
+    profile.write_text("{}\n", encoding="utf-8")
+    controls = tmp_path / "controls.json"
+    controls.write_text("{}\n", encoding="utf-8")
+    report = tmp_path / "report.json"
+    report.write_text("{}\n", encoding="utf-8")
+    verification = tmp_path / "verification.md"
+    verification.write_text("PASS\n", encoding="utf-8")
+
+    class Result:
+        returncode = 0
+        stdout = "diff --git a/src/App.py b/src/App.py\n"
+        stderr = ""
+
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: Result())
+    output = tmp_path / "bundle"
+    manifest = materialize_security_review_bundle(
+        repo_root=tmp_path,
+        run_id=run_id,
+        work_item_id="UC-001",
+        plan_path=plan,
+        profile_path=profile,
+        controls_path=controls,
+        verification_report_path=report,
+        verification_markdown_path=verification,
+        output_dir=output,
+    )
+
+    assert "implementation.diff" in manifest["files"]
+    assert json.loads((output / "changed-files.json").read_text(encoding="utf-8"))["files"] == [{"path": "src/App.py", "operation": "modify"}]
+    assert "diff --git" in (output / "implementation.diff").read_text(encoding="utf-8")

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -39,7 +39,6 @@ steps:
 
 def test_load_workflow_text_converts_yaml_to_runtime_model() -> None:
     workflow = load_workflow_text(VALID_WORKFLOW)
-
     assert workflow.name == "fix-issue"
     assert workflow.mode == RunMode.PLAN
     assert workflow.step_ids() == ("analyze", "validate")
@@ -52,9 +51,7 @@ def test_load_named_workflow_reads_from_harness_workflows_directory(tmp_path: Pa
     workflows_dir = tmp_path / ".harness" / "workflows"
     workflows_dir.mkdir(parents=True)
     (workflows_dir / "fix-issue.yaml").write_text(VALID_WORKFLOW, encoding="utf-8")
-
     workflow = load_named_workflow("fix-issue", workflows_dir=workflows_dir)
-
     assert workflow.name == "fix-issue"
     assert workflow.step_ids() == ("analyze", "validate")
 
@@ -65,16 +62,21 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
     step_ids = work_item_workflow.step_ids()
 
     assert work_item_workflow.name == "changeset-work-item-workflow"
-    assert step_ids[0:4] == (
+    assert step_ids[0:5] == (
         "load-change-set",
         "plan-work-item",
+        "materialize-security-profile",
         "secure-work-item-plan",
         "review-work-item-plan",
     )
+    assert work_item_workflow.step_by_id("materialize-security-profile").kind == StepKind.VALIDATOR
+    assert work_item_workflow.step_by_id("secure-work-item-plan").needs == ("materialize-security-profile",)
+    assert work_item_workflow.step_by_id("secure-work-item-plan").metadata["prompt_context_profile"] == "review-bundle-minimal"
     assert "materialize-execution-scope" in step_ids
     assert step_ids.index("materialize-execution-scope") < step_ids.index("execute-work-item")
     assert step_ids.index("execute-work-item") < step_ids.index("verify-work-item")
-    assert step_ids.index("verify-work-item") < step_ids.index("review-work-item-security")
+    assert step_ids.index("verify-work-item") < step_ids.index("materialize-security-review-bundle")
+    assert step_ids.index("materialize-security-review-bundle") < step_ids.index("review-work-item-security")
     assert step_ids.index("review-work-item-security") < step_ids.index("verify-work-item-security")
     assert step_ids.index("verify-work-item-security") < step_ids.index("classify-verification-result")
     assert step_ids[-2:] == ("remediate-work-item", "complete-work-item-plan")
@@ -94,17 +96,17 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
         Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),
         Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-scope.json"),
     )
-    assert work_item_workflow.step_by_id("review-work-item-security").outputs == ()
-    assert (
-        work_item_workflow.step_by_id("review-work-item-security").metadata["final_response_contract"]
-        == {
-            "channel": "final-message",
-            "format": "markdown",
-            "output": ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md",
-            "status_label": "Security Review Status",
-            "allowed_statuses": ["approved", "rejected"],
-        }
-    )
+    security_review = work_item_workflow.step_by_id("review-work-item-security")
+    assert security_review.needs == ("materialize-security-review-bundle",)
+    assert security_review.metadata["prompt_context_profile"] == "review-bundle-minimal"
+    assert security_review.outputs == ()
+    assert security_review.metadata["final_response_contract"] == {
+        "channel": "final-message",
+        "format": "markdown",
+        "output": ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md",
+        "status_label": "Security Review Status",
+        "allowed_statuses": ["approved", "rejected"],
+    }
     assert work_item_workflow.step_by_id("verify-work-item-security").kind == StepKind.VALIDATOR
     assert work_item_workflow.step_by_id("verify-work-item-security").command == (
         "python3 -m harness_codex.runtime.materialize_security_review "
@@ -117,10 +119,7 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
     )
     assert work_item_workflow.step_by_id("classify-verification-result").kind == StepKind.DECISION
     assert work_item_workflow.step_by_id("remediate-work-item").metadata["loop_target"] == "execute-work-item"
-    assert all(
-        step.metadata["execution_boundary"] == "work_item"
-        for step in work_item_workflow.steps
-    )
+    assert all(step.metadata["execution_boundary"] == "work_item" for step in work_item_workflow.steps)
     assert "create-change-set-pr" not in step_ids
     assert "complete-change-set" not in step_ids
     assert "update-project-wiki" not in step_ids
@@ -131,13 +130,6 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
         "create-change-set-pr",
         "complete-change-set",
     )
-    assert finalization_workflow.step_by_id("create-change-set-pr").needs == (
-        "verify-all-work-items-completed",
-    )
-    assert finalization_workflow.step_by_id("complete-change-set").needs == (
-        "create-change-set-pr",
-    )
-    assert all(
-        step.metadata["execution_boundary"] == "changeset_finalization"
-        for step in finalization_workflow.steps
-    )
+    assert finalization_workflow.step_by_id("create-change-set-pr").needs == ("verify-all-work-items-completed",)
+    assert finalization_workflow.step_by_id("complete-change-set").needs == ("create-change-set-pr",)
+    assert all(step.metadata["execution_boundary"] == "changeset_finalization" for step in finalization_workflow.steps)

--- a/tests/test_issue_372_canonical_finalization.py
+++ b/tests/test_issue_372_canonical_finalization.py
@@ -15,66 +15,43 @@ from harness_codex.runtime.workflows import (
 
 def test_work_item_workflow_excludes_changeset_finalization() -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    work_item_workflow = load_named_workflow(
-        "changeset-use-case-workflow",
-        workflows_dir=repo_root / ".harness/workflows",
-    )
-    finalization_workflow = load_named_workflow(
-        "changeset-finalization-workflow",
-        workflows_dir=repo_root / ".harness/workflows",
-    )
+    work_item_workflow = load_named_workflow("changeset-use-case-workflow", workflows_dir=repo_root / ".harness/workflows")
+    finalization_workflow = load_named_workflow("changeset-finalization-workflow", workflows_dir=repo_root / ".harness/workflows")
     step_ids = work_item_workflow.step_ids()
 
-    assert step_ids[:4] == (
+    assert step_ids[:5] == (
         "load-change-set",
         "plan-work-item",
+        "materialize-security-profile",
         "secure-work-item-plan",
         "review-work-item-plan",
     )
     assert "materialize-execution-scope" in step_ids
     assert step_ids.index("materialize-execution-scope") < step_ids.index("execute-work-item")
-    assert step_ids.index("verify-work-item") < step_ids.index("classify-verification-result")
+    assert step_ids.index("verify-work-item") < step_ids.index("materialize-security-review-bundle")
+    assert step_ids.index("materialize-security-review-bundle") < step_ids.index("classify-verification-result")
     assert step_ids[-2:] == ("remediate-work-item", "complete-work-item-plan")
     assert "update-project-wiki" not in step_ids
     assert "validate-project-wiki" not in step_ids
     assert "create-change-set-pr" not in step_ids
     assert "complete-change-set" not in step_ids
-    assert all(
-        step.metadata["execution_boundary"] == "work_item"
-        for step in work_item_workflow.steps
-    )
+    assert all(step.metadata["execution_boundary"] == "work_item" for step in work_item_workflow.steps)
 
     assert finalization_workflow.step_ids() == (
         "verify-all-work-items-completed",
         "create-change-set-pr",
         "complete-change-set",
     )
-    assert finalization_workflow.step_by_id("complete-change-set").needs == (
-        "create-change-set-pr",
-    )
-    assert all(
-        step.metadata["execution_boundary"] == "changeset_finalization"
-        for step in finalization_workflow.steps
-    )
+    assert finalization_workflow.step_by_id("complete-change-set").needs == ("create-change-set-pr",)
+    assert all(step.metadata["execution_boundary"] == "changeset_finalization" for step in finalization_workflow.steps)
 
 
 def test_work_item_and_finalization_workflows_materialize_without_unresolved_placeholders() -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    work_item_workflow = load_named_workflow(
-        "changeset-use-case-workflow",
-        workflows_dir=repo_root / ".harness/workflows",
-    )
-    finalization_workflow = load_named_workflow(
-        "changeset-finalization-workflow",
-        workflows_dir=repo_root / ".harness/workflows",
-    )
+    work_item_workflow = load_named_workflow("changeset-use-case-workflow", workflows_dir=repo_root / ".harness/workflows")
+    finalization_workflow = load_named_workflow("changeset-finalization-workflow", workflows_dir=repo_root / ".harness/workflows")
     change_set = ChangeSet(change_set_id="CHG-372", title="test")
-    use_case = AffectedUseCase(
-        uc_id="UC-372",
-        name="workflow test",
-        impact_type="update",
-        slice_path=Path("docs/use-cases/UC-372"),
-    )
+    use_case = AffectedUseCase(uc_id="UC-372", name="workflow test", impact_type="update", slice_path=Path("docs/use-cases/UC-372"))
     scope = PlanningInputScope(
         change_set_path=Path("docs/changes/active/CHG-372.md"),
         use_case=use_case,
@@ -86,28 +63,17 @@ def test_work_item_and_finalization_workflows_materialize_without_unresolved_pla
         plan_path=Path("docs/plans/active/UC-372/plan.md"),
     )
 
-    materialized_work_item = materialize_workflow_for_scope(
-        work_item_workflow,
-        change_set,
-        scope,
-        run_id="run-372",
-    )
-    materialized_finalization = materialize_workflow_for_scope(
-        finalization_workflow,
-        change_set,
-        scope,
-        run_id="run-372",
-    )
+    materialized_work_item = materialize_workflow_for_scope(work_item_workflow, change_set, scope, run_id="run-372")
+    materialized_finalization = materialize_workflow_for_scope(finalization_workflow, change_set, scope, run_id="run-372")
 
     verification = materialized_work_item.step_by_id("verify-work-item")
     execution_scope = materialized_work_item.step_by_id("materialize-execution-scope")
+    security_profile = materialized_work_item.step_by_id("materialize-security-profile")
     delivery = materialized_finalization.step_by_id("create-change-set-pr")
     assert Path("docs/plans/active/UC-372/plan.md") in verification.inputs
     assert Path("docs/plans/active/UC-372/plan.md") in execution_scope.inputs
+    assert Path("docs/plans/active/UC-372/plan.md") in security_profile.inputs
     assert all("<RUN-ID>" not in str(path) for path in verification.outputs)
-    assert delivery.command == (
-        "python3 -m harness_codex.runtime.change_set_pr_delivery "
-        "--change-set CHG-372 --run-id run-372"
-    )
+    assert delivery.command == "python3 -m harness_codex.runtime.change_set_pr_delivery --change-set CHG-372 --run-id run-372"
     assert unresolved_placeholders(materialized_work_item) == frozenset()
     assert unresolved_placeholders(materialized_finalization) == frozenset()

--- a/tests/test_security_plan_reviewer_contract.py
+++ b/tests/test_security_plan_reviewer_contract.py
@@ -19,22 +19,27 @@ def test_security_plan_reviewer_agent_and_skill_are_registered() -> None:
     assert "[agents.security_plan_reviewer]" in config
     assert 'name = "security_plan_reviewer"' in agent
     assert "harness-security-plan-reviewer" in agent
-    assert "OWASP ASVS 5.0.0" in skill
-    assert "OWASP Top 10:2025" in skill
-    assert "OWASP API Security Top 10:2023" in skill
+    assert "runtime-selected" in agent
+    assert "security-profile.json" in skill
+    assert "selected-controls.json" in skill
 
 
 def test_changeset_workflow_secures_plan_before_independent_review() -> None:
     workflow = load_named_workflow("changeset-use-case-workflow")
+    profile = workflow.step_by_id("materialize-security-profile")
     security = workflow.step_by_id("secure-work-item-plan")
     review = workflow.step_by_id("review-work-item-plan")
 
+    assert profile.kind.value == "validator"
     assert security.agent_id == "security_plan_reviewer"
     assert security.skill_id == "harness-security-plan-reviewer"
-    assert security.needs == ("plan-work-item",)
-    assert security.outputs == (
+    assert security.needs == ("materialize-security-profile",)
+    assert security.inputs == (
         Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),
+        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json"),
+        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json"),
     )
+    assert security.outputs == (Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),)
     assert review.needs == ("secure-work-item-plan",)
 
 
@@ -51,9 +56,7 @@ def test_full_workflow_secures_plan_before_independent_review() -> None:
 
 def test_security_reviewer_is_plan_only_and_requires_traceable_tasks() -> None:
     reference = read(".codex/agents/references/security_plan_reviewer.md")
-    baseline = read(
-        ".codex/skills/harness-security-plan-reviewer/references/owasp-baseline.md"
-    )
+    baseline = read(".codex/skills/harness-security-plan-reviewer/references/owasp-baseline.md")
     skill = read(".codex/skills/harness-security-plan-reviewer/SKILL.md")
 
     assert "Edit only the runtime-declared" in reference
@@ -64,5 +67,5 @@ def test_security_reviewer_is_plan_only_and_requires_traceable_tasks() -> None:
     assert "verification command" in baseline
     assert "minimal plan delta" in reference
     assert "Do not rewrite or narrate the full plan" in reference
-    assert "Return/apply only a minimal delta" in skill
-    assert "changed plan" in skill and "sections" in skill
+    assert "Do not read the ChangeSet" in skill
+    assert "concrete implementation, test, and verification tasks" in skill


### PR DESCRIPTION
Closes #444

## 목적

보안 plan 리뷰와 구현 후 보안 리뷰가 ChangeSet, repository settings, 전체 OWASP 기준 문서를 반복해서 읽지 않도록 runtime이 work-item 전용 보안 profile과 diff/evidence bundle을 생성합니다.

## 변경

- `security-profile.json`, `selected-controls.json` materialization
- security plan reviewer 입력을 `plan.md + profile + selected controls`로 축소
- scoped changed files, implementation diff, plan task, verification evidence로 security review bundle 생성
- implementation security reviewer 입력을 bundle 전용으로 축소
- `review-bundle-minimal` prompt profile 추가
- profile/bundle materialization runtime tests 추가

#446 병합 후 `main`을 base로 갱신했습니다. 이 PR은 최신 `main`과의 CI 및 충돌 검증 후 병합합니다.