### PR TITLE
#445 에이전트 토큰·프롬프트 구성 관측 추가

### DIFF
--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -160,11 +160,26 @@ steps:
     - static-analysis
     inputs_resolved_by: work_item_document_contract
     test_gate: .codex/test-gate.yaml required stages must PASS when applicable
+- id: collect-pre-security-token-metrics
+  kind: validator
+  name: Collect token and prompt metrics before implementation security review
+  needs:
+  - verify-work-item
+  command: python3 -m harness_codex.runtime.token_observability --repo-root . --run-id <RUN-ID> --work-item <WORK-ITEM-ID>
+  timeout_sec: 60
+  outputs:
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/metrics.json
+  - .harness/runs/<RUN-ID>/metrics.json
+  metadata:
+    stage: observability
+    scope: work_item
+    execution_boundary: work_item
+    gate_id: token-observability
 - id: materialize-security-review-bundle
   kind: validator
   name: Materialize scoped implementation diff and security evidence bundle
   needs:
-  - verify-work-item
+  - collect-pre-security-token-metrics
   command: python3 -m harness_codex.runtime.security_review_bundle bundle --repo-root . --run-id <RUN-ID> --work-item <WORK-ITEM-ID> --plan docs/plans/active/<WORK-ITEM-ID>/plan.md --profile .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json --controls .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json --verification-report .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/report.json --verification-markdown .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/verification/verification.md --output-dir .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle
   timeout_sec: 60
   inputs:
@@ -238,11 +253,26 @@ steps:
       output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md
       status_label: Security Review Status
       approved_status: approved
+- id: collect-work-item-token-metrics
+  kind: validator
+  name: Collect final work item token and prompt metrics
+  needs:
+  - verify-work-item-security
+  command: python3 -m harness_codex.runtime.token_observability --repo-root . --run-id <RUN-ID> --work-item <WORK-ITEM-ID>
+  timeout_sec: 60
+  outputs:
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/metrics.json
+  - .harness/runs/<RUN-ID>/metrics.json
+  metadata:
+    stage: observability
+    scope: work_item
+    execution_boundary: work_item
+    gate_id: token-observability
 - id: classify-verification-result
   kind: decision
   name: Classify verification or security result
   needs:
-  - verify-work-item-security
+  - collect-work-item-token-metrics
   metadata:
     stage: implementation
     scope: work_item

