### PR TITLE
feat: SQLite로 step 상태·산출물 트랜잭션 관리

### DIFF
--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -9,6 +9,14 @@ __all__ = ["__version__"]
 __version__ = "0.1.168"
 
 
+def _install_step_transaction_ledger() -> None:
+    """Make SQLite the durable authority for executed step state and artifacts."""
+
+    from harness_codex.runtime.step_transaction_patch import apply_step_transaction_patch
+
+    apply_step_transaction_patch()
+
+
 def _install_main_session_step_feedback() -> None:
     """Expose existing runtime step events to the main CLI session."""
 
@@ -136,6 +144,7 @@ def _install_security_review_bundle_prompt_profile() -> None:
     apply_security_review_prompt_patch()
 
 
+_install_step_transaction_ledger()
 _install_main_session_step_feedback()
 _install_changeset_execution_boundary()
 _install_runtime_write_boundaries()

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -9,6 +9,16 @@ __all__ = ["__version__"]
 __version__ = "0.1.168"
 
 
+def _install_main_session_step_feedback() -> None:
+    """Expose existing runtime step events to the main CLI session."""
+
+    from harness_codex.runtime.main_session_progress_patch import (
+        apply_main_session_progress_feedback_patch,
+    )
+
+    apply_main_session_progress_feedback_patch()
+
+
 def _install_changeset_execution_boundary() -> None:
     """Route the CLI hook through the two-layer ChangeSet session orchestrator.
 
@@ -126,6 +136,7 @@ def _install_security_review_bundle_prompt_profile() -> None:
     apply_security_review_prompt_patch()
 
 
+_install_main_session_step_feedback()
 _install_changeset_execution_boundary()
 _install_runtime_write_boundaries()
 _install_canonical_procedure_stage_bridge()

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -10,7 +10,7 @@ __version__ = "0.1.168"
 
 
 def _install_step_transaction_ledger() -> None:
-    """Make SQLite the durable authority for executed step state and artifacts."""
+    """Make SQLite the durable authority for per-step state and artifact revisions."""
 
     from harness_codex.runtime.step_transaction_patch import apply_step_transaction_patch
 
@@ -18,7 +18,7 @@ def _install_step_transaction_ledger() -> None:
 
 
 def _install_main_session_step_feedback() -> None:
-    """Expose existing runtime step events to the main CLI session."""
+    """Expose the SQLite active step to the main CLI session."""
 
     from harness_codex.runtime.main_session_progress_patch import (
         apply_main_session_progress_feedback_patch,

--- a/harness_codex/runtime/main_session_progress_patch.py
+++ b/harness_codex/runtime/main_session_progress_patch.py
@@ -100,7 +100,7 @@ def _active_step_row(repo_root: Path, run_id: str) -> Mapping[str, str | None] |
                 LIMIT 1
                 """
             ).fetchone()
-    except (OSError, sqlite3.DatabaseError, sqlite3.OperationalError):
+    except (OSError, sqlite3.DatabaseError):
         return None
     if row is None:
         return None

--- a/harness_codex/runtime/main_session_progress_patch.py
+++ b/harness_codex/runtime/main_session_progress_patch.py
@@ -100,7 +100,7 @@ def _active_step_row(repo_root: Path, run_id: str) -> Mapping[str, str | None] |
                 LIMIT 1
                 """
             ).fetchone()
-    except (OSError, sqlite3.DatabaseError):
+    except (OSError, sqlite3.DatabaseError, sqlite3.OperationalError):
         return None
     if row is None:
         return None

--- a/harness_codex/runtime/main_session_progress_patch.py
+++ b/harness_codex/runtime/main_session_progress_patch.py
@@ -1,0 +1,86 @@
+"""Render existing run events as periodic main-session progress feedback."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from pathlib import Path
+from time import monotonic
+from typing import Any, Callable, Mapping
+from uuid import uuid4
+
+from harness_codex.runtime.observability import read_run_events
+
+
+PROGRESS_INTERVAL_SECONDS = 30.0
+
+
+def apply_main_session_progress_feedback_patch() -> None:
+    """Reuse the run event ledger to report the active step while a run is executing."""
+
+    import harness_codex.runtime.changeset_orchestrator as orchestrator
+
+    original_apply_workflow = orchestrator.apply_workflow
+    if getattr(original_apply_workflow, "_main_session_progress_feedback", False):
+        return
+
+    def apply_workflow_with_progress(*args, **kwargs):
+        emit = kwargs.get("emit")
+        if not callable(emit):
+            return original_apply_workflow(*args, **kwargs)
+
+        repo_root = _repo_root(args, kwargs)
+        run_id = str(kwargs.get("run_id") or f"run-{uuid4().hex[:12]}")
+        if kwargs.get("run_id") != run_id:
+            kwargs = {**kwargs, "run_id": run_id}
+
+        started_at = monotonic()
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="harness-workflow") as executor:
+            future = executor.submit(original_apply_workflow, *args, **kwargs)
+            while True:
+                try:
+                    return future.result(timeout=PROGRESS_INTERVAL_SECONDS)
+                except TimeoutError:
+                    message = _progress_message(repo_root, run_id, monotonic() - started_at)
+                    if message is not None:
+                        emit(message)
+
+    apply_workflow_with_progress._main_session_progress_feedback = True
+    orchestrator.apply_workflow = apply_workflow_with_progress
+
+
+def _repo_root(args: tuple[object, ...], kwargs: Mapping[str, Any]) -> Path:
+    if "repo_root" in kwargs:
+        return Path(kwargs["repo_root"])
+    if args:
+        return Path(args[0])
+    raise TypeError("apply_workflow requires repo_root")
+
+
+def _progress_message(repo_root: Path, run_id: str, elapsed_seconds: float) -> str | None:
+    active = _active_step_event(read_run_events(repo_root, run_id))
+    if active is None:
+        return None
+
+    change_set_id = str(active.get("change_set_id") or "-")
+    work_item_id = str(active.get("work_item_id") or "-")
+    step_id = str(active.get("step_id") or "-")
+    elapsed = max(0, int(elapsed_seconds))
+    return (
+        f"진행 중: ChangeSet {change_set_id}, Work item {work_item_id}, "
+        f"step={step_id} ({elapsed}초 경과)"
+    )
+
+
+def _active_step_event(events: tuple[Mapping[str, Any], ...]) -> Mapping[str, Any] | None:
+    active: Mapping[str, Any] | None = None
+    for event in events:
+        event_type = event.get("event_type")
+        if event_type == "step.started":
+            active = event
+        elif (
+            event_type in {"step.finished", "step.raised"}
+            and active is not None
+            and event.get("step_id") == active.get("step_id")
+        ):
+            active = None
+    return active

