### PR TITLE
fix: 검증 실패 재처리 루프와 대시보드 recovery 흐름 정합화

### DIFF
--- a/.codex/skills/harness-code-planner/SKILL.md
+++ b/.codex/skills/harness-code-planner/SKILL.md
@@ -10,6 +10,7 @@ description: Create or maintain an executor-ready implementation plan for one ac
 - Use this skill only for the workflow described in the frontmatter.
 - Read `.codex/skills/harness-code-planner/references/detailed-instructions.md` before making workflow decisions or producing required artifacts.
 - When updating an existing active plan after a runtime failure, read `.codex/skills/harness-code-planner/references/plan-mutation-policy.md` before editing.
+- On a runtime-triggered rerun, use the run id and work-item id from the runtime payload to inspect the current run's `verification/repair-brief.json` when it exists. If it is absent and the post-implementation security review was rejected, inspect that run's `security/security-review.md`. Use the evidence only for the smallest required plan patch; do not copy the report into the plan.
 - Read additional files named by the detailed reference only when the current task needs them.
 - The workflow completion destination is `docs/plans/completed/<WORK-ITEM-ID>/plan.md`; this skill never writes, deletes, or moves that path.
 - Keep writes inside the scope declared by the caller or runtime payload.

--- a/.codex/skills/harness-security-implementation-reviewer/SKILL.md
+++ b/.codex/skills/harness-security-implementation-reviewer/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: harness-security-implementation-reviewer
-description: Independently review one implemented work item from a runtime-generated security bundle.
+description: Independently assess one implemented work item's code changes for security findings from a runtime-generated security bundle.
 ---
 
 # Security Implementation Reviewer
 
-- Read only `security-review-bundle/` inputs: changed files, scoped diff, profile, selected controls, plan tasks, and verification evidence.
-- Do not read ChangeSet, active-plan, repository settings, full standards, or upstream design artifacts.
+## Purpose
+
+Measure the implemented code and its verification evidence against the runtime-selected security controls. This is a post-implementation review only: identify concrete security defects or confirm that no applicable defect was found.
+
+## Required behavior
+
+- Read only `security-review-bundle/` inputs: changed files, scoped diff, security profile, selected controls, and verification evidence.
+- Base every finding on an observable changed-code location or a stated absence of required evidence. Do not turn hypothetical concerns into rejection criteria.
+- For each applicable selected control, state `pass`, `finding`, or `not-applicable` and cite the corresponding diff path, evidence file, or rationale.
+- When rejecting, describe the vulnerable behavior, impact, and the smallest implementation change needed to correct it. Do not write the correction into the plan.
+- Treat a finding that needs files outside the approved ChangeSet scope as a scope-expansion request, not as permission to change the plan or implementation scope.
+- Do not read the ChangeSet, active plan, repository settings, full standards, or upstream design artifacts.
 - Do not edit implementation code, plans, or runtime output files.
 - Return exactly one Markdown report.
 
 The first non-heading status line is exactly `Security Review Status: approved` or `Security Review Status: rejected`.
-The report contains `## Reviewed Inputs`, `## Security Findings`, `## Remediation Target`, and `## Evidence`.
-For approval, remediation target is `none`; rejection names `plan` or `implementation`.
+
+The report contains `## Reviewed Inputs`, `## Control Assessment`, `## Security Findings`, `## Required Implementation Corrections`, and `## Evidence`. For approval, `## Required Implementation Corrections` states `none`. For rejection, it names only `implementation` or `scope-expansion`; it must not ask the reviewer or executor to edit the active plan.

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -33,49 +33,11 @@ steps:
     scope: work_item
     execution_boundary: work_item
     inputs_resolved_by: work_item_document_contract
-- id: materialize-security-profile
-  kind: validator
-  name: Materialize focused security profile and applicable controls
-  needs:
-  - plan-work-item
-  command: python3 -m harness_codex.runtime.security_review_bundle profile --repo-root . --plan docs/plans/active/<WORK-ITEM-ID>/plan.md --profile-output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json --controls-output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
-  timeout_sec: 60
-  inputs:
-  - docs/plans/active/<WORK-ITEM-ID>/plan.md
-  - .codex/security/owasp-standards.json
-  outputs:
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
-  metadata:
-    stage: plan-writing
-    scope: work_item
-    execution_boundary: work_item
-    gate_id: security-profile
-- id: secure-work-item-plan
-  kind: agent
-  name: Add applicable security controls to the selected work item plan
-  needs:
-  - materialize-security-profile
-  agent_id: security_plan_reviewer
-  skill_id: harness-security-plan-reviewer
-  inputs:
-  - docs/plans/active/<WORK-ITEM-ID>/plan.md
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
-  outputs:
-  - docs/plans/active/<WORK-ITEM-ID>/plan.md
-  metadata:
-    stage: plan-writing
-    prompt_context_profile: review-bundle-minimal
-    scope: work_item
-    execution_boundary: work_item
-    gate_id: security-review
-    baseline: OWASP ASVS 5.0.0
 - id: review-work-item-plan
   kind: agent
   name: Review the work item implementation plan before execution
   needs:
-  - secure-work-item-plan
+  - plan-work-item
   agent_id: artifact_reviewer
   skill_id: harness-artifact-reviewer
   inputs:
@@ -160,11 +122,29 @@ steps:
     - static-analysis
     inputs_resolved_by: work_item_document_contract
     test_gate: .codex/test-gate.yaml required stages must PASS when applicable
+- id: materialize-security-profile
+  kind: validator
+  name: Materialize security controls for the implemented work item review
+  needs:
+  - verify-work-item
+  command: python3 -m harness_codex.runtime.security_review_bundle profile --repo-root . --plan docs/plans/active/<WORK-ITEM-ID>/plan.md --profile-output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json --controls-output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
+  timeout_sec: 60
+  inputs:
+  - docs/plans/active/<WORK-ITEM-ID>/plan.md
+  - .codex/security/owasp-standards.json
+  outputs:
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json
+  metadata:
+    stage: implementation
+    scope: work_item
+    execution_boundary: work_item
+    gate_id: security-profile
 - id: collect-pre-security-token-metrics
   kind: validator
   name: Collect token and prompt metrics before implementation security review
   needs:
-  - verify-work-item
+  - materialize-security-profile
   command: python3 -m harness_codex.runtime.token_observability --repo-root . --run-id <RUN-ID> --work-item <WORK-ITEM-ID>
   timeout_sec: 60
   outputs:
@@ -194,7 +174,6 @@ steps:
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/implementation.diff
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-profile.json
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/selected-controls.json
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-plan-tasks.md
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/verification-summary.json
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/focused-test-summary.md
   metadata:
@@ -204,7 +183,7 @@ steps:
     gate_id: security-review-bundle
 - id: review-work-item-security
   kind: agent
-  name: Independently review the implemented work item for security findings
+  name: Review the implemented code for security findings
   needs:
   - materialize-security-review-bundle
   agent_id: security_implementation_reviewer
@@ -215,7 +194,6 @@ steps:
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/implementation.diff
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-profile.json
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/selected-controls.json
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-plan-tasks.md
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/verification-summary.json
   - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/focused-test-summary.md
   metadata:
@@ -235,7 +213,7 @@ steps:
       - rejected
 - id: verify-work-item-security
   kind: validator
-  name: Materialize and validate the security review report
+  name: Materialize and validate the implementation security review report
   needs:
   - review-work-item-security
   command: python3 -m harness_codex.runtime.materialize_security_review --source .harness/runs/<RUN-ID>/steps/review-work-item-security/final-message.md --output .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review.md

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -248,8 +248,10 @@ steps:
     gate_id: token-observability
 - id: classify-verification-result
   kind: decision
-  name: Classify verification or security result
+  name: Classify verification or security result and choose the recovery owner
   needs:
+  - verify-work-item
+  - verify-work-item-security
   - collect-work-item-token-metrics
   metadata:
     stage: implementation
@@ -265,26 +267,25 @@ steps:
     - SCOPE_CONFLICT
     - SECURITY_REVIEW_FAILURE
     - VERIFICATION_GOAL_UNCLEAR
-    on_implementation_failure: remediate-work-item
+    on_implementation_failure: prepare-plan-repair
     on_unclear_e2e_goal: e2e-goal-approval
     on_document_delta_conflict: change-set-revision
     on_upstream_design_failure: upstream-design-stage
     on_environment_blocker: environment
     on_scope_conflict: change-set-revision
-    on_security_review_failure: security-review
+    on_security_review_failure: prepare-plan-repair
     on_verification_goal_unclear: verification-goal-approval
-- id: remediate-work-item
-  kind: record
-  name: Append remediation task and retry execution
+- id: prepare-plan-repair
+  kind: decision
+  name: Return a classified repair to the implementation planner
   needs:
   - classify-verification-result
-  outputs:
-  - docs/plans/active/<WORK-ITEM-ID>/plan.md
   metadata:
     stage: implementation
     scope: work_item
     execution_boundary: work_item
-    loop_target: execute-work-item
+    classifier: verification_result
+    loop_target: plan-work-item
     max_retry_count: 2
 - id: complete-work-item-plan
   kind: git

--- a/harness_codex/runtime/structured_verification_routing.py
+++ b/harness_codex/runtime/structured_verification_routing.py
@@ -32,6 +32,7 @@ _REPAIRABLE_FAILURES = {
 # Keep original methods before the patch replaces them. Generic workflows that
 # do not declare the classifier must retain the older execution semantics.
 _ORIGINAL_ENGINE_RUN = engine_module.RunnerEngine.run
+_ORIGINAL_FAILURE_DECISION_STEP = engine_module.RunnerEngine._failure_decision_step
 _ORIGINAL_STRUCTURED_VERIFICATION_RESULT = engine_module.RunnerEngine._structured_verification_result
 _ORIGINAL_RUN_AGENT = runner_module.BasicStepRunner._run_agent
 
@@ -44,6 +45,7 @@ def apply_structured_verification_routing() -> None:
 
     engine_module._failure_kind_for = _failure_kind_for
     engine_module.RunnerEngine.run = _run_with_classifier_context
+    engine_module.RunnerEngine._failure_decision_step = _failure_decision_step
     engine_module.RunnerEngine._run_runtime_step = _run_runtime_step
     engine_module.RunnerEngine._structured_verification_result = _structured_verification_result
     runner_module.BasicStepRunner._run_agent = _run_agent_with_scope_classifier
@@ -68,6 +70,24 @@ def _run_with_classifier_context(self: Any, workflow: Any, context: RunContext) 
             metadata={**dict(context.metadata), "classifier_first_recovery": True},
         )
     return _ORIGINAL_ENGINE_RUN(self, workflow, context)
