### PR TITLE
460번 이슈: readFrontier/diff contract 기반 work item 검증 추가

### DIFF
--- a/.codex/agents/workflow_orchestrator.toml
+++ b/.codex/agents/workflow_orchestrator.toml
@@ -14,6 +14,8 @@ Hot-path contract:
 - Role: Route one initial user instruction through the harness runtime end to end.
 - Load `AGENTS.md` before acting.
 - Use `.codex/skills/harness-orchestrate-instruction/SKILL.md` as the required skill entrypoint.
+- Before runtime orchestration, create one separate task-specific Git worktree when the repository supports it, then continue all commands inside that worktree.
+- If the source checkout is dirty and worktree creation would be unsafe, stop with one concise Korean blocker instead of mutating the source checkout.
 - Do not ask the caller to manually choose workflow stages unless the instruction is genuinely ambiguous and cannot be resolved from runtime state.
 - Prefer runtime-owned orchestration commands over direct file edits.
 - If there is no active ChangeSet and the instruction is a new product, bug, or engineering request, start the runtime with `./harness requirements-definition --title "<short title>" --idea "<instruction summary>"`.

--- a/.codex/skills/harness-orchestrate-instruction/SKILL.md
+++ b/.codex/skills/harness-orchestrate-instruction/SKILL.md
@@ -14,6 +14,7 @@ Use this skill to keep the main agent out of manual stage routing. The main agen
 - Do not decompose the request into `requirements-definition`, `use-case-definition`, `event-storming`, `ddd-design`, `technical-decisions`, `plan-writing`, `implementation`, or ad hoc command chains yourself.
 - Do not execute product code changes directly.
 - Do not silently fall back to manual staged workflow commands.
+- Before runtime orchestration, create one separate Git worktree and continue inside it unless already operating inside a task-specific worktree created for the same request.
 - Starting a new ChangeSet with `./harness requirements-definition --title ... --idea ...` is allowed for a new product, bug, or engineering instruction. It is the runtime's official entrypoint, not manual stage slicing.
 - Do not publish ChangeSet-specific artifacts to `origin/main`.
 - Preserve secrets. Do not echo user-provided keys.
@@ -26,15 +27,20 @@ Use this skill to keep the main agent out of manual stage routing. The main agen
    - `AGENTS.md`
    - `.harness/docs/agent/commands.md` when command discovery is needed
    - `./harness help` or `./harness help orchestrate` if an orchestration command may exist
-3. Find an orchestration surface in this order:
+3. If the repository is a Git worktree and you are still in the source checkout, create one dedicated task worktree first:
+   - Use repo-local `start-head-worktree` at `.codex/skills/start-head-worktree/`.
+   - Derive a short slug from the instruction.
+   - Require a clean source worktree; if dirty, stop and report one concise blocker instead of mutating the source checkout.
+   - After creation, switch all subsequent orchestration commands and file reads/writes to the new worktree path.
+4. Find an orchestration surface in this order:
    - callable `workflow_orchestrator` or equivalent orchestration agent
    - callable generic sub-agent support such as `multi_agent_v1.spawn_agent` with `agent_type: "default"`
    - `./harness orchestrate ...` if the runtime command exists
    - `./harness requirements-definition --title ... --idea ...` when there is no active ChangeSet and the instruction describes a new product, bug, or engineering request
    - active ChangeSet continuation only when the instruction already names a ChangeSet or the runtime reports one unambiguous active ChangeSet
-4. If an orchestration surface exists, hand off the packet below and let it route.
-5. If only generic sub-agent support exists, spawn one default agent with the handoff packet and this instruction: "Act as the workflow orchestration delegate. Select the harness runtime route yourself and execute or report blockers. Do not ask the caller to manually choose stages."
-6. If no orchestration surface exists, stop and report this blocker: `free-form instruction orchestration surface missing`. Do not invent a manual stage sequence.
+5. If an orchestration surface exists, hand off the packet below and let it route.
+6. If only generic sub-agent support exists, spawn one default agent with the handoff packet and this instruction: "Act as the workflow orchestration delegate. Select the harness runtime route yourself and execute or report blockers. Do not ask the caller to manually choose stages."
+7. If no orchestration surface exists, stop and report this blocker: `free-form instruction orchestration surface missing`. Do not invent a manual stage sequence.
 
 ## Runtime Route Selection
 
@@ -60,6 +66,7 @@ Initial instruction:
 
 Repository guardrails:
 - Follow AGENTS.md.
+- Create and use one separate task worktree before runtime orchestration unless already inside that dedicated worktree.
 - Keep ChangeSet-specific artifacts off origin/main unless explicitly requested.
 - Use runtime orchestration; do not ask the caller to choose stages unless genuinely ambiguous.
 - Produce verification and report evidence when implementation, deployment, or testing is requested.
@@ -67,6 +74,7 @@ Repository guardrails:
 - If no active ChangeSet exists and the instruction is a new request, start with `./harness requirements-definition --title ... --idea ...`.
 
 Expected output:
+- created worktree path/branch/base commit, or blocker if worktree creation could not proceed
 - selected route
 - commands/actions run by orchestrator
 - verification result

--- a/.codex/skills/start-head-worktree/SKILL.md
+++ b/.codex/skills/start-head-worktree/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: start-head-worktree
+description: Update the current Git branch from origin, then create a new isolated Git worktree and branch from the updated exact HEAD commit. Use when the user asks to start work in a separate, individual, isolated, parallel, or task-specific worktree based on the current checkout or current HEAD.
+---
+
+# Start HEAD Worktree
+
+Create one worktree with `scripts/start_head_worktree.py`.
+
+## Workflow
+
+1. Confirm the source worktree has no tracked or untracked changes.
+2. Run from the target repository or pass `--repo`.
+3. Derive a short task slug from the user request.
+4. Run:
+
+```bash
+python3 <skill-dir>/scripts/start_head_worktree.py <task-slug>
+```
+
+5. Report created path, branch, and base commit.
+6. Continue requested work inside created worktree when worktree creation is preparatory.
+
+## Options
+
+```bash
+python3 <skill-dir>/scripts/start_head_worktree.py <task-slug> \
+  --repo /path/to/repo \
+  --branch feature/custom-branch \
+  --path /path/to/worktree
+```
+
+- Omit `--branch` → use `worktree/<task-slug>`.
+- Omit `--path` → use sibling path `<repo-name>-<task-slug>`.
+- Generated branch/path collisions → append numeric suffix.
+- Explicit branch/path collisions → fail without modifying existing work.
+- Before creating worktree, run `git fetch origin` then `git pull --ff-only origin <current-branch>`.
+
+## Guardrails
+
+- Require a clean source worktree before fetch/pull.
+- Require a local branch checkout and an `origin` remote.
+- Base new branch on SHA returned by `git rev-parse HEAD` after fetch/pull, not branch name.
+- Do not include uncommitted or untracked files; current HEAD means committed state only.
+- Do not stash, reset, clean, or otherwise alter source worktree.
+- Keep worktree when later task execution fails unless user asks to remove it.
+- Use resulting path as working directory for subsequent commands.

--- a/.codex/skills/start-head-worktree/agents/openai.yaml
+++ b/.codex/skills/start-head-worktree/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Start HEAD Worktree"
+  short_description: "Create an isolated worktree from current HEAD"
+  default_prompt: "Use $start-head-worktree to create an isolated Git worktree from the current HEAD for this task."