--- a/harness_codex/runtime/main_session_progress_patch.py
+++ b/harness_codex/runtime/main_session_progress_patch.py
@@ -1,21 +1,20 @@
-"""Render existing run events as periodic main-session progress feedback."""
+"""Render SQLite-backed step transactions as periodic main-session feedback."""
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from threading import Event, Thread
 from time import monotonic
 from typing import Any, Mapping
 from uuid import uuid4
 
-from harness_codex.runtime.observability import read_run_events
-
 
 PROGRESS_INTERVAL_SECONDS = 30.0
 
 
 def apply_main_session_progress_feedback_patch() -> None:
-    """Reuse the run event ledger to report the active step while a run is executing."""
+    """Report the authoritative SQLite ``RUNNING`` step while a run executes."""
 
     import harness_codex.runtime.changeset_orchestrator as orchestrator
 
@@ -74,30 +73,39 @@ def _repo_root(args: tuple[object, ...], kwargs: Mapping[str, Any]) -> Path:
 
 
 def _progress_message(repo_root: Path, run_id: str, elapsed_seconds: float) -> str | None:
-    active = _active_step_event(read_run_events(repo_root, run_id))
+    active = _active_step_row(repo_root, run_id)
     if active is None:
         return None
 
-    change_set_id = str(active.get("change_set_id") or "-")
-    work_item_id = str(active.get("work_item_id") or "-")
-    step_id = str(active.get("step_id") or "-")
     elapsed = max(0, int(elapsed_seconds))
     return (
-        f"진행 중: ChangeSet {change_set_id}, Work item {work_item_id}, "
-        f"step={step_id} ({elapsed}초 경과)"
+        f"진행 중: ChangeSet {active['change_set_id'] or '-'}, "
+        f"Work item {active['work_item_id'] or '-'}, "
+        f"step={active['step_id']} ({elapsed}초 경과)"
     )
 
 