+
+
+def _failure_decision_step(self: Any, execution_plan: Any, failed_step: Step) -> Step | None:
+    """Route executor failures to the workflow classifier even across success-only gates."""
+
+    direct = _ORIGINAL_FAILURE_DECISION_STEP(self, execution_plan, failed_step)
+    if direct is not None:
+        return direct
+    if failed_step.id != "execute-work-item":
+        return None
+    return next(
+        (
+            step
+            for step in execution_plan.steps
+            if step.id == "classify-verification-result" and step.kind == StepKind.DECISION
+        ),
+        None,
+    )
 
 
 def _run_agent_with_scope_classifier(

--- a/harness_codex/runtime/structured_verification_routing.py
+++ b/harness_codex/runtime/structured_verification_routing.py
@@ -1,8 +1,9 @@
-"""Route every implementation verification failure through the classifier.
+"""Route work-item verification failures through a durable classifier.
 
-The runtime owns recovery routing. A verifier supplies durable evidence, the
+For classifier-enabled ChangeSet workflows, a verifier supplies evidence, the
 classifier chooses the recovery owner, and only the implementation planner
-mutates the active plan on a retry.
+mutates the active plan on a retry. Legacy graphs without the classifier retain
+their existing generic engine behavior.
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ from typing import Any
 
 from harness_codex.runtime import engine as engine_module
 from harness_codex.runtime import runner as runner_module
-from harness_codex.runtime.models import FailureKind, Step, StepKind, StepResult, StepStatus
+from harness_codex.runtime.models import FailureKind, RunContext, Step, StepKind, StepResult, StepStatus
 from harness_codex.runtime.verification_failure import (
     VerificationFailure,
     VerificationFailureClass,
@@ -28,10 +29,10 @@ _REPAIRABLE_FAILURES = {
 }
 
 
-# Keep the original methods before the patch replaces them. They are used for
-# ordinary verify-work-item report parsing and executor invocation.
+# Keep original methods before the patch replaces them. Generic workflows that
+# do not declare the classifier must retain the older execution semantics.
+_ORIGINAL_ENGINE_RUN = engine_module.RunnerEngine.run
 _ORIGINAL_STRUCTURED_VERIFICATION_RESULT = engine_module.RunnerEngine._structured_verification_result
-_ORIGINAL_FAILURE_DECISION_STEP = engine_module.RunnerEngine._failure_decision_step
 _ORIGINAL_RUN_AGENT = runner_module.BasicStepRunner._run_agent
 
 
@@ -42,11 +43,9 @@ def apply_structured_verification_routing() -> None:
         return
 
     engine_module._failure_kind_for = _failure_kind_for
+    engine_module.RunnerEngine.run = _run_with_classifier_context
     engine_module.RunnerEngine._run_runtime_step = _run_runtime_step
     engine_module.RunnerEngine._structured_verification_result = _structured_verification_result
-    engine_module.RunnerEngine._failure_decision_step = _failure_decision_step
-    engine_module.RunnerEngine._should_restart_plan_after_failed_step = _never_restart_directly
-    engine_module.RunnerEngine._should_restart_plan_after_blocked_step = _never_restart_directly
     runner_module.BasicStepRunner._run_agent = _run_agent_with_scope_classifier
     from harness_codex.runtime.verification_repair_dashboard_patch import (
         install_verification_repair_dashboard_patch,
@@ -56,52 +55,64 @@ def apply_structured_verification_routing() -> None:
     engine_module.RunnerEngine._structured_verification_routing_applied = True
 
 
-def _never_restart_directly(*_args: object, **_kwargs: object) -> bool:
-    """All verifier and scope failures must pass the classifier before recovery."""
+def _run_with_classifier_context(self: Any, workflow: Any, context: RunContext) -> Any:
+    """Mark only workflows that opt into the classifier-first recovery contract."""
 
-    return False
-
-
-def _failure_decision_step(self: Any, execution_plan: Any, failed_step: Step) -> Step | None:
-    """Expose executor scope failures to the same classifier as verifier failures."""
-
-    direct = _ORIGINAL_FAILURE_DECISION_STEP(self, execution_plan, failed_step)
-    if direct is not None:
-        return direct
-    if failed_step.id == "execute-work-item":
-        return next(
-            (
-                step
-                for step in execution_plan.steps
-                if step.id == "classify-verification-result" and step.kind == StepKind.DECISION
-            ),
-            None,
+    has_classifier = any(
+        step.id == "classify-verification-result" and step.kind == StepKind.DECISION
+        for step in workflow.steps
+    )
+    if has_classifier:
+        context = replace(
+            context,
+            metadata={**dict(context.metadata), "classifier_first_recovery": True},
         )
-    return None
+    return _ORIGINAL_ENGINE_RUN(self, workflow, context)
 
 
 def _run_agent_with_scope_classifier(
     self: Any,
     step: Step,
-    context: Any,
+    context: RunContext,
     step_dir: Path,
 ) -> StepResult:
-    """Turn executor scope blocks into classifier-visible failures."""
+    """Make executor scope blocks visible to the classifier in opted-in workflows."""
 
     result = _ORIGINAL_RUN_AGENT(self, step, context, step_dir)
+    if not context.metadata.get("classifier_first_recovery"):
+        return result
     if (
-        step.id == "execute-work-item"
-        and result.status is StepStatus.BLOCKED
-        and result.metadata.get("scope_diff_status") == "blocked"
+        step.id != "execute-work-item"
+        or result.status is not StepStatus.BLOCKED
+        or result.metadata.get("scope_diff_status") != "blocked"
     ):
-        return replace(result, status=StepStatus.FAILED, failure_kind=FailureKind.SCOPE_CONFLICT)
-    return result
+        return result
+
+    report_path = str(result.metadata.get("scope_diff_report_path") or "")
+    failure = VerificationFailure(
+        failure_class=VerificationFailureClass.SCOPE_CONFLICT,
+        owner_stage="changeset",
+        recommended_resume_target="change-set-revision",
+        evidence=(report_path,) if report_path else (),
+    )
+    return replace(
+        result,
+        status=StepStatus.FAILED,
+        # Implementation permits the engine's remediation path to invoke the
+        # classifier. The durable failure class below preserves the true cause.
+        failure_kind=FailureKind.IMPLEMENTATION,
+        metadata={
+            **dict(result.metadata),
+            "runtime_failure_class": failure.failure_class.value,
+            "verification_failure": failure.as_dict(),
+        },
+    )
 
 
 def _structured_verification_result(
     self: Any,
     step: Step,
-    context: Any,
+    context: RunContext,
     result: StepResult,
 ) -> StepResult:
     """Use verifier/security-review evidence instead of generic shell failures."""
@@ -137,13 +148,31 @@ def _structured_verification_result(
                 "verification_failure": failure.as_dict(),
             },
         )
-    return _ORIGINAL_STRUCTURED_VERIFICATION_RESULT(self, step, context, result)
+
+    structured = _ORIGINAL_STRUCTURED_VERIFICATION_RESULT(self, step, context, result)
+    if (
+        context.metadata.get("classifier_first_recovery")
+        and structured.status is StepStatus.FAILED
+        and structured.failure_kind is FailureKind.SCOPE_CONFLICT
+        and isinstance(structured.metadata.get("verification_failure"), dict)
+    ):
+        return replace(
+            structured,
+            # Avoid the engine's legacy direct scope-restart shortcut. The
+            # classifier receives the original scope failure below.
+            failure_kind=FailureKind.IMPLEMENTATION,
+            metadata={
+                **dict(structured.metadata),
+                "runtime_failure_class": VerificationFailureClass.SCOPE_CONFLICT.value,
+            },
+        )
+    return structured
 
 
 def _run_runtime_step(
     self: Any,
     step: Step,
-    context: Any,
+    context: RunContext,
     results: list[StepResult],
     *,
     retry_count: int,
@@ -174,7 +203,7 @@ def _run_runtime_step(
 
 def _structured_decision_result(
     step: Step,
-    context: Any,
+    context: RunContext,
     failed_result: StepResult,
 ) -> StepResult | None:
     """Persist a deterministic classifier decision from durable failure evidence."""
@@ -243,7 +272,7 @@ def _route_for_failure(
     return fallback
 
 
-def _write_decision_evidence(context: Any, step: Step, decision: dict[str, object]) -> Path:
+def _write_decision_evidence(context: RunContext, step: Step, decision: dict[str, object]) -> Path:
     path = context.run_dir / "steps" / step.id / "decision.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -256,7 +285,7 @@ def _write_decision_evidence(context: Any, step: Step, decision: dict[str, objec
     return path
 
 
-def _relative_to_repo(path: Path, context: Any) -> Path:
+def _relative_to_repo(path: Path, context: RunContext) -> Path:
     try:
         return path.relative_to(context.repo_root)
     except ValueError:

--- a/harness_codex/runtime/structured_verification_routing.py
+++ b/harness_codex/runtime/structured_verification_routing.py
@@ -48,6 +48,11 @@ def apply_structured_verification_routing() -> None:
     engine_module.RunnerEngine._should_restart_plan_after_failed_step = _never_restart_directly
     engine_module.RunnerEngine._should_restart_plan_after_blocked_step = _never_restart_directly
     runner_module.BasicStepRunner._run_agent = _run_agent_with_scope_classifier
+    from harness_codex.runtime.verification_repair_dashboard_patch import (
+        install_verification_repair_dashboard_patch,
+    )
+
+    install_verification_repair_dashboard_patch()
     engine_module.RunnerEngine._structured_verification_routing_applied = True
 
 

--- a/harness_codex/runtime/structured_verification_routing.py
+++ b/harness_codex/runtime/structured_verification_routing.py
@@ -1,33 +1,119 @@
-"""Integrate verifier-report routing into the existing engine boundary.
+"""Route every implementation verification failure through the classifier.
 
-The generic step runner must not execute a decision agent when a verifier has
-already persisted a structured failure report. This adapter materializes that
-decision as a durable run artifact and leaves only implementation failures
-eligible for the remediation loop.
+The runtime owns recovery routing. A verifier supplies durable evidence, the
+classifier chooses the recovery owner, and only the implementation planner
+mutates the active plan on a retry.
 """
 
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
 from harness_codex.runtime import engine as engine_module
+from harness_codex.runtime import runner as runner_module
 from harness_codex.runtime.models import FailureKind, Step, StepKind, StepResult, StepStatus
 from harness_codex.runtime.verification_failure import (
+    VerificationFailure,
     VerificationFailureClass,
     structured_failure_from_report,
 )
 
 
+_REPAIRABLE_FAILURES = {
+    VerificationFailureClass.IMPLEMENTATION_FAILURE,
+    VerificationFailureClass.SECURITY_REVIEW_FAILURE,
+}
+
+
 def apply_structured_verification_routing() -> None:
-    """Install durable verifier-result routing once after the engine is imported."""
+    """Install classifier-first recovery behavior once after engine import."""
 
     if getattr(engine_module.RunnerEngine, "_structured_verification_routing_applied", False):
         return
+
     engine_module._failure_kind_for = _failure_kind_for
     engine_module.RunnerEngine._run_runtime_step = _run_runtime_step
+    engine_module.RunnerEngine._structured_verification_result = _structured_verification_result
+    engine_module.RunnerEngine._should_restart_plan_after_failed_step = _never_restart_directly
+    engine_module.RunnerEngine._should_restart_plan_after_blocked_step = _never_restart_directly
+    runner_module.BasicStepRunner._run_agent = _run_agent_with_scope_classifier
     engine_module.RunnerEngine._structured_verification_routing_applied = True
+
+
+def _never_restart_directly(*_args: object, **_kwargs: object) -> bool:
+    """All verifier/scope failures must pass the classifier before recovery."""
+
+    return False
+
+
+def _run_agent_with_scope_classifier(
+    self: Any,
+    step: Step,
+    context: Any,
+    step_dir: Path,
+) -> StepResult:
+    """Turn executor scope blocks into classifier-visible failures."""
+
+    original = getattr(self, "_harness_original_run_agent", None)
+    if original is None:
+        original = runner_module.BasicStepRunner._run_agent
+    result = original(self, step, context, step_dir)
+    if (
+        step.id == "execute-work-item"
+        and result.status is StepStatus.BLOCKED
+        and result.metadata.get("scope_diff_status") == "blocked"
+    ):
+        return replace(result, status=StepStatus.FAILED, failure_kind=FailureKind.SCOPE_CONFLICT)
+    return result
+
+
+def _structured_verification_result(
+    self: Any,
+    step: Step,
+    context: Any,
+    result: StepResult,
+) -> StepResult:
+    """Use verifier/security-review evidence instead of generic shell failures."""
+
+    original = getattr(self, "_harness_original_structured_verification_result", None)
+    if original is None:
+        original = engine_module.RunnerEngine._structured_verification_result
+
+    if step.id == "verify-work-item-security" and result.status is StepStatus.FAILED:
+        work_item_id = str(context.metadata.get("active_work_item_id") or "")
+        security_review_path = (
+            context.repo_root
+            / ".harness"
+            / "runs"
+            / context.run_id
+            / "work-items"
+            / work_item_id
+            / "security"
+            / "security-review.md"
+        )
+        failure = VerificationFailure(
+            failure_class=VerificationFailureClass.SECURITY_REVIEW_FAILURE,
+            owner_stage="implementation-planner",
+            recommended_resume_target="prepare-plan-repair",
+            evidence=(str(security_review_path.relative_to(context.repo_root)),)
+            if security_review_path.exists()
+            else (),
+        )
+        return replace(
+            result,
+            error=result.error or "security review rejected",
+            failure_kind=FailureKind.IMPLEMENTATION,
+            metadata={
+                **dict(result.metadata),
+                "runtime_failure_class": failure.failure_class.value,
+                "security_review_path": str(security_review_path.relative_to(context.repo_root)),
+                "verification_failure": failure.as_dict(),
+            },
+        )
+    return original(self, step, context, result)
 
 
 def _run_runtime_step(
@@ -46,6 +132,15 @@ def _run_runtime_step(
         failed_step=failed_step,
         failed_result=failed_result,
     )
+    runtime_failure_class = failed_result.metadata.get("runtime_failure_class")
+    if isinstance(runtime_failure_class, str) and runtime_failure_class:
+        runtime_context = replace(
+            runtime_context,
+            metadata={
+                **dict(runtime_context.metadata),
+                "runtime_failure_kind": runtime_failure_class,
+            },
+        )
     result = _structured_decision_result(step, runtime_context, failed_result)
     if result is None:
         result = self._step_runner.run(step, runtime_context)
@@ -58,7 +153,7 @@ def _structured_decision_result(
     context: Any,
     failed_result: StepResult,
 ) -> StepResult | None:
-    """Use a durable verifier report instead of asking a runner to classify it."""
+    """Persist a deterministic classifier decision from durable failure evidence."""
 
     if step.kind != StepKind.DECISION:
         return None
@@ -69,10 +164,12 @@ def _structured_decision_result(
     if failure is None:
         return None
 
-    blocked = failure.failure_class is not VerificationFailureClass.IMPLEMENTATION_FAILURE
+    route = _route_for_failure(step, failure.failure_class, failure.recommended_resume_target)
+    repairable = failure.failure_class in _REPAIRABLE_FAILURES
+    blocked = not repairable
     reason = (
         f"verification classified as {failure.failure_class.value}; "
-        f"resume at {failure.recommended_resume_target}"
+        f"route to {route}"
     )
     decision = {
         "classifier": "verification_result",
@@ -82,10 +179,11 @@ def _structured_decision_result(
         "source_failure_kind": (
             failed_result.failure_kind.value if failed_result.failure_kind is not None else None
         ),
-        "route": failure.recommended_resume_target,
-        "recommended_resume_target": failure.recommended_resume_target,
+        "route": route,
+        "recommended_resume_target": route,
+        "retry_count": context.metadata.get("runtime_retry_count", 0),
         "blocked": blocked,
-        "owner_stage": failure.owner_stage,
+        "owner_stage": "implementation-planner" if repairable else failure.owner_stage,
         "reason": reason,
         "evidence": list(failure.evidence),
     }
@@ -101,6 +199,27 @@ def _structured_decision_result(
             "verification_failure": failure.as_dict(),
         },
     )
+
+
+def _route_for_failure(
+    step: Step,
+    failure_class: VerificationFailureClass,
+    fallback: str,
+) -> str:
+    metadata_key = {
+        VerificationFailureClass.IMPLEMENTATION_FAILURE: "on_implementation_failure",
+        VerificationFailureClass.SECURITY_REVIEW_FAILURE: "on_security_review_failure",
+        VerificationFailureClass.UNCLEAR_E2E_GOAL: "on_unclear_e2e_goal",
+        VerificationFailureClass.DOCUMENT_DELTA_CONFLICT: "on_document_delta_conflict",
+        VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: "on_upstream_design_failure",
+        VerificationFailureClass.ENVIRONMENT_BLOCKER: "on_environment_blocker",
+        VerificationFailureClass.SCOPE_CONFLICT: "on_scope_conflict",
+        VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: "on_verification_goal_unclear",
+    }.get(failure_class)
+    configured = step.metadata.get(metadata_key) if metadata_key else None
+    if isinstance(configured, str) and configured:
+        return configured
+    return fallback
 
 
 def _write_decision_evidence(context: Any, step: Step, decision: dict[str, object]) -> Path:
@@ -131,7 +250,15 @@ def _failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
         VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: FailureKind.UPSTREAM_DESIGN,
         VerificationFailureClass.ENVIRONMENT_BLOCKER: FailureKind.ENVIRONMENT_BLOCKER,
         VerificationFailureClass.SCOPE_CONFLICT: FailureKind.SCOPE_CONFLICT,
-        VerificationFailureClass.SECURITY_REVIEW_FAILURE: FailureKind.UNKNOWN,
+        # The classifier exposes the explicit security class in decision metadata.
+        # FailureKind has no separate persisted enum member in older saved runs.
+        VerificationFailureClass.SECURITY_REVIEW_FAILURE: FailureKind.IMPLEMENTATION,
         VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: FailureKind.VERIFICATION_GOAL_UNCLEAR,
     }
     return mapping[failure_class]
+
+
+# Keep the original bound methods before the patch replaces them. They are used
+# for ordinary verify-work-item report parsing and agent execution.
+engine_module.RunnerEngine._harness_original_structured_verification_result = engine_module.RunnerEngine._structured_verification_result
+runner_module.BasicStepRunner._harness_original_run_agent = runner_module.BasicStepRunner._run_agent

--- a/harness_codex/runtime/structured_verification_routing.py
+++ b/harness_codex/runtime/structured_verification_routing.py
@@ -29,8 +29,6 @@ _REPAIRABLE_FAILURES = {
 }
 
 
-# Keep original methods before the patch replaces them. Generic workflows that
-# do not declare the classifier must retain the older execution semantics.
 _ORIGINAL_ENGINE_RUN = engine_module.RunnerEngine.run
 _ORIGINAL_FAILURE_DECISION_STEP = engine_module.RunnerEngine._failure_decision_step
 _ORIGINAL_STRUCTURED_VERIFICATION_RESULT = engine_module.RunnerEngine._structured_verification_result
@@ -49,17 +47,13 @@ def apply_structured_verification_routing() -> None:
     engine_module.RunnerEngine._run_runtime_step = _run_runtime_step
     engine_module.RunnerEngine._structured_verification_result = _structured_verification_result
     runner_module.BasicStepRunner._run_agent = _run_agent_with_scope_classifier
-    from harness_codex.runtime.verification_repair_dashboard_patch import (
-        install_verification_repair_dashboard_patch,
-    )
+    from harness_codex.runtime.verification_repair_dashboard_patch import install_verification_repair_dashboard_patch
 
     install_verification_repair_dashboard_patch()
     engine_module.RunnerEngine._structured_verification_routing_applied = True
 
 
 def _run_with_classifier_context(self: Any, workflow: Any, context: RunContext) -> Any:
-    """Mark only workflows that opt into the classifier-first recovery contract."""
-
     has_classifier = any(
         step.id == "classify-verification-result" and step.kind == StepKind.DECISION
         for step in workflow.steps
@@ -73,8 +67,6 @@ def _run_with_classifier_context(self: Any, workflow: Any, context: RunContext) 
 
 
 def _failure_decision_step(self: Any, execution_plan: Any, failed_step: Step) -> Step | None:
-    """Route executor failures to the workflow classifier even across success-only gates."""
-
     direct = _ORIGINAL_FAILURE_DECISION_STEP(self, execution_plan, failed_step)
     if direct is not None:
         return direct
@@ -96,8 +88,6 @@ def _run_agent_with_scope_classifier(
     context: RunContext,
     step_dir: Path,
 ) -> StepResult:
-    """Make executor scope blocks visible to the classifier in opted-in workflows."""
-
     result = _ORIGINAL_RUN_AGENT(self, step, context, step_dir)
     if not context.metadata.get("classifier_first_recovery"):
         return result
@@ -118,8 +108,6 @@ def _run_agent_with_scope_classifier(
     return replace(
         result,
         status=StepStatus.FAILED,
-        # Implementation permits the engine's remediation path to invoke the
-        # classifier. The durable failure class below preserves the true cause.
         failure_kind=FailureKind.IMPLEMENTATION,
         metadata={
             **dict(result.metadata),
@@ -135,8 +123,6 @@ def _structured_verification_result(
     context: RunContext,
     result: StepResult,
 ) -> StepResult:
-    """Use verifier/security-review evidence instead of generic shell failures."""
-
     if step.id == "verify-work-item-security" and result.status is StepStatus.FAILED:
         work_item_id = str(context.metadata.get("active_work_item_id") or "")
         security_review_path = (
@@ -178,8 +164,6 @@ def _structured_verification_result(
     ):
         return replace(
             structured,
-            # Avoid the engine's legacy direct scope-restart shortcut. The
-            # classifier receives the original scope failure below.
             failure_kind=FailureKind.IMPLEMENTATION,
             metadata={
                 **dict(structured.metadata),
@@ -207,13 +191,15 @@ def _run_runtime_step(
     )
     runtime_failure_class = failed_result.metadata.get("runtime_failure_class")
     if isinstance(runtime_failure_class, str) and runtime_failure_class:
-        runtime_context = replace(
-            runtime_context,
-            metadata={
-                **dict(runtime_context.metadata),
-                "runtime_failure_kind": runtime_failure_class,
-            },
-        )
+        runtime_metadata = dict(runtime_context.metadata)
+        if runtime_failure_class != VerificationFailureClass.SECURITY_REVIEW_FAILURE.value:
+            runtime_metadata["runtime_failure_kind"] = runtime_failure_class
+        runtime_metadata["runtime_failure_class"] = runtime_failure_class
+        runtime_context = replace(runtime_context, metadata=runtime_metadata)
+
+    if isinstance(context.metadata, dict):
+        context.metadata.update(dict(runtime_context.metadata))
+
     result = _structured_decision_result(step, runtime_context, failed_result)
     if result is None:
         result = self._step_runner.run(step, runtime_context)
@@ -226,8 +212,6 @@ def _structured_decision_result(
     context: RunContext,
     failed_result: StepResult,
 ) -> StepResult | None:
-    """Persist a deterministic classifier decision from durable failure evidence."""
-
     if step.kind != StepKind.DECISION:
         return None
     raw_failure = failed_result.metadata.get("verification_failure")
@@ -320,8 +304,6 @@ def _failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
         VerificationFailureClass.UPSTREAM_DESIGN_CONFLICT: FailureKind.UPSTREAM_DESIGN,
         VerificationFailureClass.ENVIRONMENT_BLOCKER: FailureKind.ENVIRONMENT_BLOCKER,
         VerificationFailureClass.SCOPE_CONFLICT: FailureKind.SCOPE_CONFLICT,
-        # The classifier exposes the explicit security class in decision metadata.
-        # FailureKind has no separate persisted enum member in older saved runs.
         VerificationFailureClass.SECURITY_REVIEW_FAILURE: FailureKind.IMPLEMENTATION,
         VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: FailureKind.VERIFICATION_GOAL_UNCLEAR,
     }

--- a/harness_codex/runtime/structured_verification_routing.py
+++ b/harness_codex/runtime/structured_verification_routing.py
@@ -28,6 +28,13 @@ _REPAIRABLE_FAILURES = {
 }
 
 
+# Keep the original methods before the patch replaces them. They are used for
+# ordinary verify-work-item report parsing and executor invocation.
+_ORIGINAL_STRUCTURED_VERIFICATION_RESULT = engine_module.RunnerEngine._structured_verification_result
+_ORIGINAL_FAILURE_DECISION_STEP = engine_module.RunnerEngine._failure_decision_step
+_ORIGINAL_RUN_AGENT = runner_module.BasicStepRunner._run_agent
+
+
 def apply_structured_verification_routing() -> None:
     """Install classifier-first recovery behavior once after engine import."""
 
@@ -37,6 +44,7 @@ def apply_structured_verification_routing() -> None:
     engine_module._failure_kind_for = _failure_kind_for
     engine_module.RunnerEngine._run_runtime_step = _run_runtime_step
     engine_module.RunnerEngine._structured_verification_result = _structured_verification_result
+    engine_module.RunnerEngine._failure_decision_step = _failure_decision_step
     engine_module.RunnerEngine._should_restart_plan_after_failed_step = _never_restart_directly
     engine_module.RunnerEngine._should_restart_plan_after_blocked_step = _never_restart_directly
     runner_module.BasicStepRunner._run_agent = _run_agent_with_scope_classifier
@@ -44,9 +52,27 @@ def apply_structured_verification_routing() -> None:
 
 
 def _never_restart_directly(*_args: object, **_kwargs: object) -> bool:
-    """All verifier/scope failures must pass the classifier before recovery."""
+    """All verifier and scope failures must pass the classifier before recovery."""
 
     return False
+
+
+def _failure_decision_step(self: Any, execution_plan: Any, failed_step: Step) -> Step | None:
+    """Expose executor scope failures to the same classifier as verifier failures."""
+
+    direct = _ORIGINAL_FAILURE_DECISION_STEP(self, execution_plan, failed_step)
+    if direct is not None:
+        return direct
+    if failed_step.id == "execute-work-item":
+        return next(
+            (
+                step
+                for step in execution_plan.steps
+                if step.id == "classify-verification-result" and step.kind == StepKind.DECISION
+            ),
+            None,
+        )
+    return None
 
 
 def _run_agent_with_scope_classifier(
@@ -57,10 +83,7 @@ def _run_agent_with_scope_classifier(
 ) -> StepResult:
     """Turn executor scope blocks into classifier-visible failures."""
 
-    original = getattr(self, "_harness_original_run_agent", None)
-    if original is None:
-        original = runner_module.BasicStepRunner._run_agent
-    result = original(self, step, context, step_dir)
+    result = _ORIGINAL_RUN_AGENT(self, step, context, step_dir)
     if (
         step.id == "execute-work-item"
         and result.status is StepStatus.BLOCKED
@@ -77,10 +100,6 @@ def _structured_verification_result(
     result: StepResult,
 ) -> StepResult:
     """Use verifier/security-review evidence instead of generic shell failures."""
-
-    original = getattr(self, "_harness_original_structured_verification_result", None)
-    if original is None:
-        original = engine_module.RunnerEngine._structured_verification_result
 
     if step.id == "verify-work-item-security" and result.status is StepStatus.FAILED:
         work_item_id = str(context.metadata.get("active_work_item_id") or "")
@@ -113,7 +132,7 @@ def _structured_verification_result(
                 "verification_failure": failure.as_dict(),
             },
         )
-    return original(self, step, context, result)
+    return _ORIGINAL_STRUCTURED_VERIFICATION_RESULT(self, step, context, result)
 
 
 def _run_runtime_step(
@@ -167,10 +186,7 @@ def _structured_decision_result(
     route = _route_for_failure(step, failure.failure_class, failure.recommended_resume_target)
     repairable = failure.failure_class in _REPAIRABLE_FAILURES
     blocked = not repairable
-    reason = (
-        f"verification classified as {failure.failure_class.value}; "
-        f"route to {route}"
-    )
+    reason = f"verification classified as {failure.failure_class.value}; route to {route}"
     decision = {
         "classifier": "verification_result",
         "decision": failure.failure_class.name,
@@ -256,9 +272,3 @@ def _failure_kind_for(failure_class: VerificationFailureClass) -> FailureKind:
         VerificationFailureClass.VERIFICATION_GOAL_UNCLEAR: FailureKind.VERIFICATION_GOAL_UNCLEAR,
     }
     return mapping[failure_class]
-
-
-# Keep the original bound methods before the patch replaces them. They are used
-# for ordinary verify-work-item report parsing and agent execution.
-engine_module.RunnerEngine._harness_original_structured_verification_result = engine_module.RunnerEngine._structured_verification_result
-runner_module.BasicStepRunner._harness_original_run_agent = runner_module.BasicStepRunner._run_agent

--- a/harness_codex/runtime/verification_repair_dashboard_patch.py
+++ b/harness_codex/runtime/verification_repair_dashboard_patch.py
@@ -69,7 +69,9 @@ def _recovery_state(root: Path, change_set_id: str) -> dict[str, Any]:
     relevant = [item for item in events if item["decision"] != "VERIFICATION_PASSED"]
     last = relevant[-1] if relevant else None
     recovered_after_last_failure = bool(last and any(
-        item["decision"] == "VERIFICATION_PASSED" and item["timestamp"] > last["timestamp"]
+        item["decision"] == "VERIFICATION_PASSED"
+        and item["work_item_id"] == last["work_item_id"]
+        and item["timestamp"] > last["timestamp"]
         for item in events
     ))
     status = "recovered" if recovered_after_last_failure else _recovery_status(last)

--- a/harness_codex/runtime/verification_repair_dashboard_patch.py
+++ b/harness_codex/runtime/verification_repair_dashboard_patch.py
@@ -89,9 +89,8 @@ def _work_item_ids(root: Path, change_set_id: str) -> set[str]:
     if not change_set_path.is_file():
         return set()
     return {
-        part.name
-        for part in (root / "docs" / "plans" / "active").glob("*/plan.md")
-        if part.parent.name
+        plan_path.parent.name
+        for plan_path in (root / "docs" / "plans" / "active").glob("*/plan.md")
     }
 
 

--- a/harness_codex/runtime/verification_repair_dashboard_patch.py
+++ b/harness_codex/runtime/verification_repair_dashboard_patch.py
@@ -138,16 +138,16 @@ def _patch_dashboard_script(script: str) -> str:
     helper = '''function renderImplementationRecovery(recovery) {
   if (!recovery || recovery.status === "idle") return "";
   const active = recovery.active;
-  const status = recovery.status === "recovered" ? "recovered" : recovery.status;
-  const flow = "Verification → Classifier → Plan patch → Plan review → Scope → Implementation";
+  const status = recovery.status === "recovered" ? "복구 완료" : recovery.status === "planner-retry" ? "계획 보정 후 재시도" : "차단";
+  const flow = "검증 → 실패 분류 → 계획 보정 → 계획 검토 → 범위 확정 → 재구현";
   const summary = active
-    ? `<p class="small"><strong>${escapeHtml(active.failure_class || active.decision)}</strong> at <code>${escapeHtml(active.failed_step_id || "verification")}</code> · route <code>${escapeHtml(active.route || "blocked")}</code> · retry ${escapeHtml(active.retry_count || 0)}</p>
+    ? `<p class="small"><strong>${escapeHtml(active.failure_class || active.decision)}</strong> · 실패 단계 <code>${escapeHtml(active.failed_step_id || "verification")}</code> · 경로 <code>${escapeHtml(active.route || "blocked")}</code> · 재시도 ${escapeHtml(active.retry_count || 0)}회</p>
        <p class="small">${escapeHtml(active.reason || "")}</p>
-       ${(active.evidence || []).length ? `<p class="small">Evidence: ${(active.evidence || []).map((item) => `<code>${escapeHtml(item)}</code>`).join(" ")}</p>` : ""}`
-    : "<p class=\"small\">A prior failed attempt was repaired and later verification passed.</p>";
-  const history = (recovery.history || []).map((item) => `<li><code>${escapeHtml(item.work_item_id || "work-item")}</code> · ${escapeHtml(item.decision)} → <code>${escapeHtml(item.route || "complete")}</code>${item.retry_count ? ` (retry ${escapeHtml(item.retry_count)})` : ""}</li>`).join("");
+       ${(active.evidence || []).length ? `<p class="small">증거: ${(active.evidence || []).map((item) => `<code>${escapeHtml(item)}</code>`).join(" ")}</p>` : ""}`
+    : "<p class=\"small\">이전 실패를 보정한 뒤 후속 검증을 통과했습니다.</p>";
+  const history = (recovery.history || []).map((item) => `<li><code>${escapeHtml(item.work_item_id || "work-item")}</code> · ${escapeHtml(item.decision)} → <code>${escapeHtml(item.route || "complete")}</code>${item.retry_count ? ` (재시도 ${escapeHtml(item.retry_count)}회)` : ""}</li>`).join("");
   return `<details class="implementation-job verification-recovery" open>
-    <summary>Failure recovery: ${escapeHtml(status)}</summary>
+    <summary>실패 재처리: ${escapeHtml(status)}</summary>
     <p class="small">${flow}</p>
     ${summary}
     ${history ? `<ol class="small">${history}</ol>` : ""}

--- a/harness_codex/runtime/verification_repair_dashboard_patch.py
+++ b/harness_codex/runtime/verification_repair_dashboard_patch.py
@@ -1,0 +1,164 @@
+"""Expose classifier-driven repair attempts in the ChangeSet dashboard."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+_PATCHED_ATTR = "_harness_verification_repair_dashboard_patch_applied"
+
+
+def install_verification_repair_dashboard_patch() -> None:
+    """Attach recovery state and JavaScript rendering to the existing UI patch."""
+
+    from harness_codex.runtime import dashboard_ddd_integration_ui_patch as ddd_patch
+
+    if getattr(ddd_patch, _PATCHED_ATTR, False):
+        return
+
+    original_apply = ddd_patch.apply_dashboard_ddd_integration_ui_patch
+
+    def apply_with_verification_repair_ui() -> None:
+        original_apply()
+        _apply_runtime_state_projection()
+        _apply_dashboard_script_projection(ddd_patch)
+
+    ddd_patch.apply_dashboard_ddd_integration_ui_patch = apply_with_verification_repair_ui
+    setattr(ddd_patch, _PATCHED_ATTR, True)
+
+
+def _apply_runtime_state_projection() -> None:
+    from harness_codex.runtime import ui_server
+
+    if getattr(ui_server, _PATCHED_ATTR, False):
+        return
+    original = ui_server.implementation_progress_state
+
+    def implementation_progress_with_recovery(repo_root: Path | str, change_set_id: str) -> dict[str, Any]:
+        state = original(repo_root, change_set_id)
+        state["recovery"] = _recovery_state(Path(repo_root).resolve(), change_set_id)
+        return state
+
+    ui_server.implementation_progress_state = implementation_progress_with_recovery
+    setattr(ui_server, _PATCHED_ATTR, True)
+
+
+def _apply_dashboard_script_projection(ddd_patch: Any) -> None:
+    if getattr(ddd_patch, "_harness_verification_repair_script_patch_applied", False):
+        return
+    original = ddd_patch._patch_dashboard_script
+
+    def patch_dashboard_script_with_recovery(script: str) -> str:
+        return _patch_dashboard_script(original(script))
+
+    ddd_patch._patch_dashboard_script = patch_dashboard_script_with_recovery
+    setattr(ddd_patch, "_harness_verification_repair_script_patch_applied", True)
+
+
+def _recovery_state(root: Path, change_set_id: str) -> dict[str, Any]:
+    work_item_ids = _work_item_ids(root, change_set_id)
+    events: list[dict[str, Any]] = []
+    for path in (root / ".harness" / "runs").glob("**/steps/classify-verification-result/decision.json"):
+        event = _read_decision(path, change_set_id, work_item_ids)
+        if event is not None:
+            events.append(event)
+    events.sort(key=lambda item: item["timestamp"])
+
+    relevant = [item for item in events if item["decision"] != "VERIFICATION_PASSED"]
+    last = relevant[-1] if relevant else None
+    recovered_after_last_failure = bool(last and any(
+        item["decision"] == "VERIFICATION_PASSED" and item["timestamp"] > last["timestamp"]
+        for item in events
+    ))
+    status = "recovered" if recovered_after_last_failure else _recovery_status(last)
+    return {
+        "status": status,
+        "attempt_count": max((int(item.get("retry_count") or 0) for item in relevant), default=0),
+        "active": None if recovered_after_last_failure else last,
+        "history": [
+            {key: value for key, value in item.items() if key != "timestamp"}
+            for item in events[-8:]
+        ],
+    }
+
+
+def _work_item_ids(root: Path, change_set_id: str) -> set[str]:
+    change_set_path = root / "docs" / "changes" / "active" / f"{change_set_id}.md"
+    if not change_set_path.is_file():
+        return set()
+    return {
+        part.name
+        for part in (root / "docs" / "plans" / "active").glob("*/plan.md")
+        if part.parent.name
+    }
+
+
+def _read_decision(path: Path, change_set_id: str, work_item_ids: set[str]) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("change_set_id") != change_set_id:
+        return None
+    work_item_id = str(data.get("work_item_id") or "")
+    if work_item_ids and work_item_id not in work_item_ids:
+        return None
+    decision = str(data.get("decision") or "")
+    if not decision:
+        return None
+    return {
+        "timestamp": path.stat().st_mtime,
+        "work_item_id": work_item_id,
+        "decision": decision,
+        "failure_class": str(data.get("failure_class") or ""),
+        "failed_step_id": str(data.get("failed_step_id") or ""),
+        "route": str(data.get("route") or ""),
+        "owner_stage": str(data.get("owner_stage") or ""),
+        "retry_count": int(data.get("retry_count") or 0),
+        "reason": str(data.get("reason") or ""),
+        "evidence": [str(item) for item in data.get("evidence", []) if str(item)],
+    }
+
+
+def _recovery_status(event: dict[str, Any] | None) -> str:
+    if event is None:
+        return "idle"
+    if event.get("route") == "prepare-plan-repair":
+        return "planner-retry"
+    return "blocked"
+
+
+def _patch_dashboard_script(script: str) -> str:
+    if "function renderImplementationRecovery(recovery)" in script:
+        return script
+    source = "function renderImplementationWorkspace() {"
+    helper = '''function renderImplementationRecovery(recovery) {
+  if (!recovery || recovery.status === "idle") return "";
+  const active = recovery.active;
+  const status = recovery.status === "recovered" ? "recovered" : recovery.status;
+  const flow = "Verification → Classifier → Plan patch → Plan review → Scope → Implementation";
+  const summary = active
+    ? `<p class="small"><strong>${escapeHtml(active.failure_class || active.decision)}</strong> at <code>${escapeHtml(active.failed_step_id || "verification")}</code> · route <code>${escapeHtml(active.route || "blocked")}</code> · retry ${escapeHtml(active.retry_count || 0)}</p>
+       <p class="small">${escapeHtml(active.reason || "")}</p>
+       ${(active.evidence || []).length ? `<p class="small">Evidence: ${(active.evidence || []).map((item) => `<code>${escapeHtml(item)}</code>`).join(" ")}</p>` : ""}`
+    : "<p class=\"small\">A prior failed attempt was repaired and later verification passed.</p>";
+  const history = (recovery.history || []).map((item) => `<li><code>${escapeHtml(item.work_item_id || "work-item")}</code> · ${escapeHtml(item.decision)} → <code>${escapeHtml(item.route || "complete")}</code>${item.retry_count ? ` (retry ${escapeHtml(item.retry_count)})` : ""}</li>`).join("");
+  return `<details class="implementation-job verification-recovery" open>
+    <summary>Failure recovery: ${escapeHtml(status)}</summary>
+    <p class="small">${flow}</p>
+    ${summary}
+    ${history ? `<ol class="small">${history}</ol>` : ""}
+  </details>`;
+}
+
+function renderImplementationWorkspace() {'''
+    if source not in script:
+        raise RuntimeError("dashboard.js compatibility patch could not find implementation workspace")
+    patched = script.replace(source, helper, 1)
+    source_heading = "      <h3>Implementation</h3>"
+    target_heading = "      <h3>Implementation</h3>\n      ${renderImplementationRecovery(state?.recovery)}"
+    if source_heading not in patched:
+        raise RuntimeError("dashboard.js compatibility patch could not find implementation heading")
+    return patched.replace(source_heading, target_heading, 1)

--- a/tests/runtime/test_planner_retry_context.py
+++ b/tests/runtime/test_planner_retry_context.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_codex.runtime.engine import RunnerEngine
+from harness_codex.runtime.models import (
+    FailureKind,
+    RunContext,
+    RunMode,
+    RunStatus,
+    Step,
+    StepKind,
+    StepResult,
+    StepStatus,
+    Workflow,
+)
+
+
+class _RetryContextRunner:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.contexts: dict[str, list[RunContext]] = {}
+        self.verify_attempt = 0
+
+    def run(self, step: Step, context: RunContext) -> StepResult:
+        self.calls.append(step.id)
+        self.contexts.setdefault(step.id, []).append(context)
+        if step.id == "verify-work-item":
+            self.verify_attempt += 1
+            if self.verify_attempt == 1:
+                return StepResult(
+                    step_id=step.id,
+                    status=StepStatus.FAILED,
+                    error="focused test failed",
+                    failure_kind=FailureKind.IMPLEMENTATION,
+                    metadata={
+                        "verification_failure": {
+                            "failure_class": "implementation_failure",
+                            "owner_stage": "implementation",
+                            "recommended_resume_target": "prepare-plan-repair",
+                            "evidence": ["verification/report.json"],
+                        }
+                    },
+                )
+        return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
+
+
+def test_planner_receives_runtime_failure_context_after_classifier_retry(tmp_path: Path) -> None:
+    workflow = Workflow(
+        name="planner-retry-context",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="plan-work-item", kind=StepKind.AGENT, name="plan"),
+            Step(
+                id="execute-work-item",
+                kind=StepKind.AGENT,
+                name="execute",
+                needs=("plan-work-item",),
+            ),
+            Step(
+                id="verify-work-item",
+                kind=StepKind.VALIDATOR,
+                name="verify",
+                needs=("execute-work-item",),
+            ),
+            Step(
+                id="classify-verification-result",
+                kind=StepKind.DECISION,
+                name="classify",
+                needs=("verify-work-item",),
+                metadata={"on_implementation_failure": "prepare-plan-repair"},
+            ),
+            Step(
+                id="prepare-plan-repair",
+                kind=StepKind.DECISION,
+                name="repair handoff",
+                needs=("classify-verification-result",),
+                metadata={"loop_target": "plan-work-item"},
+            ),
+        ),
+    )
+    context = RunContext(
+        run_id="run-planner-retry",
+        workflow_name="planner-retry-context",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=tmp_path / ".harness/runs/run-planner-retry",
+        metadata={"active_work_item_id": "UC-001"},
+    )
+    runner = _RetryContextRunner()
+
+    result = RunnerEngine(runner).run(workflow, context)
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert result.retry_count == 1
+    assert runner.calls == [
+        "plan-work-item",
+        "execute-work-item",
+        "verify-work-item",
+        "classify-verification-result",
+        "prepare-plan-repair",
+        "plan-work-item",
+        "execute-work-item",
+        "verify-work-item",
+        "classify-verification-result",
+    ]
+    retry_context = runner.contexts["plan-work-item"][1]
+    assert retry_context.metadata["runtime_retry_count"] == 1
+    assert retry_context.metadata["runtime_failed_step_id"] == "verify-work-item"
+    assert retry_context.metadata["runtime_failure_kind"] == "implementation"
+    assert retry_context.metadata["runtime_failure_metadata"]["verification_failure"]["evidence"] == [
+        "verification/report.json"
+    ]

--- a/tests/runtime/test_structured_verification_routing.py
+++ b/tests/runtime/test_structured_verification_routing.py
@@ -21,11 +21,9 @@ class _VerifierRunner:
     def __init__(self, outcomes: list[StepStatus]) -> None:
         self._outcomes = iter(outcomes)
         self.calls: list[str] = []
-        self.contexts_by_step_id: dict[str, list[RunContext]] = {}
 
     def run(self, step: Step, context: RunContext) -> StepResult:
         self.calls.append(step.id)
-        self.contexts_by_step_id.setdefault(step.id, []).append(context)
         if step.id == "verify-work-item":
             status = next(self._outcomes)
             if status == StepStatus.FAILED:
@@ -50,6 +48,11 @@ def _workflow() -> Workflow:
                 kind=StepKind.DECISION,
                 name="classify",
                 needs=("verify-work-item",),
+                metadata={
+                    "on_implementation_failure": "remediate-work-item",
+                    "on_security_review_failure": "remediate-work-item",
+                    "on_scope_conflict": "change-set-revision",
+                },
             ),
             Step(
                 id="remediate-work-item",
@@ -57,28 +60,6 @@ def _workflow() -> Workflow:
                 name="remediate",
                 needs=("classify-verification-result",),
                 metadata={"loop_target": "verify-work-item"},
-            ),
-        ),
-    )
-
-
-def _workflow_with_plan_restart() -> Workflow:
-    return Workflow(
-        name="structured-routing",
-        mode=RunMode.APPLY,
-        steps=(
-            Step(id="plan-work-item", kind=StepKind.AGENT, name="plan"),
-            Step(
-                id="execute-work-item",
-                kind=StepKind.AGENT,
-                name="execute",
-                needs=("plan-work-item",),
-            ),
-            Step(
-                id="verify-work-item",
-                kind=StepKind.VALIDATOR,
-                name="verify",
-                needs=("execute-work-item",),
             ),
         ),
     )
@@ -112,7 +93,7 @@ def _write_report(tmp_path: Path, failure_class: str, owner: str, resume: str) -
     )
 
 