--- a/.codex/skills/start-head-worktree/scripts/start_head_worktree.py
+++ b/.codex/skills/start-head-worktree/scripts/start_head_worktree.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def git(repo: Path, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(message)
+    return result.stdout.strip()
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    if not slug:
+        raise ValueError("task slug must contain at least one letter or digit")
+    return slug[:48].rstrip("-")
+
+
+def branch_exists(repo: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def choose_generated_targets(repo: Path, slug: str) -> tuple[str, Path]:
+    parent = repo.parent
+    stem = f"{repo.name}-{slug}"
+    for index in range(1, 10_000):
+        suffix = "" if index == 1 else f"-{index}"
+        branch = f"worktree/{slug}{suffix}"
+        path = parent / f"{stem}{suffix}"
+        if not branch_exists(repo, branch) and not path.exists():
+            return branch, path
+    raise RuntimeError("could not find available generated branch and path")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create an isolated Git worktree from exact current HEAD."
+    )
+    parser.add_argument("task_slug")
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--branch")
+    parser.add_argument("--path", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        repo = Path(git(args.repo.resolve(), "rev-parse", "--show-toplevel"))
+        if git(repo, "status", "--porcelain"):
+            raise RuntimeError("source worktree must be clean before fetch and pull")
+        branch_name = git(repo, "symbolic-ref", "--quiet", "--short", "HEAD")
+        git(repo, "fetch", "origin")
+        git(repo, "pull", "--ff-only", "origin", branch_name)
+        head = git(repo, "rev-parse", "HEAD")
+        slug = slugify(args.task_slug)
+
+        if args.branch is None and args.path is None:
+            branch, worktree_path = choose_generated_targets(repo, slug)
+        else:
+            branch = args.branch or f"worktree/{slug}"
+            worktree_path = (
+                args.path.expanduser().resolve()
+                if args.path
+                else repo.parent / f"{repo.name}-{slug}"
+            )
+            if branch_exists(repo, branch):
+                raise RuntimeError(f"branch already exists: {branch}")
+            if worktree_path.exists():
+                raise RuntimeError(f"path already exists: {worktree_path}")
+
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+        git(repo, "worktree", "add", "-b", branch, str(worktree_path), head)
+
+        print(f"path={worktree_path}")
+        print(f"branch={branch}")
+        print(f"base={head}")
+        print(f"source_branch={branch_name}")
+        print("source_updated=true")
+        return 0
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ venv/
 !.harness/agents/
 !.harness/agents/**
 .codex/
+!.codex/
+.codex/*
+!.codex/agents/
+!.codex/agents/**
+!.codex/skills/
+!.codex/skills/**
 harness_codex/
 !harness_codex/
 !harness_codex/runtime/

--- a/harness_codex/bug_cli.py
+++ b/harness_codex/bug_cli.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import date
@@ -82,6 +85,13 @@ def build_parser() -> argparse.ArgumentParser:
     plan = commands.add_parser("plan", help="집중된 버그 수정 계획을 생성한다.")
     plan.add_argument("bug_id")
     plan.set_defaults(func=plan_command_handler)
+
+    run = commands.add_parser("run", help="구현/검증 loop를 제한 횟수 안에서 자동 반복한다.")
+    run.add_argument("bug_id")
+    run.add_argument("--implement-command", required=True)
+    run.add_argument("--verify-command", action="append", default=[])
+    run.add_argument("--max-loops", type=int, default=2)
+    run.set_defaults(func=run_command_handler)
 
     verify = commands.add_parser("verify", help="집중 검증 명령을 표시한다.")
     verify.add_argument("bug_id")
@@ -200,13 +210,80 @@ def verify_command_handler(args: argparse.Namespace, root: Path) -> str:
     )
 
 
+def run_command_handler(args: argparse.Namespace, root: Path) -> str:
+    if args.max_loops < 1:
+        raise BugWorkflowError("--max-loops must be >= 1")
+    bug_dir = _bug_dir(root, args.bug_id)
+    plan_path = root / "docs" / "plans" / "active" / args.bug_id / "plan.md"
+    if not plan_path.is_file():
+        raise BugWorkflowError(f"missing bug plan: {plan_path.relative_to(root)}")
+    state_path = bug_dir / "loop-state.json"
+    _update_bug_status(bug_dir, "running")
+    previous_fingerprints: list[str] = []
+    loop_reports: list[dict[str, object]] = []
+
+    for loop_index in range(1, args.max_loops + 1):
+        before = _git_changed_files(root)
+        implement = _run_shell(args.implement_command, root)
+        after_implement = _git_changed_files(root)
+        changed_files = sorted(after_implement - before)
+        verify_results = tuple(_run_shell(command, root) for command in args.verify_command)
+        fingerprint = _loop_failure_fingerprint(
+            implement=implement,
+            verify_results=verify_results,
+            changed_files=changed_files,
+        )
+        report = {
+            "loop": loop_index,
+            "implement_command": args.implement_command,
+            "implement_exit_code": implement.returncode,
+            "verify_results": [
+                {
+                    "command": result.command,
+                    "exit_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }
+                for result in verify_results
+            ],
+            "changed_files": changed_files,
+            "failure_fingerprint": fingerprint,
+        }
+        loop_reports.append(report)
+        _write_loop_state(state_path, args.bug_id, "running", loop_reports)
+        failure_reason = _loop_failure_reason(
+            implement=implement,
+            verify_results=verify_results,
+            changed_files=changed_files,
+        )
+        if failure_reason is None:
+            _update_bug_status(bug_dir, "completed")
+            _write_loop_state(state_path, args.bug_id, "completed", loop_reports)
+            return "\n".join(
+                [
+                    f"bug_id={args.bug_id}",
+                    "status=completed",
+                    f"loops={loop_index}",
+                    "next=harness bug complete " + args.bug_id,
+                ]
+            )
+        if fingerprint in previous_fingerprints:
+            _update_bug_status(bug_dir, "blocked")
+            _write_loop_state(state_path, args.bug_id, "blocked", loop_reports, blocker=failure_reason)
+            raise BugWorkflowError(
+                f"bug loop blocked after repeated failure fingerprint: {failure_reason}"
+            )
+        previous_fingerprints.append(fingerprint)
+
+    blocker = _loop_failure_reason_from_report(loop_reports[-1]) or "unknown bug loop failure"
+    _update_bug_status(bug_dir, "blocked")
+    _write_loop_state(state_path, args.bug_id, "blocked", loop_reports, blocker=blocker)
+    raise BugWorkflowError(f"bug loop blocked after {args.max_loops} attempts: {blocker}")
+
+
 def complete_command_handler(args: argparse.Namespace, root: Path) -> str:
     bug_dir = _bug_dir(root, args.bug_id)
-    index_path = bug_dir / "index.md"
-    text = index_path.read_text(encoding="utf-8")
-    text = re.sub(r"\|상태\|[^|\n]+\|", "|상태|completed|", text)
-    text = re.sub(r"\|마지막 갱신일\|[^|\n]+\|", f"|마지막 갱신일|{date.today().isoformat()}|", text)
-    index_path.write_text(text, encoding="utf-8")
+    _update_bug_status(bug_dir, "completed")
     return "\n".join(
         [
             f"bug_id={args.bug_id}",
@@ -449,6 +526,7 @@ def _render_plan(bug_id: str, fields: dict[str, str]) -> str:
 - [ ] 최소 수정 구현
 - [ ] targeted verification 실행
 - [ ] 필요한 경우 full test 실행
+- [ ] 반복 실패 fingerprint 확인
 - [ ] `harness memory graph status` 확인
 
 ## 3. 차단 조건
@@ -541,3 +619,132 @@ def _technical_decision_status(tier: str) -> str:
 
 def _first_line(value: str) -> str:
     return next((line for line in value.splitlines() if line.strip()), "")
+
+
+@dataclass(frozen=True)
+class ShellResult:
+    command: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _run_shell(command: str, root: Path) -> ShellResult:
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        shell=True,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return ShellResult(
+        command=command,
+        returncode=completed.returncode,
+        stdout=completed.stdout.strip(),
+        stderr=completed.stderr.strip(),
+    )
+
+
+def _git_changed_files(root: Path) -> set[str]:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return set()
+    return {
+        line[3:].strip()
+        for line in completed.stdout.splitlines()
+        if len(line) >= 4 and line[3:].strip()
+    }
+
+
+def _loop_failure_reason(
+    *,
+    implement: ShellResult,
+    verify_results: tuple[ShellResult, ...],
+    changed_files: list[str],
+) -> str | None:
+    if implement.returncode != 0:
+        return f"implement command failed: {implement.command}"
+    failed_verify = next((item for item in verify_results if item.returncode != 0), None)
+    if failed_verify is not None:
+        return f"verify command failed: {failed_verify.command}"
+    if not changed_files:
+        return "implement command made no tracked worktree changes"
+    return None
+
+
+def _loop_failure_reason_from_report(report: dict[str, object]) -> str | None:
+    if int(report.get("implement_exit_code", 0)) != 0:
+        return f"implement command failed: {report.get('implement_command', '')}"
+    for item in report.get("verify_results", []):
+        if isinstance(item, dict) and int(item.get("exit_code", 0)) != 0:
+            return f"verify command failed: {item.get('command', '')}"
+    changed_files = report.get("changed_files", [])
+    if isinstance(changed_files, list) and not changed_files:
+        return "implement command made no tracked worktree changes"
+    return None
+
+
+def _loop_failure_fingerprint(
+    *,
+    implement: ShellResult,
+    verify_results: tuple[ShellResult, ...],
+    changed_files: list[str],
+) -> str:
+    payload = {
+        "implement_command": implement.command,
+        "implement_exit_code": implement.returncode,
+        "implement_stdout": implement.stdout,
+        "implement_stderr": implement.stderr,
+        "verify_results": [
+            {
+                "command": result.command,
+                "exit_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+            for result in verify_results
+        ],
+        "changed_files": changed_files,
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _write_loop_state(
+    path: Path,
+    bug_id: str,
+    status: str,
+    loop_reports: list[dict[str, object]],
+    *,
+    blocker: str = "",
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "bug_id": bug_id,
+                "status": status,
+                "loops": loop_reports,
+                "blocker": blocker,
+                "updated_at": date.today().isoformat(),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _update_bug_status(bug_dir: Path, status: str) -> None:
+    index_path = bug_dir / "index.md"
+    text = index_path.read_text(encoding="utf-8")
+    text = re.sub(r"\|상태\|[^|\n]+\|", f"|상태|{status}|", text)
+    text = re.sub(r"\|마지막 갱신일\|[^|\n]+\|", f"|마지막 갱신일|{date.today().isoformat()}|", text)
+    index_path.write_text(text, encoding="utf-8")

--- a/harness_codex/canonical_cli.py
+++ b/harness_codex/canonical_cli.py
@@ -103,10 +103,12 @@ _TOPIC_HELP_OVERRIDES: dict[str, str] = {
         "[--path PATH]\n"
         "       harness bug triage BUG-ID [--query TEXT]\n"
         "       harness bug plan BUG-ID\n"
+        "       harness bug run BUG-ID --implement-command CMD [--verify-command CMD] [--max-loops N]\n"
         "       harness bug verify BUG-ID\n"
         "       harness bug complete BUG-ID\n\n"
         "경량 버그 수정 workflow를 실행한다. 단순 수정은 전체 ChangeSet/use-case/DDD "
-        "flow를 피하고, 검토된 memory, file cache, graph context로 넓은 스캔을 줄인다."
+        "flow를 피하고, 검토된 memory, file cache, graph context로 넓은 스캔을 줄인다. "
+        "`bug run`은 구현/검증 command를 최대 loop 횟수 안에서 반복하고 같은 failure fingerprint가 재발하면 blocked로 종료한다."
     ),
     "ddd-design-integration": _DDD_INTEGRATION_HELP,
     "changes": (

--- a/harness_codex/runtime/agent_context.py
+++ b/harness_codex/runtime/agent_context.py
@@ -27,6 +27,20 @@ AGENT_CONTEXT_FILES = (
     Path(".harness/docs/agent/design-conformance-report.md"),
     Path(".harness/docs/agent/token-reduction-report.md"),
 )
+HARNESS_GITIGNORE_ENTRIES = (
+    ".harness/",
+    "!.harness/",
+    ".harness/*",
+    "!.harness/agents/",
+    "!.harness/agents/**",
+    "!.harness/docs/",
+    "!.harness/docs/**",
+    ".codex/",
+    "harness_codex/",
+    "completions/",
+    "harness",
+    "venv/",
+)
 
 
 @dataclass(frozen=True)
@@ -103,6 +117,8 @@ def bootstrap_agent_context(
     )
     support_manifest = ensure_scope_support_manifest(repo, description, refresh_if_stale=True)
     results.append(AgentContextFileResult(support_manifest.path, support_manifest.action))
+    gitignore_action = _ensure_harness_gitignore(repo / ".gitignore")
+    results.append(AgentContextFileResult(Path(".gitignore"), gitignore_action))
 
     final_agent_words = _word_count(repo / "AGENTS.md")
     rendered_report = _render_token_reduction_report(
@@ -171,6 +187,23 @@ def _render_docs(
             llm_summary=llm_summary,
         ),
     }
+
+
+def _ensure_harness_gitignore(path: Path) -> str:
+    existing = _read_text(path)
+    lines = existing.splitlines()
+    missing = [entry for entry in HARNESS_GITIGNORE_ENTRIES if entry not in lines]
+    if not missing:
+        return "unchanged"
+    rendered: list[str] = []
+    if existing:
+        rendered.append(existing.rstrip("\n"))
+        rendered.append("")
+    rendered.append("# harness-codex 운영 파일")
+    rendered.extend(missing)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(rendered) + "\n", encoding="utf-8")
+    return "created" if not existing else "updated"
 
 
 def _render_agents(description: str, analysis: RepoAnalysis) -> str:

--- a/harness_codex/runtime/changes/work_item_documents.py
+++ b/harness_codex/runtime/changes/work_item_documents.py
@@ -45,17 +45,10 @@ _REQUIRED_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
         "technical-decisions.md",
         "e2e-goal.md",
     ),
-    WorkItemType.MAINTENANCE: (
-        "scope.md",
-        "change-intent.md",
-        "maintenance-spec.md",
-        "architecture-impact.md",
-        "verification-goal.md",
-        "links.md",
-    ),
-    WorkItemType.BUG_FIX: _COMMON_DOCUMENTS + ("reproduction.md", "regression-goal.md"),
-    WorkItemType.REFACTORING: _COMMON_DOCUMENTS + ("refactoring-contract.md",),
-    WorkItemType.FEATURE_EXTENSION: _COMMON_DOCUMENTS + ("acceptance-delta.md",),
+    WorkItemType.MAINTENANCE: (),
+    WorkItemType.BUG_FIX: (),
+    WorkItemType.REFACTORING: (),
+    WorkItemType.FEATURE_EXTENSION: (),
 }
 
 
@@ -98,14 +91,28 @@ def planner_input_paths(
     """Resolve type-aware planner inputs without UC/maintenance path guessing."""
 
     root = Path(repo_root)
+    if work_item.work_item_type == WorkItemType.USE_CASE:
+        candidates = (
+            change_set_path,
+            *required_document_paths(work_item),
+            *scaffold_document_paths(work_item),
+            Path("ARCHITECTURE.md"),
+            Path(".codex/repository-settings.md"),
+        )
+        return _existing_or_required(
+            root,
+            candidates,
+            required=(change_set_path, *required_document_paths(work_item)),
+        )
+
     candidates = (
         change_set_path,
-        *required_document_paths(work_item),
+        work_item.slice_path,
         *scaffold_document_paths(work_item),
         Path("ARCHITECTURE.md"),
         Path(".codex/repository-settings.md"),
     )
-    return _existing_or_required(root, candidates, required=(change_set_path, *required_document_paths(work_item)))
+    return _existing_or_required(root, candidates, required=(change_set_path,))
 
 
 def executor_input_paths(

--- a/harness_codex/runtime/changeset_orchestrator.py
+++ b/harness_codex/runtime/changeset_orchestrator.py
@@ -44,6 +44,29 @@ from harness_codex.runtime.workflows import (
     write_materialized_workflow_manifest,
 )
 
+RUNTIME_LINK_PATHS = (
+    Path("harness"),
+    Path("harness_codex"),
+    Path(".codex/agents"),
+    Path(".codex/skills"),
+    Path(".harness/workflows"),
+)
+
+HARNESS_WORKTREE_COPY_PATHS = (
+    Path("docs/changes"),
+    Path("docs/use-cases"),
+    Path("docs/maintenance"),
+    Path("docs/plans"),
+    Path("docs/design"),
+    Path(".harness/docs/agent"),
+    Path(".harness/agents"),
+    Path(".codex/repository-settings.md"),
+    Path(".codex/test-gate.yaml"),
+    Path("AGENTS.md"),
+    Path("ARCHITECTURE.md"),
+    Path("context.md"),
+)
+
 WORK_ITEM_WORKFLOW_NAME = "changeset-use-case-workflow"
 FINALIZATION_WORKFLOW_NAME = "changeset-finalization-workflow"
 SESSION_WORKFLOW_NAME = "changeset-session"
@@ -563,27 +586,11 @@ def _hydrate_runtime_worktree(
     copy_project_docs: bool,
 ) -> None:
     _ensure_runs_link(source_root, target_root)
-    for relative in (
-        Path("harness"),
-        Path("harness_codex"),
-        Path(".codex/agents"),
-        Path(".codex/skills"),
-        Path(".harness/workflows"),
-    ):
+    for relative in RUNTIME_LINK_PATHS:
         _mirror_path(source_root / relative, target_root / relative, symlink=True)
     if not copy_project_docs:
         return
-    for relative in (
-        Path("docs/changes"),
-        Path("docs/use-cases"),
-        Path("docs/plans"),
-        Path("docs/design"),
-        Path(".codex/repository-settings.md"),
-        Path(".codex/test-gate.yaml"),
-        Path("AGENTS.md"),
-        Path("ARCHITECTURE.md"),
-        Path("context.md"),
-    ):
+    for relative in HARNESS_WORKTREE_COPY_PATHS:
         _mirror_path(source_root / relative, target_root / relative, symlink=False)
 
 

--- a/harness_codex/runtime/materialize_execution_report.py
+++ b/harness_codex/runtime/materialize_execution_report.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 from pathlib import Path
 from typing import Sequence
 
+from harness_codex.runtime.step_state import write_step_state_handoff
 from harness_codex.runtime.xml_handoff import read_handoff, write_handoff
 
 
@@ -22,6 +24,8 @@ def materialize_execution_report(
     scope = read_handoff(_absolute(repo_root, scope_path), expected_type="execution-scope")
     source = _absolute(repo_root, source_path)
     summary = source.read_text(encoding="utf-8") if source.is_file() else ""
+    work_item_dir = _absolute(repo_root, output_path).parent
+    execution_json = _load_execution_json(work_item_dir / "execution-report.json")
     payload = {
         "schema_version": 1,
         "change_set_id": scope["change_set_id"],
@@ -31,8 +35,21 @@ def materialize_execution_report(
         "executor_final_message_path": str(source_path),
         "summary": summary,
         "changed_files": _changed_files(repo_root),
+        "work_item_profile": scope.get("work_item_profile"),
+        "consumed": execution_json.get("consumed", {}),
+        "frontier_expansion": execution_json.get("frontier_expansion", []),
+        "actual_changes": execution_json.get("actual_changes", []),
+        "test_evidence": execution_json.get("test_evidence", []),
     }
     write_handoff(_absolute(repo_root, output_path), "execution-report", payload)
+    write_step_state_handoff(
+        repo_root,
+        change_set_id=str(scope["change_set_id"]),
+        work_item_id=str(scope["work_item_id"]),
+        step_id="materialize-execution-report",
+        handoff_type="execution-report",
+        payload=payload,
+    )
 
 
 def _changed_files(repo_root: Path) -> list[str]:
@@ -50,6 +67,16 @@ def _changed_files(repo_root: Path) -> list[str]:
 
 def _absolute(repo_root: Path, path: Path) -> Path:
     return path if path.is_absolute() else repo_root / path
+
+
+def _load_execution_json(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/harness_codex/runtime/materialize_execution_report.py
+++ b/harness_codex/runtime/materialize_execution_report.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 from pathlib import Path
 from typing import Sequence
 
@@ -34,11 +33,13 @@ def materialize_execution_report(
         "execution_scope_path": str(scope_path),
         "executor_final_message_path": str(source_path),
         "summary": summary,
-        "changed_files": _changed_files(repo_root),
         "work_item_profile": scope.get("work_item_profile"),
         "consumed": execution_json.get("consumed", {}),
         "frontier_expansion": execution_json.get("frontier_expansion", []),
-        "actual_changes": execution_json.get("actual_changes", []),
+        "declared_changes": execution_json.get(
+            "declared_changes",
+            execution_json.get("actual_changes", []),
+        ),
         "test_evidence": execution_json.get("test_evidence", []),
     }
     write_handoff(_absolute(repo_root, output_path), "execution-report", payload)
@@ -50,20 +51,6 @@ def materialize_execution_report(
         handoff_type="execution-report",
         payload=payload,
     )
-
-
-def _changed_files(repo_root: Path) -> list[str]:
-    result = subprocess.run(
-        ["git", "status", "--porcelain=v1"],
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if result.returncode:
-        return []
-    return [line[3:] for line in result.stdout.splitlines() if len(line) >= 4]
-
 
 def _absolute(repo_root: Path, path: Path) -> Path:
     return path if path.is_absolute() else repo_root / path

--- a/harness_codex/runtime/materialize_execution_scope.py
+++ b/harness_codex/runtime/materialize_execution_scope.py
@@ -8,6 +8,8 @@ import re
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.changes.models import WorkItemType
 from harness_codex.runtime.xml_handoff import write_handoff
 
 _REQUIRED: Mapping[str, tuple[str, ...]] = {
@@ -17,6 +19,20 @@ _REQUIRED: Mapping[str, tuple[str, ...]] = {
     "external_contract_read_allowlist": ("외부 계약 읽기 허용 목록", "External Contract Read Allowlist"),
     "task_checklist": ("작업 체크리스트", "Task Checklist"),
     "focused_verification": ("집중 검증", "Focused Verification"),
+}
+_PROFILE_REQUIRED: Mapping[str, tuple[str, ...]] = {
+    "use_case": (
+        "execution_scope",
+        "package_dependency_contract",
+        "domain_implementation_contract",
+        "external_contract_read_allowlist",
+        "task_checklist",
+        "focused_verification",
+    ),
+    "maintenance": (
+        "task_checklist",
+        "focused_verification",
+    ),
 }
 _HEADING = re.compile(r"(?m)^##\s+(.+?)\s*$")
 _PLACEHOLDER = re.compile(r"(?:\bTODO\b|\bpending\b|^\s*[-*]\s*\.\.\.\s*$)", re.IGNORECASE)
@@ -48,7 +64,8 @@ def materialize_execution_scope(
         raise FileNotFoundError(f"active plan is required: {plan_path}")
     text = plan.read_text(encoding="utf-8")
     sections = _sections(text)
-    missing = _invalid_sections(sections)
+    work_item_profile = _work_item_profile(repo_root, change_set_id, work_item_id)
+    missing = _invalid_sections(sections, work_item_profile)
     if enforce_full_contract and missing:
         raise ExecutionPlanContractError("executor-ready plan contract is incomplete: " + ", ".join(missing))
 
@@ -67,10 +84,19 @@ def materialize_execution_scope(
         "schema_version": 2,
         "change_set_id": change_set_id,
         "work_item_id": work_item_id,
+        "work_item_profile": work_item_profile,
         "active_plan_path": _relative(plan, repo_root),
         "plan_sha256": plan_sha256,
         "plan_fingerprint": plan_fingerprint,
         "execution_report_path": str(report_path),
+        "read_frontier": _candidate_rows(sections, ("Context Discovery", "컨텍스트 탐색"), ("Read Frontier", "readFrontier", "조회 프론티어")),
+        "write_intent": _candidate_rows(sections, ("Write Intent", "수정 의도"), ()),
+        "verification_plan": _plain_lines(
+            _section_text(sections, ("Verification Plan", "검증 계획", "Focused Regression Plan", "집중 회귀 계획"))
+        ),
+        "ddd_test_obligations": _plain_lines(
+            _section_text(sections, ("DDD Test Obligations", "DDD 테스트 의무"))
+        ),
         "runtime_write_authority": {
             "model": "ChangeSet included scope",
             "plan_grants_write_authority": False,
@@ -118,9 +144,10 @@ def _sections(text: str) -> dict[str, str]:
     }
 
 
-def _invalid_sections(sections: Mapping[str, str]) -> list[str]:
+def _invalid_sections(sections: Mapping[str, str], work_item_profile: str) -> list[str]:
     errors: list[str] = []
-    for aliases in _REQUIRED.values():
+    for key in _PROFILE_REQUIRED.get(work_item_profile, _PROFILE_REQUIRED["use_case"]):
+        aliases = _REQUIRED[key]
         heading = next((alias for alias in aliases if alias in sections), None)
         if heading is None:
             errors.append(f"missing section: {aliases[0]}")
@@ -150,6 +177,80 @@ def _has_template_placeholder(content: str) -> bool:
 
 def _sha(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _work_item_profile(repo_root: Path, change_set_id: str, work_item_id: str) -> str:
+    change_set_path = repo_root / "docs" / "changes" / "active" / f"{change_set_id}.md"
+    if change_set_path.is_file():
+        change_set = parse_changeset_markdown(
+            change_set_path.read_text(encoding="utf-8"),
+            path=change_set_path.relative_to(repo_root),
+        )
+        for item in change_set.ordered_work_items():
+            if item.work_item_id == work_item_id:
+                return "use_case" if item.work_item_type == WorkItemType.USE_CASE else "maintenance"
+    use_case_dir = repo_root / "docs" / "use-cases" / work_item_id
+    return "use_case" if use_case_dir.exists() else "maintenance"
+
+
+def _section_text(sections: Mapping[str, str], names: Sequence[str]) -> str:
+    for name in names:
+        if name in sections:
+            return sections[name]
+    return ""
+
+
+def _candidate_rows(
+    sections: Mapping[str, str],
+    parent_names: Sequence[str],
+    child_names: Sequence[str],
+) -> list[dict[str, str]]:
+    content = _section_text(sections, parent_names)
+    if not content and child_names:
+        content = _section_text(sections, child_names)
+    elif content and child_names:
+        subsection = _subsection_text(content, child_names)
+        if subsection:
+            content = subsection
+    rows: list[dict[str, str]] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(("- ", "* ")):
+            continue
+        body = stripped[2:].strip()
+        path_match = re.search(r"`([^`]+)`", body)
+        path = path_match.group(1).strip() if path_match else body.split(":", 1)[0].strip()
+        if not path:
+            continue
+        rows.append(
+            {
+                "path": path,
+                "reason": body,
+            }
+        )
+    return rows
+
+
+def _subsection_text(content: str, names: Sequence[str]) -> str:
+    lines = content.splitlines()
+    active = False
+    collected: list[str] = []
+    for line in lines:
+        if line.startswith("### "):
+            title = line[4:].strip()
+            if title in names:
+                active = True
+                collected = []
+                continue
+            if active:
+                break
+        if active:
+            collected.append(line)
+    return "\n".join(collected).strip()
+
+
+def _plain_lines(content: str) -> list[str]:
+    return [line.strip() for line in content.splitlines() if line.strip()]
 
 
 def _execution_report_path_from_scope_output(output_path: Path, work_item_id: str) -> Path:

--- a/harness_codex/runtime/step_state.py
+++ b/harness_codex/runtime/step_state.py
@@ -1,0 +1,63 @@
+"""Step-local XML handoff storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from harness_codex.runtime.xml_handoff import read_handoff, write_handoff
+
+
+def step_state_xml_path(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    step_id: str,
+) -> Path:
+    root = Path(repo_root)
+    return (
+        root
+        / ".harness"
+        / "state"
+        / "step-state"
+        / change_set_id
+        / work_item_id
+        / step_id
+        / "state.xml"
+    )
+
+
+def write_step_state_handoff(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    step_id: str,
+    handoff_type: str,
+    payload: Mapping[str, Any],
+) -> Path:
+    path = step_state_xml_path(
+        repo_root,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        step_id=step_id,
+    )
+    return write_handoff(path, handoff_type, payload)
+
+
+def read_step_state_handoff(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    step_id: str,
+    expected_type: str,
+) -> dict[str, Any]:
+    path = step_state_xml_path(
+        repo_root,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        step_id=step_id,
+    )
+    return read_handoff(path, expected_type=expected_type)

--- a/harness_codex/runtime/verify_work_item.py
+++ b/harness_codex/runtime/verify_work_item.py
@@ -575,7 +575,7 @@ def _retained_execution_report_result(
         blocker_parts.extend(_stringify_blocker(item) for item in blockers)
     if isinstance(remaining_tasks, list) and remaining_tasks:
         blocker_parts.append("remaining verification tasks: " + "; ".join(str(item) for item in remaining_tasks))
-    diff_contract_blockers = _diff_contract_blockers(payload)
+    diff_contract_blockers = _diff_contract_blockers({**payload, "repo_root": str(repo_root)})
     if diff_contract_blockers:
         blocker_parts.extend(diff_contract_blockers)
 
@@ -633,28 +633,24 @@ def _stringify_blocker(value: object) -> str:
 
 
 def _diff_contract_blockers(payload: Mapping[str, object]) -> list[str]:
-    actual_changes_raw = payload.get("actual_changes")
-    if not isinstance(actual_changes_raw, list):
+    declared_changes_raw = payload.get("declared_changes", payload.get("actual_changes"))
+    if not isinstance(declared_changes_raw, list):
         return []
-    changed_files = {
-        str(item).strip()
-        for item in payload.get("changed_files", [])
-        if isinstance(item, str) and str(item).strip()
-    }
-    actual_changes = [item for item in actual_changes_raw if isinstance(item, Mapping)]
-    actual_paths = {
+    changed_files = _observed_changed_files(payload)
+    declared_changes = [item for item in declared_changes_raw if isinstance(item, Mapping)]
+    declared_paths = {
         str(item.get("path") or "").strip()
-        for item in actual_changes
+        for item in declared_changes
         if str(item.get("path") or "").strip()
     }
     blockers: list[str] = []
-    undocumented = sorted(path for path in changed_files if path not in actual_paths)
+    undocumented = sorted(path for path in changed_files if path not in declared_paths)
     if undocumented:
         blockers.append("diff contract undocumented changed files: " + ", ".join(undocumented))
-    for item in actual_changes:
+    for item in declared_changes:
         path = str(item.get("path") or "").strip()
         if not path:
-            blockers.append("diff contract actual_changes entry is missing path")
+            blockers.append("diff contract declared_changes entry is missing path")
             continue
         reason = str(item.get("reason") or item.get("linked_intent") or "").strip()
         if not reason:
@@ -664,6 +660,38 @@ def _diff_contract_blockers(payload: Mapping[str, object]) -> list[str]:
         if cross_boundary and not edge:
             blockers.append(f"diff contract missing boundary edge explanation: {path}")
     return blockers
+
+
+def _observed_changed_files(payload: Mapping[str, object]) -> set[str]:
+    repo_root_value = payload.get("repo_root")
+    if isinstance(repo_root_value, str) and repo_root_value.strip():
+        observed = _git_changed_files(Path(repo_root_value))
+        if observed is not None:
+            return observed
+    return {
+        str(item).strip()
+        for item in payload.get("changed_files", [])
+        if isinstance(item, str) and str(item).strip()
+    }
+
+
+def _git_changed_files(repo_root: Path) -> set[str] | None:
+    if not repo_root.exists():
+        return None
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if status.returncode != 0:
+        return None
+    return {
+        line[3:].strip()
+        for line in status.stdout.splitlines()
+        if len(line) >= 4 and line[3:].strip()
+    }
 
 
 def _obligation_name(line: str) -> str | None:

--- a/harness_codex/runtime/verify_work_item.py
+++ b/harness_codex/runtime/verify_work_item.py
@@ -575,6 +575,9 @@ def _retained_execution_report_result(
         blocker_parts.extend(_stringify_blocker(item) for item in blockers)
     if isinstance(remaining_tasks, list) and remaining_tasks:
         blocker_parts.append("remaining verification tasks: " + "; ".join(str(item) for item in remaining_tasks))
+    diff_contract_blockers = _diff_contract_blockers(payload)
+    if diff_contract_blockers:
+        blocker_parts.extend(diff_contract_blockers)
 
     return WorkItemVerificationResult(
         change_set_id=change_set_id,
@@ -627,6 +630,40 @@ def _stringify_blocker(value: object) -> str:
             return f"{kind}: {detail}"
         return str(detail)
     return str(value)
+
+
+def _diff_contract_blockers(payload: Mapping[str, object]) -> list[str]:
+    actual_changes_raw = payload.get("actual_changes")
+    if not isinstance(actual_changes_raw, list):
+        return []
+    changed_files = {
+        str(item).strip()
+        for item in payload.get("changed_files", [])
+        if isinstance(item, str) and str(item).strip()
+    }
+    actual_changes = [item for item in actual_changes_raw if isinstance(item, Mapping)]
+    actual_paths = {
+        str(item.get("path") or "").strip()
+        for item in actual_changes
+        if str(item.get("path") or "").strip()
+    }
+    blockers: list[str] = []
+    undocumented = sorted(path for path in changed_files if path not in actual_paths)
+    if undocumented:
+        blockers.append("diff contract undocumented changed files: " + ", ".join(undocumented))
+    for item in actual_changes:
+        path = str(item.get("path") or "").strip()
+        if not path:
+            blockers.append("diff contract actual_changes entry is missing path")
+            continue
+        reason = str(item.get("reason") or item.get("linked_intent") or "").strip()
+        if not reason:
+            blockers.append(f"diff contract missing change reason: {path}")
+        cross_boundary = bool(item.get("cross_boundary") or item.get("cross_bc"))
+        edge = str(item.get("edge_path") or item.get("boundary_edge") or "").strip()
+        if cross_boundary and not edge:
+            blockers.append(f"diff contract missing boundary edge explanation: {path}")
+    return blockers
 
 
 def _obligation_name(line: str) -> str | None:

--- a/harness_codex/runtime/workflows/materializer.py
+++ b/harness_codex/runtime/workflows/materializer.py
@@ -49,6 +49,7 @@ def materialize_workflow_for_scope(
             "change_set_id": change_set.change_set_id,
             "work_item_id": scope.display_id,
             "work_item_type": scope.work_item_type.value,
+            "work_item_profile": _work_item_profile(scope.work_item_type),
             "replacements": replacements,
             "gate_policy": policy.as_dict(),
             "skipped_gates": skipped_gates,
@@ -80,6 +81,10 @@ def materialization_replacements(
         "<WORK-ITEM-ID>": scope.display_id,
         "<RUN-ID>": run_id,
     }
+
+
+def _work_item_profile(work_item_type: WorkItemType) -> str:
+    return "use_case" if work_item_type == WorkItemType.USE_CASE else "maintenance"
 
 
 def unresolved_placeholders(workflow: Workflow) -> frozenset[str]:

--- a/harness_codex/runtime/worktree_support.py
+++ b/harness_codex/runtime/worktree_support.py
@@ -8,6 +8,29 @@ import subprocess
 from pathlib import Path
 from uuid import uuid4
 
+RUNTIME_LINK_PATHS = (
+    Path("harness"),
+    Path("harness_codex"),
+    Path(".codex/agents"),
+    Path(".codex/skills"),
+    Path(".harness/workflows"),
+)
+
+HARNESS_WORKTREE_COPY_PATHS = (
+    Path("docs/changes"),
+    Path("docs/use-cases"),
+    Path("docs/maintenance"),
+    Path("docs/plans"),
+    Path("docs/design"),
+    Path(".harness/docs/agent"),
+    Path(".harness/agents"),
+    Path(".codex/repository-settings.md"),
+    Path(".codex/test-gate.yaml"),
+    Path("AGENTS.md"),
+    Path("ARCHITECTURE.md"),
+    Path("context.md"),
+)
+
 
 def git(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     completed = subprocess.run(
@@ -96,27 +119,11 @@ def hydrate_runtime_worktree(
     copy_project_docs: bool,
 ) -> None:
     ensure_runs_link(source_root, target_root)
-    for relative in (
-        Path("harness"),
-        Path("harness_codex"),
-        Path(".codex/agents"),
-        Path(".codex/skills"),
-        Path(".harness/workflows"),
-    ):
+    for relative in RUNTIME_LINK_PATHS:
         mirror_path(source_root / relative, target_root / relative, symlink=True)
     if not copy_project_docs:
         return
-    for relative in (
-        Path("docs/changes"),
-        Path("docs/use-cases"),
-        Path("docs/plans"),
-        Path("docs/design"),
-        Path(".codex/repository-settings.md"),
-        Path(".codex/test-gate.yaml"),
-        Path("AGENTS.md"),
-        Path("ARCHITECTURE.md"),
-        Path("context.md"),
-    ):
+    for relative in HARNESS_WORKTREE_COPY_PATHS:
         mirror_path(source_root / relative, target_root / relative, symlink=False)
 
 
@@ -153,14 +160,7 @@ def mirror_path(source: Path, target: Path, *, symlink: bool) -> None:
 
 
 def remove_runtime_links(repo_root: Path) -> None:
-    for relative in (
-        Path(".harness/runs"),
-        Path(".harness/workflows"),
-        Path(".codex/agents"),
-        Path(".codex/skills"),
-        Path("harness"),
-        Path("harness_codex"),
-    ):
+    for relative in (Path(".harness/runs"), *RUNTIME_LINK_PATHS):
         target = repo_root / relative
         if target.is_symlink():
             target.unlink()

--- a/tests/test_bug_cli.py
+++ b/tests/test_bug_cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import subprocess
 
 from harness_codex import bug_cli, canonical_cli
 
@@ -65,5 +66,78 @@ def test_public_help_includes_bug_workflow() -> None:
     help_text = canonical_cli.help_command("bug")
 
     assert "harness bug start" in help_text
+    assert "harness bug run BUG-ID" in help_text
     assert "memory" in help_text
     assert "graph" in help_text
+
+
+def test_bug_run_completes_with_single_successful_loop(tmp_path: Path) -> None:
+    assert bug_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "start",
+            "--title",
+            "파일 없음",
+            "--symptom",
+            "missing file",
+        ]
+    ) == 0
+    bug_id = next((tmp_path / "docs/maintenance").glob("BUG-*")).name
+    assert bug_cli.main(["--repo-root", str(tmp_path), "plan", bug_id]) == 0
+
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    result = bug_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "run",
+            bug_id,
+            "--implement-command",
+            "mkdir -p src && printf 'ok\\n' > src/fix.txt",
+            "--verify-command",
+            "test -f src/fix.txt",
+        ]
+    )
+
+    assert result == 0
+    assert "|상태|completed|" in (tmp_path / "docs/maintenance" / bug_id / "index.md").read_text(encoding="utf-8")
+    loop_state = (tmp_path / "docs/maintenance" / bug_id / "loop-state.json").read_text(encoding="utf-8")
+    assert '"status": "completed"' in loop_state
+
+
+def test_bug_run_blocks_after_repeated_failure_fingerprint(tmp_path: Path) -> None:
+    assert bug_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "start",
+            "--title",
+            "반복 실패",
+            "--symptom",
+            "repeat failure",
+        ]
+    ) == 0
+    bug_id = next((tmp_path / "docs/maintenance").glob("BUG-*")).name
+    assert bug_cli.main(["--repo-root", str(tmp_path), "plan", bug_id]) == 0
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+
+    result = bug_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "run",
+            bug_id,
+            "--implement-command",
+            "true",
+            "--verify-command",
+            "false",
+            "--max-loops",
+            "2",
+        ]
+    )
+
+    assert result == 2
+    assert "|상태|blocked|" in (tmp_path / "docs/maintenance" / bug_id / "index.md").read_text(encoding="utf-8")
+    loop_state = (tmp_path / "docs/maintenance" / bug_id / "loop-state.json").read_text(encoding="utf-8")
+    assert '"status": "blocked"' in loop_state

--- a/tests/test_issue_460_contracts.py
+++ b/tests/test_issue_460_contracts.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_codex.runtime.changes import ChangeSetResolver
+from harness_codex.runtime.materialize_execution_scope import materialize_execution_scope
+from harness_codex.runtime.verify_work_item import verify_work_item
+
+
+def test_maintenance_changeset_runtime_ready_without_global_scope_docs(tmp_path: Path) -> None:
+    change_set = tmp_path / "docs/changes/active/CHG-001.md"
+    change_set.parent.mkdir(parents=True)
+    change_set.write_text(
+        "\n".join(
+            [
+                "# CHG-001",
+                "",
+                "## 1. 메타데이터",
+                "",
+                "|항목|값|",
+                "|---|---|",
+                "|ChangeSet ID|CHG-001|",
+                "",
+                "## 2. 구현 의도",
+                "",
+                "- 요청 요약: maintenance runtime-ready gate 완화",
+                "",
+                "## 6. 영향 작업",
+                "",
+                "|Work Item ID|Type|Name|Impact Type|Slice Path|Status|",
+                "|---|---|---|---|---|---|",
+                "|BUG-001|maintenance|정렬 버그 수정|update|docs/maintenance/BUG-001|ready|",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs/maintenance/BUG-001").mkdir(parents=True)
+
+    resolver = ChangeSetResolver(tmp_path)
+    blocked = resolver.validate_active_change_set(resolver.load(change_set))
+
+    assert blocked is None
+
+
+def test_materialize_execution_scope_includes_issue_460_contract_fields(tmp_path: Path) -> None:
+    change_set = tmp_path / "docs/changes/active/CHG-001.md"
+    plan = tmp_path / "docs/plans/active/BUG-001/plan.md"
+    change_set.parent.mkdir(parents=True)
+    plan.parent.mkdir(parents=True)
+    change_set.write_text(
+        "\n".join(
+            [
+                "# CHG-001",
+                "",
+                "## 1. 메타데이터",
+                "",
+                "|항목|값|",
+                "|---|---|",
+                "|ChangeSet ID|CHG-001|",
+                "",
+                "## 2. 구현 의도",
+                "",
+                "- 요청 요약: frontier 기반 maintenance 계획",
+                "",
+                "## 6. 영향 작업",
+                "",
+                "|Work Item ID|Type|Name|Impact Type|Slice Path|Status|",
+                "|---|---|---|---|---|---|",
+                "|BUG-001|maintenance|정렬 버그 수정|update|docs/maintenance/BUG-001|ready|",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    plan.write_text(
+        "\n".join(
+            [
+                "# BUG-001 계획",
+                "",
+                "## Context Discovery",
+                "",
+                "### Read Frontier",
+                "",
+                "- `app/service.py`: 실패 stacktrace 상위 frame",
+                "",
+                "## Write Intent",
+                "",
+                "- `app/service.py`: 정렬 기준 수정",
+                "- `tests/test_service.py`: 회귀 테스트 추가",
+                "",
+                "## 작업 체크리스트",
+                "",
+                "- [ ] `app/service.py` 정렬 기준 수정",
+                "",
+                "## Focused Regression Plan",
+                "",
+                "- `./venv/bin/python3 -m pytest -q tests/test_service.py`",
+                "",
+                "## 집중 검증",
+                "",
+                "- [ ] VERIFY-001 Tests: `./venv/bin/python3 -m pytest -q tests/test_service.py`",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = materialize_execution_scope(
+        repo_root=tmp_path,
+        change_set_id="CHG-001",
+        work_item_id="BUG-001",
+        plan_path=Path("docs/plans/active/BUG-001/plan.md"),
+        output_path=Path(".harness/runs/run-1/work-items/BUG-001/execution-scope.xml"),
+    )
+
+    assert payload["work_item_profile"] == "maintenance"
+    assert payload["read_frontier"] == [{"path": "app/service.py", "reason": "`app/service.py`: 실패 stacktrace 상위 frame"}]
+    assert payload["write_intent"][0]["path"] == "app/service.py"
+    assert payload["verification_plan"] == ["- `./venv/bin/python3 -m pytest -q tests/test_service.py`"]
+
+
+def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> None:
+    (tmp_path / "docs/plans/active/BUG-001").mkdir(parents=True)
+    (tmp_path / "docs/maintenance/BUG-001").mkdir(parents=True)
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / "docs/plans/active/BUG-001/plan.md").write_text(
+        "\n".join(
+            [
+                "# 계획",
+                "## 집중 검증",
+                "- [ ] VERIFY-001 Tests: `./venv/bin/python3 -m pytest -q tests/test_bug.py`",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs/maintenance/BUG-001/verification-goal.md").write_text("# 검증\n", encoding="utf-8")
+    (tmp_path / ".codex/test-gate.yaml").write_text("required: []\n", encoding="utf-8")
+    evidence_root = tmp_path / ".harness/runs/run-1/work-items/BUG-001/steps/execute-work-item/evidence"
+    evidence_root.mkdir(parents=True)
+    for name in ("build.txt", "tests.txt", "e2e.txt", "test-gate.txt", "runtime.txt", "static-analysis.txt"):
+        (evidence_root / name).write_text("PASS\n", encoding="utf-8")
+    report = tmp_path / ".harness/runs/run-1/work-items/BUG-001/execution-report.json"
+    report.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "change_set_id": "CHG-001",
+                "work_item_id": "BUG-001",
+                "plan_path": "docs/plans/active/BUG-001/plan.md",
+                "plan_fingerprint": "sha256:test",
+                "status": "completed",
+                "completed_tasks": [],
+                "remaining_tasks": [],
+                "changed_files": ["app/service.py", "tests/test_bug.py"],
+                "verification": [
+                    {"label": "Build", "status": "PASS", "evidence_path": str(evidence_root / "build.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "Tests", "status": "PASS", "evidence_path": str(evidence_root / "tests.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "E2E 또는 maintenance verification", "status": "PASS", "evidence_path": str(evidence_root / "e2e.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "Test gate", "status": "PASS", "evidence_path": str(evidence_root / "test-gate.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "Runtime server verification", "status": "PASS", "evidence_path": str(evidence_root / "runtime.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "Static analysis", "status": "PASS", "evidence_path": str(evidence_root / "static-analysis.txt").replace(str(tmp_path) + "/", "")},
+                ],
+                "blockers": [],
+                "actual_changes": [
+                    {"path": "app/service.py", "action": "modified", "reason": "정렬 기준 수정"}
+                ],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = verify_work_item(
+        tmp_path,
+        change_set_id="CHG-001",
+        work_item_id="BUG-001",
+        run_id="run-1",
+        write_legacy_reports=False,
+    )
+
+    assert not result.passed
+    assert result.blocker is not None
+    assert "diff contract undocumented changed files" in result.blocker

--- a/tests/test_issue_460_contracts.py
+++ b/tests/test_issue_460_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from harness_codex.runtime.changes import ChangeSetResolver
@@ -122,6 +123,9 @@ def test_materialize_execution_scope_includes_issue_460_contract_fields(tmp_path
 
 
 def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True)
     (tmp_path / "docs/plans/active/BUG-001").mkdir(parents=True)
     (tmp_path / "docs/maintenance/BUG-001").mkdir(parents=True)
     (tmp_path / ".codex").mkdir()
@@ -138,6 +142,15 @@ def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> 
     )
     (tmp_path / "docs/maintenance/BUG-001/verification-goal.md").write_text("# 검증\n", encoding="utf-8")
     (tmp_path / ".codex/test-gate.yaml").write_text("required: []\n", encoding="utf-8")
+    tracked = tmp_path / "app/service.py"
+    tracked.parent.mkdir(parents=True, exist_ok=True)
+    tracked.write_text("before\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True)
+    tracked.write_text("after\n", encoding="utf-8")
+    untracked = tmp_path / "tests/test_bug.py"
+    untracked.parent.mkdir(parents=True, exist_ok=True)
+    untracked.write_text("def test_bug():\n    assert True\n", encoding="utf-8")
     evidence_root = tmp_path / ".harness/runs/run-1/work-items/BUG-001/steps/execute-work-item/evidence"
     evidence_root.mkdir(parents=True)
     for name in ("build.txt", "tests.txt", "e2e.txt", "test-gate.txt", "runtime.txt", "static-analysis.txt"):
@@ -154,7 +167,6 @@ def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> 
                 "status": "completed",
                 "completed_tasks": [],
                 "remaining_tasks": [],
-                "changed_files": ["app/service.py", "tests/test_bug.py"],
                 "verification": [
                     {"label": "Build", "status": "PASS", "evidence_path": str(evidence_root / "build.txt").replace(str(tmp_path) + "/", "")},
                     {"label": "Tests", "status": "PASS", "evidence_path": str(evidence_root / "tests.txt").replace(str(tmp_path) + "/", "")},
@@ -164,7 +176,7 @@ def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> 
                     {"label": "Static analysis", "status": "PASS", "evidence_path": str(evidence_root / "static-analysis.txt").replace(str(tmp_path) + "/", "")},
                 ],
                 "blockers": [],
-                "actual_changes": [
+                "declared_changes": [
                     {"path": "app/service.py", "action": "modified", "reason": "정렬 기준 수정"}
                 ],
             },
@@ -185,3 +197,58 @@ def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> 
     assert not result.passed
     assert result.blocker is not None
     assert "diff contract undocumented changed files" in result.blocker
+
+
+def test_materialize_execution_report_keeps_declared_changes_only(tmp_path: Path) -> None:
+    from harness_codex.runtime.materialize_execution_report import materialize_execution_report
+
+    scope = tmp_path / ".harness/runs/run-1/work-items/BUG-001/execution-scope.xml"
+    source = tmp_path / ".harness/runs/run-1/steps/execute-work-item/final-message.md"
+    output = tmp_path / ".harness/runs/run-1/work-items/BUG-001/execution-report.xml"
+    scope.parent.mkdir(parents=True, exist_ok=True)
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("done\n", encoding="utf-8")
+    report_json = output.parent / "execution-report.json"
+    report_json.write_text(
+        json.dumps(
+            {
+                "declared_changes": [
+                    {"path": "app/service.py", "action": "modified", "reason": "정렬 수정"}
+                ],
+                "frontier_expansion": [{"path": "app/service.py", "reason": "stacktrace"}],
+                "test_evidence": [{"command": "pytest -q tests/test_bug.py", "result": "passed"}],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    from harness_codex.runtime.xml_handoff import write_handoff, read_handoff
+
+    write_handoff(
+        scope,
+        "execution-scope",
+        {
+            "schema_version": 2,
+            "change_set_id": "CHG-001",
+            "work_item_id": "BUG-001",
+            "work_item_profile": "maintenance",
+            "active_plan_path": "docs/plans/active/BUG-001/plan.md",
+            "plan_sha256": "abc",
+            "plan_fingerprint": "sha256:abc",
+            "execution_report_path": str(output.relative_to(tmp_path)),
+        },
+    )
+
+    materialize_execution_report(
+        repo_root=tmp_path,
+        scope_path=scope.relative_to(tmp_path),
+        source_path=source.relative_to(tmp_path),
+        output_path=output.relative_to(tmp_path),
+    )
+
+    payload = read_handoff(output, expected_type="execution-report")
+    assert "changed_files" not in payload
+    assert payload["declared_changes"] == [
+        {"path": "app/service.py", "action": "modified", "reason": "정렬 수정"}
+    ]

--- a/tests/test_scope_support_manifest.py
+++ b/tests/test_scope_support_manifest.py
@@ -30,6 +30,8 @@ def test_bootstrap_agent_context_creates_repo_scope_support_manifest(
     assert manifest_path.exists()
     assert SCOPE_SUPPORT_MANIFEST_PATH in result.changed_paths
     assert 'allow = ["build.gradle", "scripts/**", "src/main/resources/**"]' in manifest_text
+    gitignore_text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert "harness_codex/" in gitignore_text
 
 
 def test_scope_support_manifest_refreshes_when_stale(tmp_path: Path) -> None:
@@ -64,3 +66,16 @@ def test_scope_support_manifest_refreshes_when_stale(tmp_path: Path) -> None:
     assert result.action == "updated"
     assert 'src/main/resources/**' in manifest_text
     assert 'fingerprint = "stale"' not in manifest_text
+
+
+def test_bootstrap_agent_context_updates_existing_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("build/\n", encoding="utf-8")
+
+    result = bootstrap_agent_context(tmp_path, "테스트 리포지토리")
+
+    gitignore_text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+
+    assert Path(".gitignore") in result.changed_paths
+    assert "build/\n" in gitignore_text
+    assert "harness_codex/" in gitignore_text
+    assert ".harness/" in gitignore_text

--- a/tests/test_worktree_support.py
+++ b/tests/test_worktree_support.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from harness_codex.runtime.worktree_support import committable_status_paths, safe_ref_part
+from pathlib import Path
+
+from harness_codex.runtime.worktree_support import (
+    committable_status_paths,
+    hydrate_runtime_worktree,
+    safe_ref_part,
+)
 
 
 def test_safe_ref_part_removes_git_unsafe_characters() -> None:
@@ -25,3 +31,30 @@ def test_committable_status_paths_keeps_renamed_destination() -> None:
     status = "R  docs/new.md\0docs/old.md\0"
 
     assert committable_status_paths(status) == ("docs/new.md",)
+
+
+def test_hydrate_runtime_worktree_copies_ignored_harness_artifacts(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    (source / ".harness/docs/agent").mkdir(parents=True)
+    (source / ".harness/docs/agent/context.md").write_text("# context\n", encoding="utf-8")
+    (source / ".harness/agents").mkdir(parents=True)
+    (source / ".harness/agents/scope-support.toml").write_text("version = \"1\"\n", encoding="utf-8")
+    (source / "docs/maintenance/BUG-001").mkdir(parents=True)
+    (source / "docs/maintenance/BUG-001/index.md").write_text("# bug\n", encoding="utf-8")
+    (source / "docs/changes/active").mkdir(parents=True)
+    (source / "docs/changes/active/CHG-001.md").write_text("# change\n", encoding="utf-8")
+    (source / ".harness/workflows").mkdir(parents=True)
+    (source / "harness_codex").mkdir(parents=True)
+    (source / ".codex/agents").mkdir(parents=True)
+    (source / ".codex/skills").mkdir(parents=True)
+    (source / "harness").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    hydrate_runtime_worktree(source, target, copy_project_docs=True)
+
+    assert (target / ".harness/runs").is_symlink()
+    assert (target / ".harness/docs/agent/context.md").read_text(encoding="utf-8") == "# context\n"
+    assert (target / ".harness/agents/scope-support.toml").read_text(encoding="utf-8") == 'version = "1"\n'
+    assert (target / "docs/maintenance/BUG-001/index.md").read_text(encoding="utf-8") == "# bug\n"
+    assert (target / "docs/changes/active/CHG-001.md").read_text(encoding="utf-8") == "# change\n"
+    assert (target / "harness_codex").is_symlink()


### PR DESCRIPTION
## 구현 의도
- maintenance work item이 전역 scope 문서 없이도 runtime-ready 되게 validation gate를 완화했다.
- plan/execution/verifier 사이에 `readFrontier`, `writeIntent`, `actualChanges`를 전달할 최소 contract를 추가했다.
- verifier가 실행 보고서의 `actual_changes`와 실제 변경 파일 목록을 비교하도록 diff contract를 넣었다.

## 구현 접근
- `work_item_documents`에서 maintenance 계열 work item의 필수 문서 강제를 제거하고, planner input을 ChangeSet + existing slice 문서 중심으로 재구성했다.
- `materialize_execution_scope`에서 work item profile을 판별하고, plan에서 `read_frontier`, `write_intent`, `verification_plan`, `ddd_test_obligations`를 추출해 XML payload에 포함했다.
- `materialize_execution_report`와 `verify_work_item`에서 execution report JSON의 `actual_changes`/`frontier_expansion`/`test_evidence`를 읽어 verifier blocker로 승격했다.
- workflow materializer metadata에 `work_item_profile`을 기록하고, 회귀 테스트를 추가했다.

## 검증 방법
- `PYTHONPATH=. ./venv/bin/python3 -m pytest -q tests/test_issue_460_contracts.py tests/test_bug_cli.py tests/test_verification_xml_contract.py tests/test_agent_capabilities.py tests/test_engine_runtime_integration.py tests/test_materialize_security_review.py tests/test_plan_review_canonical_cache.py tests/test_procedure_stage_runtime_state.py tests/test_xml_handoff.py`

## 위험 및 롤백
- plan 섹션 파싱은 heading 기반이라 문서 포맷 편차가 크면 `read_frontier`/`write_intent`가 비어 있을 수 있다.
- execution report JSON을 새 필드 없이 작성하는 기존 executor 흐름은 계속 허용하지만, `actual_changes`를 쓰기 시작하면 diff contract가 즉시 엄격해진다.
- 롤백은 PR revert로 가능하고, 영향 범위는 runtime scope materialization / verifier / maintenance document gate로 제한된다.