-def _active_step_event(events: tuple[Mapping[str, Any], ...]) -> Mapping[str, Any] | None:
-    active: Mapping[str, Any] | None = None
-    for event in events:
-        event_type = event.get("event_type")
-        if event_type == "step.started":
-            active = event
-        elif (
-            event_type in {"step.finished", "step.raised"}
-            and active is not None
-            and event.get("step_id") == active.get("step_id")
-        ):
-            active = None
-    return active
+def _active_step_row(repo_root: Path, run_id: str) -> Mapping[str, str | None] | None:
+    path = repo_root / ".harness" / "runs" / run_id / "state.sqlite3"
+    if not path.exists():
+        return None
+    try:
+        with sqlite3.connect(path, timeout=1) as connection:
+            row = connection.execute(
+                """
+                SELECT change_set_id, work_item_id, step_id
+                FROM step_transactions
+                WHERE state = 'RUNNING'
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            ).fetchone()
+    except (OSError, sqlite3.DatabaseError):
+        return None
+    if row is None:
+        return None
+    return {
+        "change_set_id": row[0],
+        "work_item_id": row[1],
+        "step_id": row[2],
+    }

--- a/harness_codex/runtime/main_session_progress_patch.py
+++ b/harness_codex/runtime/main_session_progress_patch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
 from time import monotonic
-from typing import Any, Callable, Mapping
+from typing import Any, Mapping
 from uuid import uuid4
 
 from harness_codex.runtime.observability import read_run_events

--- a/harness_codex/runtime/main_session_progress_patch.py
+++ b/harness_codex/runtime/main_session_progress_patch.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
+from threading import Event, Thread
 from time import monotonic
 from typing import Any, Mapping
 from uuid import uuid4
@@ -34,18 +34,35 @@ def apply_main_session_progress_feedback_patch() -> None:
             kwargs = {**kwargs, "run_id": run_id}
 
         started_at = monotonic()
-        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="harness-workflow") as executor:
-            future = executor.submit(original_apply_workflow, *args, **kwargs)
-            while True:
-                try:
-                    return future.result(timeout=PROGRESS_INTERVAL_SECONDS)
-                except TimeoutError:
-                    message = _progress_message(repo_root, run_id, monotonic() - started_at)
-                    if message is not None:
-                        emit(message)
+        stop = Event()
+        reporter = Thread(
+            target=_report_progress_until_stopped,
+            args=(stop, emit, repo_root, run_id, started_at),
+            name="harness-progress-feedback",
+            daemon=True,
+        )
+        reporter.start()
+        try:
+            return original_apply_workflow(*args, **kwargs)
+        finally:
+            stop.set()
+            reporter.join()
 
     apply_workflow_with_progress._main_session_progress_feedback = True
     orchestrator.apply_workflow = apply_workflow_with_progress
+
+
+def _report_progress_until_stopped(
+    stop: Event,
+    emit,
+    repo_root: Path,
+    run_id: str,
+    started_at: float,
+) -> None:
+    while not stop.wait(PROGRESS_INTERVAL_SECONDS):
+        message = _progress_message(repo_root, run_id, monotonic() - started_at)
+        if message is not None:
+            emit(message)
 
 
 def _repo_root(args: tuple[object, ...], kwargs: Mapping[str, Any]) -> Path:

--- a/harness_codex/runtime/step_transaction_patch.py
+++ b/harness_codex/runtime/step_transaction_patch.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
-
-from harness_codex.runtime.models import StepResult, StepStatus
+from harness_codex.runtime.models import RunMode, StepResult, StepStatus
 from harness_codex.runtime.runner import StepRunner
 from harness_codex.runtime.step_transaction_store import StepTransactionStore
 
@@ -36,10 +34,10 @@ class TransactionalStepRunner:
 
 
 def apply_step_transaction_patch() -> None:
-    """Decorate the active runner at engine execution time.
+    """Decorate execution and terminal engine decisions with SQLite transactions.
 
-    This deliberately patches ``RunnerEngine.run`` rather than ``BasicStepRunner.run``
-    so rollback, scope, and delivery patches remain in their existing order.
+    The runner wrapper handles actual executions. Engine decision hooks cover steps
+    that are intentionally skipped or policy-blocked before a runner is invoked.
     """
 
     import harness_codex.runtime.engine as engine_module
@@ -49,11 +47,38 @@ def apply_step_transaction_patch() -> None:
         return
 
     original_run = RunnerEngine.run
+    original_skip_reason = RunnerEngine._work_item_step_skip_reason
+    original_policy_evaluation = RunnerEngine._evaluate_command_policy
 
     def transactional_workflow_run(self, workflow, context):
         if not isinstance(self._step_runner, TransactionalStepRunner):
             self._step_runner = TransactionalStepRunner(self._step_runner)
         return original_run(self, workflow, context)
 
+    def transactional_skip_reason(self, step, context):
+        reason = original_skip_reason(self, step, context)
+        if reason is not None and context.mode is RunMode.APPLY:
+            _record_terminal_step(step, context, StepStatus.SKIPPED, reason)
+        return reason
+
+    def transactional_policy_evaluation(self, step, context):
+        decision = original_policy_evaluation(self, step, context)
+        if decision is not None and not decision.allowed and context.mode is RunMode.APPLY:
+            _record_terminal_step(step, context, StepStatus.BLOCKED, decision.reason)
+        return decision
+
     RunnerEngine.run = transactional_workflow_run
+    RunnerEngine._work_item_step_skip_reason = transactional_skip_reason
+    RunnerEngine._evaluate_command_policy = transactional_policy_evaluation
     RunnerEngine._step_transaction_patch_applied = True
+
+
+def _record_terminal_step(step, context, status: StepStatus, error: str) -> None:
+    store = StepTransactionStore(context.repo_root, context.run_id)
+    transaction = store.begin(step, context)
+    store.finish(
+        transaction,
+        step,
+        context,
+        StepResult(step_id=step.id, status=status, error=error),
+    )

--- a/harness_codex/runtime/step_transaction_patch.py
+++ b/harness_codex/runtime/step_transaction_patch.py
@@ -1,0 +1,59 @@
+"""Install SQLite-backed step transaction handling without changing runner behavior."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from harness_codex.runtime.models import StepResult, StepStatus
+from harness_codex.runtime.runner import StepRunner
+from harness_codex.runtime.step_transaction_store import StepTransactionStore
+
+
+class TransactionalStepRunner:
+    """Commit step metadata and artifact facts only after the delegate returns."""
+
+    def __init__(self, delegate: StepRunner) -> None:
+        self._delegate = delegate
+
+    def run(self, step, context):
+        store = StepTransactionStore(context.repo_root, context.run_id)
+        transaction = store.begin(step, context)
+        try:
+            result = self._delegate.run(step, context)
+        except BaseException as exc:
+            store.finish(
+                transaction,
+                step,
+                context,
+                StepResult(
+                    step_id=step.id,
+                    status=StepStatus.FAILED,
+                    error=f"{type(exc).__name__}: {exc}",
+                ),
+            )
+            raise
+        return store.finish(transaction, step, context, result)
+
+
+def apply_step_transaction_patch() -> None:
+    """Decorate the active runner at engine execution time.
+
+    This deliberately patches ``RunnerEngine.run`` rather than ``BasicStepRunner.run``
+    so rollback, scope, and delivery patches remain in their existing order.
+    """
+
+    import harness_codex.runtime.engine as engine_module
+
+    RunnerEngine = engine_module.RunnerEngine
+    if getattr(RunnerEngine, "_step_transaction_patch_applied", False):
+        return
+
+    original_run = RunnerEngine.run
+
+    def transactional_workflow_run(self, workflow, context):
+        if not isinstance(self._step_runner, TransactionalStepRunner):
+            self._step_runner = TransactionalStepRunner(self._step_runner)
+        return original_run(self, workflow, context)
+
+    RunnerEngine.run = transactional_workflow_run
+    RunnerEngine._step_transaction_patch_applied = True

--- a/harness_codex/runtime/step_transaction_store.py
+++ b/harness_codex/runtime/step_transaction_store.py
@@ -84,6 +84,12 @@ class StepTransactionStore:
                     role="output",
                     phase="before",
                 )
+                self._record_changed_files(
+                    connection,
+                    transaction_id,
+                    context.repo_root,
+                    phase="before",
+                )
                 return StepTransaction(transaction_id=transaction_id, attempt=attempt)
 
     def finish(
@@ -106,7 +112,12 @@ class StepTransactionStore:
                     role="output",
                     phase="after",
                 )
-                self._record_changed_files(connection, transaction.transaction_id, context.repo_root)
+                self._record_changed_files(
+                    connection,
+                    transaction.transaction_id,
+                    context.repo_root,
+                    phase="after",
+                )
                 missing_outputs = _missing_outputs(context.repo_root, outputs)
                 if result.status is StepStatus.SUCCEEDED and missing_outputs:
                     final_result = StepResult(
@@ -179,6 +190,8 @@ class StepTransactionStore:
         connection: sqlite3.Connection,
         transaction_id: int,
         repo_root: Path,
+        *,
+        phase: str,
     ) -> None:
         for path in _changed_files(repo_root):
             exists, kind, checksum, size_bytes = _artifact_facts(repo_root / path)
@@ -186,14 +199,14 @@ class StepTransactionStore:
                 """
                 INSERT INTO step_artifacts (
                     transaction_id, path, role, phase, exists_flag, kind, checksum, size_bytes
-                ) VALUES (?, ?, 'changed_file', 'after', ?, ?, ?, ?)
+                ) VALUES (?, ?, 'changed_file', ?, ?, ?, ?, ?)
                 ON CONFLICT(transaction_id, path, role, phase) DO UPDATE SET
                     exists_flag = excluded.exists_flag,
                     kind = excluded.kind,
                     checksum = excluded.checksum,
                     size_bytes = excluded.size_bytes
                 """,
-                (transaction_id, str(path), int(exists), kind, checksum, size_bytes),
+                (transaction_id, str(path), phase, int(exists), kind, checksum, size_bytes),
             )
 
     @contextmanager
@@ -307,13 +320,16 @@ def _directory_checksum(path: Path) -> str:
 def _changed_files(repo_root: Path) -> tuple[Path, ...]:
     import subprocess
 
-    completed = subprocess.run(
-        ["git", "status", "--porcelain=v1", "-z"],
-        cwd=repo_root,
-        text=False,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            ["git", "status", "--porcelain=v1", "-z"],
+            cwd=repo_root,
+            text=False,
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return ()
     if completed.returncode != 0:
         return ()
     entries = [entry for entry in completed.stdout.split(b"\0") if entry]

--- a/harness_codex/runtime/step_transaction_store.py
+++ b/harness_codex/runtime/step_transaction_store.py
@@ -1,0 +1,365 @@
+"""SQLite-backed durable transaction ledger for workflow steps."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from harness_codex.runtime.models import RunContext, Step, StepResult, StepStatus
+
+
+SCHEMA_VERSION = 1
+_DB_FILE_NAME = "state.sqlite3"
+
+
+@dataclass(frozen=True)
+class StepTransaction:
+    transaction_id: int
+    attempt: int
+
+
+class StepTransactionStore:
+    """The authoritative, append-only per-step state and artifact ledger for one run."""
+
+    def __init__(self, repo_root: Path | str, run_id: str) -> None:
+        self._path = Path(repo_root) / ".harness" / "runs" / run_id / _DB_FILE_NAME
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def begin(self, step: Step, context: RunContext) -> StepTransaction:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connection() as connection:
+            self._initialize(connection)
+            self._recover_interrupted(connection)
+            with _transaction(connection):
+                attempt = int(
+                    connection.execute(
+                        """
+                        SELECT COALESCE(MAX(attempt), 0) + 1
+                        FROM step_transactions
+                        WHERE run_id = ? AND work_item_id = ? AND step_id = ?
+                        """,
+                        (context.run_id, _work_item_id(context), step.id),
+                    ).fetchone()[0]
+                )
+                cursor = connection.execute(
+                    """
+                    INSERT INTO step_transactions (
+                        run_id, workflow_name, change_set_id, work_item_id, step_id,
+                        step_kind, attempt, state, result_status, started_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'RUNNING', 'running', ?)
+                    """,
+                    (
+                        context.run_id,
+                        context.workflow_name,
+                        _change_set_id(context),
+                        _work_item_id(context),
+                        step.id,
+                        step.kind.value,
+                        attempt,
+                        _now(),
+                    ),
+                )
+                transaction_id = int(cursor.lastrowid)
+                self._record_artifacts(
+                    connection,
+                    transaction_id,
+                    context.repo_root,
+                    step.inputs,
+                    role="input",
+                    phase="before",
+                )
+                self._record_artifacts(
+                    connection,
+                    transaction_id,
+                    context.repo_root,
+                    step.outputs,
+                    role="output",
+                    phase="before",
+                )
+                return StepTransaction(transaction_id=transaction_id, attempt=attempt)
+
+    def finish(
+        self,
+        transaction: StepTransaction,
+        step: Step,
+        context: RunContext,
+        result: StepResult,
+    ) -> StepResult:
+        final_result = result
+        with self._connection() as connection:
+            self._initialize(connection)
+            with _transaction(connection):
+                outputs = tuple(step.outputs)
+                self._record_artifacts(
+                    connection,
+                    transaction.transaction_id,
+                    context.repo_root,
+                    outputs,
+                    role="output",
+                    phase="after",
+                )
+                self._record_changed_files(connection, transaction.transaction_id, context.repo_root)
+                missing_outputs = _missing_outputs(context.repo_root, outputs)
+                if result.status is StepStatus.SUCCEEDED and missing_outputs:
+                    final_result = StepResult(
+                        step_id=result.step_id,
+                        status=StepStatus.FAILED,
+                        exit_code=result.exit_code,
+                        output_path=result.output_path,
+                        error=(
+                            "declared step outputs missing: "
+                            + ", ".join(str(path) for path in missing_outputs)
+                        ),
+                        failure_kind=result.failure_kind,
+                        metadata=dict(result.metadata),
+                    )
+                state = _transaction_state(final_result.status)
+                connection.execute(
+                    """
+                    UPDATE step_transactions
+                    SET state = ?, result_status = ?, failure_kind = ?, error = ?, finished_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        state,
+                        final_result.status.value,
+                        final_result.failure_kind.value if final_result.failure_kind else None,
+                        final_result.error,
+                        _now(),
+                        transaction.transaction_id,
+                    ),
+                )
+        return final_result
+
+    def _record_artifacts(
+        self,
+        connection: sqlite3.Connection,
+        transaction_id: int,
+        repo_root: Path,
+        paths: Iterable[Path],
+        *,
+        role: str,
+        phase: str,
+    ) -> None:
+        for path in paths:
+            relative = Path(path)
+            absolute = repo_root / relative
+            exists, kind, checksum, size_bytes = _artifact_facts(absolute)
+            connection.execute(
+                """
+                INSERT INTO step_artifacts (
+                    transaction_id, path, role, phase, exists_flag, kind, checksum, size_bytes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(transaction_id, path, role, phase) DO UPDATE SET
+                    exists_flag = excluded.exists_flag,
+                    kind = excluded.kind,
+                    checksum = excluded.checksum,
+                    size_bytes = excluded.size_bytes
+                """,
+                (
+                    transaction_id,
+                    str(relative),
+                    role,
+                    phase,
+                    int(exists),
+                    kind,
+                    checksum,
+                    size_bytes,
+                ),
+            )
+
+    def _record_changed_files(
+        self,
+        connection: sqlite3.Connection,
+        transaction_id: int,
+        repo_root: Path,
+    ) -> None:
+        for path in _changed_files(repo_root):
+            absolute = repo_root / path
+            exists, kind, checksum, size_bytes = _artifact_facts(absolute)
+            connection.execute(
+                """
+                INSERT INTO step_artifacts (
+                    transaction_id, path, role, phase, exists_flag, kind, checksum, size_bytes
+                ) VALUES (?, ?, 'changed_file', 'after', ?, ?, ?, ?)
+                ON CONFLICT(transaction_id, path, role, phase) DO UPDATE SET
+                    exists_flag = excluded.exists_flag,
+                    kind = excluded.kind,
+                    checksum = excluded.checksum,
+                    size_bytes = excluded.size_bytes
+                """,
+                (transaction_id, str(path), int(exists), kind, checksum, size_bytes),
+            )
+
+    @contextmanager
+    def _connection(self):
+        connection = sqlite3.connect(self._path)
+        try:
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.execute("PRAGMA journal_mode = WAL")
+            connection.execute("PRAGMA synchronous = FULL")
+            yield connection
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _initialize(connection: sqlite3.Connection) -> None:
+        connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS schema_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS step_transactions (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                workflow_name TEXT NOT NULL,
+                change_set_id TEXT,
+                work_item_id TEXT,
+                step_id TEXT NOT NULL,
+                step_kind TEXT NOT NULL,
+                attempt INTEGER NOT NULL,
+                state TEXT NOT NULL CHECK(state IN ('RUNNING', 'COMMITTED', 'FAILED', 'BLOCKED', 'SKIPPED', 'INTERRUPTED')),
+                result_status TEXT NOT NULL,
+                failure_kind TEXT,
+                error TEXT,
+                started_at TEXT NOT NULL,
+                finished_at TEXT,
+                UNIQUE(run_id, work_item_id, step_id, attempt)
+            );
+            CREATE TABLE IF NOT EXISTS step_artifacts (
+                transaction_id INTEGER NOT NULL REFERENCES step_transactions(id) ON DELETE CASCADE,
+                path TEXT NOT NULL,
+                role TEXT NOT NULL CHECK(role IN ('input', 'output', 'changed_file')),
+                phase TEXT NOT NULL CHECK(phase IN ('before', 'after')),
+                exists_flag INTEGER NOT NULL CHECK(exists_flag IN (0, 1)),
+                kind TEXT NOT NULL,
+                checksum TEXT,
+                size_bytes INTEGER,
+                PRIMARY KEY(transaction_id, path, role, phase)
+            );
+            CREATE INDEX IF NOT EXISTS idx_step_transactions_run ON step_transactions(run_id, id);
+            CREATE INDEX IF NOT EXISTS idx_step_artifacts_transaction ON step_artifacts(transaction_id);
+            """
+        )
+        connection.execute(
+            "INSERT OR REPLACE INTO schema_meta(key, value) VALUES ('schema_version', ?)",
+            (str(SCHEMA_VERSION),),
+        )
+
+    @staticmethod
+    def _recover_interrupted(connection: sqlite3.Connection) -> None:
+        connection.execute(
+            """
+            UPDATE step_transactions
+            SET state = 'INTERRUPTED', result_status = 'blocked',
+                error = COALESCE(error, 'runtime stopped before step transaction committed'),
+                finished_at = COALESCE(finished_at, ?)
+            WHERE state = 'RUNNING'
+            """,
+            (_now(),),
+        )
+
+
+def _transaction_state(status: StepStatus) -> str:
+    return {
+        StepStatus.SUCCEEDED: "COMMITTED",
+        StepStatus.FAILED: "FAILED",
+        StepStatus.BLOCKED: "BLOCKED",
+        StepStatus.SKIPPED: "SKIPPED",
+        StepStatus.PENDING: "INTERRUPTED",
+        StepStatus.RUNNING: "RUNNING",
+    }[status]
+
+
+def _artifact_facts(path: Path) -> tuple[bool, str, str | None, int | None]:
+    try:
+        if path.is_file():
+            payload = path.read_bytes()
+            return True, "file", hashlib.sha256(payload).hexdigest(), len(payload)
+        if path.is_dir():
+            return True, "directory", _directory_checksum(path), None
+    except OSError:
+        return False, "missing", None, None
+    return False, "missing", None, None
+
+
+def _directory_checksum(path: Path) -> str:
+    digest = hashlib.sha256()
+    for child in sorted(item for item in path.rglob("*") if item.is_file()):
+        relative = child.relative_to(path).as_posix().encode("utf-8")
+        digest.update(relative)
+        digest.update(b"\0")
+        try:
+            digest.update(hashlib.sha256(child.read_bytes()).digest())
+        except OSError:
+            digest.update(b"<unreadable>")
+    return digest.hexdigest()
+
+
+def _changed_files(repo_root: Path) -> tuple[Path, ...]:
+    import subprocess
+
+    completed = subprocess.run(
+        ["git", "status", "--porcelain=v1", "-z"],
+        cwd=repo_root,
+        text=False,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return ()
+    entries = [entry for entry in completed.stdout.split(b"\0") if entry]
+    paths: list[Path] = []
+    skip_rename_source = False
+    for entry in entries:
+        if skip_rename_source:
+            paths.append(Path(entry.decode("utf-8", errors="replace")))
+            skip_rename_source = False
+            continue
+        if len(entry) < 4:
+            continue
+        status = entry[:2]
+        paths.append(Path(entry[3:].decode("utf-8", errors="replace")))
+        if b"R" in status or b"C" in status:
+            skip_rename_source = True
+    return tuple(dict.fromkeys(paths))
+
+
+def _missing_outputs(repo_root: Path, outputs: Iterable[Path]) -> tuple[Path, ...]:
+    return tuple(path for path in outputs if not (repo_root / path).exists())
+
+
+def _change_set_id(context: RunContext) -> str | None:
+    value = context.metadata.get("change_set_id")
+    return str(value) if value not in (None, "") else None
+
+
+def _work_item_id(context: RunContext) -> str:
+    value = context.metadata.get("active_work_item_id")
+    return str(value) if value not in (None, "") else "-"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@contextmanager
+def _transaction(connection: sqlite3.Connection):
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        yield
+    except BaseException:
+        connection.rollback()
+        raise
+    else:
+        connection.commit()

--- a/harness_codex/runtime/step_transaction_store.py
+++ b/harness_codex/runtime/step_transaction_store.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Iterable, Mapping
+from typing import Iterable
 
 from harness_codex.runtime.models import RunContext, Step, StepResult, StepStatus
 
@@ -122,7 +121,6 @@ class StepTransactionStore:
                         failure_kind=result.failure_kind,
                         metadata=dict(result.metadata),
                     )
-                state = _transaction_state(final_result.status)
                 connection.execute(
                     """
                     UPDATE step_transactions
@@ -130,7 +128,7 @@ class StepTransactionStore:
                     WHERE id = ?
                     """,
                     (
-                        state,
+                        _transaction_state(final_result.status),
                         final_result.status.value,
                         final_result.failure_kind.value if final_result.failure_kind else None,
                         final_result.error,
@@ -152,8 +150,7 @@ class StepTransactionStore:
     ) -> None:
         for path in paths:
             relative = Path(path)
-            absolute = repo_root / relative
-            exists, kind, checksum, size_bytes = _artifact_facts(absolute)
+            exists, kind, checksum, size_bytes = _artifact_facts(repo_root / relative)
             connection.execute(
                 """
                 INSERT INTO step_artifacts (
@@ -184,8 +181,7 @@ class StepTransactionStore:
         repo_root: Path,
     ) -> None:
         for path in _changed_files(repo_root):
-            absolute = repo_root / path
-            exists, kind, checksum, size_bytes = _artifact_facts(absolute)
+            exists, kind, checksum, size_bytes = _artifact_facts(repo_root / path)
             connection.execute(
                 """
                 INSERT INTO step_artifacts (
@@ -255,6 +251,7 @@ class StepTransactionStore:
             "INSERT OR REPLACE INTO schema_meta(key, value) VALUES ('schema_version', ?)",
             (str(SCHEMA_VERSION),),
         )
+        connection.commit()
 
     @staticmethod
     def _recover_interrupted(connection: sqlite3.Connection) -> None:
@@ -268,6 +265,7 @@ class StepTransactionStore:
             """,
             (_now(),),
         )
+        connection.commit()
 
 
 def _transaction_state(status: StepStatus) -> str:

--- a/tests/test_main_session_progress_feedback.py
+++ b/tests/test_main_session_progress_feedback.py
@@ -1,33 +1,48 @@
+import sqlite3
 from pathlib import Path
 
 from harness_codex.runtime import main_session_progress_patch as progress
 
 
-def test_active_step_event_ignores_completed_steps() -> None:
-    active = progress._active_step_event(
-        (
-            {"event_type": "step.started", "step_id": "plan-work-item"},
-            {"event_type": "step.finished", "step_id": "plan-work-item"},
-            {"event_type": "step.started", "step_id": "execute-work-item"},
+def test_active_step_row_reads_latest_running_sqlite_transaction(tmp_path: Path) -> None:
+    database = tmp_path / ".harness" / "runs" / "run-test" / "state.sqlite3"
+    database.parent.mkdir(parents=True)
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """
+            CREATE TABLE step_transactions (
+                id INTEGER PRIMARY KEY,
+                change_set_id TEXT,
+                work_item_id TEXT,
+                step_id TEXT,
+                state TEXT
+            )
+            """
         )
-    )
+        connection.executemany(
+            "INSERT INTO step_transactions(change_set_id, work_item_id, step_id, state) VALUES (?, ?, ?, ?)",
+            [
+                ("CHG-081", "UC-030", "plan-work-item", "COMMITTED"),
+                ("CHG-081", "UC-031", "execute-work-item", "RUNNING"),
+            ],
+        )
 
-    assert active is not None
-    assert active["step_id"] == "execute-work-item"
+    assert progress._active_step_row(tmp_path, "run-test") == {
+        "change_set_id": "CHG-081",
+        "work_item_id": "UC-031",
+        "step_id": "execute-work-item",
+    }
 
 
-def test_progress_message_uses_existing_run_event_fields(monkeypatch) -> None:
+def test_progress_message_uses_sqlite_step_state(monkeypatch) -> None:
     monkeypatch.setattr(
         progress,
-        "read_run_events",
-        lambda _repo_root, _run_id: (
-            {
-                "event_type": "step.started",
-                "change_set_id": "CHG-081",
-                "work_item_id": "UC-031",
-                "step_id": "verify-work-item",
-            },
-        ),
+        "_active_step_row",
+        lambda _repo_root, _run_id: {
+            "change_set_id": "CHG-081",
+            "work_item_id": "UC-031",
+            "step_id": "verify-work-item",
+        },
     )
 
     message = progress._progress_message(Path("."), "run-test", 30.9)

--- a/tests/test_main_session_progress_feedback.py
+++ b/tests/test_main_session_progress_feedback.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from harness_codex.runtime import main_session_progress_patch as progress
+
+
+def test_active_step_event_ignores_completed_steps() -> None:
+    active = progress._active_step_event(
+        (
+            {"event_type": "step.started", "step_id": "plan-work-item"},
+            {"event_type": "step.finished", "step_id": "plan-work-item"},
+            {"event_type": "step.started", "step_id": "execute-work-item"},
+        )
+    )
+
+    assert active is not None
+    assert active["step_id"] == "execute-work-item"
+
+
+def test_progress_message_uses_existing_run_event_fields(monkeypatch) -> None:
+    monkeypatch.setattr(
+        progress,
+        "read_run_events",
+        lambda _repo_root, _run_id: (
+            {
+                "event_type": "step.started",
+                "change_set_id": "CHG-081",
+                "work_item_id": "UC-031",
+                "step_id": "verify-work-item",
+            },
+        ),
+    )
+
+    message = progress._progress_message(Path("."), "run-test", 30.9)
+
+    assert message == (
+        "진행 중: ChangeSet CHG-081, Work item UC-031, "
+        "step=verify-work-item (30초 경과)"
+    )

--- a/tests/test_step_transaction_store.py
+++ b/tests/test_step_transaction_store.py
@@ -43,7 +43,7 @@ def test_step_commit_persists_status_and_artifact_revision(tmp_path: Path) -> No
         state, status = connection.execute(
             "SELECT state, result_status FROM step_transactions"
         ).fetchone()
-        before, after = connection.execute(
+        revisions = connection.execute(
             """
             SELECT phase, exists_flag
             FROM step_artifacts
@@ -54,7 +54,7 @@ def test_step_commit_persists_status_and_artifact_revision(tmp_path: Path) -> No
         ).fetchall()
 
     assert (state, status) == ("COMMITTED", "succeeded")
-    assert (before, after) == (("after", 1), ("before", 0))
+    assert revisions == [("after", 1), ("before", 0)]
 
 
 def test_missing_declared_output_fails_the_step_transaction(tmp_path: Path) -> None:

--- a/tests/test_step_transaction_store.py
+++ b/tests/test_step_transaction_store.py
@@ -1,0 +1,102 @@
+import sqlite3
+from pathlib import Path
+
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind, StepResult, StepStatus
+from harness_codex.runtime.step_transaction_store import StepTransactionStore
+
+
+def _context(repo_root: Path) -> RunContext:
+    return RunContext(
+        run_id="run-transaction",
+        workflow_name="changeset-work-item-workflow",
+        mode=RunMode.APPLY,
+        repo_root=repo_root,
+        workdir=repo_root,
+        run_dir=repo_root / ".harness" / "runs" / "run-transaction" / "work-items" / "UC-001",
+        metadata={"change_set_id": "CHG-001", "active_work_item_id": "UC-001"},
+    )
+
+
+def test_step_commit_persists_status_and_artifact_revision(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    step = Step(
+        id="plan-work-item",
+        kind=StepKind.AGENT,
+        name="write plan",
+        outputs=(Path("docs/plans/active/UC-001/plan.md"),),
+    )
+    store = StepTransactionStore(tmp_path, context.run_id)
+
+    transaction = store.begin(step, context)
+    output = tmp_path / step.outputs[0]
+    output.parent.mkdir(parents=True)
+    output.write_text("# Plan\n", encoding="utf-8")
+    result = store.finish(
+        transaction,
+        step,
+        context,
+        StepResult(step_id=step.id, status=StepStatus.SUCCEEDED),
+    )
+
+    assert result.status is StepStatus.SUCCEEDED
+    with sqlite3.connect(store.path) as connection:
+        state, status = connection.execute(
+            "SELECT state, result_status FROM step_transactions"
+        ).fetchone()
+        before, after = connection.execute(
+            """
+            SELECT phase, exists_flag
+            FROM step_artifacts
+            WHERE path = ? AND role = 'output'
+            ORDER BY phase
+            """,
+            (str(step.outputs[0]),),
+        ).fetchall()
+
+    assert (state, status) == ("COMMITTED", "succeeded")
+    assert (before, after) == (("after", 1), ("before", 0))
+
+
+def test_missing_declared_output_fails_the_step_transaction(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    step = Step(
+        id="verify-work-item",
+        kind=StepKind.VALIDATOR,
+        name="verify",
+        outputs=(Path(".harness/runs/run-transaction/verification/report.json"),),
+    )
+    store = StepTransactionStore(tmp_path, context.run_id)
+
+    transaction = store.begin(step, context)
+    result = store.finish(
+        transaction,
+        step,
+        context,
+        StepResult(step_id=step.id, status=StepStatus.SUCCEEDED),
+    )
+
+    assert result.status is StepStatus.FAILED
+    assert result.error == "declared step outputs missing: .harness/runs/run-transaction/verification/report.json"
+    with sqlite3.connect(store.path) as connection:
+        state, status = connection.execute(
+            "SELECT state, result_status FROM step_transactions"
+        ).fetchone()
+
+    assert (state, status) == ("FAILED", "failed")
+
+
+def test_next_step_marks_abandoned_running_transaction_interrupted(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    step = Step(id="execute-work-item", kind=StepKind.AGENT, name="execute")
+    store = StepTransactionStore(tmp_path, context.run_id)
+
+    first = store.begin(step, context)
+    second = store.begin(step, context)
+
+    assert second.attempt == first.attempt + 1
+    with sqlite3.connect(store.path) as connection:
+        states = connection.execute(
+            "SELECT state FROM step_transactions ORDER BY attempt"
+        ).fetchall()
+
+    assert states == [("INTERRUPTED",), ("RUNNING",)]


### PR DESCRIPTION
## 변경

각 workflow step의 상태와 산출물 사실을 run별 SQLite DB로 관리합니다.

```text
.harness/runs/<RUN-ID>/state.sqlite3
```

- `step_transactions`: ChangeSet, work item, step, attempt, 상태 전이, 오류, 시각
- `step_artifacts`: declared input/output과 Git 변경 파일의 step 전·후 존재 여부, 종류, 체크섬, 크기

## 정합성 규칙

1. step 시작은 `RUNNING`과 시작 시점 산출물 스냅샷을 SQLite 트랜잭션으로 기록합니다.
2. step 종료 시 실제 산출물 스냅샷과 최종 상태를 같은 SQLite 트랜잭션으로 확정합니다.
3. 성공한 step에서 선언한 output이 없으면 성공을 확정하지 않고 `FAILED`로 전환합니다.
4. skip과 정책 차단도 각각 `SKIPPED`, `BLOCKED`로 DB에 남깁니다.
5. 비정상 종료 뒤 남아 있는 `RUNNING` 레코드는 다음 step 시작 시 `INTERRUPTED`로 복구합니다.
6. 메인 세션의 30초 진행 알림도 NDJSON이 아니라 SQLite의 현재 `RUNNING` step을 읽습니다.

외부 프로세스가 파일시스템에 쓰는 작업은 SQLite와 단일 ACID 트랜잭션으로 묶을 수 없으므로, 시작/종료 스냅샷과 `INTERRUPTED` 복구를 통해 DB 상태와 파일 사실의 불일치를 감지·표현합니다.

## 테스트

- 성공 step의 상태/산출물 before-after revision 기록
- 선언 output 누락 시 성공 확정 방지
- 중단된 `RUNNING` step 복구
- SQLite 기반 메인 세션 진행 상태 조회

이 환경에서는 전체 pytest를 실행할 수 없었습니다.