-def test_environment_report_blocks_without_remediation(tmp_path: Path) -> None:
+def test_environment_report_is_classified_and_blocks_without_remediation(tmp_path: Path) -> None:
     _write_report(tmp_path, "environment_blocker", "environment", "environment")
     runner = _VerifierRunner([StepStatus.FAILED])
 
@@ -124,24 +105,10 @@ def test_environment_report_blocks_without_remediation(tmp_path: Path) -> None:
     decision = result.metadata["decisions"][-1]
     assert decision["failure_class"] == "environment_blocker"
     assert decision["route"] == "environment"
-    assert decision["recommended_resume_target"] == "environment"
     assert decision["owner_stage"] == "environment"
-    assert decision["evidence"] == ["stderr: verification/command-01.stderr.txt"]
-
-    decision_path = (
-        tmp_path
-        / ".harness/runs/run-1/steps/classify-verification-result/decision.json"
-    )
-    payload = json.loads(decision_path.read_text(encoding="utf-8"))
-    assert payload["failure_class"] == "environment_blocker"
-    assert payload["decision"] == "ENVIRONMENT_BLOCKER"
-    assert payload["route"] == "environment"
-    assert payload["recommended_resume_target"] == "environment"
-    assert payload["owner_stage"] == "environment"
-    assert payload["evidence"] == ["stderr: verification/command-01.stderr.txt"]
 
 
-def test_implementation_report_retries_only_the_remediation_loop(tmp_path: Path) -> None:
+def test_implementation_report_retries_only_after_classifier_decision(tmp_path: Path) -> None:
     _write_report(tmp_path, "implementation_failure", "implementation", "remediate-work-item")
     runner = _VerifierRunner([StepStatus.FAILED, StepStatus.SUCCEEDED])
 
