### PR TITLE
perf: UC별 DDD 호출 축소 및 agent 산출물 계약 강제

### DIFF
--- a/.codex/agents/references/ddd-architect-output-template.md
+++ b/.codex/agents/references/ddd-architect-output-template.md
@@ -10,6 +10,8 @@ input_hashes:
   use_case: sha256:...
   event_storming: sha256:...
   e2e_goal: sha256:...
+  ubiquitous_language: sha256:... # required when docs/design/ubiquitous-language.md exists
+  architecture_baseline: sha256:... # required when ARCHITECTURE.md exists
 ---
 
 # <UC-ID>. DDD Candidate Design
@@ -75,9 +77,11 @@ Do not append another Mermaid fence or managed range.
 the same managed range. A rerun replaces that same range after merging supported
 claims from any legacy visualization ranges.
 
-`input_hashes` is a runtime contract. Every hash must match the exact current bytes
-of the active ChangeSet, use-case slice, event-storming slice, and E2E goal used to
-make this candidate. A candidate becomes stale when any declared source changes.
+`input_hashes` is a runtime contract. Hash the exact current bytes of the active
+ChangeSet, use-case slice, event-storming slice, and E2E goal. Also hash
+`docs/design/ubiquitous-language.md` and `ARCHITECTURE.md` whenever they exist,
+because either baseline can affect a reuse, modification, boundary, or ownership
+claim. A candidate becomes stale when any declared source changes.
 
 `ddd-design.md` is a candidate. `ddd-design-integration` reconciles all candidate
 claims for a ChangeSet and is the only DDD stage that may promote an accepted

--- a/.codex/agents/references/ddd-architect-output-template.md
+++ b/.codex/agents/references/ddd-architect-output-template.md
@@ -6,7 +6,10 @@ status: candidate
 change_set: <CHG-ID>
 work_item: <UC-ID>
 input_hashes:
+  change_set_document: sha256:...
+  use_case: sha256:...
   event_storming: sha256:...
+  e2e_goal: sha256:...
 ---
 
 # <UC-ID>. DDD Candidate Design
@@ -71,6 +74,10 @@ Do not append another Mermaid fence or managed range.
 `behaviors`, `aggregates`, `application_flow`, and `bounded_contexts` all update
 the same managed range. A rerun replaces that same range after merging supported
 claims from any legacy visualization ranges.
+
+`input_hashes` is a runtime contract. Every hash must match the exact current bytes
+of the active ChangeSet, use-case slice, event-storming slice, and E2E goal used to
+make this candidate. A candidate becomes stale when any declared source changes.
 
 `ddd-design.md` is a candidate. `ddd-design-integration` reconciles all candidate
 claims for a ChangeSet and is the only DDD stage that may promote an accepted

--- a/.codex/skills/harness-ddd-design/references/detailed-instructions.md
+++ b/.codex/skills/harness-ddd-design/references/detailed-instructions.md
@@ -15,6 +15,9 @@
   - `docs/use-cases/<UC-ID>/use-case.md`
   - `docs/use-cases/<UC-ID>/event-storming.md`
   - `docs/use-cases/<UC-ID>/e2e-goal.md`
+- conditional baseline input:
+  - `docs/design/ubiquitous-language.md` when it exists
+  - `ARCHITECTURE.md` when it exists
 - output file:
   - `docs/use-cases/<UC-ID>/ddd-design.md`
 
@@ -29,6 +32,8 @@
   - `use_case`: selected use-case slice
   - `event_storming`: selected event-storming slice
   - `e2e_goal`: selected E2E goal slice
+  - `ubiquitous_language`: `docs/design/ubiquitous-language.md`가 존재할 때
+  - `architecture_baseline`: `ARCHITECTURE.md`가 존재할 때
 - 어떤 입력 hash라도 현재 파일과 다르면 candidate는 stale이다. 기존 후보를 repair할 때도 모든 hash를 새로 계산하며, 유효한 대체 후보가 완성되기 전에는 기존 파일을 삭제하지 않는다.
 
 ## Slice-first flow

--- a/.codex/skills/harness-ddd-design/references/detailed-instructions.md
+++ b/.codex/skills/harness-ddd-design/references/detailed-instructions.md
@@ -23,7 +23,13 @@
 - 쓰기 범위는 `docs/use-cases/<UC-ID>/ddd-design.md` 하나다.
 - `ARCHITECTURE.md`를 수정하지 않는다.
 - 다른 UC 후보나 downstream technical decision, diagram, plan을 수정하지 않는다.
-- 후보 문서 상단에는 `status: candidate`, ChangeSet ID, Work Item ID, Event Storming input hash를 기록한다.
+- 후보 문서 상단에는 `status: candidate`, ChangeSet ID, Work Item ID를 기록한다.
+- `input_hashes`에는 현재 입력 바이트의 SHA-256을 아래 키로 모두 기록한다.
+  - `change_set_document`: active ChangeSet
+  - `use_case`: selected use-case slice
+  - `event_storming`: selected event-storming slice
+  - `e2e_goal`: selected E2E goal slice
+- 어떤 입력 hash라도 현재 파일과 다르면 candidate는 stale이다. 기존 후보를 repair할 때도 모든 hash를 새로 계산하며, 유효한 대체 후보가 완성되기 전에는 기존 파일을 삭제하지 않는다.
 
 ## Slice-first flow
 
@@ -71,4 +77,4 @@
 
 ## Handoff
 
-`ddd-design-integration`은 모든 후보의 claim을 정규화해 canonical contract를 만든다. candidate 문서가 나중에 변경되면 input hash 불일치로 integration과 downstream 산출물은 stale이다.
+`ddd-design-integration`은 모든 후보의 claim을 정규화해 canonical contract를 만든다. candidate 문서가 나중에 변경되거나 input hash가 현재 source와 불일치하면 integration과 downstream 산출물은 stale이다.

--- a/.codex/skills/harness-ddd-integration/references/detailed-instructions.md
+++ b/.codex/skills/harness-ddd-integration/references/detailed-instructions.md
@@ -5,9 +5,10 @@
 1. active ChangeSet에서 affected use case를 확인한다.
 2. 모든 UC의 `ddd-design.md`가 candidate로 준비됐는지 확인한다. 누락된 후보가 있으면 해당 DDD stage로 block을 라우팅한다.
 3. 각 후보의 Event Storming, Use Case, E2E goal, `context.md`, 기존 `ARCHITECTURE.md`를 읽는다.
-4. 모델 claim을 정규화한 뒤 동일성, Aggregate 소유권, lifecycle, invariant, command/event 의미를 비교한다.
-5. 모든 후보 claim을 accepted, deferred, rejected, blocked 중 하나로 추적한다.
-6. accepted일 때만 Markdown 결정 기록, JSON contract, 필요한 `ARCHITECTURE.md` delta를 작성한다.
+4. 모든 후보의 `input_hashes`가 현재 ChangeSet, Use Case, Event Storming, E2E goal의 exact SHA-256과 일치하는지 확인한다. 하나라도 불일치하면 stale candidate로 처리하고 DDD stage로 되돌린다.
+5. 모델 claim을 정규화한 뒤 동일성, Aggregate 소유권, lifecycle, invariant, command/event 의미를 비교한다.
+6. 모든 후보 claim을 accepted, deferred, rejected, blocked 중 하나로 추적한다.
+7. accepted일 때만 Markdown 결정 기록, JSON contract, 필요한 `ARCHITECTURE.md` delta를 작성한다.
 
 ## 병합 규칙
 
@@ -27,13 +28,14 @@
 - 권한·일관성·검증 규칙이 충돌하는 경우
 - 같은 command/event 이름의 의미가 다른 경우
 - canonical noun, actor role, state label의 의미 경계가 모호한 경우
+- candidate path가 `docs/use-cases/<UC-ID>/ddd-design.md`가 아니거나 candidate의 source provenance가 stale인 경우
 
 Blocker는 가장 가까운 소유 단계로 라우팅한다.
 
 - 요구사항 정책 부족: `requirements-definition`
 - canonical 용어·alias·상태 의미 부족: `ubiquitous-language-definition`
 - flow, command/event, policy evidence 부족: `event-storming`
-- 특정 후보의 DDD 구조 불완전: `ddd-architecture-definition --uc <UC-ID>`
+- 특정 후보의 DDD 구조 불완전 또는 input hash stale: `ddd-architecture-definition --uc <UC-ID>`
 
 ## 산출물 경로
 
@@ -42,7 +44,7 @@ ChangeSet 자체가 `docs/changes/active/<CHG-ID>.md` 파일이므로 같은 이
 - `docs/changes/active/<CHG-ID>.ddd-integration.md`
 - `docs/changes/active/<CHG-ID>.ddd-integration.json`
 
-JSON은 runtime validator가 읽는다. candidate input hash가 달라지면 통합 결과와 downstream 단계는 stale이다.
+JSON은 runtime validator가 읽는다. candidate 파일 hash와 candidate 내부의 모든 source input hash가 현재 source와 달라지면 통합 결과와 downstream 단계는 stale이다.
 
 ## JSON contract 필수 schema
 
@@ -51,6 +53,7 @@ JSON은 runtime validator가 읽는다. candidate input hash가 달라지면 통
 - `change_set`: ChangeSet ID 문자열
 - `candidate_inputs`: candidate별 입력 배열
   - 각 항목은 `uc_id`, `path`, `hash`를 포함한다.
+  - `path`는 반드시 `docs/use-cases/<UC-ID>/ddd-design.md`여야 한다.
   - `hash` 값은 `sha256:<hex>` 형식이다. `sha256` key만 쓰지 말고 반드시 `hash` key를 쓴다.
 - `coverage`: UC별 반영 상태 mapping
   - 예: `"coverage": {"UC-030": "accepted", "UC-031": "accepted"}`

--- a/harness_codex/__init__.py
+++ b/harness_codex/__init__.py
@@ -10,44 +10,52 @@ __version__ = "0.1.169"
 
 
 def _install_step_transaction_ledger() -> None:
-    """Make SQLite the durable authority for per-step state and artifact revisions."""
-
     from harness_codex.runtime.step_transaction_patch import apply_step_transaction_patch
-
     apply_step_transaction_patch()
 
 
 def _install_main_session_step_feedback() -> None:
-    """Expose the SQLite active step to the main CLI session."""
-
-    from harness_codex.runtime.main_session_progress_patch import (
-        apply_main_session_progress_feedback_patch,
-    )
-
+    from harness_codex.runtime.main_session_progress_patch import apply_main_session_progress_feedback_patch
     apply_main_session_progress_feedback_patch()
 
 
+def _install_agent_output_contract() -> None:
+    from harness_codex.runtime.agent_output_contract_patch import apply_agent_output_contract_patch
+    apply_agent_output_contract_patch()
+
+
+def _install_agent_trace_retention() -> None:
+    from harness_codex.runtime.agent_trace_retention_patch import apply_agent_trace_retention_patch
+    apply_agent_trace_retention_patch()
+
+
+def _install_token_observability_trace_retention() -> None:
+    from harness_codex.runtime.token_observability_trace_retention_patch import apply_token_observability_trace_retention_patch
+    apply_token_observability_trace_retention_patch()
+
+
+def _install_ddd_candidate_efficiency() -> None:
+    from harness_codex.runtime.ddd_candidate_efficiency_patch import apply_ddd_candidate_efficiency_patch
+    apply_ddd_candidate_efficiency_patch()
+
+
+def _install_ddd_candidate_input_integrity() -> None:
+    from harness_codex.runtime.ddd_candidate_input_integrity_patch import apply_ddd_candidate_input_integrity_patch
+    apply_ddd_candidate_input_integrity_patch()
+
+
+def _install_ddd_integration_candidate_provenance() -> None:
+    from harness_codex.runtime.ddd_integration_candidate_provenance_patch import apply_ddd_integration_candidate_provenance_patch
+    apply_ddd_integration_candidate_provenance_patch()
+
+
 def _install_changeset_execution_boundary() -> None:
-    """Route the CLI hook through the two-layer ChangeSet session orchestrator.
-
-    The public parser and injected test doubles stay stable while execution moves
-    from one mixed workflow to explicit work-item and finalization boundaries.
-    """
-
     cli = import_module("harness_codex.cli")
     if getattr(cli, "_changeset_execution_boundary_installed", False):
         return
-
     from harness_codex.runtime.changeset_orchestrator import apply_workflow
 
     def load_session_workflow(*loader_args, **loader_kwargs):
-        """Load a runtime workflow while retaining the command test seam.
-
-        Production loaders return a ``Workflow`` with concrete steps. Older command
-        tests inject a named mutable handle only; normalize that handle so boundary
-        validation can still run over its empty test-step set without weakening the
-        validation of production workflow definitions.
-        """
         workflow = cli.load_named_workflow(*loader_args, **loader_kwargs)
         if not hasattr(workflow, "steps"):
             setattr(workflow, "steps", ())
@@ -69,35 +77,17 @@ def _install_changeset_execution_boundary() -> None:
 
 
 def _install_runtime_write_boundaries() -> None:
-    """Install declared write scopes before fail-closed violation recovery."""
-
-    from harness_codex.runtime.agent_write_scope_policy_patch import (
-        apply_agent_write_scope_policy_patch,
-    )
-    from harness_codex.runtime.scope_violation_recovery_patch import (
-        apply_scope_violation_recovery_patch,
-    )
-
+    from harness_codex.runtime.agent_write_scope_policy_patch import apply_agent_write_scope_policy_patch
+    from harness_codex.runtime.scope_violation_recovery_patch import apply_scope_violation_recovery_patch
     apply_agent_write_scope_policy_patch()
     apply_scope_violation_recovery_patch()
 
 
 def _install_canonical_procedure_stage_bridge() -> None:
-    """Install canonical state bridges after the CLI module is complete."""
-
-    from harness_codex.runtime.dashboard_final_design_result_patch import (
-        apply_dashboard_final_design_result_patch,
-    )
-    from harness_codex.runtime.dashboard_gate_state_patch import (
-        apply_dashboard_gate_state_patch,
-    )
-    from harness_codex.runtime.procedure_stage_runtime_state_patch import (
-        apply_procedure_stage_runtime_state_patch,
-    )
-    from harness_codex.runtime.temporary_changeset_canonical_state_patch import (
-        apply_temporary_changeset_canonical_state_patch,
-    )
-
+    from harness_codex.runtime.dashboard_final_design_result_patch import apply_dashboard_final_design_result_patch
+    from harness_codex.runtime.dashboard_gate_state_patch import apply_dashboard_gate_state_patch
+    from harness_codex.runtime.procedure_stage_runtime_state_patch import apply_procedure_stage_runtime_state_patch
+    from harness_codex.runtime.temporary_changeset_canonical_state_patch import apply_temporary_changeset_canonical_state_patch
     apply_procedure_stage_runtime_state_patch()
     apply_temporary_changeset_canonical_state_patch()
     apply_dashboard_gate_state_patch()
@@ -105,47 +95,33 @@ def _install_canonical_procedure_stage_bridge() -> None:
 
 
 def _install_changeset_deletion_cleanup() -> None:
-    """Install deletion cleanup after the legacy CLI module is fully defined."""
-
-    from harness_codex.runtime.changeset_deletion_runtime_patch import (
-        apply_changeset_deletion_runtime_cleanup_patch,
-    )
-
+    from harness_codex.runtime.changeset_deletion_runtime_patch import apply_changeset_deletion_runtime_cleanup_patch
     apply_changeset_deletion_runtime_cleanup_patch()
 
 
 def _install_changeset_scope_isolation() -> None:
-    """Keep global harvest artifacts scoped to the currently active ChangeSet."""
-
-    from harness_codex.runtime.changeset_scope_isolation_patch import (
-        apply_changeset_scope_isolation_patch,
-    )
-
+    from harness_codex.runtime.changeset_scope_isolation_patch import apply_changeset_scope_isolation_patch
     apply_changeset_scope_isolation_patch()
 
 
 def _install_final_canonical_gate_authority() -> None:
-    """Ensure explicit RunState decisions always outrank editable table rows."""
-
-    from harness_codex.runtime.canonical_stage_gate_authority_patch import (
-        apply_canonical_stage_gate_authority_patch,
-    )
-
+    from harness_codex.runtime.canonical_stage_gate_authority_patch import apply_canonical_stage_gate_authority_patch
     apply_canonical_stage_gate_authority_patch()
 
 
 def _install_security_review_bundle_prompt_profile() -> None:
-    """Install minimal prompt handling for bundle-scoped security reviewers."""
-
-    from harness_codex.runtime.security_review_prompt_patch import (
-        apply_security_review_prompt_patch,
-    )
-
+    from harness_codex.runtime.security_review_prompt_patch import apply_security_review_prompt_patch
     apply_security_review_prompt_patch()
 
 
 _install_step_transaction_ledger()
 _install_main_session_step_feedback()
+_install_agent_output_contract()
+_install_agent_trace_retention()
+_install_token_observability_trace_retention()
+_install_ddd_candidate_efficiency()
+_install_ddd_candidate_input_integrity()
+_install_ddd_integration_candidate_provenance()
 _install_changeset_execution_boundary()
 _install_runtime_write_boundaries()
 _install_canonical_procedure_stage_bridge()

--- a/harness_codex/runtime/agent_output_contract_patch.py
+++ b/harness_codex/runtime/agent_output_contract_patch.py
@@ -1,0 +1,100 @@
+"""Fail closed when an agent creates malformed declared output artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+
+def apply_agent_output_contract_patch() -> None:
+    """Extend output validation and cover cached-agent early returns.
+
+    The base runner validates normal provider results before writing `result.json`,
+    but review-cache hits return early. The finalizer validates both paths and
+    rewrites the persisted result if a cached output violates the declaration.
+    """
+
+    import harness_codex.runtime.runner as runner
+    from harness_codex.runtime.models import FailureKind, StepStatus
+
+    original_validate = runner._validate_agent_outputs
+    if not getattr(original_validate, "_agent_output_contract_patch", False):
+        def validate_agent_outputs(step, context):
+            error = original_validate(step, context)
+            if error:
+                return error
+            return _validate_declared_output_shapes(step, context.repo_root)
+
+        validate_agent_outputs._agent_output_contract_patch = True
+        runner._validate_agent_outputs = validate_agent_outputs
+
+    BasicStepRunner = runner.BasicStepRunner
+    if getattr(BasicStepRunner, "_agent_output_contract_finalizer_patch", False):
+        return
+    original_run_agent = BasicStepRunner._run_agent
+
+    def run_agent(self, step, context, step_dir: Path):
+        result = original_run_agent(self, step, context, step_dir)
+        if result.status is not StepStatus.SUCCEEDED:
+            return result
+        error = _validate_declared_output_shapes(step, context.repo_root)
+        if error is None:
+            return result
+
+        failed = replace(
+            result,
+            status=StepStatus.FAILED,
+            error=error,
+            failure_kind=FailureKind.IMPLEMENTATION,
+            metadata={**dict(result.metadata), "output_contract_status": "failed"},
+        )
+        _persist_output_contract_failure(runner, context, step, step_dir, failed)
+        return failed
+
+    BasicStepRunner._run_agent = run_agent
+    BasicStepRunner._agent_output_contract_finalizer_patch = True
+
+
+def _validate_declared_output_shapes(step, repo_root: Path) -> str | None:
+    text_suffixes = {".md", ".json", ".txt", ".yaml", ".yml", ".toml"}
+    for relative in step.outputs:
+        path = repo_root / relative
+        if path.is_symlink():
+            return f"agent output must not be a symlink: {relative}"
+        if Path(relative).suffix and not path.is_file():
+            return f"agent output must be a regular file: {relative}"
+        if path.is_file() and Path(relative).suffix.lower() in text_suffixes:
+            try:
+                if path.stat().st_size == 0:
+                    return f"agent output must not be empty: {relative}"
+            except OSError:
+                return f"agent output is unreadable: {relative}"
+    return None
+
+
+def _persist_output_contract_failure(runner, context, step, step_dir: Path, result) -> None:
+    path = step_dir / "result.json"
+    payload = _read_json(path)
+    payload.update(
+        {
+            "step_id": step.id,
+            "agent_id": step.agent_id,
+            "status": result.status.value,
+            "exit_code": result.exit_code,
+            "error": result.error,
+            "failure_kind": result.failure_kind.value if result.failure_kind else None,
+            "metadata": dict(result.metadata),
+        }
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    runner._write_response_snapshot(context, step.id, path)
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}

--- a/harness_codex/runtime/agent_trace_reference_cleanup_patch.py
+++ b/harness_codex/runtime/agent_trace_reference_cleanup_patch.py
@@ -1,0 +1,36 @@
+"""Remove run-root log references when accepted traces are compacted."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def apply_agent_trace_reference_cleanup_patch() -> None:
+    """Keep compact trace metadata from pointing at deleted stdout/stderr files."""
+
+    import harness_codex.runtime.agent_trace_retention_patch as trace
+
+    original_remove = trace._remove_raw_logs
+    if getattr(original_remove, "_trace_reference_cleanup_patch", False):
+        return
+
+    def remove_raw_logs(stdout_path: Path, stderr_path: Path) -> None:
+        step_dir = stdout_path.parent
+        run_dir = step_dir.parent.parent
+        step_id = step_dir.name
+        paths = (
+            stdout_path,
+            stderr_path,
+            run_dir / f"stdout-{step_id}.log",
+            run_dir / f"stderr-{step_id}.log",
+        )
+        for path in paths:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError:
+                continue
+
+    remove_raw_logs._trace_reference_cleanup_patch = True
+    trace._remove_raw_logs = remove_raw_logs

--- a/harness_codex/runtime/agent_trace_retention_patch.py
+++ b/harness_codex/runtime/agent_trace_retention_patch.py
@@ -1,0 +1,329 @@
+"""Compact successful agent traces only after the runtime accepts the artifact contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Mapping
+
+from harness_codex.runtime.models import StepStatus
+
+
+SUCCESS_STDERR_TAIL_BYTES = 16_384
+TRACE_SUMMARY_SCHEMA_VERSION = 1
+
+
+def apply_agent_trace_retention_patch() -> None:
+    """Move trace cleanup after deterministic runtime contract checks.
+
+    `ConfigurableCliAgentAdapter` only knows that the provider process returned
+    zero. It does not know whether output, scope, review, or mutation contracts
+    will later fail in `BasicStepRunner._run_agent`. Compacting there discarded the
+    only useful evidence for malformed agent output. The wrapper below runs after
+    those checks and never compacts failed or blocked steps.
+    """
+
+    import harness_codex.runtime.runner as runner
+
+    original_run_agent = runner.BasicStepRunner._run_agent
+    if getattr(original_run_agent, "_agent_trace_retention_patch", False):
+        return
+
+    def run_agent(self, step, context, step_dir):
+        result = original_run_agent(self, step, context, step_dir)
+        if result.status is not StepStatus.SUCCEEDED or _retains_full_trace(step):
+            return result
+
+        metadata = _compact_accepted_agent_trace(
+            runner=runner,
+            step=step,
+            context=context,
+            step_dir=step_dir,
+            result=result,
+        )
+        if metadata is None:
+            # Missing final-message/result evidence or cleanup failure keeps full
+            # logs. Trace optimization must never weaken failure diagnosis.
+            return result
+        return replace(result, metadata={**dict(result.metadata), **metadata})
+
+    run_agent._agent_trace_retention_patch = True
+    runner.BasicStepRunner._run_agent = run_agent
+
+
+def _retains_full_trace(step) -> bool:
+    value = step.metadata.get("agent_trace_retention", "summary")
+    return str(value).strip().lower() == "full"
+
+
+def _compact_accepted_agent_trace(*, runner, step, context, step_dir: Path, result):
+    result_path = step_dir / "result.json"
+    final_message_path = step_dir / "final-message.md"
+    stdout_path = step_dir / "stdout.txt"
+    stderr_path = step_dir / "stderr.txt"
+
+    contract = _accepted_contract(step, context, result_path, final_message_path, result)
+    if contract is None:
+        return None
+
+    summary = {
+        "schema_version": TRACE_SUMMARY_SCHEMA_VERSION,
+        "retention": "summary",
+        "contract": contract,
+        "streams": {
+            "stdout": _artifact_summary(stdout_path),
+            "stderr": _artifact_summary(stderr_path, include_tail=True),
+        },
+        "final_message": _artifact_summary(final_message_path),
+    }
+    usage = _provider_usage(stdout_path)
+    if usage:
+        summary["usage"] = usage
+
+    summary_path = step_dir / "trace-summary.json"
+    try:
+        _atomic_write_json(summary_path, summary)
+        _compact_checkpoint(step_dir / "checkpoint.json")
+        _update_result_metadata(result_path, summary_path, usage)
+        runner._write_response_snapshot(context, step.id, result_path)
+        _remove_raw_logs(stdout_path, stderr_path)
+    except OSError:
+        return None
+
+    return {
+        "trace_retention": "summary",
+        "trace_summary_path": str(runner._relative_to_repo(summary_path, context)),
+        "trace_contract_status": "accepted",
+        **({"usage": usage} if usage else {}),
+    }
+
+
+def _accepted_contract(step, context, result_path: Path, final_message_path: Path, result) -> dict[str, Any] | None:
+    """Return a durable receipt only for an already accepted agent result."""
+
+    if result.status is not StepStatus.SUCCEEDED:
+        return None
+    if not result_path.is_file() or not final_message_path.is_file():
+        return None
+
+    payload = _read_json(result_path)
+    if payload.get("status") != StepStatus.SUCCEEDED.value:
+        return None
+    if payload.get("step_id") != step.id:
+        return None
+
+    outputs: list[dict[str, Any]] = []
+    for relative in step.outputs:
+        absolute = context.repo_root / relative
+        snapshot = _artifact_summary(absolute)
+        if not snapshot.get("present"):
+            return None
+        outputs.append({"path": str(relative), **snapshot})
+
+    return {
+        "step_id": step.id,
+        "agent_id": step.agent_id,
+        "result_status": StepStatus.SUCCEEDED.value,
+        "declared_outputs": outputs,
+        "final_message_path": str(final_message_path.relative_to(context.repo_root)),
+    }
+
+
+def _provider_usage(stdout_path: Path) -> dict[str, int | None]:
+    """Extract provider accounting by streaming JSONL before raw stdout is removed."""
+
+    merged = _empty_usage()
+    found = False
+    try:
+        with stdout_path.open("r", encoding="utf-8") as stream:
+            for line in stream:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                for candidate in _usage_candidates(event):
+                    for key, value in candidate.items():
+                        if value is not None:
+                            merged[key] = value
+                            found = True
+    except OSError:
+        return {}
+    if not found:
+        return {}
+    if merged["total_tokens"] is None and all(
+        isinstance(merged[key], int)
+        for key in ("input_tokens", "output_tokens", "reasoning_tokens")
+    ):
+        merged["total_tokens"] = sum(
+            int(merged[key]) for key in ("input_tokens", "output_tokens", "reasoning_tokens")
+        )
+    return {
+        "input_tokens": merged["input_tokens"],
+        "prompt_tokens": merged["input_tokens"],
+        "cached_input_tokens": merged["cached_input_tokens"],
+        "cached_prompt_tokens": merged["cached_input_tokens"],
+        "output_tokens": merged["output_tokens"],
+        "completion_tokens": merged["output_tokens"],
+        "reasoning_tokens": merged["reasoning_tokens"],
+        "total_tokens": merged["total_tokens"],
+    }
+
+
+def _usage_candidates(value: Any) -> list[dict[str, int | None]]:
+    stack = [value]
+    candidates: list[dict[str, int | None]] = []
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            source = current.get("usage") if isinstance(current.get("usage"), Mapping) else current
+            candidate = _normalize_usage(source)
+            if any(item is not None for item in candidate.values()):
+                candidates.append(candidate)
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+    return candidates
+
+
+def _normalize_usage(value: Mapping[str, Any]) -> dict[str, int | None]:
+    aliases = {
+        "input_tokens": ("input_tokens", "prompt_tokens"),
+        "cached_input_tokens": ("cached_input_tokens", "cached_prompt_tokens"),
+        "output_tokens": ("output_tokens", "completion_tokens"),
+        "reasoning_tokens": ("reasoning_tokens",),
+        "total_tokens": ("total_tokens",),
+    }
+    return {
+        target: next(
+            (
+                value[key]
+                for key in names
+                if isinstance(value.get(key), int) and value[key] >= 0
+            ),
+            None,
+        )
+        for target, names in aliases.items()
+    }
+
+
+def _empty_usage() -> dict[str, int | None]:
+    return {
+        "input_tokens": None,
+        "cached_input_tokens": None,
+        "output_tokens": None,
+        "reasoning_tokens": None,
+        "total_tokens": None,
+    }
+
+
+def _artifact_summary(path: Path, *, include_tail: bool = False) -> dict[str, Any]:
+    try:
+        if path.is_file():
+            size_bytes = path.stat().st_size
+            summary: dict[str, Any] = {
+                "present": True,
+                "kind": "file",
+                "bytes": size_bytes,
+                "sha256": _sha256(path),
+            }
+            if include_tail and size_bytes:
+                summary["tail"] = _tail(path)
+            return summary
+        if path.is_dir():
+            return {
+                "present": True,
+                "kind": "directory",
+                "files": sum(1 for child in path.rglob("*") if child.is_file()),
+                "sha256": _directory_sha256(path),
+            }
+    except OSError:
+        pass
+    return {"present": False, "bytes": 0}
+
+
+def _tail(path: Path) -> str:
+    try:
+        with path.open("rb") as stream:
+            size_bytes = path.stat().st_size
+            stream.seek(max(0, size_bytes - SUCCESS_STDERR_TAIL_BYTES), os.SEEK_SET)
+            return stream.read(SUCCESS_STDERR_TAIL_BYTES).decode("utf-8", errors="replace").strip()
+    except OSError:
+        return ""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _directory_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    for child in sorted(item for item in path.rglob("*") if item.is_file()):
+        digest.update(str(child.relative_to(path)).encode("utf-8"))
+        digest.update(_sha256(child).encode("ascii"))
+    return digest.hexdigest()
+
+
+def _compact_checkpoint(path: Path) -> None:
+    if not path.is_file():
+        return
+    payload = _read_json(path)
+    if not payload:
+        return
+    evidence_paths = payload.get("evidence_paths")
+    if isinstance(evidence_paths, list):
+        payload["evidence_paths"] = [
+            item
+            for item in evidence_paths
+            if not str(item).replace("\\", "/").endswith("/stdout.txt")
+        ]
+    payload["trace_retention"] = "summary"
+    _atomic_write_json(path, payload)
+
+
+def _update_result_metadata(result_path: Path, summary_path: Path, usage: Mapping[str, Any]) -> None:
+    payload = _read_json(result_path)
+    metadata = payload.get("metadata")
+    metadata = dict(metadata) if isinstance(metadata, Mapping) else {}
+    metadata.pop("stdout_path", None)
+    metadata.pop("stderr_path", None)
+    metadata.update(
+        {
+            "trace_retention": "summary",
+            "trace_summary_path": str(summary_path),
+            "trace_contract_status": "accepted",
+        }
+    )
+    if usage:
+        metadata["usage"] = dict(usage)
+    payload["metadata"] = metadata
+    _atomic_write_json(result_path, payload)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _remove_raw_logs(stdout_path: Path, stderr_path: Path) -> None:
+    for path in (stdout_path, stderr_path):
+        path.unlink(missing_ok=True)

--- a/harness_codex/runtime/ddd_candidate_baseline_provenance_patch.py
+++ b/harness_codex/runtime/ddd_candidate_baseline_provenance_patch.py
@@ -1,0 +1,68 @@
+"""Require source hashes for DDD baselines when those baselines exist."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+
+_BASELINE_PATHS = {
+    "ubiquitous_language": Path("docs/design/ubiquitous-language.md"),
+    "architecture_baseline": Path("ARCHITECTURE.md"),
+}
+
+
+def apply_ddd_candidate_baseline_provenance_patch() -> None:
+    """Extend candidate provenance without weakening required slice hashes."""
+
+    import harness_codex.runtime.ddd_candidate_input_integrity_patch as integrity
+    import harness_codex.runtime.harvest_ui as ui
+
+    if getattr(integrity, "_ddd_candidate_baseline_provenance_patch_applied", False):
+        return
+
+    original_validate = integrity._validate_all_input_hashes
+    original_expected = integrity._expected_hashes
+    original_contract = ui._ddd_run_all_contract
+
+    def expected_hashes(root: Path, change_set_id: str, uc_id: str) -> dict[str, str]:
+        hashes = dict(original_expected(root, change_set_id, uc_id))
+        hashes.update(_baseline_hashes(root))
+        return hashes
+
+    def validate_all(root: Path, change_set_id: str, uc_id: str) -> str:
+        error = original_validate(root, change_set_id, uc_id)
+        if error:
+            return error
+        declared = integrity._declared_input_hashes(
+            (root / "docs" / "use-cases" / uc_id / "ddd-design.md").read_text(encoding="utf-8")
+        )
+        for key, expected in _baseline_hashes(root).items():
+            if key not in declared:
+                return f"DDD candidate input_hashes is missing `{key}`"
+            if declared[key] != expected:
+                return f"DDD candidate input hash mismatch for `{key}`"
+        return ""
+
+    def candidate_contract(change_set_id: str, targets, state) -> str:
+        return (
+            original_contract(change_set_id, targets, state).rstrip()
+            + "\nWhen present, also hash `docs/design/ubiquitous-language.md` as "
+            + "`ubiquitous_language` and `ARCHITECTURE.md` as `architecture_baseline`.\n"
+        )
+
+    integrity._expected_hashes = expected_hashes
+    integrity._validate_all_input_hashes = validate_all
+    ui._ddd_run_all_contract = candidate_contract
+    integrity._ddd_candidate_baseline_provenance_patch_applied = True
+
+
+def _baseline_hashes(root: Path) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for key, relative in _BASELINE_PATHS.items():
+        path = root / relative
+        if path.is_file() and not path.is_symlink():
+            hashes[key] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    return hashes