--- a/harness_codex/runtime/token_observability.py
+++ b/harness_codex/runtime/token_observability.py
@@ -1,0 +1,186 @@
+"""Collect durable token, prompt, and declared-input metrics from run artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+_ALIASES = {
+    "input_tokens": ("input_tokens", "prompt_tokens"),
+    "cached_input_tokens": ("cached_input_tokens", "cached_prompt_tokens"),
+    "output_tokens": ("output_tokens", "completion_tokens"),
+    "reasoning_tokens": ("reasoning_tokens",),
+    "total_tokens": ("total_tokens",),
+}
+_EXCLUSIONS = {
+    "execution-minimal": ["ChangeSet body", "workflow definition", "repository source-of-truth previews", "repository settings", "long-term memory"],
+    "review-bundle-minimal": ["ChangeSet body", "workflow definition", "repository source-of-truth previews", "repository settings", "full OWASP standards source", "long-term memory", "upstream design artifacts"],
+}
+
+
+def collect_work_item_metrics(*, repo_root: Path, run_id: str, work_item_id: str) -> dict[str, Any]:
+    run_dir = repo_root / ".harness/runs" / run_id
+    steps_dir = run_dir / "steps"
+    steps = [_collect_step(repo_root, path) for path in sorted(steps_dir.iterdir()) if path.is_dir()] if steps_dir.is_dir() else []
+    steps = [item for item in steps if item]
+    totals = _sum(steps)
+    payload = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "work_item_id": work_item_id,
+        "usage_source": "provider" if any(item["usage_source"] == "provider" for item in steps) else "estimated",
+        "totals": totals,
+        "prompt_token_estimate": sum(int(item["prompt_token_estimate"]) for item in steps),
+        "prompt_static_context_estimate": sum(int(item["prompt_static_context_estimate"]) for item in steps),
+        "provider_calls": sum(int(item["provider_calls"]) for item in steps),
+        "review_cache_hits": sum(1 for item in steps if item["review_cache_hit"]),
+        "steps": steps,
+    }
+    _write_json(run_dir / "work-items" / work_item_id / "metrics.json", payload)
+    current = _read_json(run_dir / "metrics.json")
+    work_items = dict(current.get("work_items") or {})
+    work_items[work_item_id] = payload
+    _write_json(run_dir / "metrics.json", {"schema_version": 1, "run_id": run_id, "work_items": work_items})
+    return payload
+
+
+def _collect_step(repo_root: Path, step_dir: Path) -> dict[str, Any] | None:
+    prompt_path, invocation_path, result_path, stdout_path = (step_dir / "prompt.md", step_dir / "invocation.json", step_dir / "result.json", step_dir / "stdout.txt")
+    if not any(path.is_file() for path in (prompt_path, invocation_path, result_path, stdout_path)):
+        return None
+    invocation, result = _read_json(invocation_path), _read_json(result_path)
+    metadata = result.get("metadata") if isinstance(result.get("metadata"), Mapping) else {}
+    manifest = _prompt_manifest(_read_text(prompt_path))
+    usage = extract_codex_usage(_read_text(stdout_path))
+    normalized = usage["usage"]
+    profile = str((invocation.get("metadata") or {}).get("prompt_context_profile") or "default")
+    record = {
+        "schema_version": 1,
+        "step_id": invocation.get("step_id") or step_dir.name,
+        "agent_id": invocation.get("agent_id"),
+        "usage_source": "provider" if usage["found"] else "estimated",
+        **normalized,
+        "prompt_token_estimate": manifest["total_estimated_tokens"],
+        "prompt_static_context_estimate": manifest["static_context_estimated_tokens"],
+        "provider_calls": 0 if metadata.get("review_cache_hit") else 1,
+        "review_cache_hit": bool(metadata.get("review_cache_hit")),
+        "status": result.get("status"),
+    }
+    _write_json(step_dir / "usage.json", record)
+    _write_json(step_dir / "prompt-manifest.json", manifest)
+    _write_json(step_dir / "resolved-inputs.json", _resolved_inputs(repo_root, invocation, profile))
+    return record
+
+
+def extract_codex_usage(stdout: str) -> dict[str, Any]:
+    candidates: list[dict[str, int | None]] = []
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except (TypeError, ValueError):
+            continue
+        candidates.extend(_usage_candidates(event))
+    if not candidates:
+        return {"found": False, "usage": _empty_usage()}
+    merged = _empty_usage()
+    for candidate in candidates:
+        for key, value in candidate.items():
+            if value is not None:
+                merged[key] = value
+    if merged["total_tokens"] is None and all(isinstance(merged[key], int) for key in ("input_tokens", "output_tokens", "reasoning_tokens")):
+        merged["total_tokens"] = sum(merged[key] for key in ("input_tokens", "output_tokens", "reasoning_tokens"))
+    return {"found": True, "usage": merged}
+
+
+def _usage_candidates(value: Any) -> list[dict[str, int | None]]:
+    stack, records = [value], []
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            source = current.get("usage") if isinstance(current.get("usage"), Mapping) else current
+            record = _normalize(source)
+            if any(item is not None for item in record.values()):
+                records.append(record)
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+    return records
+
+
+def _normalize(mapping: Mapping[str, Any]) -> dict[str, int | None]:
+    result = _empty_usage()
+    for destination, aliases in _ALIASES.items():
+        result[destination] = next((mapping[key] for key in aliases if isinstance(mapping.get(key), int) and mapping[key] >= 0), None)
+    return result
+
+
+def _empty_usage() -> dict[str, int | None]:
+    return {key: None for key in _ALIASES}
+
+
+def _prompt_manifest(text: str) -> dict[str, Any]:
+    matches = list(re.finditer(r"(?m)^##\s+(.+?)\s*$", text))
+    sections = []
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        body = text[match.start():end]
+        sections.append({"name": match.group(1), "chars": len(body), "utf8_bytes": len(body.encode("utf-8")), "estimated_tokens": _estimate(body), "static_context": any(token in match.group(1).lower() for token in ("repository source", "workflow", "repository settings", "changeset", "long-term memory"))})
+    return {"schema_version": 1, "sections": sections, "total_chars": len(text), "total_utf8_bytes": len(text.encode("utf-8")), "total_estimated_tokens": _estimate(text), "static_context_estimated_tokens": sum(section["estimated_tokens"] for section in sections if section["static_context"])}
+
+
+def _resolved_inputs(repo_root: Path, invocation: Mapping[str, Any], profile: str) -> dict[str, Any]:
+    rows = []
+    for raw in invocation.get("inputs", []) if isinstance(invocation.get("inputs"), list) else []:
+        path = Path(str(raw)); absolute = path if path.is_absolute() else repo_root / path
+        rows.append({"path": str(path), "required": True, "reason": "workflow-declared input", "bytes": absolute.stat().st_size if absolute.is_file() else None, "estimated_tokens": _estimate(_read_text(absolute)) if absolute.is_file() else None})
+    return {"schema_version": 1, "profile": profile, "inputs": rows, "excluded_inputs": [{"description": value, "reason": f"{profile} profile excludes this context"} for value in _EXCLUSIONS.get(profile, [])]}
+
+
+def _sum(records: list[Mapping[str, Any]]) -> dict[str, int | None]:
+    result: dict[str, int | None] = {}
+    for key in _ALIASES:
+        values = [record.get(key) for record in records if isinstance(record.get(key), int)]
+        result[key] = sum(values) if values else None
+    return result
+
+
+def _estimate(text: str) -> int:
+    return math.ceil(len(text) / 4) if text else 0
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--work-item", required=True)
+    args = parser.parse_args(argv)
+    collect_work_item_metrics(repo_root=Path(args.repo_root).resolve(), run_id=args.run_id, work_item_id=args.work_item)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_token_observability.py
+++ b/tests/runtime/test_token_observability.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.token_observability import collect_work_item_metrics, extract_codex_usage
+
+
+def test_extract_codex_usage_normalizes_aliases() -> None:
+    result = extract_codex_usage(json.dumps({"usage": {"prompt_tokens": 120, "cached_prompt_tokens": 20, "completion_tokens": 30, "reasoning_tokens": 50}}))
+    assert result["found"] is True
+    assert result["usage"] == {"input_tokens": 120, "cached_input_tokens": 20, "output_tokens": 30, "reasoning_tokens": 50, "total_tokens": 200}
+
+
+def test_collect_metrics_writes_step_and_run_artifacts(tmp_path: Path) -> None:
+    run_id, work_item = "run-001", "UC-001"
+    step = tmp_path / ".harness/runs" / run_id / "steps/execute-work-item"
+    step.mkdir(parents=True)
+    (step / "prompt.md").write_text("## 1. Runtime Instruction\n\nexecutor\n\n## 2. Delegation Contract\n\n{}\n", encoding="utf-8")
+    (step / "invocation.json").write_text(json.dumps({"step_id": "execute-work-item", "agent_id": "implementation_executor", "inputs": ["docs/plans/active/UC-001/plan.md"], "metadata": {"prompt_context_profile": "execution-minimal"}}), encoding="utf-8")
+    (step / "result.json").write_text(json.dumps({"status": "succeeded", "metadata": {}}), encoding="utf-8")
+    (step / "stdout.txt").write_text(json.dumps({"usage": {"input_tokens": 80, "output_tokens": 12}}) + "\n", encoding="utf-8")
+    plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n", encoding="utf-8")
+
+    metrics = collect_work_item_metrics(repo_root=tmp_path, run_id=run_id, work_item_id=work_item)
+
+    usage = json.loads((step / "usage.json").read_text(encoding="utf-8"))
+    resolved = json.loads((step / "resolved-inputs.json").read_text(encoding="utf-8"))
+    assert usage["usage_source"] == "provider"
+    assert usage["input_tokens"] == 80
+    assert metrics["totals"]["output_tokens"] == 12
+    assert resolved["inputs"][0]["path"] == "docs/plans/active/UC-001/plan.md"
+    assert any(row["description"] == "ChangeSet body" for row in resolved["excluded_inputs"])

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -75,10 +75,12 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
     assert "materialize-execution-scope" in step_ids
     assert step_ids.index("materialize-execution-scope") < step_ids.index("execute-work-item")
     assert step_ids.index("execute-work-item") < step_ids.index("verify-work-item")
-    assert step_ids.index("verify-work-item") < step_ids.index("materialize-security-review-bundle")
+    assert step_ids.index("verify-work-item") < step_ids.index("collect-pre-security-token-metrics")
+    assert step_ids.index("collect-pre-security-token-metrics") < step_ids.index("materialize-security-review-bundle")
     assert step_ids.index("materialize-security-review-bundle") < step_ids.index("review-work-item-security")
     assert step_ids.index("review-work-item-security") < step_ids.index("verify-work-item-security")
-    assert step_ids.index("verify-work-item-security") < step_ids.index("classify-verification-result")
+    assert step_ids.index("verify-work-item-security") < step_ids.index("collect-work-item-token-metrics")
+    assert step_ids.index("collect-work-item-token-metrics") < step_ids.index("classify-verification-result")
     assert step_ids[-2:] == ("remediate-work-item", "complete-work-item-plan")
 
     assert work_item_workflow.step_by_id("plan-work-item").agent_id == "implementation_planner"
@@ -96,6 +98,8 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
         Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),
         Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-scope.json"),
     )
+    assert work_item_workflow.step_by_id("collect-pre-security-token-metrics").kind == StepKind.VALIDATOR
+    assert work_item_workflow.step_by_id("collect-work-item-token-metrics").kind == StepKind.VALIDATOR
     security_review = work_item_workflow.step_by_id("review-work-item-security")
     assert security_review.needs == ("materialize-security-review-bundle",)
     assert security_review.metadata["prompt_context_profile"] == "review-bundle-minimal"

--- a/tests/test_issue_372_canonical_finalization.py
+++ b/tests/test_issue_372_canonical_finalization.py
@@ -28,8 +28,10 @@ def test_work_item_workflow_excludes_changeset_finalization() -> None:
     )
     assert "materialize-execution-scope" in step_ids
     assert step_ids.index("materialize-execution-scope") < step_ids.index("execute-work-item")
-    assert step_ids.index("verify-work-item") < step_ids.index("materialize-security-review-bundle")
-    assert step_ids.index("materialize-security-review-bundle") < step_ids.index("classify-verification-result")
+    assert step_ids.index("verify-work-item") < step_ids.index("collect-pre-security-token-metrics")
+    assert step_ids.index("collect-pre-security-token-metrics") < step_ids.index("materialize-security-review-bundle")
+    assert step_ids.index("verify-work-item-security") < step_ids.index("collect-work-item-token-metrics")
+    assert step_ids.index("collect-work-item-token-metrics") < step_ids.index("classify-verification-result")
     assert step_ids[-2:] == ("remediate-work-item", "complete-work-item-plan")
     assert "update-project-wiki" not in step_ids
     assert "validate-project-wiki" not in step_ids
@@ -69,11 +71,15 @@ def test_work_item_and_finalization_workflows_materialize_without_unresolved_pla
     verification = materialized_work_item.step_by_id("verify-work-item")
     execution_scope = materialized_work_item.step_by_id("materialize-execution-scope")
     security_profile = materialized_work_item.step_by_id("materialize-security-profile")
+    pre_security_metrics = materialized_work_item.step_by_id("collect-pre-security-token-metrics")
+    final_metrics = materialized_work_item.step_by_id("collect-work-item-token-metrics")
     delivery = materialized_finalization.step_by_id("create-change-set-pr")
     assert Path("docs/plans/active/UC-372/plan.md") in verification.inputs
     assert Path("docs/plans/active/UC-372/plan.md") in execution_scope.inputs
     assert Path("docs/plans/active/UC-372/plan.md") in security_profile.inputs
     assert all("<RUN-ID>" not in str(path) for path in verification.outputs)
+    assert all("<RUN-ID>" not in str(path) for path in pre_security_metrics.outputs)
+    assert all("<RUN-ID>" not in str(path) for path in final_metrics.outputs)
     assert delivery.command == "python3 -m harness_codex.runtime.change_set_pr_delivery --change-set CHG-372 --run-id run-372"
     assert unresolved_placeholders(materialized_work_item) == frozenset()
     assert unresolved_placeholders(materialized_finalization) == frozenset()


### PR DESCRIPTION
Closes #445

## 변경

- agent step별 provider usage, prompt manifest, resolved inputs artifact를 생성합니다.
- work item/run metrics를 집계합니다.
- provider usage가 없으면 실제 토큰은 null로 유지하고 prompt 추정치와 분리합니다.
- product verification 직후와 security review 뒤에 관측을 수집합니다.

#447 병합 후 최신 `main` 위에서 재구성하며, CI 통과 후 병합합니다.