@@ -150,45 +117,35 @@ def test_implementation_report_retries_only_the_remediation_loop(tmp_path: Path)
     assert result.status is RunStatus.SUCCEEDED
     assert runner.calls.count("verify-work-item") == 2
     assert runner.calls.count("remediate-work-item") == 1
+    decision_path = tmp_path / ".harness/runs/run-1/steps/classify-verification-result/decision.json"
+    payload = json.loads(decision_path.read_text(encoding="utf-8"))
+    assert payload["decision"] == "IMPLEMENTATION_FAILURE"
+    assert payload["route"] == "remediate-work-item"
 
 
-def test_security_report_preserves_security_route_without_implementation_retry(tmp_path: Path) -> None:
+def test_security_report_returns_through_same_repair_loop(tmp_path: Path) -> None:
     _write_report(tmp_path, "security_review_failure", "security-review", "security-review")
+    runner = _VerifierRunner([StepStatus.FAILED, StepStatus.SUCCEEDED])
+
+    result = RunnerEngine(runner).run(_workflow(), _context(tmp_path))
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert runner.calls.count("verify-work-item") == 2
+    decision_path = tmp_path / ".harness/runs/run-1/steps/classify-verification-result/decision.json"
+    payload = json.loads(decision_path.read_text(encoding="utf-8"))
+    assert payload["decision"] == "SECURITY_REVIEW_FAILURE"
+    assert payload["route"] == "remediate-work-item"
+
+
+def test_scope_conflict_always_reaches_classifier_before_stopping(tmp_path: Path) -> None:
+    _write_report(tmp_path, "scope_conflict", "changeset", "change-set-revision")
     runner = _VerifierRunner([StepStatus.FAILED])
 
     result = RunnerEngine(runner).run(_workflow(), _context(tmp_path))
 
     assert result.status is RunStatus.BLOCKED