--- a/harness_codex/runtime/ddd_candidate_baseline_provenance_patch.py
+++ b/harness_codex/runtime/ddd_candidate_baseline_provenance_patch.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import re
 from pathlib import Path
 
@@ -36,9 +35,13 @@ def apply_ddd_candidate_baseline_provenance_patch() -> None:
         error = original_validate(root, change_set_id, uc_id)
         if error:
             return error
-        declared = integrity._declared_input_hashes(
-            (root / "docs" / "use-cases" / uc_id / "ddd-design.md").read_text(encoding="utf-8")
-        )
+        try:
+            text = (root / "docs" / "use-cases" / uc_id / "ddd-design.md").read_text(
+                encoding="utf-8"
+            )
+        except OSError:
+            return f"DDD candidate is unreadable for baseline provenance: {uc_id}"
+        declared = _declared_baseline_hashes(text)
         for key, expected in _baseline_hashes(root).items():
             if key not in declared:
                 return f"DDD candidate input_hashes is missing `{key}`"
@@ -66,3 +69,21 @@ def _baseline_hashes(root: Path) -> dict[str, str]:
         if path.is_file() and not path.is_symlink():
             hashes[key] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
     return hashes
+
+
+def _declared_baseline_hashes(text: str) -> dict[str, str]:
+    front = re.match(r"\A---\n(?P<body>.*?)\n---\n?", text, flags=re.DOTALL)
+    if front is None:
+        return {}
+    block = re.search(
+        r"(?m)^input_hashes:[ \t]*\n(?P<body>(?:^[ \t]+.*(?:\n|$))*)",
+        front.group("body"),
+    )
+    if block is None:
+        return {}
+    values: dict[str, str] = {}
+    for key in _BASELINE_PATHS:
+        match = re.search(rf"(?m)^\s+{re.escape(key)}:\s*(\S+)\s*$", block.group("body"))
+        if match is not None:
+            values[key] = match.group(1).strip("'\"")
+    return values

--- a/harness_codex/runtime/ddd_candidate_efficiency_patch.py
+++ b/harness_codex/runtime/ddd_candidate_efficiency_patch.py
@@ -1,0 +1,392 @@
+"""Execute one DDD candidate per use case with deterministic artifact contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_CANDIDATE_SCHEMA_VERSION = 1
+_REQUIRED_HEADINGS = (
+    "## Impact Assessment",
+    "## Entity / Value Objects",
+    "## Behaviors",
+    "## Application Flow",
+    "## Aggregates",
+    "## Bounded Contexts",
+    "## Integration Impact",
+    "## Architecture Visualization",
+)
+
+
+def apply_ddd_candidate_efficiency_patch() -> None:
+    import harness_codex.runtime.harvest_ui as ui
+
+    if getattr(ui, "_ddd_candidate_efficiency_patch_applied", False):
+        return
+
+    original_advance_all = ui._advance_all_ddd_architecture
+    original_validate_slice = ui._validate_ddd_design_slice
+    ui.DDD_RUN_ALL_TIMEOUT_SEC = ui.DDD_TIMEOUT_SEC
+
+    def validate_slice(path: Path, completed_step: str) -> tuple[bool, str]:
+        ready, error = original_validate_slice(path, completed_step)
+        if not ready:
+            return ready, error
+        return _validate_visualization_contract(path)
+
+    def candidate_advance(
+        root,
+        session: dict[str, Any],
+        change_set_id: str,
+        *,
+        uc_id: str | None = None,
+        step_id: str | None = None,
+    ) -> None:
+        state = session["ddd_architecture"]
+        target_uc = uc_id or _first_incomplete_uc(ui, state)
+        if target_uc is None:
+            ui._refresh_ddd_completion(state)
+            session["runtime_error"] = ""
+            return
+        targets = _targets_for_uc(ui, state, target_uc)
+        if targets:
+            _run_candidate(
+                ui=ui,
+                original_advance_all=original_advance_all,
+                root=Path(root),
+                session=session,
+                change_set_id=change_set_id,
+                uc_id=target_uc,
+                targets=targets,
+            )
+
+    def candidate_advance_all(root, session: dict[str, Any], change_set_id: str, _targets) -> None:
+        state = session["ddd_architecture"]
+        for uc_id in state.get("uc_ids", []):
+            targets = _targets_for_uc(ui, state, uc_id)
+            if not targets:
+                continue
+            _run_candidate(
+                ui=ui,
+                original_advance_all=original_advance_all,
+                root=Path(root),
+                session=session,
+                change_set_id=change_set_id,
+                uc_id=uc_id,
+                targets=targets,
+            )
+            if state.get("status") in {"needs_input", "error"}:
+                return
+        ui._refresh_ddd_completion(state)
+        session["runtime_error"] = ""
+
+    def candidate_contract(change_set_id: str, targets, state: dict[str, Any]) -> str:
+        uc_ids = sorted({str(target["uc_id"]) for target in targets})
+        if len(uc_ids) != 1:
+            raise ValueError("DDD candidate invocation must target exactly one use case")
+        uc_id = uc_ids[0]
+        item = state["items"][uc_id]
+        answers = {
+            step_id: value.get("clarifications", [])
+            for step_id, value in item.get("steps", {}).items()
+            if value.get("clarifications")
+        }
+        return f"""## DDD Candidate Execution
+
+Target ChangeSet: {change_set_id}
+Target Use Case: {uc_id}
+
+Create or repair the complete candidate at `docs/use-cases/{uc_id}/ddd-design.md`
+in this one turn. Use the selected `harness-ddd-design` skill as the authoritative
+format contract. Do not generate code or edit `ARCHITECTURE.md`.
+
+The runtime accepts a `complete` result only when the candidate has all required
+sections, exactly one Mermaid graph inside the `entity_vo` managed range, candidate
+front matter matching this ChangeSet and use case, and an `event_storming` input hash
+matching the current event-storming artifact. The runtime also rejects actual writes
+outside this candidate file; `changed_files` is only a claim and is not authoritative.
+
+Complete all DDD sections together: Impact Assessment, Entity / Value Objects,
+Behaviors, Application Flow, Aggregates, Bounded Contexts, Integration Impact,
+and one cumulative Mermaid graph. Use the selected slice first; read baseline
+artifacts only when that slice lacks evidence for reuse or modification.
+
+Return JSON keys: status, questions, changed_files, blocker, impact,
+completed_steps, current_target.
+- `complete`: all five DDD sections are complete.
+- `needs_input`: exactly one question; `current_target` names the blocking section.
+- `blocked`: an upstream evidence gap cannot be resolved by one answer.
+
+Prior answers:
+{json.dumps(answers, ensure_ascii=False)}
+"""
+
+    ui._validate_ddd_design_slice = validate_slice
+    ui._advance_ddd_architecture = candidate_advance
+    ui._advance_all_ddd_architecture = candidate_advance_all
+    ui._ddd_run_all_contract = candidate_contract
+    ui._ddd_candidate_efficiency_patch_applied = True
+
+
+def _run_candidate(
+    *,
+    ui,
+    original_advance_all,
+    root: Path,
+    session: dict[str, Any],
+    change_set_id: str,
+    uc_id: str,
+    targets: list[dict[str, str]],
+) -> None:
+    state = session["ddd_architecture"]
+    try:
+        _prepare_fresh_candidate(root, state, uc_id)
+        before = _git_snapshot(root)
+        if before is None:
+            raise ValueError("DDD candidate contract requires a Git worktree for write-scope verification")
+
+        original_advance_all(root, session, change_set_id, targets)
+        scope_error = _validate_candidate_write_scope(root, change_set_id, uc_id, before)
+        if scope_error:
+            raise ValueError(scope_error)
+
+        if _all_complete(state, uc_id, targets):
+            error = _validate_complete_candidate(root, change_set_id, uc_id)
+            if error:
+                raise ValueError(error)
+            _write_candidate_receipt(root, change_set_id, uc_id, status="accepted")
+    except (OSError, ValueError) as exc:
+        _mark_candidate_error(ui, state, uc_id, targets, str(exc))
+        session["runtime_error"] = str(exc)
+
+
+def _prepare_fresh_candidate(root: Path, state: Mapping[str, Any], uc_id: str) -> None:
+    steps = state["items"][uc_id]["steps"]
+    if any(step.get("status") == "complete" for step in steps.values()):
+        return
+    path = root / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    if path.is_symlink():
+        raise ValueError(f"DDD candidate output must not be a symlink: {path}")
+    if path.is_dir():
+        raise ValueError(f"DDD candidate output must be a file: {path}")
+    path.unlink(missing_ok=True)
+
+
+def _all_complete(state: Mapping[str, Any], uc_id: str, targets: list[dict[str, str]]) -> bool:
+    steps = state["items"][uc_id]["steps"]
+    return bool(targets) and all(steps[target["step_id"]].get("status") == "complete" for target in targets)
+
+
+def _validate_candidate_write_scope(root: Path, change_set_id: str, uc_id: str, before: Mapping[str, str]) -> str:
+    after = _git_snapshot(root)
+    if after is None:
+        return "DDD candidate contract could not read the Git worktree after execution"
+    changed = sorted(path for path in set(before) | set(after) if before.get(path) != after.get(path))
+    allowed = {f"docs/use-cases/{uc_id}/ddd-design.md"}
+    disallowed = [path for path in changed if path not in allowed and not path.startswith(".harness/")]
+    _write_scope_receipt(root, change_set_id, uc_id, changed, disallowed)
+    if disallowed:
+        return "DDD candidate wrote outside its declared output: " + ", ".join(disallowed)
+    return ""
+
+
+def _git_snapshot(root: Path) -> dict[str, str] | None:
+    probe = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if probe.returncode != 0 or probe.stdout.strip() != "true":
+        return None
+    paths: set[str] = set()
+    for command in (
+        ["git", "diff", "--name-only"],
+        ["git", "diff", "--name-only", "--cached"],
+        ["git", "ls-files", "--others", "--exclude-standard"],
+    ):
+        completed = subprocess.run(command, cwd=root, text=True, capture_output=True, check=False)
+        if completed.returncode == 0:
+            paths.update(line.strip() for line in completed.stdout.splitlines() if line.strip())
+    return {relative: _path_digest(root / relative) for relative in sorted(paths)}
+
+
+def _path_digest(path: Path) -> str:
+    if path.is_file():
+        return "file:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    if path.is_dir():
+        digest = hashlib.sha256()
+        for child in sorted(item for item in path.rglob("*") if item.is_file()):
+            digest.update(str(child.relative_to(path)).encode("utf-8"))
+            digest.update(child.read_bytes())
+        return "dir:" + digest.hexdigest()
+    return "missing"
+
+
+def _validate_visualization_contract(path: Path) -> tuple[bool, str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False, f"unreadable DDD candidate: {path}"
+    if text.count("```mermaid") != 1:
+        return False, f"DDD candidate must contain exactly one Mermaid graph: {path}"
+    start = "<!-- harness:ddd-visualization:entity_vo:start -->"
+    end = "<!-- harness:ddd-visualization:entity_vo:end -->"
+    if text.count(start) != 1 or text.count(end) != 1:
+        return False, f"DDD candidate must contain one entity_vo visualization managed range: {path}"
+    section = text.find("## Architecture Visualization")
+    range_start = text.find(start)
+    graph_start = text.find("```mermaid")
+    range_end = text.find(end)
+    graph_end = text.find("```", graph_start + len("```mermaid"))
+    if section < 0 or not (section < range_start < graph_start < graph_end < range_end):
+        return False, f"DDD Mermaid graph must be closed inside Architecture Visualization entity_vo range: {path}"
+    return True, ""
+
+
+def _validate_complete_candidate(root: Path, change_set_id: str, uc_id: str) -> str:
+    relative = Path("docs") / "use-cases" / uc_id / "ddd-design.md"
+    path = root / relative
+    if not path.is_file() or path.is_symlink():
+        return f"DDD candidate output must be a regular file: {path}"
+    text = path.read_text(encoding="utf-8")
+    for heading in _REQUIRED_HEADINGS:
+        if len(re.findall(rf"(?m)^{re.escape(heading)}\s*$", text)) != 1:
+            return f"DDD candidate must contain exactly one `{heading}` heading"
+    ready, error = _validate_visualization_contract(path)
+    if not ready:
+        return error
+    front_matter = _front_matter(text)
+    if not front_matter:
+        return "DDD candidate is missing required YAML front matter"
+    if _front_value(front_matter, "status") != "candidate":
+        return "DDD candidate front matter must declare `status: candidate`"
+    if _front_value(front_matter, "change_set") != change_set_id:
+        return f"DDD candidate front matter change_set must equal `{change_set_id}`"
+    if _front_value(front_matter, "work_item") != uc_id:
+        return f"DDD candidate front matter work_item must equal `{uc_id}`"
+
+    event_path = root / "docs" / "use-cases" / uc_id / "event-storming.md"
+    if not event_path.is_file():
+        return f"DDD candidate is missing event-storming input: {event_path}"
+    expected_event_hash = hashlib.sha256(event_path.read_bytes()).hexdigest()
+    actual_event_hash = _front_value(front_matter, "event_storming")
+    if actual_event_hash != f"sha256:{expected_event_hash}":
+        return "DDD candidate event_storming input hash does not match current event-storming artifact"
+
+    _write_document_contract_sidecar(
+        root=root,
+        relative=relative,
+        text=text,
+        change_set_id=change_set_id,
+        uc_id=uc_id,
+    )
+    return ""
+
+
+def _write_document_contract_sidecar(
+    *,
+    root: Path,
+    relative: Path,
+    text: str,
+    change_set_id: str,
+    uc_id: str,
+) -> None:
+    from harness_codex.runtime.document_metadata import infer_document_metadata, write_contract_sidecar
+
+    source_docs = (
+        Path("docs") / "changes" / "active" / f"{change_set_id}.md",
+        Path("docs") / "use-cases" / uc_id / "use-case.md",
+        Path("docs") / "use-cases" / uc_id / "event-storming.md",
+        Path("docs") / "use-cases" / uc_id / "e2e-goal.md",
+    )
+    metadata = infer_document_metadata(
+        relative,
+        change_set_id=change_set_id,
+        work_item_id=uc_id,
+        source_docs=source_docs,
+        status="candidate",
+    )
+    write_contract_sidecar(root, relative, text, metadata, upstream_docs=source_docs)
+
+
+def _front_matter(text: str) -> str:
+    match = re.match(r"\A---\n(?P<body>.*?)\n---\n?", text, flags=re.DOTALL)
+    return match.group("body") if match else ""
+
+
+def _front_value(front_matter: str, key: str) -> str:
+    match = re.search(rf"(?m)^\s*{re.escape(key)}:\s*(\S+)\s*$", front_matter)
+    return match.group(1).strip("'\"") if match else ""
+
+
+def _write_scope_receipt(root: Path, change_set_id: str, uc_id: str, changed: list[str], disallowed: list[str]) -> None:
+    _write_json(
+        root / ".harness" / "contracts" / change_set_id / uc_id / "ddd-candidate-scope.json",
+        {
+            "schema_version": _CANDIDATE_SCHEMA_VERSION,
+            "change_set_id": change_set_id,
+            "work_item_id": uc_id,
+            "status": "blocked" if disallowed else "accepted",
+            "changed_files": changed,
+            "disallowed_files": disallowed,
+        },
+    )
+
+
+def _write_candidate_receipt(root: Path, change_set_id: str, uc_id: str, *, status: str) -> None:
+    output = root / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    _write_json(
+        root / ".harness" / "contracts" / change_set_id / uc_id / "ddd-candidate.runtime.json",
+        {
+            "schema_version": _CANDIDATE_SCHEMA_VERSION,
+            "change_set_id": change_set_id,
+            "work_item_id": uc_id,
+            "status": status,
+            "output": str(output.relative_to(root)),
+            "output_sha256": hashlib.sha256(output.read_bytes()).hexdigest(),
+        },
+    )
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _mark_candidate_error(ui, state: dict[str, Any], uc_id: str, targets: list[dict[str, str]], error: str) -> None:
+    item = state["items"][uc_id]
+    for target in targets:
+        step = item["steps"][target["step_id"]]
+        step["status"] = "error"
+        step["error"] = error
+        step["current_question"] = None
+    ui._refresh_ddd_completion(state)
+    state["current_uc"] = uc_id
+    state["current_step"] = targets[0]["step_id"]
+    state["status"] = "error"
+    state["complete"] = False
+
+
+def _first_incomplete_uc(ui, state: dict[str, Any]) -> str | None:
+    for uc_id in state.get("uc_ids", []):
+        if _targets_for_uc(ui, state, uc_id):
+            return str(uc_id)
+    return None
+
+
+def _targets_for_uc(ui, state: dict[str, Any], uc_id: str) -> list[dict[str, str]]:
+    steps = state["items"][uc_id]["steps"]
+    return [
+        {"uc_id": uc_id, "step_id": step_id, "label": label}
+        for step_id, label in ui.DDD_STEPS
+        if steps.get(step_id, {}).get("status") in {"pending", "running", "error", "stale"}
+    ]

--- a/harness_codex/runtime/ddd_candidate_input_integrity_patch.py
+++ b/harness_codex/runtime/ddd_candidate_input_integrity_patch.py
@@ -1,0 +1,225 @@
+"""Validate every source artifact declared by a DDD candidate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_INPUT_HASH_KEYS = (
+    "change_set_document",
+    "use_case",
+    "event_storming",
+    "e2e_goal",
+)
+
+
+def apply_ddd_candidate_input_integrity_patch() -> None:
+    """Reject stale candidates and preserve evidence across candidate retries.
+
+    The base candidate validator already checks document shape and the
+    event-storming hash. This patch extends that check to every declared source,
+    records accepted input fingerprints, keeps old candidate evidence during repair,
+    and uses the runtime's ignored-inclusive worktree snapshot for write scope.
+    """
+
+    import harness_codex.runtime.ddd_candidate_efficiency_patch as candidate
+    import harness_codex.runtime.harvest_ui as ui
+
+    if getattr(candidate, "_ddd_candidate_input_integrity_patch_applied", False):
+        return
+
+    original_validate = candidate._validate_complete_candidate
+    original_receipt = candidate._write_candidate_receipt
+    original_contract = ui._ddd_run_all_contract
+
+    def validate_complete(root: Path, change_set_id: str, uc_id: str) -> str:
+        error = original_validate(root, change_set_id, uc_id)
+        if error:
+            _write_validation_receipt(root, change_set_id, uc_id, status="blocked", error=error)
+            return error
+        error = _validate_all_input_hashes(root, change_set_id, uc_id)
+        _write_validation_receipt(
+            root,
+            change_set_id,
+            uc_id,
+            status="accepted" if not error else "blocked",
+            error=error,
+        )
+        return error
+
+    def prepare_candidate(root: Path, state, uc_id: str) -> None:
+        _preserve_existing_candidate_output(root, uc_id)
+
+    def validate_write_scope(root: Path, change_set_id: str, uc_id: str, before) -> str:
+        return _validate_candidate_write_scope(candidate, root, change_set_id, uc_id, before)
+
+    def write_receipt(root: Path, change_set_id: str, uc_id: str, *, status: str) -> None:
+        original_receipt(root, change_set_id, uc_id, status=status)
+        path = root / ".harness" / "contracts" / change_set_id / uc_id / "ddd-candidate.runtime.json"
+        payload = _read_json(path)
+        if not payload:
+            return
+        payload["input_hashes"] = _expected_hashes(root, change_set_id, uc_id)
+        _atomic_write_json(path, payload)
+
+    def candidate_contract(change_set_id: str, targets, state) -> str:
+        return (
+            original_contract(change_set_id, targets, state).rstrip()
+            + "\n\n"
+            + "Candidate front matter input_hashes must include exact SHA-256 values for: "
+            + "change_set_document, use_case, event_storming, e2e_goal. "
+            + "Use the current bytes of the four declared inputs; do not reuse stale hashes. "
+            + "Repair an existing candidate in place; do not delete it before a valid replacement exists.\n"
+        )
+
+    candidate._validate_complete_candidate = validate_complete
+    candidate._prepare_fresh_candidate = prepare_candidate
+    candidate._validate_candidate_write_scope = validate_write_scope
+    candidate._write_candidate_receipt = write_receipt
+    candidate._git_snapshot = _ignored_inclusive_git_snapshot
+    ui._ddd_run_all_contract = candidate_contract
+    candidate._ddd_candidate_input_integrity_patch_applied = True
+
+
+def _ignored_inclusive_git_snapshot(root: Path):
+    """Match the generic agent policy's snapshot semantics, including ignored files."""
+
+    from harness_codex.runtime.agent_write_scope_policy_patch import (
+        _capture_worktree_snapshot,
+        _inside_git_work_tree,
+    )
+
+    if not _inside_git_work_tree(root):
+        return None
+    return _capture_worktree_snapshot(root)
+
+
+def _validate_candidate_write_scope(candidate, root: Path, change_set_id: str, uc_id: str, before) -> str:
+    after = _ignored_inclusive_git_snapshot(root)
+    if after is None:
+        return "DDD candidate contract could not read the Git worktree after execution"
+    changed = sorted(path for path in set(before) | set(after) if before.get(path) != after.get(path))
+    allowed = {f"docs/use-cases/{uc_id}/ddd-design.md"}
+    disallowed = [path for path in changed if path not in allowed]
+    candidate._write_scope_receipt(root, change_set_id, uc_id, changed, disallowed)
+    if disallowed:
+        return "DDD candidate wrote outside its declared output: " + ", ".join(disallowed)
+    return ""
+
+
+def _preserve_existing_candidate_output(root: Path, uc_id: str) -> None:
+    path = root / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    if path.is_symlink():
+        raise ValueError(f"DDD candidate output must not be a symlink: {path}")
+    if path.exists() and not path.is_file():
+        raise ValueError(f"DDD candidate output must be a regular file: {path}")
+
+
+def _source_paths(change_set_id: str, uc_id: str) -> dict[str, Path]:
+    return {
+        "change_set_document": Path("docs") / "changes" / "active" / f"{change_set_id}.md",
+        "use_case": Path("docs") / "use-cases" / uc_id / "use-case.md",
+        "event_storming": Path("docs") / "use-cases" / uc_id / "event-storming.md",
+        "e2e_goal": Path("docs") / "use-cases" / uc_id / "e2e-goal.md",
+    }
+
+
+def _expected_hashes(root: Path, change_set_id: str, uc_id: str) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for key, relative in _source_paths(change_set_id, uc_id).items():
+        absolute = root / relative
+        if absolute.is_file() and not absolute.is_symlink():
+            hashes[key] = "sha256:" + hashlib.sha256(absolute.read_bytes()).hexdigest()
+    return hashes
+
+
+def _validate_all_input_hashes(root: Path, change_set_id: str, uc_id: str) -> str:
+    candidate_path = root / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    try:
+        text = candidate_path.read_text(encoding="utf-8")
+    except OSError:
+        return f"DDD candidate is unreadable: {candidate_path}"
+
+    declared = _declared_input_hashes(text)
+    expected = _expected_hashes(root, change_set_id, uc_id)
+    sources = _source_paths(change_set_id, uc_id)
+    for key in _INPUT_HASH_KEYS:
+        source = sources[key]
+        if key not in expected:
+            return f"DDD candidate is missing required regular input artifact: {source}"
+        if key not in declared:
+            return f"DDD candidate input_hashes is missing `{key}`"
+        if declared[key] != expected[key]:
+            return f"DDD candidate input hash mismatch for `{key}`"
+    return ""
+
+
+def _declared_input_hashes(text: str) -> dict[str, str]:
+    front = _front_matter(text)
+    if not front:
+        return {}
+    block = re.search(
+        r"(?m)^input_hashes:[ \t]*\n(?P<body>(?:^[ \t]+.*(?:\n|$))*)",
+        front,
+    )
+    if block is None:
+        return {}
+    values: dict[str, str] = {}
+    body = block.group("body")
+    for key in _INPUT_HASH_KEYS:
+        match = re.search(rf"(?m)^\s+{re.escape(key)}:\s*(\S+)\s*$", body)
+        if match is not None:
+            values[key] = match.group(1).strip("'\"")
+    return values
+
+
+def _write_validation_receipt(
+    root: Path,
+    change_set_id: str,
+    uc_id: str,
+    *,
+    status: str,
+    error: str,
+) -> None:
+    candidate = root / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "change_set_id": change_set_id,
+        "work_item_id": uc_id,
+        "status": status,
+        "error": error,
+        "input_hashes": _expected_hashes(root, change_set_id, uc_id),
+    }
+    if candidate.is_file() and not candidate.is_symlink():
+        payload["candidate_sha256"] = hashlib.sha256(candidate.read_bytes()).hexdigest()
+    _atomic_write_json(
+        root / ".harness" / "contracts" / change_set_id / uc_id / "ddd-candidate.validation.json",
+        payload,
+    )
+
+
+def _front_matter(text: str) -> str:
+    match = re.match(r"\A---\n(?P<body>.*?)\n---\n?", text, flags=re.DOTALL)
+    return match.group("body") if match else ""
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _atomic_write_json(path: Path, payload: Mapping) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)

