### PR TITLE
[feat] DDD 질문 오케스트레이터 skill 추가

### DIFF
--- a/.codex/agents/question_orchestrator.toml
+++ b/.codex/agents/question_orchestrator.toml
@@ -1,0 +1,18 @@
+name = "question_orchestrator"
+description = "Answer harness ChangeSet implementation questions through bounded DDD scope routing"
+model = "gpt-5.4"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the question_orchestrator agent.
+
+Hot-path contract:
+- Role: Answer implementation questions without changing code.
+- Load `.codex/agents/references/question_orchestrator.md` before making workflow decisions.
+- Treat the provided `harness changes question` JSON as the route authority.
+- Read `preferred_read_scope` and `read_order` first.
+- Keep source reads inside the candidate bounded context, aggregate, module, or package unless a named import/public API/compile reference requires expansion.
+- Do not edit files, run implementation workflows, modify tests, commit, push, or open PRs.
+- Preserve unrelated worktree changes.
+- Report the answer, evidence paths, scope expansions, and uncertainty clearly in Korean.
+"""

--- a/.codex/agents/references/question_orchestrator.md
+++ b/.codex/agents/references/question_orchestrator.md
@@ -1,0 +1,55 @@
+# Question Orchestrator Instructions
+
+You answer questions about code produced or touched by a harness ChangeSet.
+
+## Required Inputs
+
+- Original user question.
+- `harness changes question <CHG-ID> --query ... --json` output.
+
+If the route JSON is missing, stop and ask the caller to run the router first. Do not infer a whole-repository search plan by yourself.
+
+## Operating Rules
+
+1. Classify intent from route JSON.
+   - `question`: continue.
+   - `implementation`: stop and report that the request belongs to implementation orchestration.
+
+2. Read in this order:
+   - `docs/changes/active/<CHG-ID>.md` or `docs/changes/completed/<CHG-ID>.md`
+   - affected `docs/use-cases/<UC-ID>/` and plan artifacts when present
+   - top candidate module/BC/aggregate paths from `preferred_read_scope`
+   - only then named imports, public APIs, or shared utilities required to answer the question
+
+3. Keep searches bounded:
+   - Use `rg <term> <scoped-paths>` instead of repo-wide `rg`.
+   - Do not read unrelated bounded contexts for comparison unless the question explicitly asks for comparison.
+   - Do not open broad logs, generated artifacts, or full history unless the route names them.
+
+4. Do not mutate:
+   - No file edits.
+   - No test rewrites.
+   - No runtime/workflow/skill changes.
+   - No git operations.
+
+5. Answer in Korean.
+   - Preserve identifiers, class names, method names, file paths, commands, JSON keys, and canonical domain terms.
+   - Cite evidence with file paths and line numbers when available.
+   - Include scope expansion reasons if any file outside `preferred_read_scope` was read.
+
+## Answer Format
+
+```markdown
+답변:
+<concise answer>
+
+근거:
+- <path:line>: <why it matters>
+
+조회 범위:
+- 기본 범위: <paths>
+- 확장 범위: <paths or 없음>, 이유: <reason>
+
+불확실성:
+- <remaining uncertainty or 없음>
+```

--- a/.codex/skills/harness-changes/SKILL.md
+++ b/.codex/skills/harness-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-changes
-description: Operate harness ChangeSets through the runtime CLI. Use when the user asks to list, inspect, show contents, delete, continue, or document deltas for ChangeSets with `harness changes`.
+description: Operate harness ChangeSets through the runtime CLI. Use when the user asks to list, inspect, show contents, delete, continue, route implementation questions, or document deltas for ChangeSets with `harness changes`.
 ---
 
 # Harness Changes
@@ -11,6 +11,7 @@ description: Operate harness ChangeSets through the runtime CLI. Use when the us
 - `./harness changes active`
 - `./harness changes show <CHG-ID>`
 - `./harness changes contents <CHG-ID>`
+- `./harness changes question <CHG-ID> --query TEXT [--uc <UC-ID>] [--json]`
 - `./harness changes continue <CHG-ID>`
 - `./harness changes delete <CHG-ID>`
 - `./harness changes document-delta <CHG-ID> --uc <UC-ID> --summary TEXT --plan|--preview|--apply`
@@ -20,5 +21,6 @@ description: Operate harness ChangeSets through the runtime CLI. Use when the us
 1. Use `list` or `active` before ID-specific commands when the target is unclear.
 2. For destructive deletion, show exact ChangeSet ID and affected path first, then require explicit user confirmation.
 3. For `document-delta`, prefer `--preview` or `--plan` before `--apply` unless the user explicitly requested apply.
-4. Summarize command output; do not paste long artifacts.
-5. Preserve ChangeSet/use-case/work-item boundaries.
+4. For implementation questions, use `$harness-question-router`; it runs `changes question` and delegates read-only scoped analysis.
+5. Summarize command output; do not paste long artifacts.
+6. Preserve ChangeSet/use-case/work-item boundaries.

--- a/.codex/skills/harness-question-router/SKILL.md
+++ b/.codex/skills/harness-question-router/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: harness-question-router
+description: Answer questions about harness-implemented DDD code by routing the request through `harness changes question`, identifying whether it is a question or implementation request, then delegating scoped read-only analysis to the question_orchestrator agent. Use when the user asks how implemented behavior works, why a ChangeSet implementation behaves a certain way, where code for a BC/aggregate/module lives, or asks for an explanation rather than a code change.
+---
+
+# Harness Question Router
+
+## Workflow
+
+1. Resolve the target ChangeSet.
+   - Use the user-provided `CHG-ID` when present.
+   - Otherwise run `./harness changes active` or `./harness changes list` and choose the only clear active ChangeSet.
+   - If multiple targets remain plausible, ask one concise clarification.
+
+2. Run the router before reading product code:
+
+```bash
+./harness changes question <CHG-ID> --query "<USER QUESTION>" [--uc <UC-ID>] --json
+```
+
+3. Interpret the route.
+   - If `intent` is `implementation`, do not answer as a question. Tell the user it should go through `harness changes continue` or `harness implementation`.
+   - If `intent` is `question`, continue with scoped read-only analysis.
+
+4. Delegate to the dedicated agent when available.
+   - agent id: `question_orchestrator`
+   - config: `.codex/agents/question_orchestrator.toml`
+   - required reference: `.codex/agents/references/question_orchestrator.md`
+
+5. Pass this prompt shape to the agent:
+
+```text
+사용자 질문:
+<original user question>
+
+라우팅 JSON:
+<exact JSON from harness changes question>
+
+작업:
+- 라우팅 JSON의 preferred_read_scope와 read_order를 먼저 따른다.
+- 코드/문서 조회는 후보 BC/module/aggregate 범위에 제한한다.
+- 범위 밖 조회가 필요하면 이유를 먼저 설명하고 최소 파일만 읽는다.
+- 파일 수정, 테스트 수정, runtime 수정, git 작업은 하지 않는다.
+- 답변은 한국어로 작성하고, 근거 파일 경로를 포함한다.
+```
+
+6. If the dedicated agent cannot be spawned, answer locally using the same route and read limits. Do not broaden code search to the whole repository.
+
+## Read Limits
+
+- Read ChangeSet and affected UC artifacts first.
+- Read only `preferred_read_scope` paths before expanding.
+- Prefer `rg` within scoped paths over repository-wide search.
+- Expand outside scope only for imports, public APIs, compile references, or clearly named shared utilities.
+- Do not modify files while answering a question.
+
+## Output
+
+Return:
+
+- direct answer
+- scoped evidence paths
+- any scope expansion performed and why
+- residual uncertainty when the route could not identify a BC/module/aggregate

--- a/.codex/skills/harness-question-router/agents/openai.yaml
+++ b/.codex/skills/harness-question-router/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Question Router"
+  short_description: "Route ChangeSet questions to scoped code reads"
+  default_prompt: "Use $harness-question-router to answer implementation questions through bounded DDD scope routing."

--- a/.github/workflows/bump-runtime-version.yml
+++ b/.github/workflows/bump-runtime-version.yml
@@ -31,6 +31,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add harness_codex/__init__.py
+          git add -f harness_codex/__init__.py
           git commit -m "chore: 런타임 패치 버전 자동 증가"
           git push origin HEAD:main


### PR DESCRIPTION
## 구현 의도

#451이 `runtime: DDD 질문 라우터 추가` 커밋까지 merge된 뒤, 후속으로 필요해진 skill/agent 오케스트레이션 경로를 별도 PR로 분리합니다.

목표는 사용자가 구현 결과에 대해 단순 질문을 했을 때 전체 저장소를 넓게 탐색하지 않고, ChangeSet → affected UC → DDD Bounded Context/Aggregate/module 후보 순서로 제한 조회한 뒤 답변하도록 만드는 것입니다.

## 구현 접근

- `$harness-question-router` skill을 추가했습니다.
- skill은 답변 전에 `./harness changes question <CHG-ID> --query ... --json`을 먼저 실행하도록 지시합니다.
- 라우팅 결과가 `question`이면 전용 `question_orchestrator` agent에 원질문과 route JSON을 전달합니다.
- `question_orchestrator` agent config와 상세 reference를 추가했습니다.
- agent는 `preferred_read_scope`와 `read_order`를 우선 적용하고, 파일 수정/테스트 수정/runtime 수정/git 작업을 금지합니다.
- 기존 `$harness-changes` skill에 `changes question` 명령과 `$harness-question-router` 위임을 추가했습니다.
- `bump-runtime-version.yml`의 `git add harness_codex/__init__.py`가 `.gitignore` 때문에 실패하던 문제를 `git add -f`로 수정했습니다.

## 검증 방법

- `python3 /home/jiwoo/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/harness-question-router`
- `python3`로 `.codex/agents/question_orchestrator.toml` TOML 파싱 확인
- `python3`로 `.github/workflows/bump-runtime-version.yml` YAML 파싱 확인
- `git log origin/main..HEAD`가 이번 PR의 두 커밋만 포함하는지 확인

## 위험 및 롤백

위험은 질문 답변이 보수적으로 동작해 필요한 파일을 즉시 넓게 읽지 않을 수 있다는 점입니다. 이 경우 agent는 범위 확장 이유를 명시하고 최소 파일만 추가 조회해야 합니다.

롤백은 이 PR을 revert하면 됩니다. runtime 질문 라우터 CLI 자체는 #451에 이미 포함되어 있고, 이 PR은 skill/agent 호출 계약과 CI bump staging 수정만 추가합니다.