-    assert result.failure_kind is FailureKind.UNKNOWN
+    assert result.failure_kind is FailureKind.SCOPE_CONFLICT
     assert runner.calls == ["verify-work-item"]
-    assert result.metadata["decisions"][-1]["decision"] == "SECURITY_REVIEW_FAILURE"
-    assert result.metadata["decisions"][-1]["route"] == "security-review"
-
-
-def test_scope_conflict_report_restarts_planner_with_verifier_evidence(tmp_path: Path) -> None:
-    _write_report(
-        tmp_path,
-        "scope_conflict",
-        "changeset",
-        "change-set-revision",
-    )
-    runner = _VerifierRunner([StepStatus.FAILED, StepStatus.SUCCEEDED])
-
-    result = RunnerEngine(runner).run(_workflow_with_plan_restart(), _context(tmp_path))
-
-    assert result.status is RunStatus.SUCCEEDED
-    assert runner.calls == [
-        "plan-work-item",
-        "execute-work-item",
-        "verify-work-item",
-        "plan-work-item",
-        "execute-work-item",
-        "verify-work-item",
-    ]
-    retry_context = runner.contexts_by_step_id["plan-work-item"][1]
-    assert retry_context.metadata["runtime_failed_step_id"] == "verify-work-item"
-    assert retry_context.metadata["runtime_failure_kind"] == "scope_conflict"
-    assert "verification/command-01.stderr.txt" in retry_context.metadata["runtime_failure_error"]
-    assert retry_context.metadata["runtime_failure_metadata"]["verification_failure"]["evidence"] == [
-        "stderr: verification/command-01.stderr.txt"
-    ]
+    decision = result.metadata["decisions"][-1]
+    assert decision["decision"] == "SCOPE_CONFLICT"
+    assert decision["route"] == "change-set-revision"