--- a/harness_codex/runtime/ddd_candidate_rollback_patch.py
+++ b/harness_codex/runtime/ddd_candidate_rollback_patch.py
@@ -1,0 +1,155 @@
+"""Rollback candidate output bytes when an interactive DDD attempt is not accepted."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+
+def apply_ddd_candidate_rollback_patch() -> None:
+    """Make candidate retries filesystem-transactional at the output boundary.
+
+    The SQLite ledger records the agent attempt's before/after facts. This wrapper
+    prevents an unaccepted attempt from leaving a partial candidate as the current
+    working artifact: only a candidate whose five UI sections are complete remains
+    in place. The rollback receipt preserves the attempt/restore relationship.
+    """
+
+    import harness_codex.runtime.ddd_candidate_efficiency_patch as candidate
+    import harness_codex.runtime.harvest_ui as ui
+
+    original_run_candidate = candidate._run_candidate
+    if getattr(original_run_candidate, "_ddd_candidate_rollback_patch", False):
+        return
+
+    def run_candidate(*, ui, original_advance_all, root, session, change_set_id, uc_id, targets):
+        snapshot = _capture_candidate(root, change_set_id, uc_id)
+        original_run_candidate(
+            ui=ui,
+            original_advance_all=original_advance_all,
+            root=root,
+            session=session,
+            change_set_id=change_set_id,
+            uc_id=uc_id,
+            targets=targets,
+        )
+        if _candidate_is_accepted(ui, session, uc_id):
+            _write_rollback_receipt(
+                root,
+                change_set_id,
+                uc_id,
+                snapshot,
+                restored=False,
+                reason="accepted",
+            )
+            return
+        _restore_candidate(root, uc_id, snapshot)
+        _write_rollback_receipt(
+            root,
+            change_set_id,
+            uc_id,
+            snapshot,
+            restored=True,
+            reason=str(session.get("runtime_error") or session["ddd_architecture"].get("status") or "not accepted"),
+        )
+
+    run_candidate._ddd_candidate_rollback_patch = True
+    candidate._run_candidate = run_candidate
+
+
+def _candidate_path(root: Path, uc_id: str) -> Path:
+    return root / "docs" / "use-cases" / uc_id / "ddd-design.md"
+
+
+def _capture_candidate(root: Path, change_set_id: str, uc_id: str) -> dict[str, Any]:
+    path = _candidate_path(root, uc_id)
+    snapshot_root = root / ".harness" / "contracts" / change_set_id / uc_id
+    backup = snapshot_root / "ddd-candidate.before.md"
+    snapshot_root.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise ValueError(f"DDD candidate output must not be a symlink: {path}")
+    if not path.exists():
+        backup.unlink(missing_ok=True)
+        return {"existed": False, "backup": str(backup.relative_to(root)), "sha256": None}
+    if not path.is_file():
+        raise ValueError(f"DDD candidate output must be a regular file: {path}")
+    payload = path.read_bytes()
+    _atomic_write_bytes(backup, payload)
+    return {
+        "existed": True,
+        "backup": str(backup.relative_to(root)),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _restore_candidate(root: Path, uc_id: str, snapshot: Mapping[str, Any]) -> None:
+    path = _candidate_path(root, uc_id)
+    backup_value = snapshot.get("backup")
+    backup = root / str(backup_value) if isinstance(backup_value, str) else None
+    if snapshot.get("existed"):
+        if backup is None or not backup.is_file():
+            raise ValueError(f"DDD candidate rollback backup is missing: {backup_value}")
+        _atomic_write_bytes(path, backup.read_bytes())
+        return
+    if path.exists() or path.is_symlink():
+        path.unlink()
+
+
+def _candidate_is_accepted(ui, session: Mapping[str, Any], uc_id: str) -> bool:
+    state = session.get("ddd_architecture")
+    if not isinstance(state, Mapping) or state.get("status") == "error":
+        return False
+    item = state.get("items", {}).get(uc_id)
+    if not isinstance(item, Mapping):
+        return False
+    steps = item.get("steps", {})
+    return all(
+        isinstance(steps.get(step_id), Mapping)
+        and steps[step_id].get("status") == "complete"
+        for step_id, _label in ui.DDD_STEPS
+    )
+
+
+def _write_rollback_receipt(
+    root: Path,
+    change_set_id: str,
+    uc_id: str,
+    snapshot: Mapping[str, Any],
+    *,
+    restored: bool,
+    reason: str,
+) -> None:
+    path = root / ".harness" / "contracts" / change_set_id / uc_id / "ddd-candidate.rollback.json"
+    current = _candidate_path(root, uc_id)
+    payload = {
+        "schema_version": 1,
+        "change_set_id": change_set_id,
+        "work_item_id": uc_id,
+        "restored": restored,
+        "reason": reason,
+        "before": dict(snapshot),
+        "current_sha256": hashlib.sha256(current.read_bytes()).hexdigest()
+        if current.is_file() and not current.is_symlink()
+        else None,
+    }
+    _atomic_write_json(path, payload)
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_bytes(payload)
+    temporary.replace(path)
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)

--- a/harness_codex/runtime/ddd_candidate_rollback_patch.py
+++ b/harness_codex/runtime/ddd_candidate_rollback_patch.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any, Mapping
 
 
-
 def apply_ddd_candidate_rollback_patch() -> None:
     """Make candidate retries filesystem-transactional at the output boundary.
 