--- a/tests/runtime/test_structured_verification_routing.py
+++ b/tests/runtime/test_structured_verification_routing.py
@@ -37,6 +37,31 @@ class _VerifierRunner:
         return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
 
 
+class _ExecutorScopeRunner:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run(self, step: Step, context: RunContext) -> StepResult:
+        self.calls.append(step.id)
+        if step.id == "execute-work-item":
+            return StepResult(
+                step_id=step.id,
+                status=StepStatus.FAILED,
+                error="scope diff blocked unexpected files",
+                failure_kind=FailureKind.IMPLEMENTATION,
+                metadata={
+                    "runtime_failure_class": "scope_conflict",
+                    "verification_failure": {
+                        "failure_class": "scope_conflict",
+                        "owner_stage": "changeset",
+                        "recommended_resume_target": "change-set-revision",
+                        "evidence": ["scope-diff-report.json"],
+                    },
+                },
+            )
+        return StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
+
+
 def _workflow() -> Workflow:
     return Workflow(
         name="structured-routing",
@@ -60,6 +85,42 @@ def _workflow() -> Workflow:
                 name="remediate",
                 needs=("classify-verification-result",),
                 metadata={"loop_target": "verify-work-item"},
+            ),
+        ),
+    )
+
+
+def _workflow_with_executor_scope() -> Workflow:
+    return Workflow(
+        name="structured-routing-executor-scope",
+        mode=RunMode.APPLY,
+        steps=(
+            Step(id="plan-work-item", kind=StepKind.AGENT, name="plan"),
+            Step(
+                id="execute-work-item",
+                kind=StepKind.AGENT,
+                name="execute",
+                needs=("plan-work-item",),
+            ),
+            Step(
+                id="verify-work-item",
+                kind=StepKind.VALIDATOR,
+                name="verify",
+                needs=("execute-work-item",),
+            ),
+            Step(
+                id="classify-verification-result",
+                kind=StepKind.DECISION,
+                name="classify",
+                needs=("verify-work-item",),
+                metadata={"on_scope_conflict": "change-set-revision"},
+            ),
+            Step(
+                id="prepare-plan-repair",
+                kind=StepKind.DECISION,
+                name="repair handoff",
+                needs=("classify-verification-result",),
+                metadata={"loop_target": "plan-work-item"},
             ),
         ),
     )
@@ -149,3 +210,20 @@ def test_scope_conflict_always_reaches_classifier_before_stopping(tmp_path: Path
     decision = result.metadata["decisions"][-1]
     assert decision["decision"] == "SCOPE_CONFLICT"
     assert decision["route"] == "change-set-revision"
+
+
+def test_executor_scope_conflict_reaches_classifier_across_success_only_gates(tmp_path: Path) -> None:
+    runner = _ExecutorScopeRunner()
+
+    result = RunnerEngine(runner).run(_workflow_with_executor_scope(), _context(tmp_path))
+
+    assert result.status is RunStatus.BLOCKED
+    assert runner.calls == [
+        "plan-work-item",
+        "execute-work-item",
+        "classify-verification-result",
+    ]
+    decision = result.metadata["decisions"][-1]
+    assert decision["decision"] == "SCOPE_CONFLICT"
+    assert decision["route"] == "change-set-revision"
+    assert decision["failed_step_id"] == "execute-work-item"

--- a/tests/runtime/test_verification_repair_dashboard_patch.py
+++ b/tests/runtime/test_verification_repair_dashboard_patch.py
@@ -56,7 +56,7 @@ def test_recovery_projection_exposes_planner_retry_and_evidence(tmp_path: Path) 
     ]
 
 
-def test_dashboard_script_renders_recovery_flow_once() -> None:
+def test_dashboard_script_renders_korean_recovery_flow_once() -> None:
     script = '''function renderImplementationWorkspace() {
   return `<section class="panel implementation-actions">
       <h3>Implementation</h3>
@@ -66,6 +66,7 @@ def test_dashboard_script_renders_recovery_flow_once() -> None:
     patched = _patch_dashboard_script(script)
 
     assert "function renderImplementationRecovery(recovery)" in patched
-    assert "Verification → Classifier → Plan patch → Plan review → Scope → Implementation" in patched
+    assert "검증 → 실패 분류 → 계획 보정 → 계획 검토 → 범위 확정 → 재구현" in patched
+    assert "실패 재처리:" in patched
     assert "${renderImplementationRecovery(state?.recovery)}" in patched
     assert _patch_dashboard_script(patched) == patched

--- a/tests/runtime/test_verification_repair_dashboard_patch.py
+++ b/tests/runtime/test_verification_repair_dashboard_patch.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_codex.runtime.verification_repair_dashboard_patch import (
+    _patch_dashboard_script,
+    _recovery_state,
+)
+
+
+def _write_decision(root: Path, *, decision: str, route: str, retry_count: int) -> None:
+    path = root / ".harness/runs/run-1/work-items/UC-001/steps/classify-verification-result/decision.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "change_set_id": "CHG-001",
+                "work_item_id": "UC-001",
+                "decision": decision,
+                "failure_class": "security_review_failure",
+                "failed_step_id": "verify-work-item-security",
+                "route": route,
+                "owner_stage": "implementation-planner",
+                "retry_count": retry_count,
+                "reason": "security review rejected",
+                "evidence": [".harness/runs/run-1/work-items/UC-001/security/security-review.md"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_recovery_projection_exposes_planner_retry_and_evidence(tmp_path: Path) -> None:
+    change_set = tmp_path / "docs/changes/active/CHG-001.md"
+    change_set.parent.mkdir(parents=True)
+    change_set.write_text("# CHG-001\n", encoding="utf-8")
+    plan = tmp_path / "docs/plans/active/UC-001/plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# plan\n", encoding="utf-8")
+    _write_decision(
+        tmp_path,
+        decision="SECURITY_REVIEW_FAILURE",
+        route="prepare-plan-repair",
+        retry_count=1,
+    )
+
+    state = _recovery_state(tmp_path, "CHG-001")
+
+    assert state["status"] == "planner-retry"
+    assert state["attempt_count"] == 1
+    assert state["active"]["failed_step_id"] == "verify-work-item-security"
+    assert state["active"]["route"] == "prepare-plan-repair"
+    assert state["active"]["evidence"] == [
+        ".harness/runs/run-1/work-items/UC-001/security/security-review.md"
+    ]
+
+
+def test_dashboard_script_renders_recovery_flow_once() -> None:
+    script = '''function renderImplementationWorkspace() {
+  return `<section class="panel implementation-actions">
+      <h3>Implementation</h3>
+    </section>`;
+}'''
+
+    patched = _patch_dashboard_script(script)
+
+    assert "function renderImplementationRecovery(recovery)" in patched
+    assert "Verification → Classifier → Plan patch → Plan review → Scope → Implementation" in patched
+    assert "${renderImplementationRecovery(state?.recovery)}" in patched
+    assert _patch_dashboard_script(patched) == patched

--- a/tests/runtime/test_verification_repair_loop_runtime_e2e.py
+++ b/tests/runtime/test_verification_repair_loop_runtime_e2e.py
@@ -45,7 +45,7 @@ def _write_active_plan_and_failure_artifacts(tmp_path: Path) -> None:
     report = {
         "failure_class": "implementation_failure",
         "owner_stage": "implementation",
-        "recommended_resume_target": "remediate-work-item",
+        "recommended_resume_target": "plan-work-item",
         "failure_fingerprint": "token-validation-failure",
         "failed_gates": ["focused-token-test"],
         "failed_commands": [
@@ -70,7 +70,7 @@ def _write_active_plan_and_failure_artifacts(tmp_path: Path) -> None:
             {
                 "schema_version": 1,
                 "repair_attempt": 1,
-                "resume_target": "execute-work-item",
+                "resume_target": "plan-work-item",
                 "failure": {
                     "fingerprint": report["failure_fingerprint"],
                     "failed_commands": report["failed_commands"],
@@ -84,14 +84,20 @@ def _write_active_plan_and_failure_artifacts(tmp_path: Path) -> None:
     )
 
 
-def test_runtime_retries_implementation_after_failed_verification(tmp_path: Path) -> None:
-    """Run the real engine loop: execute -> fail verify -> repair -> execute -> pass."""
+def test_runtime_routes_failed_verification_to_planner_without_mutating_plan(tmp_path: Path) -> None:
+    """Run the real engine loop: plan -> execute -> fail verify -> classify -> plan."""
 
     _write_active_plan_and_failure_artifacts(tmp_path)
     workflow = Workflow(
         name="repair-loop-e2e",
         mode=RunMode.APPLY,
         steps=(
+            Step(
+                id="plan-work-item",
+                kind=StepKind.SHELL,
+                name="simulate planner patch pass",
+                command="true",
+            ),
             Step(
                 id="execute-work-item",
                 kind=StepKind.SHELL,
@@ -101,6 +107,7 @@ def test_runtime_retries_implementation_after_failed_verification(tmp_path: Path
                     "then touch .harness/repaired; "
                     "else touch .harness/retry-started; fi"
                 ),
+                needs=("plan-work-item",),
             ),
             Step(
                 id="verify-work-item",
@@ -114,14 +121,14 @@ def test_runtime_retries_implementation_after_failed_verification(tmp_path: Path
                 kind=StepKind.DECISION,
                 name="classify failed verification",
                 needs=("verify-work-item",),
+                metadata={"classifier": "verification_result", "on_implementation_failure": "prepare-plan-repair"},
             ),
             Step(
-                id="remediate-work-item",
-                kind=StepKind.RECORD,
-                name="record repair handoff",
+                id="prepare-plan-repair",
+                kind=StepKind.DECISION,
+                name="return repair to planner",
                 needs=("classify-verification-result",),
-                outputs=(Path("docs/plans/active/UC-001/plan.md"),),
-                metadata={"loop_target": "execute-work-item"},
+                metadata={"classifier": "verification_result", "loop_target": "plan-work-item"},
             ),
         ),
     )
@@ -135,10 +142,12 @@ def test_runtime_retries_implementation_after_failed_verification(tmp_path: Path
 
     step_ids = [step.step_id for step in result.step_results]
     assert step_ids == [
+        "plan-work-item",
         "execute-work-item",
         "verify-work-item",
         "classify-verification-result",
-        "remediate-work-item",
+        "prepare-plan-repair",
+        "plan-work-item",
         "execute-work-item",
         "verify-work-item",
         "classify-verification-result",
@@ -154,4 +163,4 @@ def test_runtime_retries_implementation_after_failed_verification(tmp_path: Path
     assert brief["failure"]["failed_commands"][0]["command"] == "test -f .harness/repaired"
 
     plan_text = (tmp_path / "docs/plans/active/UC-001/plan.md").read_text(encoding="utf-8")
-    assert "## Runtime Remediation" in plan_text
+    assert plan_text == "# UC-001 plan\n\n- [ ] Repair token validation\n"

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -82,7 +82,7 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
     assert step_ids.index("review-work-item-security") < step_ids.index("verify-work-item-security")
     assert step_ids.index("verify-work-item-security") < step_ids.index("collect-work-item-token-metrics")
     assert step_ids.index("collect-work-item-token-metrics") < step_ids.index("classify-verification-result")
-    assert step_ids[-2:] == ("remediate-work-item", "complete-work-item-plan")
+    assert step_ids[-2:] == ("prepare-plan-repair", "complete-work-item-plan")
 
     assert work_item_workflow.step_by_id("plan-work-item").agent_id == "implementation_planner"
     assert work_item_workflow.step_by_id("plan-work-item").skill_id == "harness-code-planner"
@@ -141,8 +141,17 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
         for step in (*work_item_workflow.steps, *finalization_workflow.steps)
         if step.kind == StepKind.GIT
     )
-    assert work_item_workflow.step_by_id("classify-verification-result").kind == StepKind.DECISION
-    assert work_item_workflow.step_by_id("remediate-work-item").metadata["loop_target"] == "execute-work-item"
+    classifier = work_item_workflow.step_by_id("classify-verification-result")
+    assert classifier.kind == StepKind.DECISION
+    assert classifier.needs == (
+        "verify-work-item",
+        "verify-work-item-security",
+        "collect-work-item-token-metrics",
+    )
+    repair = work_item_workflow.step_by_id("prepare-plan-repair")
+    assert repair.kind == StepKind.DECISION
+    assert repair.metadata["loop_target"] == "plan-work-item"
+    assert repair.outputs == ()
     assert all(step.metadata["execution_boundary"] == "work_item" for step in work_item_workflow.steps)
     assert "create-change-set-pr" not in step_ids
     assert "complete-change-set" not in step_ids

--- a/tests/runtime/test_workflow_loader.py
+++ b/tests/runtime/test_workflow_loader.py
@@ -65,19 +65,18 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
     assert step_ids[0:5] == (
         "load-change-set",
         "plan-work-item",
-        "materialize-security-profile",
-        "secure-work-item-plan",
         "review-work-item-plan",
+        "materialize-execution-scope",
+        "execute-work-item",
     )
+    assert "secure-work-item-plan" not in step_ids
     assert "repair-affected-files-scope" not in step_ids
-    assert work_item_workflow.step_by_id("materialize-security-profile").kind == StepKind.VALIDATOR
-    assert work_item_workflow.step_by_id("materialize-security-profile").needs == ("plan-work-item",)
-    assert work_item_workflow.step_by_id("secure-work-item-plan").needs == ("materialize-security-profile",)
-    assert work_item_workflow.step_by_id("secure-work-item-plan").metadata["prompt_context_profile"] == "review-bundle-minimal"
+    assert work_item_workflow.step_by_id("review-work-item-plan").needs == ("plan-work-item",)
     assert "materialize-execution-scope" in step_ids
     assert step_ids.index("materialize-execution-scope") < step_ids.index("execute-work-item")
     assert step_ids.index("execute-work-item") < step_ids.index("verify-work-item")
-    assert step_ids.index("verify-work-item") < step_ids.index("collect-pre-security-token-metrics")
+    assert step_ids.index("verify-work-item") < step_ids.index("materialize-security-profile")
+    assert step_ids.index("materialize-security-profile") < step_ids.index("collect-pre-security-token-metrics")
     assert step_ids.index("collect-pre-security-token-metrics") < step_ids.index("materialize-security-review-bundle")
     assert step_ids.index("materialize-security-review-bundle") < step_ids.index("review-work-item-security")
     assert step_ids.index("review-work-item-security") < step_ids.index("verify-work-item-security")
@@ -89,8 +88,6 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
     assert work_item_workflow.step_by_id("plan-work-item").skill_id == "harness-code-planner"
     assert work_item_workflow.step_by_id("plan-work-item").metadata["stage"] == "plan-writing"
     assert work_item_workflow.step_by_id("plan-work-item").metadata["prompt_context_profile"] == "plan"
-    assert work_item_workflow.step_by_id("secure-work-item-plan").agent_id == "security_plan_reviewer"
-    assert work_item_workflow.step_by_id("review-work-item-plan").needs == ("secure-work-item-plan",)
     assert work_item_workflow.step_by_id("review-work-item-plan").metadata["prompt_context_profile"] == "review"
     assert work_item_workflow.step_by_id("materialize-execution-scope").kind == StepKind.VALIDATOR
     assert work_item_workflow.step_by_id("execute-work-item").skill_id == "harness-implementation-executor"
@@ -103,12 +100,16 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
     assert work_item_workflow.step_by_id("execute-work-item").outputs == (
         Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/execution-report.json"),
     )
+    assert work_item_workflow.step_by_id("materialize-security-profile").needs == ("verify-work-item",)
     assert work_item_workflow.step_by_id("collect-pre-security-token-metrics").kind == StepKind.VALIDATOR
     assert work_item_workflow.step_by_id("collect-work-item-token-metrics").kind == StepKind.VALIDATOR
     security_review = work_item_workflow.step_by_id("review-work-item-security")
     assert security_review.needs == ("materialize-security-review-bundle",)
     assert security_review.metadata["prompt_context_profile"] == "review-bundle-minimal"
     assert security_review.outputs == ()
+    assert Path(
+        ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-plan-tasks.md"
+    ) not in security_review.inputs
     assert security_review.metadata["final_response_contract"] == {
         "channel": "final-message",
         "format": "markdown",
@@ -161,6 +162,5 @@ def test_default_workflows_separate_work_item_safety_from_changeset_delivery() -
 def test_harvest_workflow_bootstrap_outputs_use_harness_docs_agent_paths() -> None:
     workflow = load_named_workflow("harvest-workflow")
     outputs = workflow.step_by_id("harvest-requirements").metadata["bootstrap_outputs"]
-
     assert ".harness/docs/agent/context.md" in outputs
     assert "docs/agent/context.md" not in outputs

--- a/tests/test_issue_372_canonical_finalization.py
+++ b/tests/test_issue_372_canonical_finalization.py
@@ -22,18 +22,19 @@ def test_work_item_workflow_excludes_changeset_finalization() -> None:
     assert step_ids[:5] == (
         "load-change-set",
         "plan-work-item",
-        "materialize-security-profile",
-        "secure-work-item-plan",
         "review-work-item-plan",
+        "materialize-execution-scope",
+        "execute-work-item",
     )
+    assert "secure-work-item-plan" not in step_ids
     assert "repair-affected-files-scope" not in step_ids
     assert "materialize-execution-scope" in step_ids
     assert step_ids.index("materialize-execution-scope") < step_ids.index("execute-work-item")
-    assert step_ids.index("verify-work-item") < step_ids.index("collect-pre-security-token-metrics")
-    assert step_ids.index("collect-pre-security-token-metrics") < step_ids.index("materialize-security-review-bundle")
+    assert step_ids.index("verify-work-item") < step_ids.index("materialize-security-profile")
+    assert step_ids.index("materialize-security-profile") < step_ids.index("collect-pre-security-token-metrics")
     assert step_ids.index("verify-work-item-security") < step_ids.index("collect-work-item-token-metrics")
     assert step_ids.index("collect-work-item-token-metrics") < step_ids.index("classify-verification-result")
-    assert step_ids[-2:] == ("remediate-work-item", "complete-work-item-plan")
+    assert step_ids[-2:] == ("prepare-plan-repair", "complete-work-item-plan")
     assert "update-project-wiki" not in step_ids
     assert "validate-project-wiki" not in step_ids
     assert "create-change-set-pr" not in step_ids
@@ -129,12 +130,12 @@ def test_skipped_gate_steps_preserve_transitive_dependencies() -> None:
         run_id="run-skip",
     )
 
-    assert materialized.step_by_id("review-work-item-plan").needs == (
-        "materialize-security-profile",
-    )
+    assert materialized.step_by_id("review-work-item-plan").needs == ("plan-work-item",)
     assert materialized.step_by_id("materialize-execution-scope").needs == (
         "review-work-item-plan",
     )
     assert materialized.step_by_id("classify-verification-result").needs == (
+        "verify-work-item",
+        "verify-work-item-security",
         "collect-work-item-token-metrics",
     )

--- a/tests/test_project_wiki_workflow.py
+++ b/tests/test_project_wiki_workflow.py
@@ -34,15 +34,15 @@ def test_work_item_and_finalization_workflows_keep_wiki_explicit() -> None:
     assert {
         "load-change-set",
         "plan-work-item",
-        "secure-work-item-plan",
         "review-work-item-plan",
         "execute-work-item",
         "verify-work-item",
         "verify-work-item-security",
         "classify-verification-result",
-        "remediate-work-item",
+        "prepare-plan-repair",
         "complete-work-item-plan",
     } <= work_item_step_ids
+    assert "secure-work-item-plan" not in work_item_step_ids
     assert "create-change-set-pr" not in work_item_step_ids
     assert "complete-change-set" not in work_item_step_ids
     assert {

--- a/tests/test_security_plan_reviewer_contract.py
+++ b/tests/test_security_plan_reviewer_contract.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from harness_codex.runtime.models import HARNESS_FULL_WORKFLOW
 from harness_codex.runtime.workflows.loader import load_named_workflow
 
 
@@ -11,61 +10,40 @@ def read(path: str) -> str:
     return (REPO_ROOT / path).read_text(encoding="utf-8")
 
 
-def test_security_plan_reviewer_agent_and_skill_are_registered() -> None:
-    config = read(".codex/config.toml")
-    agent = read(".codex/agents/security_plan_reviewer.toml")
-    skill = read(".codex/skills/harness-security-plan-reviewer/SKILL.md")
-
-    assert "[agents.security_plan_reviewer]" in config
-    assert 'name = "security_plan_reviewer"' in agent
-    assert "harness-security-plan-reviewer" in agent
-    assert "runtime-selected" in agent
-    assert "security-profile.json" in skill
-    assert "selected-controls.json" in skill
-
-
-def test_changeset_workflow_secures_plan_before_independent_review() -> None:
+def test_changeset_workflow_has_one_plan_writing_agent() -> None:
     workflow = load_named_workflow("changeset-use-case-workflow")
-    profile = workflow.step_by_id("materialize-security-profile")
-    security = workflow.step_by_id("secure-work-item-plan")
+    plan = workflow.step_by_id("plan-work-item")
     review = workflow.step_by_id("review-work-item-plan")
 
-    assert profile.kind.value == "validator"
-    assert security.agent_id == "security_plan_reviewer"
-    assert security.skill_id == "harness-security-plan-reviewer"
-    assert security.needs == ("materialize-security-profile",)
-    assert security.inputs == (
-        Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),
-        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-profile.json"),
-        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/selected-controls.json"),
-    )
-    assert security.outputs == (Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),)
-    assert review.needs == ("secure-work-item-plan",)
+    assert plan.agent_id == "implementation_planner"
+    assert plan.skill_id == "harness-code-planner"
+    assert plan.outputs == (Path("docs/plans/active/<WORK-ITEM-ID>/plan.md"),)
+    assert review.needs == ("plan-work-item",)
+    assert "secure-work-item-plan" not in workflow.step_ids()
 
 
-def test_full_workflow_secures_plan_before_independent_review() -> None:
-    security = HARNESS_FULL_WORKFLOW.step_by_id("secure-use-case-plan")
-    review = HARNESS_FULL_WORKFLOW.step_by_id("review-use-case-plan")
+def test_security_review_runs_only_after_implementation_verification() -> None:
+    workflow = load_named_workflow("changeset-use-case-workflow")
+    step_ids = workflow.step_ids()
+    profile = workflow.step_by_id("materialize-security-profile")
+    reviewer = workflow.step_by_id("review-work-item-security")
 
-    assert security.agent_id == "security_plan_reviewer"
-    assert security.skill_id == "harness-security-plan-reviewer"
-    assert security.needs == ("planner-create-use-case-plan",)
-    assert security.outputs == (Path("docs/plans/active/<UC-ID>/plan.md"),)
-    assert review.needs == ("secure-use-case-plan",)
+    assert profile.needs == ("verify-work-item",)
+    assert step_ids.index("execute-work-item") < step_ids.index("verify-work-item")
+    assert step_ids.index("verify-work-item") < step_ids.index("materialize-security-profile")
+    assert step_ids.index("materialize-security-profile") < step_ids.index("review-work-item-security")
+    assert reviewer.agent_id == "security_implementation_reviewer"
+    assert reviewer.outputs == ()
+    assert Path(
+        ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/security/security-review-bundle/security-plan-tasks.md"
+    ) not in reviewer.inputs
 
 
-def test_security_reviewer_is_plan_only_and_requires_traceable_tasks() -> None:
-    reference = read(".codex/agents/references/security_plan_reviewer.md")
-    baseline = read(".codex/skills/harness-security-plan-reviewer/references/owasp-baseline.md")
-    skill = read(".codex/skills/harness-security-plan-reviewer/SKILL.md")
+def test_security_implementation_reviewer_is_read_only_and_code_evidence_based() -> None:
+    skill = read(".codex/skills/harness-security-implementation-reviewer/SKILL.md")
 
-    assert "Edit only the runtime-declared" in reference
-    assert "Do not implement code" in reference
-    assert "Do not fabricate ASVS requirement identifiers" in reference
-    assert "implementation tasks" in baseline
-    assert "focused tests" in baseline
-    assert "verification command" in baseline
-    assert "minimal plan delta" in reference
-    assert "Do not rewrite or narrate the full plan" in reference
-    assert "Do not read the ChangeSet" in skill
-    assert "concrete implementation, test, and verification tasks" in skill
+    assert "post-implementation review only" in skill
+    assert "changed-code location" in skill
+    assert "Do not edit implementation code, plans, or runtime output files." in skill
+    assert "scope-expansion request" in skill
+    assert "Required Implementation Corrections" in skill


### PR DESCRIPTION
## 변경 사항
- 구현 검증·보안 검토·scope-diff 실패를 classifier 중심으로 분류
- 구현/보안 실패는 plan repair 후 planner로 재진입
- scope conflict는 ChangeSet revision 경로로 차단
- 재시도 context를 planner까지 전달
- Implementation UI에 실패 단계, 분류 route, 재시도 횟수, evidence, 이력 표시

## 검증
- classifier routing, executor scope routing, planner retry context, dashboard recovery projection 회귀 테스트 추가/수정
- 이 환경에서는 로컬 pytest 실행은 하지 못함