@@ -73,7 +72,12 @@ def _capture_candidate(root: Path, change_set_id: str, uc_id: str) -> dict[str, 
         raise ValueError(f"DDD candidate output must not be a symlink: {path}")
     if not path.exists():
         backup.unlink(missing_ok=True)
-        return {"existed": False, "backup": str(backup.relative_to(root)), "sha256": None}
+        return {
+            "existed": False,
+            "backup": str(backup.relative_to(root)),
+            "sha256": None,
+            "_payload": None,
+        }
     if not path.is_file():
         raise ValueError(f"DDD candidate output must be a regular file: {path}")
     payload = path.read_bytes()
@@ -82,14 +86,19 @@ def _capture_candidate(root: Path, change_set_id: str, uc_id: str) -> dict[str, 
         "existed": True,
         "backup": str(backup.relative_to(root)),
         "sha256": hashlib.sha256(payload).hexdigest(),
+        "_payload": payload,
     }
 
 
 def _restore_candidate(root: Path, uc_id: str, snapshot: Mapping[str, Any]) -> None:
     path = _candidate_path(root, uc_id)
-    backup_value = snapshot.get("backup")
-    backup = root / str(backup_value) if isinstance(backup_value, str) else None
     if snapshot.get("existed"):
+        payload = snapshot.get("_payload")
+        if isinstance(payload, bytes):
+            _atomic_write_bytes(path, payload)
+            return
+        backup_value = snapshot.get("backup")
+        backup = root / str(backup_value) if isinstance(backup_value, str) else None
         if backup is None or not backup.is_file():
             raise ValueError(f"DDD candidate rollback backup is missing: {backup_value}")
         _atomic_write_bytes(path, backup.read_bytes())
@@ -130,12 +139,20 @@ def _write_rollback_receipt(
         "work_item_id": uc_id,
         "restored": restored,
         "reason": reason,
-        "before": dict(snapshot),
+        "before": _receipt_snapshot(snapshot),
         "current_sha256": hashlib.sha256(current.read_bytes()).hexdigest()
         if current.is_file() and not current.is_symlink()
         else None,
     }
     _atomic_write_json(path, payload)
+
+
+def _receipt_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "existed": bool(snapshot.get("existed")),
+        "backup": snapshot.get("backup"),
+        "sha256": snapshot.get("sha256"),
+    }
 
 
 def _atomic_write_bytes(path: Path, payload: bytes) -> None:

--- a/harness_codex/runtime/ddd_candidate_rollback_patch.py
+++ b/harness_codex/runtime/ddd_candidate_rollback_patch.py
@@ -26,15 +26,27 @@ def apply_ddd_candidate_rollback_patch() -> None:
 
     def run_candidate(*, ui, original_advance_all, root, session, change_set_id, uc_id, targets):
         snapshot = _capture_candidate(root, change_set_id, uc_id)
-        original_run_candidate(
-            ui=ui,
-            original_advance_all=original_advance_all,
-            root=root,
-            session=session,
-            change_set_id=change_set_id,
-            uc_id=uc_id,
-            targets=targets,
-        )
+        try:
+            original_run_candidate(
+                ui=ui,
+                original_advance_all=original_advance_all,
+                root=root,
+                session=session,
+                change_set_id=change_set_id,
+                uc_id=uc_id,
+                targets=targets,
+            )
+        except BaseException as exc:
+            _restore_candidate(root, uc_id, snapshot)
+            _write_rollback_receipt(
+                root,
+                change_set_id,
+                uc_id,
+                snapshot,
+                restored=True,
+                reason=f"unexpected exception: {exc}",
+            )
+            raise
         if _candidate_is_accepted(ui, session, uc_id):
             _write_rollback_receipt(
                 root,

--- a/harness_codex/runtime/ddd_integration_candidate_provenance_patch.py
+++ b/harness_codex/runtime/ddd_integration_candidate_provenance_patch.py
@@ -8,14 +8,18 @@ from typing import Any, Mapping
 
 
 def apply_ddd_integration_candidate_provenance_patch() -> None:
-    """Add source-provenance checks to ChangeSet-level DDD integration."""
+    """Install candidate integrity/rollback then add integration provenance checks."""
 
     from harness_codex.runtime.ddd_candidate_baseline_provenance_patch import (
         apply_ddd_candidate_baseline_provenance_patch,
     )
+    from harness_codex.runtime.ddd_candidate_rollback_patch import (
+        apply_ddd_candidate_rollback_patch,
+    )
     import harness_codex.runtime.ddd_integration as integration
 
     apply_ddd_candidate_baseline_provenance_patch()
+    apply_ddd_candidate_rollback_patch()
     original_verify = integration.verify_ddd_integration
     if getattr(original_verify, "_ddd_candidate_provenance_patch", False):
         return

--- a/harness_codex/runtime/ddd_integration_candidate_provenance_patch.py
+++ b/harness_codex/runtime/ddd_integration_candidate_provenance_patch.py
@@ -7,12 +7,15 @@ from pathlib import Path
 from typing import Any, Mapping
 
 
-
 def apply_ddd_integration_candidate_provenance_patch() -> None:
     """Add source-provenance checks to ChangeSet-level DDD integration."""
 
+    from harness_codex.runtime.ddd_candidate_baseline_provenance_patch import (
+        apply_ddd_candidate_baseline_provenance_patch,
+    )
     import harness_codex.runtime.ddd_integration as integration
 
+    apply_ddd_candidate_baseline_provenance_patch()
     original_verify = integration.verify_ddd_integration
     if getattr(original_verify, "_ddd_candidate_provenance_patch", False):
         return

--- a/harness_codex/runtime/ddd_integration_candidate_provenance_patch.py
+++ b/harness_codex/runtime/ddd_integration_candidate_provenance_patch.py
@@ -1,0 +1,71 @@
+"""Fail DDD integration when a referenced candidate is stale against its sources."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+
+def apply_ddd_integration_candidate_provenance_patch() -> None:
+    """Add source-provenance checks to ChangeSet-level DDD integration."""
+
+    import harness_codex.runtime.ddd_integration as integration
+
+    original_verify = integration.verify_ddd_integration
+    if getattr(original_verify, "_ddd_candidate_provenance_patch", False):
+        return
+
+    def verify_ddd_integration(repo_root: Path, *, change_set_id: str):
+        valid, problems = original_verify(repo_root, change_set_id=change_set_id)
+        if not valid:
+            return valid, problems
+
+        json_path = repo_root / integration.integration_paths(change_set_id)[1]
+        try:
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return False, tuple([*problems, f"unreadable integration contract: {json_path}"])
+        if payload.get("status") != "accepted":
+            return valid, problems
+
+        candidate_problems = _candidate_provenance_problems(
+            repo_root,
+            change_set_id,
+            payload,
+        )
+        return not candidate_problems, tuple([*problems, *candidate_problems])
+
+    verify_ddd_integration._ddd_candidate_provenance_patch = True
+    integration.verify_ddd_integration = verify_ddd_integration
+
+
+def _candidate_provenance_problems(
+    repo_root: Path,
+    change_set_id: str,
+    integration_contract: Mapping[str, Any],
+) -> list[str]:
+    """Check that every accepted integration candidate has current source hashes."""
+
+    from harness_codex.runtime.ddd_candidate_input_integrity_patch import (
+        _validate_all_input_hashes,
+    )
+
+    problems: list[str] = []
+    candidates = integration_contract.get("candidate_inputs")
+    for item in candidates if isinstance(candidates, list) else []:
+        if not isinstance(item, Mapping):
+            continue
+        uc_id = item.get("uc_id")
+        relative = item.get("path")
+        if not isinstance(uc_id, str) or not isinstance(relative, str):
+            continue
+        expected = Path("docs") / "use-cases" / uc_id / "ddd-design.md"
+        if Path(relative) != expected:
+            problems.append(f"candidate input path must be {expected}: {relative}")
+            continue
+        error = _validate_all_input_hashes(repo_root, change_set_id, uc_id)
+        if error:
+            problems.append(f"candidate provenance invalid for {uc_id}: {error}")
+    return problems

--- a/harness_codex/runtime/interactive_agent_scope_validation_patch.py
+++ b/harness_codex/runtime/interactive_agent_scope_validation_patch.py
@@ -1,0 +1,151 @@
+"""Validate direct interactive agent writes against declared outputs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def apply_interactive_agent_scope_validation_patch() -> None:
+    """Wrap interactive adapter calls with a post-execution scope validator.
+
+    Interactive UI calls bypass ``BasicStepRunner._run_agent`` and therefore do not
+    receive the standard agent write policy. The inner transaction wrapper records
+    the provider attempt; this outer wrapper records a separate blocked validator
+    transaction only when the actual worktree delta escapes declared outputs.
+    """
+
+    import harness_codex.runtime.runner as runner
+    from harness_codex.runtime.interactive_agent_transaction_patch import (
+        _write_interactive_result,
+    )
+    from harness_codex.runtime.models import FailureKind, Step, StepKind, StepResult, StepStatus
+    from harness_codex.runtime.step_transaction_store import StepTransactionStore
+
+    original_run = runner.ConfigurableCliAgentAdapter.run
+    if getattr(original_run, "_interactive_agent_scope_validation_patch", False):
+        return
+
+    def run(self, request):
+        if not request.step.metadata.get("interactive"):
+            return original_run(self, request)
+
+        before = _capture_snapshot(request.context.repo_root)
+        result = original_run(self, request)
+        blocked = _blocked_paths(request, before)
+        if not blocked:
+            return result
+
+        error = "interactive agent wrote outside declared outputs: " + ", ".join(blocked)
+        validator = Step(
+            id=f"{request.step.id}-interactive-scope-validation",
+            kind=StepKind.VALIDATOR,
+            name=f"Validate interactive write scope for {request.step.id}",
+            inputs=tuple(request.step.outputs),
+            metadata={
+                "interactive": True,
+                "validator_for": request.step.id,
+                "blocked_files": tuple(blocked),
+            },
+        )
+        store = StepTransactionStore(request.context.repo_root, request.context.run_id)
+        transaction = store.begin(validator, request.context)
+        validation_result = store.finish(
+            transaction,
+            validator,
+            request.context,
+            StepResult(
+                step_id=validator.id,
+                status=StepStatus.BLOCKED,
+                error=error,
+                failure_kind=FailureKind.SCOPE_CONFLICT,
+                metadata={"blocked_files": tuple(blocked)},
+            ),
+        )
+        _write_scope_receipt(request.step_dir, request.step.id, blocked, validation_result)
+        blocked_result = runner.AgentRunResult(
+            status=StepStatus.BLOCKED,
+            exit_code=result.exit_code,
+            error=error,
+            metadata={
+                **dict(result.metadata),
+                "interactive_scope_status": "blocked",
+                "interactive_scope_blocked_files": tuple(blocked),
+                "interactive_scope_transaction_id": transaction.transaction_id,
+            },
+        )
+        _write_interactive_result(
+            request.step_dir,
+            StepResult(
+                step_id=request.step.id,
+                status=StepStatus.BLOCKED,
+                exit_code=result.exit_code,
+                error=error,
+                failure_kind=FailureKind.SCOPE_CONFLICT,
+                metadata=dict(blocked_result.metadata),
+            ),
+        )
+        runner._write_response_snapshot(
+            request.context,
+            request.step.id,
+            request.step_dir / "result.json",
+        )
+        return blocked_result
+
+    run._interactive_agent_scope_validation_patch = True
+    runner.ConfigurableCliAgentAdapter.run = run
+
+
+def _capture_snapshot(repo_root: Path):
+    from harness_codex.runtime.agent_write_scope_policy_patch import (
+        _capture_worktree_snapshot,
+        _inside_git_work_tree,
+    )
+
+    if not _inside_git_work_tree(repo_root):
+        return None
+    return _capture_worktree_snapshot(repo_root)
+
+
+def _blocked_paths(request, before) -> list[str]:
+    if before is None:
+        return []
+    after = _capture_snapshot(request.context.repo_root)
+    if after is None:
+        return ["<unable to capture interactive write scope>"]
+    changed = sorted(
+        path for path in set(before) | set(after) if before.get(path) != after.get(path)
+    )
+    return [path for path in changed if not _is_declared_output(path, request.step.outputs)]
+
+
+def _is_declared_output(path: str, outputs) -> bool:
+    for output in outputs:
+        declared = str(Path(str(output))).rstrip("/")
+        if not declared:
+            continue
+        if Path(declared).suffix:
+            if path == declared:
+                return True
+        elif path == declared or path.startswith(declared + "/"):
+            return True
+    return False
+
+
+def _write_scope_receipt(step_dir: Path, step_id: str, blocked: list[str], result) -> None:
+    path = step_dir / "interactive-scope-validation.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "step_id": step_id,
+                "status": result.status.value,
+                "error": result.error,
+                "blocked_files": blocked,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )

--- a/harness_codex/runtime/interactive_agent_transaction_patch.py
+++ b/harness_codex/runtime/interactive_agent_transaction_patch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import replace
 from pathlib import Path
 
@@ -43,41 +44,39 @@ def apply_interactive_agent_transaction_patch() -> None:
             )
             raise
 
-        step_result = StepResult(
-            step_id=request.step.id,
-            status=agent_result.status,
-            exit_code=agent_result.exit_code,
-            error=agent_result.error,
-            failure_kind=(
-                FailureKind.IMPLEMENTATION
-                if agent_result.status is StepStatus.FAILED
-                else FailureKind.ENVIRONMENT_BLOCKER
-                if agent_result.status is StepStatus.BLOCKED
-                else None
-            ),
-            metadata=dict(agent_result.metadata),
+        outcome, blocker = _interactive_outcome(request.step_dir)
+        step_result = _step_result_for_agent(
+            request,
+            agent_result,
+            outcome=outcome,
+            blocker=blocker,
+            validate_output=_validate_declared_output_shapes,
+            step_result_type=StepResult,
+            step_status=StepStatus,
+            failure_kind=FailureKind,
         )
-        if step_result.status is StepStatus.SUCCEEDED:
-            contract_error = _validate_declared_output_shapes(
-                request.step,
-                request.context.repo_root,
-            )
-            if contract_error:
-                step_result = replace(
-                    step_result,
-                    status=StepStatus.FAILED,
-                    error=contract_error,
-                    failure_kind=FailureKind.IMPLEMENTATION,
-                )
         final = store.finish(transaction, request.step, request.context, step_result)
         _write_interactive_result(request.step_dir, final)
+
+        # A semantic `needs_input` / `blocked` message is a successful provider
+        # invocation. Preserve that provider success so harvest_ui can parse the
+        # question or blocker, while SQLite records the terminal blocked state.
+        return_status = (
+            agent_result.status
+            if agent_result.status is StepStatus.SUCCEEDED
+            and outcome in {"needs_input", "blocked"}
+            else final.status
+        )
+        return_error = agent_result.error if return_status is agent_result.status else final.error
         return runner.AgentRunResult(
-            status=final.status,
+            status=return_status,
             exit_code=final.exit_code,
-            error=final.error,
+            error=return_error,
             metadata={
                 **dict(agent_result.metadata),
                 **dict(final.metadata),
+                "interactive_outcome": outcome or "provider_result",
+                "interactive_ledger_status": final.status.value,
                 "interactive_step_transaction_id": transaction.transaction_id,
                 "interactive_step_attempt": transaction.attempt,
             },
@@ -85,6 +84,77 @@ def apply_interactive_agent_transaction_patch() -> None:
 
     run._interactive_agent_transaction_patch = True
     runner.ConfigurableCliAgentAdapter.run = run
+
+
+def _step_result_for_agent(
+    request,
+    agent_result,
+    *,
+    outcome: str,
+    blocker: str,
+    validate_output,
+    step_result_type,
+    step_status,
+    failure_kind,
+):
+    if agent_result.status is not step_status.SUCCEEDED:
+        return step_result_type(
+            step_id=request.step.id,
+            status=agent_result.status,
+            exit_code=agent_result.exit_code,
+            error=agent_result.error,
+            failure_kind=(
+                failure_kind.IMPLEMENTATION
+                if agent_result.status is step_status.FAILED
+                else failure_kind.ENVIRONMENT_BLOCKER
+                if agent_result.status is step_status.BLOCKED
+                else None
+            ),
+            metadata=dict(agent_result.metadata),
+        )
+    if outcome in {"needs_input", "blocked"}:
+        return step_result_type(
+            step_id=request.step.id,
+            status=step_status.BLOCKED,
+            exit_code=agent_result.exit_code,
+            error=blocker or f"interactive agent outcome: {outcome}",
+            failure_kind=failure_kind.UNCLEAR_E2E_GOAL if outcome == "needs_input" else failure_kind.UPSTREAM_DESIGN,
+            metadata={**dict(agent_result.metadata), "interactive_outcome": outcome},
+        )
+
+    contract_error = validate_output(request.step, request.context.repo_root)
+    return step_result_type(
+        step_id=request.step.id,
+        status=step_status.FAILED if contract_error else step_status.SUCCEEDED,
+        exit_code=agent_result.exit_code,
+        error=contract_error or agent_result.error,
+        failure_kind=failure_kind.IMPLEMENTATION if contract_error else None,
+        metadata=dict(agent_result.metadata),
+    )
+
+
+def _interactive_outcome(step_dir: Path) -> tuple[str, str]:
+    path = step_dir / "final-message.md"
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return "", ""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+        if match is None:
+            return "", ""
+        try:
+            payload = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return "", ""
+    if not isinstance(payload, dict):
+        return "", ""
+    outcome = str(payload.get("status", "") or "").strip().lower()
+    if outcome not in {"needs_input", "blocked"}:
+        return "", ""
+    return outcome, str(payload.get("blocker", "") or "")
 
 
 def _write_interactive_result(step_dir: Path, result) -> None:

--- a/harness_codex/runtime/interactive_agent_transaction_patch.py
+++ b/harness_codex/runtime/interactive_agent_transaction_patch.py
@@ -56,11 +56,13 @@ def apply_interactive_agent_transaction_patch() -> None:
             failure_kind=FailureKind,
         )
         final = store.finish(transaction, request.step, request.context, step_result)
-        _write_interactive_result(request.step_dir, final)
+        result_path = _write_interactive_result(request.step_dir, final)
+        runner._write_response_snapshot(request.context, request.step.id, result_path)
 
         # A semantic `needs_input` / `blocked` message is a successful provider
         # invocation. Preserve that provider success so harvest_ui can parse the
-        # question or blocker, while SQLite records the terminal blocked state.
+        # question or blocker, while SQLite and the run-root response record the
+        # terminal blocked state.
         return_status = (
             agent_result.status
             if agent_result.status is StepStatus.SUCCEEDED
@@ -118,7 +120,11 @@ def _step_result_for_agent(
             status=step_status.BLOCKED,
             exit_code=agent_result.exit_code,
             error=blocker or f"interactive agent outcome: {outcome}",
-            failure_kind=failure_kind.UNCLEAR_E2E_GOAL if outcome == "needs_input" else failure_kind.UPSTREAM_DESIGN,
+            failure_kind=(
+                failure_kind.UNCLEAR_E2E_GOAL
+                if outcome == "needs_input"
+                else failure_kind.UPSTREAM_DESIGN
+            ),
             metadata={**dict(agent_result.metadata), "interactive_outcome": outcome},
         )
 
@@ -157,7 +163,7 @@ def _interactive_outcome(step_dir: Path) -> tuple[str, str]:
     return outcome, str(payload.get("blocker", "") or "")
 
 
-def _write_interactive_result(step_dir: Path, result) -> None:
+def _write_interactive_result(step_dir: Path, result) -> Path:
     """Expose the adapter outcome without making interactive UI depend on it."""
 
     payload = {
@@ -171,3 +177,4 @@ def _write_interactive_result(step_dir: Path, result) -> None:
     path = step_dir / "result.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path

--- a/harness_codex/runtime/interactive_agent_transaction_patch.py
+++ b/harness_codex/runtime/interactive_agent_transaction_patch.py
@@ -1,0 +1,103 @@
+"""Record direct interactive agent calls in the shared SQLite step ledger."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+
+def apply_interactive_agent_transaction_patch() -> None:
+    """Wrap only interactive adapter calls; standard workflow calls use RunnerEngine."""
+
+    import harness_codex.runtime.runner as runner
+    from harness_codex.runtime.agent_output_contract_patch import (
+        _validate_declared_output_shapes,
+    )
+    from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
+    from harness_codex.runtime.step_transaction_store import StepTransactionStore
+
+    original_run = runner.ConfigurableCliAgentAdapter.run
+    if getattr(original_run, "_interactive_agent_transaction_patch", False):
+        return
+
+    def run(self, request):
+        if not request.step.metadata.get("interactive"):
+            return original_run(self, request)
+
+        store = StepTransactionStore(request.context.repo_root, request.context.run_id)
+        transaction = store.begin(request.step, request.context)
+        try:
+            agent_result = original_run(self, request)
+        except BaseException as exc:
+            store.finish(
+                transaction,
+                request.step,
+                request.context,
+                StepResult(
+                    step_id=request.step.id,
+                    status=StepStatus.FAILED,
+                    error=str(exc),
+                    failure_kind=FailureKind.IMPLEMENTATION,
+                ),
+            )
+            raise
+
+        step_result = StepResult(
+            step_id=request.step.id,
+            status=agent_result.status,
+            exit_code=agent_result.exit_code,
+            error=agent_result.error,
+            failure_kind=(
+                FailureKind.IMPLEMENTATION
+                if agent_result.status is StepStatus.FAILED
+                else FailureKind.ENVIRONMENT_BLOCKER
+                if agent_result.status is StepStatus.BLOCKED
+                else None
+            ),
+            metadata=dict(agent_result.metadata),
+        )
+        if step_result.status is StepStatus.SUCCEEDED:
+            contract_error = _validate_declared_output_shapes(
+                request.step,
+                request.context.repo_root,
+            )
+            if contract_error:
+                step_result = replace(
+                    step_result,
+                    status=StepStatus.FAILED,
+                    error=contract_error,
+                    failure_kind=FailureKind.IMPLEMENTATION,
+                )
+        final = store.finish(transaction, request.step, request.context, step_result)
+        _write_interactive_result(request.step_dir, final)
+        return runner.AgentRunResult(
+            status=final.status,
+            exit_code=final.exit_code,
+            error=final.error,
+            metadata={
+                **dict(agent_result.metadata),
+                **dict(final.metadata),
+                "interactive_step_transaction_id": transaction.transaction_id,
+                "interactive_step_attempt": transaction.attempt,
+            },
+        )
+
+    run._interactive_agent_transaction_patch = True
+    runner.ConfigurableCliAgentAdapter.run = run
+
+
+def _write_interactive_result(step_dir: Path, result) -> None:
+    """Expose the adapter outcome without making interactive UI depend on it."""
+
+    payload = {
+        "step_id": result.step_id,
+        "status": result.status.value,
+        "exit_code": result.exit_code,
+        "error": result.error,
+        "failure_kind": result.failure_kind.value if result.failure_kind else None,
+        "metadata": dict(result.metadata),
+    }
+    path = step_dir / "result.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")

--- a/harness_codex/runtime/token_observability_trace_retention_patch.py
+++ b/harness_codex/runtime/token_observability_trace_retention_patch.py
@@ -1,0 +1,42 @@
+"""Keep token metrics available after successful stdout retention is compacted."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def apply_token_observability_trace_retention_patch() -> None:
+    """Use the compact usage persisted in result metadata when stdout is absent."""
+
+    import harness_codex.runtime.token_observability as observability
+
+    original_collect_step = observability._collect_step
+    if getattr(original_collect_step, "_trace_retention_usage_fallback", False):
+        return
+
+    def collect_step(repo_root: Path, step_dir: Path) -> dict[str, Any] | None:
+        record = original_collect_step(repo_root, step_dir)
+        if record is None or record.get("usage_source") == "provider":
+            return record
+
+        usage = _compact_provider_usage(observability._read_json(step_dir / "result.json"))
+        normalized = observability._normalize(usage)
+        if not any(value is not None for value in normalized.values()):
+            return record
+
+        record.update(normalized)
+        record["usage_source"] = "provider"
+        observability._write_json(step_dir / "usage.json", record)
+        return record
+
+    collect_step._trace_retention_usage_fallback = True
+    observability._collect_step = collect_step
+
+
+def _compact_provider_usage(result: Mapping[str, Any]) -> Mapping[str, Any]:
+    metadata = result.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return {}
+    usage = metadata.get("usage")
+    return usage if isinstance(usage, Mapping) else {}

--- a/harness_codex/runtime/token_observability_trace_retention_patch.py
+++ b/harness_codex/runtime/token_observability_trace_retention_patch.py
@@ -7,14 +7,18 @@ from typing import Any, Mapping
 
 
 def apply_token_observability_trace_retention_patch() -> None:
-    """Use compact usage metadata and clean stale run-root log references."""
+    """Install compact trace, interactive ledger, and usage fallback hooks."""
 
     from harness_codex.runtime.agent_trace_reference_cleanup_patch import (
         apply_agent_trace_reference_cleanup_patch,
     )
+    from harness_codex.runtime.interactive_agent_transaction_patch import (
+        apply_interactive_agent_transaction_patch,
+    )
     import harness_codex.runtime.token_observability as observability
 
     apply_agent_trace_reference_cleanup_patch()
+    apply_interactive_agent_transaction_patch()
     original_collect_step = observability._collect_step
     if getattr(original_collect_step, "_trace_retention_usage_fallback", False):
         return

--- a/harness_codex/runtime/token_observability_trace_retention_patch.py
+++ b/harness_codex/runtime/token_observability_trace_retention_patch.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping
 
 
 def apply_token_observability_trace_retention_patch() -> None:
-    """Install compact trace, interactive ledger, and usage fallback hooks."""
+    """Install compact trace, interactive ledger/scope, and usage fallback hooks."""
 
     from harness_codex.runtime.agent_trace_reference_cleanup_patch import (
         apply_agent_trace_reference_cleanup_patch,
@@ -15,10 +15,14 @@ def apply_token_observability_trace_retention_patch() -> None:
     from harness_codex.runtime.interactive_agent_transaction_patch import (
         apply_interactive_agent_transaction_patch,
     )
+    from harness_codex.runtime.interactive_agent_scope_validation_patch import (
+        apply_interactive_agent_scope_validation_patch,
+    )
     import harness_codex.runtime.token_observability as observability
 
     apply_agent_trace_reference_cleanup_patch()
     apply_interactive_agent_transaction_patch()
+    apply_interactive_agent_scope_validation_patch()
     original_collect_step = observability._collect_step
     if getattr(original_collect_step, "_trace_retention_usage_fallback", False):
         return

--- a/harness_codex/runtime/token_observability_trace_retention_patch.py
+++ b/harness_codex/runtime/token_observability_trace_retention_patch.py
@@ -7,10 +7,14 @@ from typing import Any, Mapping
 
 
 def apply_token_observability_trace_retention_patch() -> None:
-    """Use the compact usage persisted in result metadata when stdout is absent."""
+    """Use compact usage metadata and clean stale run-root log references."""
 
+    from harness_codex.runtime.agent_trace_reference_cleanup_patch import (
+        apply_agent_trace_reference_cleanup_patch,
+    )
     import harness_codex.runtime.token_observability as observability
 
+    apply_agent_trace_reference_cleanup_patch()
     original_collect_step = observability._collect_step
     if getattr(original_collect_step, "_trace_retention_usage_fallback", False):
         return

--- a/tests/test_agent_output_contract_patch.py
+++ b/tests/test_agent_output_contract_patch.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from harness_codex.runtime.agent_output_contract_patch import (
+    _persist_output_contract_failure,
+    _validate_declared_output_shapes,
+)
+from harness_codex.runtime.models import FailureKind, StepResult, StepStatus
+
+
+class _Runner:
+    @staticmethod
+    def _write_response_snapshot(context, step_id: str, result_path: Path) -> None:
+        target = context.run_dir / f"response-{step_id}.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(result_path.read_bytes())
+
+
+def _step(*outputs: str):
+    return SimpleNamespace(id="review", agent_id="artifact_reviewer", outputs=tuple(Path(path) for path in outputs))
+
+
+def test_rejects_empty_declared_markdown_output(tmp_path: Path) -> None:
+    output = tmp_path / "docs" / "candidate.md"
+    output.parent.mkdir(parents=True)
+    output.write_text("", encoding="utf-8")
+
+    assert _validate_declared_output_shapes(_step("docs/candidate.md"), tmp_path) == "agent output must not be empty: docs/candidate.md"
+
+
+def test_rejects_directory_for_declared_file_output(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "candidate.md").mkdir(parents=True)
+
+    assert _validate_declared_output_shapes(_step("docs/candidate.md"), tmp_path) == "agent output must be a regular file: docs/candidate.md"
+
+
+def test_accepts_nonempty_declared_directory_output(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "use-cases").mkdir(parents=True)
+
+    assert _validate_declared_output_shapes(_step("docs/use-cases"), tmp_path) is None
+
+
+def test_persists_final_output_contract_failure(tmp_path: Path) -> None:
+    run_dir = tmp_path / ".harness" / "runs" / "run-001"
+    step_dir = run_dir / "steps" / "review"
+    step_dir.mkdir(parents=True)
+    (step_dir / "result.json").write_text(
+        json.dumps({"step_id": "review", "status": "succeeded", "metadata": {}}),
+        encoding="utf-8",
+    )
+    context = SimpleNamespace(run_dir=run_dir)
+    result = StepResult(
+        step_id="review",
+        status=StepStatus.FAILED,
+        error="agent output must not be empty: docs/review.md",
+        failure_kind=FailureKind.IMPLEMENTATION,
+        metadata={"output_contract_status": "failed"},
+    )
+
+    _persist_output_contract_failure(_Runner, context, _step("docs/review.md"), step_dir, result)
+
+    payload = json.loads((step_dir / "result.json").read_text(encoding="utf-8"))
+    assert payload["status"] == "failed"
+    assert payload["metadata"]["output_contract_status"] == "failed"
+    assert (run_dir / "response-review.json").is_file()

--- a/tests/test_agent_trace_reference_cleanup_patch.py
+++ b/tests/test_agent_trace_reference_cleanup_patch.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import harness_codex.runtime.agent_trace_retention_patch as trace
+from harness_codex.runtime.agent_trace_reference_cleanup_patch import (
+    apply_agent_trace_reference_cleanup_patch,
+)
+
+
+def test_compaction_removes_run_root_log_references(tmp_path: Path) -> None:
+    apply_agent_trace_reference_cleanup_patch()
+    run_dir = tmp_path / ".harness" / "runs" / "run-001"
+    step_dir = run_dir / "steps" / "ddd"
+    step_dir.mkdir(parents=True)
+    stdout = step_dir / "stdout.txt"
+    stderr = step_dir / "stderr.txt"
+    stdout.write_text("stdout", encoding="utf-8")
+    stderr.write_text("stderr", encoding="utf-8")
+    stdout_reference = run_dir / "stdout-ddd.log"
+    stderr_reference = run_dir / "stderr-ddd.log"
+    stdout_reference.write_text("See canonical artifact", encoding="utf-8")
+    stderr_reference.write_text("See canonical artifact", encoding="utf-8")
+
+    trace._remove_raw_logs(stdout, stderr)
+
+    assert not stdout.exists()
+    assert not stderr.exists()
+    assert not stdout_reference.exists()
+    assert not stderr_reference.exists()

--- a/tests/test_agent_trace_retention_patch.py
+++ b/tests/test_agent_trace_retention_patch.py
@@ -1,0 +1,212 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.agent_trace_retention_patch import (
+    _accepted_contract,
+    _artifact_summary,
+    _compact_accepted_agent_trace,
+    _compact_checkpoint,
+    _provider_usage,
+    _remove_raw_logs,
+)
+from harness_codex.runtime.models import RunContext, RunMode, Step, StepKind, StepResult, StepStatus
+
+
+class _Runner:
+    @staticmethod
+    def _relative_to_repo(path: Path, context: RunContext) -> Path:
+        return path.relative_to(context.repo_root)
+
+    @staticmethod
+    def _write_response_snapshot(context: RunContext, step_id: str, result_path: Path) -> None:
+        target = context.run_dir / f"response-{step_id}.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(result_path.read_bytes())
+
+
+def _context(tmp_path: Path) -> RunContext:
+    run_dir = tmp_path / ".harness" / "runs" / "run-001"
+    return RunContext(
+        run_id="run-001",
+        workflow_name="workflow",
+        mode=RunMode.APPLY,
+        repo_root=tmp_path,
+        workdir=tmp_path,
+        run_dir=run_dir,
+    )
+
+
+def _step() -> Step:
+    return Step(
+        id="ddd",
+        kind=StepKind.AGENT,
+        name="DDD",
+        agent_id="ddd_architect",
+        outputs=(Path("docs/use-cases/UC-001/ddd-design.md"),),
+    )
+
+
+def _accepted_result_files(tmp_path: Path) -> tuple[RunContext, Step, Path, StepResult]:
+    context = _context(tmp_path)
+    step = _step()
+    step_dir = context.run_dir / "steps" / step.id
+    step_dir.mkdir(parents=True)
+    output = context.repo_root / step.outputs[0]
+    output.parent.mkdir(parents=True)
+    output.write_text("# candidate\n", encoding="utf-8")
+    (step_dir / "final-message.md").write_text('{"status":"complete"}', encoding="utf-8")
+    (step_dir / "stdout.txt").write_text('{"usage":{"input_tokens":10,"output_tokens":5,"reasoning_tokens":2}}\n', encoding="utf-8")
+    (step_dir / "stderr.txt").write_text("warning\n", encoding="utf-8")
+    (step_dir / "result.json").write_text(
+        json.dumps({"step_id": step.id, "status": "succeeded", "metadata": {}}),
+        encoding="utf-8",
+    )
+    return context, step, step_dir, StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
+
+
+def test_trace_contract_requires_final_message_and_accepted_result(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    step = _step()
+    step_dir = context.run_dir / "steps" / step.id
+    step_dir.mkdir(parents=True)
+    output = context.repo_root / step.outputs[0]
+    output.parent.mkdir(parents=True)
+    output.write_text("# candidate\n", encoding="utf-8")
+    (step_dir / "result.json").write_text(
+        json.dumps({"step_id": step.id, "status": "succeeded", "metadata": {}}),
+        encoding="utf-8",
+    )
+    result = StepResult(step_id=step.id, status=StepStatus.SUCCEEDED)
+
+    assert _accepted_contract(step, context, step_dir / "result.json", step_dir / "final-message.md", result) is None
+
+    (step_dir / "final-message.md").write_text('{"status":"complete"}', encoding="utf-8")
+    contract = _accepted_contract(step, context, step_dir / "result.json", step_dir / "final-message.md", result)
+
+    assert contract is not None
+    assert contract["result_status"] == "succeeded"
+    assert contract["declared_outputs"][0]["path"] == str(step.outputs[0])
+
+
+def test_trace_contract_rejects_failed_or_missing_output(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    step = _step()
+    step_dir = context.run_dir / "steps" / step.id
+    step_dir.mkdir(parents=True)
+    (step_dir / "final-message.md").write_text("done", encoding="utf-8")
+    (step_dir / "result.json").write_text(
+        json.dumps({"step_id": step.id, "status": "succeeded"}),
+        encoding="utf-8",
+    )
+
+    assert _accepted_contract(
+        step,
+        context,
+        step_dir / "result.json",
+        step_dir / "final-message.md",
+        StepResult(step_id=step.id, status=StepStatus.FAILED),
+    ) is None
+    assert _accepted_contract(
+        step,
+        context,
+        step_dir / "result.json",
+        step_dir / "final-message.md",
+        StepResult(step_id=step.id, status=StepStatus.SUCCEEDED),
+    ) is None
+
+
+def test_compaction_requires_accepted_contract_then_removes_raw_logs(tmp_path: Path) -> None:
+    context, step, step_dir, result = _accepted_result_files(tmp_path)
+
+    metadata = _compact_accepted_agent_trace(
+        runner=_Runner,
+        step=step,
+        context=context,
+        step_dir=step_dir,
+        result=result,
+    )
+
+    assert metadata is not None
+    assert metadata["trace_contract_status"] == "accepted"
+    assert not (step_dir / "stdout.txt").exists()
+    assert not (step_dir / "stderr.txt").exists()
+    persisted = json.loads((step_dir / "result.json").read_text(encoding="utf-8"))
+    assert persisted["metadata"]["trace_retention"] == "summary"
+    assert persisted["metadata"]["usage"]["input_tokens"] == 10
+    assert (step_dir / "trace-summary.json").is_file()
+
+
+def test_trace_summary_includes_hash_and_stderr_tail(tmp_path: Path) -> None:
+    stdout = tmp_path / "stdout.txt"
+    stderr = tmp_path / "stderr.txt"
+    stdout.write_text("event\n" * 10, encoding="utf-8")
+    stderr.write_text("warning\n" * 10, encoding="utf-8")
+
+    stdout_summary = _artifact_summary(stdout)
+    stderr_summary = _artifact_summary(stderr, include_tail=True)
+
+    assert stdout_summary["bytes"] == stdout.stat().st_size
+    assert len(stdout_summary["sha256"]) == 64
+    assert stderr_summary["tail"].endswith("warning")
+
+
+def test_compact_trace_keeps_provider_usage_before_stdout_delete(tmp_path: Path) -> None:
+    stdout = tmp_path / "stdout.txt"
+    stdout.write_text(
+        json.dumps(
+            {
+                "usage": {
+                    "input_tokens": 120,
+                    "cached_input_tokens": 20,
+                    "output_tokens": 30,
+                    "reasoning_tokens": 40,
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert _provider_usage(stdout) == {
+        "input_tokens": 120,
+        "prompt_tokens": 120,
+        "cached_input_tokens": 20,
+        "cached_prompt_tokens": 20,
+        "output_tokens": 30,
+        "completion_tokens": 30,
+        "reasoning_tokens": 40,
+        "total_tokens": 190,
+    }
+
+
+def test_compact_checkpoint_drops_deleted_stdout_evidence(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "checkpoint.json"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "evidence_paths": [
+                    ".harness/runs/run/steps/execute/stdout.txt",
+                    ".harness/runs/run/steps/execute/final-message.md",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _compact_checkpoint(checkpoint)
+
+    payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert payload["trace_retention"] == "summary"
+    assert payload["evidence_paths"] == [".harness/runs/run/steps/execute/final-message.md"]
+
+
+def test_remove_raw_logs_deletes_success_stream_files(tmp_path: Path) -> None:
+    stdout = tmp_path / "stdout.txt"
+    stderr = tmp_path / "stderr.txt"
+    stdout.write_text("stdout", encoding="utf-8")
+    stderr.write_text("stderr", encoding="utf-8")
+
+    _remove_raw_logs(stdout, stderr)
+
+    assert not stdout.exists()
+    assert not stderr.exists()

--- a/tests/test_ddd_candidate_baseline_provenance_patch.py
+++ b/tests/test_ddd_candidate_baseline_provenance_patch.py
@@ -1,0 +1,53 @@
+import hashlib
+from pathlib import Path
+
+import harness_codex.runtime.ddd_candidate_input_integrity_patch as integrity
+from harness_codex.runtime.ddd_candidate_baseline_provenance_patch import (
+    _baseline_hashes,
+)
+
+
+def _write(root: Path, relative: str, text: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _candidate(change_set_id: str, uc_id: str, hashes: dict[str, str]) -> str:
+    lines = [
+        "---",
+        "status: candidate",
+        f"change_set: {change_set_id}",
+        f"work_item: {uc_id}",
+        "input_hashes:",
+    ]
+    lines.extend(f"  {key}: {value}" for key, value in hashes.items())
+    lines.extend(["---", "# candidate", ""])
+    return "\n".join(lines)
+
+
+def test_requires_present_ubiquitous_and_architecture_baseline_hashes(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    primary = {
+        "change_set_document": _write(tmp_path, f"docs/changes/active/{change_set_id}.md", "change\n"),
+        "use_case": _write(tmp_path, f"docs/use-cases/{uc_id}/use-case.md", "uc\n"),
+        "event_storming": _write(tmp_path, f"docs/use-cases/{uc_id}/event-storming.md", "events\n"),
+        "e2e_goal": _write(tmp_path, f"docs/use-cases/{uc_id}/e2e-goal.md", "e2e\n"),
+    }
+    _write(tmp_path, "docs/design/ubiquitous-language.md", "language\n")
+    _write(tmp_path, "ARCHITECTURE.md", "architecture\n")
+    hashes = {
+        key: "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        for key, path in primary.items()
+    }
+    candidate = tmp_path / f"docs/use-cases/{uc_id}/ddd-design.md"
+    candidate.write_text(_candidate(change_set_id, uc_id, hashes), encoding="utf-8")
+
+    assert integrity._validate_all_input_hashes(tmp_path, change_set_id, uc_id) == "DDD candidate input_hashes is missing `ubiquitous_language`"
+
+    hashes.update(_baseline_hashes(tmp_path))
+    candidate.write_text(_candidate(change_set_id, uc_id, hashes), encoding="utf-8")
+
+    assert integrity._validate_all_input_hashes(tmp_path, change_set_id, uc_id) == ""

--- a/tests/test_ddd_candidate_efficiency_patch.py
+++ b/tests/test_ddd_candidate_efficiency_patch.py
@@ -1,0 +1,188 @@
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import harness_codex.runtime.ddd_candidate_input_integrity_patch as integrity_patch
+from harness_codex.runtime.ddd_candidate_efficiency_patch import (
+    _targets_for_uc,
+    _validate_candidate_write_scope,
+    _validate_complete_candidate,
+    _validate_visualization_contract,
+)
+
+
+def test_targets_for_uc_groups_all_unfinished_sections_in_one_candidate() -> None:
+    ui = SimpleNamespace(
+        DDD_STEPS=(
+            ("entity_vo", "Entity / Value Objects"),
+            ("behaviors", "Behaviors"),
+            ("application_flow", "Application Flow"),
+            ("aggregates", "Aggregates"),
+            ("bounded_contexts", "Bounded Contexts"),
+        )
+    )
+    state = {
+        "items": {
+            "UC-031": {
+                "steps": {
+                    "entity_vo": {"status": "complete"},
+                    "behaviors": {"status": "pending"},
+                    "application_flow": {"status": "error"},
+                    "aggregates": {"status": "stale"},
+                    "bounded_contexts": {"status": "pending"},
+                }
+            }
+        }
+    }
+
+    assert _targets_for_uc(ui, state, "UC-031") == [
+        {"uc_id": "UC-031", "step_id": "behaviors", "label": "Behaviors"},
+        {"uc_id": "UC-031", "step_id": "application_flow", "label": "Application Flow"},
+        {"uc_id": "UC-031", "step_id": "aggregates", "label": "Aggregates"},
+        {"uc_id": "UC-031", "step_id": "bounded_contexts", "label": "Bounded Contexts"},
+    ]
+
+
+def _write_inputs(root: Path, change_set_id: str, uc_id: str) -> dict[str, str]:
+    paths = {
+        "change_set_document": root / "docs" / "changes" / "active" / f"{change_set_id}.md",
+        "use_case": root / "docs" / "use-cases" / uc_id / "use-case.md",
+        "event_storming": root / "docs" / "use-cases" / uc_id / "event-storming.md",
+        "e2e_goal": root / "docs" / "use-cases" / uc_id / "e2e-goal.md",
+    }
+    for key, path in paths.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"# {key}\n", encoding="utf-8")
+    return {
+        key: "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        for key, path in paths.items()
+    }
+
+
+def _candidate(change_set_id: str, uc_id: str, hashes: dict[str, str]) -> str:
+    return f"""---
+status: candidate
+change_set: {change_set_id}
+work_item: {uc_id}
+input_hashes:
+  change_set_document: {hashes['change_set_document']}
+  use_case: {hashes['use_case']}
+  event_storming: {hashes['event_storming']}
+  e2e_goal: {hashes['e2e_goal']}
+---
+# {uc_id}. DDD Candidate Design
+
+## Impact Assessment
+|Element Type|Element|Status|Baseline Evidence|Event Storming Evidence|
+|---|---|---|---|---|
+|Entity|Workspace|new|none|WorkspaceCreated|
+
+## Entity / Value Objects
+|Entity|Attributes / VOs|Status|Previous Definition|Proposed Definition|Evidence|
+|---|---|---|---|---|---|
+|Workspace|workspaceId: WorkspaceId|new|none|Workspace aggregate|WorkspaceCreated|
+
+## Behaviors
+|Owner / Service|Signature|Participants|Placement|Policy Evidence|
+|---|---|---|---|---|
+|Workspace|create(WorkspaceId)|Workspace|Aggregate|WorkspaceCreated|
+
+## Application Flow
+|Application Service|Signature|Description|Calls|Evidence|
+|---|---|---|---|---|
+|CreateWorkspace|create(WorkspaceId)|Creates workspace|Workspace.create|WorkspaceCreated|
+
+## Aggregates
+|Aggregate|Aggregate Root|Members|Atomic Invariant|Evidence|
+|---|---|---|---|---|
+|Workspace|Workspace|WorkspaceId|workspace id is unique|WorkspaceCreated|
+
+## Bounded Contexts
+|Bounded Context|Owned Aggregates / Entities|Boundary Reason|Communication Type|Target BC|Evidence|
+|---|---|---|---|---|---|
+|Workspace|Workspace|workspace lifecycle|None|None|WorkspaceCreated|
+
+## Integration Impact
+- Shared Aggregate / Entity claims to reconcile: none
+- Candidate-only assumptions / unresolved conflicts: none
+
+## Architecture Visualization
+<!-- harness:ddd-visualization:entity_vo:start -->
+```mermaid
+classDiagram
+    class Workspace {{
+        <<entity>>
+        +WorkspaceId workspaceId
+    }}
+```
+<!-- harness:ddd-visualization:entity_vo:end -->
+"""
+
+
+def test_complete_candidate_requires_current_input_hash_and_managed_graph(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    hashes = _write_inputs(tmp_path, change_set_id, uc_id)
+    candidate_path = tmp_path / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    candidate_path.write_text(_candidate(change_set_id, uc_id, hashes), encoding="utf-8")
+
+    assert _validate_complete_candidate(tmp_path, change_set_id, uc_id) == ""
+    assert (tmp_path / ".harness" / "contracts" / change_set_id / uc_id / "ddd_design.contract.json").is_file()
+
+
+def test_complete_candidate_rejects_stale_event_hash(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    hashes = _write_inputs(tmp_path, change_set_id, uc_id)
+    hashes["event_storming"] = "sha256:" + "0" * 64
+    candidate_path = tmp_path / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    candidate_path.write_text(_candidate(change_set_id, uc_id, hashes), encoding="utf-8")
+
+    assert "event_storming input hash" in _validate_complete_candidate(tmp_path, change_set_id, uc_id)
+
+
+def test_visualization_contract_rejects_multiple_mermaid_graphs(tmp_path: Path) -> None:
+    path = tmp_path / "ddd-design.md"
+    path.write_text(
+        """## Architecture Visualization
+<!-- harness:ddd-visualization:entity_vo:start -->
+```mermaid
+classDiagram
+```
+```mermaid
+classDiagram
+```
+<!-- harness:ddd-visualization:entity_vo:end -->
+""",
+        encoding="utf-8",
+    )
+
+    ready, error = _validate_visualization_contract(path)
+    assert not ready
+    assert "exactly one Mermaid" in error
+
+
+def test_candidate_scope_rejects_all_actual_writes_outside_output(monkeypatch, tmp_path: Path) -> None:
+    snapshots = iter(
+        [
+            {"docs/use-cases/UC-001/ddd-design.md": {"sha256": "before"}},
+            {
+                "docs/use-cases/UC-001/ddd-design.md": {"sha256": "after"},
+                "ARCHITECTURE.md": {"sha256": "changed"},
+                ".harness/private-agent-note.txt": {"sha256": "changed"},
+            },
+        ]
+    )
+    monkeypatch.setattr(integrity_patch, "_ignored_inclusive_git_snapshot", lambda _root: next(snapshots))
+
+    error = _validate_candidate_write_scope(
+        tmp_path,
+        "CHG-20260707-1",
+        "UC-001",
+        {"docs/use-cases/UC-001/ddd-design.md": {"sha256": "before"}},
+    )
+
+    assert "ARCHITECTURE.md" in error
+    assert ".harness/private-agent-note.txt" in error
+    receipt = tmp_path / ".harness" / "contracts" / "CHG-20260707-1" / "UC-001" / "ddd-candidate-scope.json"
+    assert receipt.is_file()

--- a/tests/test_ddd_candidate_input_integrity_patch.py
+++ b/tests/test_ddd_candidate_input_integrity_patch.py
@@ -1,0 +1,126 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.ddd_candidate_input_integrity_patch import (
+    _declared_input_hashes,
+    _expected_hashes,
+    _preserve_existing_candidate_output,
+    _validate_all_input_hashes,
+    _write_validation_receipt,
+)
+
+
+def _write_sources(root: Path, change_set_id: str, uc_id: str) -> None:
+    files = {
+        root / "docs" / "changes" / "active" / f"{change_set_id}.md": "# change\n",
+        root / "docs" / "use-cases" / uc_id / "use-case.md": "# use case\n",
+        root / "docs" / "use-cases" / uc_id / "event-storming.md": "# event storming\n",
+        root / "docs" / "use-cases" / uc_id / "e2e-goal.md": "# e2e goal\n",
+    }
+    for path, text in files.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
+def _candidate(change_set_id: str, uc_id: str, hashes: dict[str, str]) -> str:
+    return f"""---
+status: candidate
+change_set: {change_set_id}
+work_item: {uc_id}
+input_hashes:
+  change_set_document: {hashes['change_set_document']}
+  use_case: {hashes['use_case']}
+  event_storming: {hashes['event_storming']}
+  e2e_goal: {hashes['e2e_goal']}
+---
+# candidate
+"""
+
+
+def test_validates_all_declared_ddd_source_hashes(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    _write_sources(tmp_path, change_set_id, uc_id)
+    hashes = _expected_hashes(tmp_path, change_set_id, uc_id)
+    candidate = tmp_path / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    candidate.write_text(_candidate(change_set_id, uc_id, hashes), encoding="utf-8")
+
+    assert _validate_all_input_hashes(tmp_path, change_set_id, uc_id) == ""
+
+
+def test_rejects_stale_e2e_goal_hash(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    _write_sources(tmp_path, change_set_id, uc_id)
+    hashes = _expected_hashes(tmp_path, change_set_id, uc_id)
+    hashes["e2e_goal"] = "sha256:" + "0" * 64
+    candidate = tmp_path / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    candidate.write_text(_candidate(change_set_id, uc_id, hashes), encoding="utf-8")
+
+    assert _validate_all_input_hashes(tmp_path, change_set_id, uc_id) == "DDD candidate input hash mismatch for `e2e_goal`"
+
+
+def test_rejects_missing_change_set_document_hash(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    _write_sources(tmp_path, change_set_id, uc_id)
+    hashes = _expected_hashes(tmp_path, change_set_id, uc_id)
+    candidate = tmp_path / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    candidate.write_text(
+        _candidate(change_set_id, uc_id, hashes).replace(
+            f"  change_set_document: {hashes['change_set_document']}\n",
+            "",
+        ),
+        encoding="utf-8",
+    )
+
+    assert _validate_all_input_hashes(tmp_path, change_set_id, uc_id) == "DDD candidate input_hashes is missing `change_set_document`"
+
+
+def test_preserves_existing_candidate_instead_of_deleting_before_retry(tmp_path: Path) -> None:
+    candidate = tmp_path / "docs" / "use-cases" / "UC-001" / "ddd-design.md"
+    candidate.parent.mkdir(parents=True)
+    candidate.write_text("last valid candidate evidence", encoding="utf-8")
+
+    _preserve_existing_candidate_output(tmp_path, "UC-001")
+
+    assert candidate.read_text(encoding="utf-8") == "last valid candidate evidence"
+
+
+def test_records_candidate_validation_failure(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    _write_sources(tmp_path, change_set_id, uc_id)
+
+    _write_validation_receipt(
+        tmp_path,
+        change_set_id,
+        uc_id,
+        status="blocked",
+        error="DDD candidate input hash mismatch for `e2e_goal`",
+    )
+
+    receipt = tmp_path / ".harness" / "contracts" / change_set_id / uc_id / "ddd-candidate.validation.json"
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert payload["status"] == "blocked"
+    assert payload["error"].endswith("`e2e_goal`")
+    assert set(payload["input_hashes"]) == {"change_set_document", "use_case", "event_storming", "e2e_goal"}
+
+
+def test_parses_only_nested_input_hashes() -> None:
+    content = """---
+change_set: CHG-1
+input_hashes:
+  change_set_document: sha256:abc
+  use_case: sha256:def
+  event_storming: sha256:ghi
+  e2e_goal: sha256:jkl
+---
+"""
+
+    assert _declared_input_hashes(content) == {
+        "change_set_document": "sha256:abc",
+        "use_case": "sha256:def",
+        "event_storming": "sha256:ghi",
+        "e2e_goal": "sha256:jkl",
+    }

--- a/tests/test_ddd_candidate_rollback_patch.py
+++ b/tests/test_ddd_candidate_rollback_patch.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from harness_codex.runtime.ddd_candidate_rollback_patch import (
+    _capture_candidate,
+    _restore_candidate,
+    _write_rollback_receipt,
+)
+
+
+def test_restores_previous_candidate_after_unaccepted_attempt(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    candidate = tmp_path / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    candidate.parent.mkdir(parents=True)
+    candidate.write_text("previous valid candidate", encoding="utf-8")
+
+    snapshot = _capture_candidate(tmp_path, change_set_id, uc_id)
+    candidate.write_text("partial invalid candidate", encoding="utf-8")
+
+    _restore_candidate(tmp_path, uc_id, snapshot)
+    _write_rollback_receipt(
+        tmp_path,
+        change_set_id,
+        uc_id,
+        snapshot,
+        restored=True,
+        reason="DDD candidate input hash mismatch",
+    )
+
+    assert candidate.read_text(encoding="utf-8") == "previous valid candidate"
+    receipt = tmp_path / ".harness" / "contracts" / change_set_id / uc_id / "ddd-candidate.rollback.json"
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert payload["restored"] is True
+    assert payload["before"]["existed"] is True
+
+
+def test_removes_new_partial_candidate_when_no_previous_candidate_existed(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    candidate = tmp_path / "docs" / "use-cases" / uc_id / "ddd-design.md"
+
+    snapshot = _capture_candidate(tmp_path, change_set_id, uc_id)
+    candidate.parent.mkdir(parents=True)
+    candidate.write_text("partial candidate", encoding="utf-8")
+
+    _restore_candidate(tmp_path, uc_id, snapshot)
+
+    assert not candidate.exists()

--- a/tests/test_ddd_integration_candidate_provenance_patch.py
+++ b/tests/test_ddd_integration_candidate_provenance_patch.py
@@ -1,0 +1,75 @@
+import hashlib
+from pathlib import Path
+
+from harness_codex.runtime.ddd_integration_candidate_provenance_patch import (
+    _candidate_provenance_problems,
+)
+
+
+def _write_sources(root: Path, change_set_id: str, uc_id: str) -> dict[str, str]:
+    paths = {
+        "change_set_document": root / "docs" / "changes" / "active" / f"{change_set_id}.md",
+        "use_case": root / "docs" / "use-cases" / uc_id / "use-case.md",
+        "event_storming": root / "docs" / "use-cases" / uc_id / "event-storming.md",
+        "e2e_goal": root / "docs" / "use-cases" / uc_id / "e2e-goal.md",
+    }
+    for path in paths.values():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name + "\n", encoding="utf-8")
+    return {
+        key: "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        for key, path in paths.items()
+    }
+
+
+def _candidate(change_set_id: str, uc_id: str, hashes: dict[str, str]) -> str:
+    return f"""---
+status: candidate
+change_set: {change_set_id}
+work_item: {uc_id}
+input_hashes:
+  change_set_document: {hashes['change_set_document']}
+  use_case: {hashes['use_case']}
+  event_storming: {hashes['event_storming']}
+  e2e_goal: {hashes['e2e_goal']}
+---
+# candidate
+"""
+
+
+def test_integration_rejects_stale_candidate_provenance(tmp_path: Path) -> None:
+    change_set_id = "CHG-20260707-1"
+    uc_id = "UC-001"
+    hashes = _write_sources(tmp_path, change_set_id, uc_id)
+    candidate = tmp_path / "docs" / "use-cases" / uc_id / "ddd-design.md"
+    hashes["use_case"] = "sha256:" + "0" * 64
+    candidate.write_text(_candidate(change_set_id, uc_id, hashes), encoding="utf-8")
+
+    problems = _candidate_provenance_problems(
+        tmp_path,
+        change_set_id,
+        {
+            "candidate_inputs": [
+                {
+                    "uc_id": uc_id,
+                    "path": f"docs/use-cases/{uc_id}/ddd-design.md",
+                }
+            ]
+        },
+    )
+
+    assert problems == ["candidate provenance invalid for UC-001: DDD candidate input hash mismatch for `use_case`"]
+
+
+def test_integration_rejects_candidate_path_substitution(tmp_path: Path) -> None:
+    problems = _candidate_provenance_problems(
+        tmp_path,
+        "CHG-20260707-1",
+        {
+            "candidate_inputs": [
+                {"uc_id": "UC-001", "path": "docs/other.md"},
+            ]
+        },
+    )
+
+    assert problems == ["candidate input path must be docs/use-cases/UC-001/ddd-design.md: docs/other.md"]

--- a/tests/test_interactive_agent_transaction_patch.py
+++ b/tests/test_interactive_agent_transaction_patch.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from harness_codex.runtime.interactive_agent_transaction_patch import (
+    _interactive_outcome,
+    _step_result_for_agent,
+)
+from harness_codex.runtime.models import FailureKind, StepStatus
+
+
+def _request(tmp_path: Path):
+    step = SimpleNamespace(id="ddd")
+    context = SimpleNamespace(repo_root=tmp_path)
+    return SimpleNamespace(step=step, context=context)
+
+
+def test_needs_input_is_blocked_in_ledger_without_output_contract_failure(tmp_path: Path) -> None:
+    step_dir = tmp_path / "step"
+    step_dir.mkdir()
+    (step_dir / "final-message.md").write_text(
+        json.dumps({"status": "needs_input", "questions": [{"question": "Which policy?"}]}),
+        encoding="utf-8",
+    )
+    outcome, blocker = _interactive_outcome(step_dir)
+    agent_result = SimpleNamespace(
+        status=StepStatus.SUCCEEDED,
+        exit_code=0,
+        error=None,
+        metadata={},
+    )
+
+    result = _step_result_for_agent(
+        _request(tmp_path),
+        agent_result,
+        outcome=outcome,
+        blocker=blocker,
+        validate_output=lambda *_args: "missing output",
+        step_result_type=__import__("harness_codex.runtime.models", fromlist=["StepResult"]).StepResult,
+        step_status=StepStatus,
+        failure_kind=FailureKind,
+    )
+
+    assert result.status is StepStatus.BLOCKED
+    assert result.failure_kind is FailureKind.UNCLEAR_E2E_GOAL
+
+
+def test_complete_requires_output_contract(tmp_path: Path) -> None:
+    agent_result = SimpleNamespace(
+        status=StepStatus.SUCCEEDED,
+        exit_code=0,
+        error=None,
+        metadata={},
+    )
+
+    result = _step_result_for_agent(
+        _request(tmp_path),
+        agent_result,
+        outcome="",
+        blocker="",
+        validate_output=lambda *_args: "agent output must not be empty: docs/candidate.md",
+        step_result_type=__import__("harness_codex.runtime.models", fromlist=["StepResult"]).StepResult,
+        step_status=StepStatus,
+        failure_kind=FailureKind,
+    )
+
+    assert result.status is StepStatus.FAILED
+    assert result.failure_kind is FailureKind.IMPLEMENTATION

--- a/tests/test_token_observability_trace_retention_patch.py
+++ b/tests/test_token_observability_trace_retention_patch.py
@@ -1,0 +1,28 @@
+from harness_codex.runtime.token_observability_trace_retention_patch import (
+    _compact_provider_usage,
+)
+
+
+def test_compact_provider_usage_reads_trace_retention_metadata() -> None:
+    result = {
+        "metadata": {
+            "trace_retention": "summary",
+            "usage": {
+                "input_tokens": 120,
+                "cached_input_tokens": 20,
+                "output_tokens": 30,
+                "reasoning_tokens": 40,
+            },
+        }
+    }
+
+    assert _compact_provider_usage(result) == {
+        "input_tokens": 120,
+        "cached_input_tokens": 20,
+        "output_tokens": 30,
+        "reasoning_tokens": 40,
+    }
+
+
+def test_compact_provider_usage_ignores_missing_metadata() -> None:
+    assert _compact_provider_usage({}) == {}


### PR DESCRIPTION
## DDD 실행
- DDD agent 실행을 UC별 candidate 1회로 축소합니다.
- UI의 5개 DDD 카드는 유지하고, deterministic validator가 각 완료 상태를 반영합니다.

## Candidate 산출물 계약
agent의 `complete` 응답만 신뢰하지 않습니다. candidate는 실제 write scope, regular output, 필수 섹션, 단일 Mermaid managed range, source provenance를 모두 통과해야 accepted 됩니다.

- tracked·untracked·ignored 파일을 포함한 실제 write delta 검사
- ChangeSet, Use Case, Event Storming, E2E Goal 네 primary hash 검증
- 존재하는 ubiquitous language와 `ARCHITECTURE.md` baseline hash도 검증
- integration 단계에서 candidate path와 모든 source provenance 재검증
- 재시도 전 candidate bytes를 backup하고, `needs_input`·blocked·계약 실패·예외 시 이전 후보로 rollback
- validation, scope, runtime, rollback receipt 기록

## 표준·interactive agent 경계
- 일반 agent는 empty/symlink/directory file output을 실패 처리하고 cache-hit도 최종 output 계약을 재검증합니다.
- interactive UI agent도 SQLite step transaction에 기록됩니다.
- interactive `needs_input`은 UI 질문 흐름을 유지하면서 ledger에는 blocked transaction으로 기록됩니다.
- interactive agent가 declared output 밖을 쓰면 별도 SQLite scope-validator transaction이 blocked로 기록되고 UI에도 blocked 결과를 반환합니다.

## Trace retention
- raw stdout/stderr는 provider 성공만으로 삭제하지 않습니다.
- output/scope/review 등 runtime contract를 통과한 standard workflow agent만 trace summary로 compact합니다.
- compact 시 run-root의 dangling stdout/stderr reference도 제거합니다.
- 실패·timeout·blocked와 interactive DDD trace는 full trace를 유지합니다.
- compact provider usage를 result metadata에 보존합니다.

## 검증
계약 단위 테스트를 추가했습니다. 이 환경에는 local checkout이 없어 전체 pytest는 실행하지 못했습니다. GitHub Actions run도 현재 연결돼 있지 않습니다.