### PR TITLE
bug workflow를 worktree 격리와 xml 메타로 전환

### DIFF
--- a/harness_codex/bug_cli.py
+++ b/harness_codex/bug_cli.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from xml.etree import ElementTree
 
 from harness_codex.runtime.changeset_memory import ChangeSetMemoryError, search_memory
 from harness_codex.runtime.file_memory_cache import FileMemoryCacheError, warm_file_cache
@@ -15,6 +19,16 @@ from harness_codex.runtime.graph_context import (
     GraphContextError,
     graph_context_status,
     query_graph_context,
+)
+from harness_codex.runtime.worktree_support import (
+    add_worktree,
+    git,
+    hydrate_runtime_worktree,
+    is_git_worktree,
+    remove_worktree,
+    safe_ref_part,
+    usable_worktree,
+    worktrees_base_dir,
 )
 
 BUG_ID_PATTERN = re.compile(r"^BUG-\d{8}-\d{3}$")
@@ -32,6 +46,12 @@ class BugContext:
     paths: tuple[str, ...]
     memory_context: str
     graph_context: str
+
+
+@dataclass(frozen=True)
+class BugRunWorktree:
+    root: Path
+    branch: str
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -83,6 +103,13 @@ def build_parser() -> argparse.ArgumentParser:
     plan.add_argument("bug_id")
     plan.set_defaults(func=plan_command_handler)
 
+    run = commands.add_parser("run", help="구현/검증 loop를 제한 횟수 안에서 자동 반복한다.")
+    run.add_argument("bug_id")
+    run.add_argument("--implement-command", required=True)
+    run.add_argument("--verify-command", action="append", default=[])
+    run.add_argument("--max-loops", type=int, default=2)
+    run.set_defaults(func=run_command_handler)
+
     verify = commands.add_parser("verify", help="집중 검증 명령을 표시한다.")
     verify.add_argument("bug_id")
     verify.set_defaults(func=verify_command_handler)
@@ -110,7 +137,7 @@ def start_command_handler(args: argparse.Namespace, root: Path) -> str:
     )
     bug_dir.mkdir(parents=True)
     files = {
-        "index.md": _render_index(context, "draft"),
+        "index.xml": _render_index_xml(context, "draft"),
         "change-intent.md": _render_change_intent(context),
         "verification-goal.md": _render_verification_goal(context),
         "triage.md": _render_triage(context),
@@ -200,13 +227,119 @@ def verify_command_handler(args: argparse.Namespace, root: Path) -> str:
     )
 
 
+def run_command_handler(args: argparse.Namespace, root: Path) -> str:
+    if args.max_loops < 1:
+        raise BugWorkflowError("--max-loops must be >= 1")
+    if not is_git_worktree(root):
+        raise BugWorkflowError("bug run requires a git repository for worktree isolation")
+    head = git(root, "rev-parse", "--verify", "HEAD", check=False)
+    if head.returncode != 0:
+        raise BugWorkflowError("bug run requires at least one commit before creating an isolated worktree")
+    bug_dir = _bug_dir(root, args.bug_id)
+    plan_path = root / "docs" / "plans" / "active" / args.bug_id / "plan.md"
+    if not plan_path.is_file():
+        raise BugWorkflowError(f"missing bug plan: {plan_path.relative_to(root)}")
+    state_path = bug_dir / "loop-state.json"
+    bug_worktree = _prepare_bug_run_worktree(root, args.bug_id)
+    _update_bug_status(bug_dir, "running")
+    previous_fingerprints: list[str] = []
+    loop_reports: list[dict[str, object]] = []
+
+    for loop_index in range(1, args.max_loops + 1):
+        before = _git_changed_files(bug_worktree.root)
+        implement = _run_shell(args.implement_command, bug_worktree.root)
+        after_implement = _git_changed_files(bug_worktree.root)
+        changed_files = sorted(after_implement - before)
+        verify_results = tuple(_run_shell(command, bug_worktree.root) for command in args.verify_command)
+        fingerprint = _loop_failure_fingerprint(
+            implement=implement,
+            verify_results=verify_results,
+            changed_files=changed_files,
+        )
+        report = {
+            "loop": loop_index,
+            "implement_command": args.implement_command,
+            "implement_exit_code": implement.returncode,
+            "verify_results": [
+                {
+                    "command": result.command,
+                    "exit_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }
+                for result in verify_results
+            ],
+            "changed_files": changed_files,
+            "failure_fingerprint": fingerprint,
+            "worktree_root": str(bug_worktree.root),
+            "worktree_branch": bug_worktree.branch,
+        }
+        loop_reports.append(report)
+        _write_loop_state(
+            state_path,
+            args.bug_id,
+            "running",
+            loop_reports,
+            worktree_root=bug_worktree.root,
+            worktree_branch=bug_worktree.branch,
+        )
+        failure_reason = _loop_failure_reason(
+            implement=implement,
+            verify_results=verify_results,
+            changed_files=changed_files,
+        )
+        if failure_reason is None:
+            _update_bug_status(bug_dir, "completed")
+            _write_loop_state(
+                state_path,
+                args.bug_id,
+                "completed",
+                loop_reports,
+                worktree_root=bug_worktree.root,
+                worktree_branch=bug_worktree.branch,
+            )
+            return "\n".join(
+                [
+                    f"bug_id={args.bug_id}",
+                    "status=completed",
+                    f"loops={loop_index}",
+                    f"worktree={bug_worktree.root}",
+                    "next=harness bug complete " + args.bug_id,
+                ]
+            )
+        if fingerprint in previous_fingerprints:
+            _update_bug_status(bug_dir, "blocked")
+            _write_loop_state(
+                state_path,
+                args.bug_id,
+                "blocked",
+                loop_reports,
+                blocker=failure_reason,
+                worktree_root=bug_worktree.root,
+                worktree_branch=bug_worktree.branch,
+            )
+            raise BugWorkflowError(
+                f"bug loop blocked after repeated failure fingerprint: {failure_reason}"
+            )
+        previous_fingerprints.append(fingerprint)
+
+    blocker = _loop_failure_reason_from_report(loop_reports[-1]) or "unknown bug loop failure"
+    _update_bug_status(bug_dir, "blocked")
+    _write_loop_state(
+        state_path,
+        args.bug_id,
+        "blocked",
+        loop_reports,
+        blocker=blocker,
+        worktree_root=bug_worktree.root,
+        worktree_branch=bug_worktree.branch,
+    )
+    raise BugWorkflowError(f"bug loop blocked after {args.max_loops} attempts: {blocker}")
+
+
 def complete_command_handler(args: argparse.Namespace, root: Path) -> str:
     bug_dir = _bug_dir(root, args.bug_id)
-    index_path = bug_dir / "index.md"
-    text = index_path.read_text(encoding="utf-8")
-    text = re.sub(r"\|상태\|[^|\n]+\|", "|상태|completed|", text)
-    text = re.sub(r"\|마지막 갱신일\|[^|\n]+\|", f"|마지막 갱신일|{date.today().isoformat()}|", text)
-    index_path.write_text(text, encoding="utf-8")
+    _update_bug_status(bug_dir, "completed")
     return "\n".join(
         [
             f"bug_id={args.bug_id}",
@@ -275,32 +408,42 @@ def _graph_context(root: Path, query: str) -> str:
     return "\n".join(lines)
 
 
-def _render_index(context: BugContext, status: str) -> str:
-    return f"""# {context.bug_id}. {context.title}
-
-## 1. Slice 상태
-
-|항목|값|
-|---|---|
-|Bug ID|`{context.bug_id}`|
-|상태|{status}|
-|심각도|{context.severity}|
-|Workflow tier|{context.tier}|
-|마지막 갱신일|{date.today().isoformat()}|
-
-## 2. 문서 목록
-
-|문서|목적|상태|
-|---|---|---|
-|`change-intent.md`|버그 증상과 수정 범위|draft|
-|`triage.md`|memory/cache/graph 기반 탐색 결과|draft|
-|`verification-goal.md`|재현/검증 기준|draft|
-|`technical-decisions.md`|경계/정책 결정|{_technical_decision_status(context.tier)}|
-
-## 3. 확인 필요
-
-- 재현 테스트 또는 재현 증거 확보
-"""
+def _render_index_xml(context: BugContext, status: str) -> str:
+    documents = [
+        ("change-intent.md", "버그 증상과 수정 범위", "draft"),
+        ("triage.md", "memory/cache/graph 기반 탐색 결과", "draft"),
+        ("verification-goal.md", "재현/검증 기준", "draft"),
+        ("technical-decisions.md", "경계/정책 결정", _technical_decision_status(context.tier)),
+    ]
+    lines = [
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+        "<bug-slice>",
+        f"  <bug-id>{_xml_escape(context.bug_id)}</bug-id>",
+        f"  <title>{_xml_escape(context.title)}</title>",
+        f"  <status>{_xml_escape(status)}</status>",
+        f"  <severity>{_xml_escape(context.severity)}</severity>",
+        f"  <workflow-tier>{_xml_escape(context.tier)}</workflow-tier>",
+        f"  <updated-at>{date.today().isoformat()}</updated-at>",
+        "  <documents>",
+    ]
+    for name, purpose, doc_status in documents:
+        lines.extend(
+            [
+                f"    <document path=\"{_xml_escape(name)}\" status=\"{_xml_escape(doc_status)}\">",
+                f"      <purpose>{_xml_escape(purpose)}</purpose>",
+                "    </document>",
+            ]
+        )
+    lines.extend(
+        [
+            "  </documents>",
+            "  <checks>",
+            "    <check>재현 테스트 또는 재현 증거 확보</check>",
+            "  </checks>",
+            "</bug-slice>",
+        ]
+    )
+    return "\n".join(lines) + "\n"
 
 
 def _render_change_intent(context: BugContext) -> str:
@@ -449,6 +592,7 @@ def _render_plan(bug_id: str, fields: dict[str, str]) -> str:
 - [ ] 최소 수정 구현
 - [ ] targeted verification 실행
 - [ ] 필요한 경우 full test 실행
+- [ ] 반복 실패 fingerprint 확인
 - [ ] `harness memory graph status` 확인
 
 ## 3. 차단 조건
@@ -494,28 +638,28 @@ def _bug_dir(root: Path, bug_id: str) -> Path:
 
 
 def _read_bug_fields(bug_dir: Path) -> dict[str, str]:
-    index = (bug_dir / "index.md").read_text(encoding="utf-8") if (bug_dir / "index.md").exists() else ""
+    index = _read_index_xml(bug_dir / "index.xml")
     change = (bug_dir / "change-intent.md").read_text(encoding="utf-8") if (bug_dir / "change-intent.md").exists() else ""
     fields = {
-        "title": _title(index) or bug_dir.name,
-        "severity": _table_value(index, "심각도") or "medium",
-        "tier": _table_value(index, "Workflow tier") or "behavior",
+        "title": index.get("title", bug_dir.name) or bug_dir.name,
+        "severity": index.get("severity", "medium") or "medium",
+        "tier": index.get("workflow-tier", "behavior") or "behavior",
         "symptom": _section_body(change, "## 2. 증상"),
         "paths": _section_body(change, "## 3. 영향 후보 경로"),
     }
     return fields
 
 
-def _title(text: str) -> str:
-    first = next((line for line in text.splitlines() if line.startswith("# ")), "")
-    return first.split(". ", 1)[1].strip() if ". " in first else first.removeprefix("# ").strip()
-
-
-def _table_value(text: str, key: str) -> str:
-    for line in text.splitlines():
-        if line.startswith(f"|{key}|"):
-            return line.strip("|").split("|", 1)[1].strip().strip("`")
-    return ""
+def _read_index_xml(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    root = ElementTree.fromstring(path.read_text(encoding="utf-8"))
+    fields: dict[str, str] = {}
+    for tag in ("bug-id", "title", "status", "severity", "workflow-tier", "updated-at"):
+        value = root.findtext(tag)
+        if value is not None:
+            fields[tag] = value.strip()
+    return fields
 
 
 def _section_body(text: str, heading: str) -> str:
@@ -541,3 +685,166 @@ def _technical_decision_status(tier: str) -> str:
 
 def _first_line(value: str) -> str:
     return next((line for line in value.splitlines() if line.strip()), "")
+
+
+def _prepare_bug_run_worktree(repo_root: Path, bug_id: str) -> BugRunWorktree:
+    safe_bug = safe_ref_part(bug_id)
+    safe_run = safe_ref_part("bug-run")
+    worktree_root = worktrees_base_dir(repo_root, safe_bug, safe_run) / "execution"
+    branch = f"harness/bug/{safe_bug}/execution"
+    reuse = usable_worktree(worktree_root, branch)
+    if worktree_root.exists() and not reuse:
+        remove_worktree(repo_root, worktree_root)
+    if not reuse:
+        add_worktree(repo_root, worktree_root, branch, "HEAD")
+    hydrate_runtime_worktree(repo_root, worktree_root, copy_project_docs=True)
+    return BugRunWorktree(root=worktree_root, branch=branch)
+
+
+@dataclass(frozen=True)
+class ShellResult:
+    command: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _run_shell(command: str, root: Path) -> ShellResult:
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        shell=True,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return ShellResult(
+        command=command,
+        returncode=completed.returncode,
+        stdout=completed.stdout.strip(),
+        stderr=completed.stderr.strip(),
+    )
+
+
+def _git_changed_files(root: Path) -> set[str]:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return set()
+    return {
+        line[3:].strip()
+        for line in completed.stdout.splitlines()
+        if len(line) >= 4 and line[3:].strip()
+    }
+
+
+def _loop_failure_reason(
+    *,
+    implement: ShellResult,
+    verify_results: tuple[ShellResult, ...],
+    changed_files: list[str],
+) -> str | None:
+    if implement.returncode != 0:
+        return f"implement command failed: {implement.command}"
+    failed_verify = next((item for item in verify_results if item.returncode != 0), None)
+    if failed_verify is not None:
+        return f"verify command failed: {failed_verify.command}"
+    if not changed_files:
+        return "implement command made no tracked worktree changes"
+    return None
+
+
+def _loop_failure_reason_from_report(report: dict[str, object]) -> str | None:
+    if int(report.get("implement_exit_code", 0)) != 0:
+        return f"implement command failed: {report.get('implement_command', '')}"
+    for item in report.get("verify_results", []):
+        if isinstance(item, dict) and int(item.get("exit_code", 0)) != 0:
+            return f"verify command failed: {item.get('command', '')}"
+    changed_files = report.get("changed_files", [])
+    if isinstance(changed_files, list) and not changed_files:
+        return "implement command made no tracked worktree changes"
+    return None
+
+
+def _loop_failure_fingerprint(
+    *,
+    implement: ShellResult,
+    verify_results: tuple[ShellResult, ...],
+    changed_files: list[str],
+) -> str:
+    payload = {
+        "implement_command": implement.command,
+        "implement_exit_code": implement.returncode,
+        "implement_stdout": implement.stdout,
+        "implement_stderr": implement.stderr,
+        "verify_results": [
+            {
+                "command": result.command,
+                "exit_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+            for result in verify_results
+        ],
+        "changed_files": changed_files,
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _write_loop_state(
+    path: Path,
+    bug_id: str,
+    status: str,
+    loop_reports: list[dict[str, object]],
+    *,
+    blocker: str = "",
+    worktree_root: Path | None = None,
+    worktree_branch: str = "",
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "bug_id": bug_id,
+                "status": status,
+                "worktree_root": str(worktree_root) if worktree_root is not None else "",
+                "worktree_branch": worktree_branch,
+                "loops": loop_reports,
+                "blocker": blocker,
+                "updated_at": date.today().isoformat(),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _update_bug_status(bug_dir: Path, status: str) -> None:
+    index_path = bug_dir / "index.xml"
+    root = ElementTree.fromstring(index_path.read_text(encoding="utf-8"))
+    status_node = root.find("status")
+    updated_at_node = root.find("updated-at")
+    if status_node is None or updated_at_node is None:
+        raise BugWorkflowError(f"invalid bug index xml: {index_path}")
+    status_node.text = status
+    updated_at_node.text = date.today().isoformat()
+    index_path.write_text(
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + ElementTree.tostring(root, encoding="unicode"),
+        encoding="utf-8",
+    )
+
+
+def _xml_escape(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )

--- a/harness_codex/canonical_cli.py
+++ b/harness_codex/canonical_cli.py
@@ -103,10 +103,13 @@ _TOPIC_HELP_OVERRIDES: dict[str, str] = {
         "[--path PATH]\n"
         "       harness bug triage BUG-ID [--query TEXT]\n"
         "       harness bug plan BUG-ID\n"
+        "       harness bug run BUG-ID --implement-command CMD [--verify-command CMD] [--max-loops N]\n"
         "       harness bug verify BUG-ID\n"
         "       harness bug complete BUG-ID\n\n"
         "경량 버그 수정 workflow를 실행한다. 단순 수정은 전체 ChangeSet/use-case/DDD "
-        "flow를 피하고, 검토된 memory, file cache, graph context로 넓은 스캔을 줄인다."
+        "flow를 피하고, 검토된 memory, file cache, graph context로 넓은 스캔을 줄인다. "
+        "`bug run`은 별도 git worktree를 준비한 뒤 그 안에서 구현/검증 command를 실행한다. "
+        "`bug run`은 구현/검증 command를 최대 loop 횟수 안에서 반복하고 같은 failure fingerprint가 재발하면 blocked로 종료한다."
     ),
     "ddd-design-integration": _DDD_INTEGRATION_HELP,
     "changes": (

--- a/harness_codex/runtime/changes/work_item_documents.py
+++ b/harness_codex/runtime/changes/work_item_documents.py
@@ -45,17 +45,10 @@ _REQUIRED_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
         "technical-decisions.md",
         "e2e-goal.md",
     ),
-    WorkItemType.MAINTENANCE: (
-        "scope.md",
-        "change-intent.md",
-        "maintenance-spec.md",
-        "architecture-impact.md",
-        "verification-goal.md",
-        "links.md",
-    ),
-    WorkItemType.BUG_FIX: _COMMON_DOCUMENTS + ("reproduction.md", "regression-goal.md"),
-    WorkItemType.REFACTORING: _COMMON_DOCUMENTS + ("refactoring-contract.md",),
-    WorkItemType.FEATURE_EXTENSION: _COMMON_DOCUMENTS + ("acceptance-delta.md",),
+    WorkItemType.MAINTENANCE: (),
+    WorkItemType.BUG_FIX: (),
+    WorkItemType.REFACTORING: (),
+    WorkItemType.FEATURE_EXTENSION: (),
 }
 
 
@@ -98,14 +91,28 @@ def planner_input_paths(
     """Resolve type-aware planner inputs without UC/maintenance path guessing."""
 
     root = Path(repo_root)
+    if work_item.work_item_type == WorkItemType.USE_CASE:
+        candidates = (
+            change_set_path,
+            *required_document_paths(work_item),
+            *scaffold_document_paths(work_item),
+            Path("ARCHITECTURE.md"),
+            Path(".codex/repository-settings.md"),
+        )
+        return _existing_or_required(
+            root,
+            candidates,
+            required=(change_set_path, *required_document_paths(work_item)),
+        )
+
     candidates = (
         change_set_path,
-        *required_document_paths(work_item),
+        work_item.slice_path,
         *scaffold_document_paths(work_item),
         Path("ARCHITECTURE.md"),
         Path(".codex/repository-settings.md"),
     )
-    return _existing_or_required(root, candidates, required=(change_set_path, *required_document_paths(work_item)))
+    return _existing_or_required(root, candidates, required=(change_set_path,))
 
 
 def executor_input_paths(

--- a/harness_codex/runtime/materialize_execution_report.py
+++ b/harness_codex/runtime/materialize_execution_report.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 from pathlib import Path
 from typing import Sequence
 
+from harness_codex.runtime.step_state import write_step_state_handoff
 from harness_codex.runtime.xml_handoff import read_handoff, write_handoff
 
 
@@ -22,6 +24,8 @@ def materialize_execution_report(
     scope = read_handoff(_absolute(repo_root, scope_path), expected_type="execution-scope")
     source = _absolute(repo_root, source_path)
     summary = source.read_text(encoding="utf-8") if source.is_file() else ""
+    work_item_dir = _absolute(repo_root, output_path).parent
+    execution_json = _load_execution_json(work_item_dir / "execution-report.json")
     payload = {
         "schema_version": 1,
         "change_set_id": scope["change_set_id"],
@@ -31,8 +35,21 @@ def materialize_execution_report(
         "executor_final_message_path": str(source_path),
         "summary": summary,
         "changed_files": _changed_files(repo_root),
+        "work_item_profile": scope.get("work_item_profile"),
+        "consumed": execution_json.get("consumed", {}),
+        "frontier_expansion": execution_json.get("frontier_expansion", []),
+        "actual_changes": execution_json.get("actual_changes", []),
+        "test_evidence": execution_json.get("test_evidence", []),
     }
     write_handoff(_absolute(repo_root, output_path), "execution-report", payload)
+    write_step_state_handoff(
+        repo_root,
+        change_set_id=str(scope["change_set_id"]),
+        work_item_id=str(scope["work_item_id"]),
+        step_id="materialize-execution-report",
+        handoff_type="execution-report",
+        payload=payload,
+    )
 
 
 def _changed_files(repo_root: Path) -> list[str]:
@@ -50,6 +67,16 @@ def _changed_files(repo_root: Path) -> list[str]:
 
 def _absolute(repo_root: Path, path: Path) -> Path:
     return path if path.is_absolute() else repo_root / path
+
+
+def _load_execution_json(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/harness_codex/runtime/materialize_execution_report.py
+++ b/harness_codex/runtime/materialize_execution_report.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 from pathlib import Path
 from typing import Sequence
 
@@ -34,11 +33,13 @@ def materialize_execution_report(
         "execution_scope_path": str(scope_path),
         "executor_final_message_path": str(source_path),
         "summary": summary,
-        "changed_files": _changed_files(repo_root),
         "work_item_profile": scope.get("work_item_profile"),
         "consumed": execution_json.get("consumed", {}),
         "frontier_expansion": execution_json.get("frontier_expansion", []),
-        "actual_changes": execution_json.get("actual_changes", []),
+        "declared_changes": execution_json.get(
+            "declared_changes",
+            execution_json.get("actual_changes", []),
+        ),
         "test_evidence": execution_json.get("test_evidence", []),
     }
     write_handoff(_absolute(repo_root, output_path), "execution-report", payload)
@@ -50,20 +51,6 @@ def materialize_execution_report(
         handoff_type="execution-report",
         payload=payload,
     )
-
-
-def _changed_files(repo_root: Path) -> list[str]:
-    result = subprocess.run(
-        ["git", "status", "--porcelain=v1"],
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if result.returncode:
-        return []
-    return [line[3:] for line in result.stdout.splitlines() if len(line) >= 4]
-
 
 def _absolute(repo_root: Path, path: Path) -> Path:
     return path if path.is_absolute() else repo_root / path

--- a/harness_codex/runtime/materialize_execution_scope.py
+++ b/harness_codex/runtime/materialize_execution_scope.py
@@ -8,6 +8,8 @@ import re
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.changes.models import WorkItemType
 from harness_codex.runtime.xml_handoff import write_handoff
 
 _REQUIRED: Mapping[str, tuple[str, ...]] = {
@@ -17,6 +19,20 @@ _REQUIRED: Mapping[str, tuple[str, ...]] = {
     "external_contract_read_allowlist": ("외부 계약 읽기 허용 목록", "External Contract Read Allowlist"),
     "task_checklist": ("작업 체크리스트", "Task Checklist"),
     "focused_verification": ("집중 검증", "Focused Verification"),
+}
+_PROFILE_REQUIRED: Mapping[str, tuple[str, ...]] = {
+    "use_case": (
+        "execution_scope",
+        "package_dependency_contract",
+        "domain_implementation_contract",
+        "external_contract_read_allowlist",
+        "task_checklist",
+        "focused_verification",
+    ),
+    "maintenance": (
+        "task_checklist",
+        "focused_verification",
+    ),
 }
 _HEADING = re.compile(r"(?m)^##\s+(.+?)\s*$")
 _PLACEHOLDER = re.compile(r"(?:\bTODO\b|\bpending\b|^\s*[-*]\s*\.\.\.\s*$)", re.IGNORECASE)
@@ -48,7 +64,8 @@ def materialize_execution_scope(
         raise FileNotFoundError(f"active plan is required: {plan_path}")
     text = plan.read_text(encoding="utf-8")
     sections = _sections(text)
-    missing = _invalid_sections(sections)
+    work_item_profile = _work_item_profile(repo_root, change_set_id, work_item_id)
+    missing = _invalid_sections(sections, work_item_profile)
     if enforce_full_contract and missing:
         raise ExecutionPlanContractError("executor-ready plan contract is incomplete: " + ", ".join(missing))
 
@@ -67,10 +84,19 @@ def materialize_execution_scope(
         "schema_version": 2,
         "change_set_id": change_set_id,
         "work_item_id": work_item_id,
+        "work_item_profile": work_item_profile,
         "active_plan_path": _relative(plan, repo_root),
         "plan_sha256": plan_sha256,
         "plan_fingerprint": plan_fingerprint,
         "execution_report_path": str(report_path),
+        "read_frontier": _candidate_rows(sections, ("Context Discovery", "컨텍스트 탐색"), ("Read Frontier", "readFrontier", "조회 프론티어")),
+        "write_intent": _candidate_rows(sections, ("Write Intent", "수정 의도"), ()),
+        "verification_plan": _plain_lines(
+            _section_text(sections, ("Verification Plan", "검증 계획", "Focused Regression Plan", "집중 회귀 계획"))
+        ),
+        "ddd_test_obligations": _plain_lines(
+            _section_text(sections, ("DDD Test Obligations", "DDD 테스트 의무"))
+        ),
         "runtime_write_authority": {
             "model": "ChangeSet included scope",
             "plan_grants_write_authority": False,
@@ -118,9 +144,10 @@ def _sections(text: str) -> dict[str, str]:
     }
 
 
-def _invalid_sections(sections: Mapping[str, str]) -> list[str]:
+def _invalid_sections(sections: Mapping[str, str], work_item_profile: str) -> list[str]:
     errors: list[str] = []
-    for aliases in _REQUIRED.values():
+    for key in _PROFILE_REQUIRED.get(work_item_profile, _PROFILE_REQUIRED["use_case"]):
+        aliases = _REQUIRED[key]
         heading = next((alias for alias in aliases if alias in sections), None)
         if heading is None:
             errors.append(f"missing section: {aliases[0]}")
@@ -150,6 +177,80 @@ def _has_template_placeholder(content: str) -> bool:
 
 def _sha(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _work_item_profile(repo_root: Path, change_set_id: str, work_item_id: str) -> str:
+    change_set_path = repo_root / "docs" / "changes" / "active" / f"{change_set_id}.md"
+    if change_set_path.is_file():
+        change_set = parse_changeset_markdown(
+            change_set_path.read_text(encoding="utf-8"),
+            path=change_set_path.relative_to(repo_root),
+        )
+        for item in change_set.ordered_work_items():
+            if item.work_item_id == work_item_id:
+                return "use_case" if item.work_item_type == WorkItemType.USE_CASE else "maintenance"
+    use_case_dir = repo_root / "docs" / "use-cases" / work_item_id
+    return "use_case" if use_case_dir.exists() else "maintenance"
+
+
+def _section_text(sections: Mapping[str, str], names: Sequence[str]) -> str:
+    for name in names:
+        if name in sections:
+            return sections[name]
+    return ""
+
+
+def _candidate_rows(
+    sections: Mapping[str, str],
+    parent_names: Sequence[str],
+    child_names: Sequence[str],
+) -> list[dict[str, str]]:
+    content = _section_text(sections, parent_names)
+    if not content and child_names:
+        content = _section_text(sections, child_names)
+    elif content and child_names:
+        subsection = _subsection_text(content, child_names)
+        if subsection:
+            content = subsection
+    rows: list[dict[str, str]] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(("- ", "* ")):
+            continue
+        body = stripped[2:].strip()
+        path_match = re.search(r"`([^`]+)`", body)
+        path = path_match.group(1).strip() if path_match else body.split(":", 1)[0].strip()
+        if not path:
+            continue
+        rows.append(
+            {
+                "path": path,
+                "reason": body,
+            }
+        )
+    return rows
+
+
+def _subsection_text(content: str, names: Sequence[str]) -> str:
+    lines = content.splitlines()
+    active = False
+    collected: list[str] = []
+    for line in lines:
+        if line.startswith("### "):
+            title = line[4:].strip()
+            if title in names:
+                active = True
+                collected = []
+                continue
+            if active:
+                break
+        if active:
+            collected.append(line)
+    return "\n".join(collected).strip()
+
+
+def _plain_lines(content: str) -> list[str]:
+    return [line.strip() for line in content.splitlines() if line.strip()]
 
 
 def _execution_report_path_from_scope_output(output_path: Path, work_item_id: str) -> Path:

--- a/harness_codex/runtime/step_state.py
+++ b/harness_codex/runtime/step_state.py
@@ -1,0 +1,63 @@
+"""Step-local XML handoff storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from harness_codex.runtime.xml_handoff import read_handoff, write_handoff
+
+
+def step_state_xml_path(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    step_id: str,
+) -> Path:
+    root = Path(repo_root)
+    return (
+        root
+        / ".harness"
+        / "state"
+        / "step-state"
+        / change_set_id
+        / work_item_id
+        / step_id
+        / "state.xml"
+    )
+
+
+def write_step_state_handoff(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    step_id: str,
+    handoff_type: str,
+    payload: Mapping[str, Any],
+) -> Path:
+    path = step_state_xml_path(
+        repo_root,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        step_id=step_id,
+    )
+    return write_handoff(path, handoff_type, payload)
+
+
+def read_step_state_handoff(
+    repo_root: Path | str,
+    *,
+    change_set_id: str,
+    work_item_id: str,
+    step_id: str,
+    expected_type: str,
+) -> dict[str, Any]:
+    path = step_state_xml_path(
+        repo_root,
+        change_set_id=change_set_id,
+        work_item_id=work_item_id,
+        step_id=step_id,
+    )
+    return read_handoff(path, expected_type=expected_type)

--- a/harness_codex/runtime/verify_work_item.py
+++ b/harness_codex/runtime/verify_work_item.py
@@ -575,7 +575,7 @@ def _retained_execution_report_result(
         blocker_parts.extend(_stringify_blocker(item) for item in blockers)
     if isinstance(remaining_tasks, list) and remaining_tasks:
         blocker_parts.append("remaining verification tasks: " + "; ".join(str(item) for item in remaining_tasks))
-    diff_contract_blockers = _diff_contract_blockers(payload)
+    diff_contract_blockers = _diff_contract_blockers({**payload, "repo_root": str(repo_root)})
     if diff_contract_blockers:
         blocker_parts.extend(diff_contract_blockers)
 
@@ -633,28 +633,24 @@ def _stringify_blocker(value: object) -> str:
 
 
 def _diff_contract_blockers(payload: Mapping[str, object]) -> list[str]:
-    actual_changes_raw = payload.get("actual_changes")
-    if not isinstance(actual_changes_raw, list):
+    declared_changes_raw = payload.get("declared_changes", payload.get("actual_changes"))
+    if not isinstance(declared_changes_raw, list):
         return []
-    changed_files = {
-        str(item).strip()
-        for item in payload.get("changed_files", [])
-        if isinstance(item, str) and str(item).strip()
-    }
-    actual_changes = [item for item in actual_changes_raw if isinstance(item, Mapping)]
-    actual_paths = {
+    changed_files = _observed_changed_files(payload)
+    declared_changes = [item for item in declared_changes_raw if isinstance(item, Mapping)]
+    declared_paths = {
         str(item.get("path") or "").strip()
-        for item in actual_changes
+        for item in declared_changes
         if str(item.get("path") or "").strip()
     }
     blockers: list[str] = []
-    undocumented = sorted(path for path in changed_files if path not in actual_paths)
+    undocumented = sorted(path for path in changed_files if path not in declared_paths)
     if undocumented:
         blockers.append("diff contract undocumented changed files: " + ", ".join(undocumented))
-    for item in actual_changes:
+    for item in declared_changes:
         path = str(item.get("path") or "").strip()
         if not path:
-            blockers.append("diff contract actual_changes entry is missing path")
+            blockers.append("diff contract declared_changes entry is missing path")
             continue
         reason = str(item.get("reason") or item.get("linked_intent") or "").strip()
         if not reason:
@@ -664,6 +660,38 @@ def _diff_contract_blockers(payload: Mapping[str, object]) -> list[str]:
         if cross_boundary and not edge:
             blockers.append(f"diff contract missing boundary edge explanation: {path}")
     return blockers
+
+
+def _observed_changed_files(payload: Mapping[str, object]) -> set[str]:
+    repo_root_value = payload.get("repo_root")
+    if isinstance(repo_root_value, str) and repo_root_value.strip():
+        observed = _git_changed_files(Path(repo_root_value))
+        if observed is not None:
+            return observed
+    return {
+        str(item).strip()
+        for item in payload.get("changed_files", [])
+        if isinstance(item, str) and str(item).strip()
+    }
+
+
+def _git_changed_files(repo_root: Path) -> set[str] | None:
+    if not repo_root.exists():
+        return None
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if status.returncode != 0:
+        return None
+    return {
+        line[3:].strip()
+        for line in status.stdout.splitlines()
+        if len(line) >= 4 and line[3:].strip()
+    }
 
 
 def _obligation_name(line: str) -> str | None:

--- a/harness_codex/runtime/verify_work_item.py
+++ b/harness_codex/runtime/verify_work_item.py
@@ -575,6 +575,9 @@ def _retained_execution_report_result(
         blocker_parts.extend(_stringify_blocker(item) for item in blockers)
     if isinstance(remaining_tasks, list) and remaining_tasks:
         blocker_parts.append("remaining verification tasks: " + "; ".join(str(item) for item in remaining_tasks))
+    diff_contract_blockers = _diff_contract_blockers(payload)
+    if diff_contract_blockers:
+        blocker_parts.extend(diff_contract_blockers)
 
     return WorkItemVerificationResult(
         change_set_id=change_set_id,
@@ -627,6 +630,40 @@ def _stringify_blocker(value: object) -> str:
             return f"{kind}: {detail}"
         return str(detail)
     return str(value)
+
+
+def _diff_contract_blockers(payload: Mapping[str, object]) -> list[str]:
+    actual_changes_raw = payload.get("actual_changes")
+    if not isinstance(actual_changes_raw, list):
+        return []
+    changed_files = {
+        str(item).strip()
+        for item in payload.get("changed_files", [])
+        if isinstance(item, str) and str(item).strip()
+    }
+    actual_changes = [item for item in actual_changes_raw if isinstance(item, Mapping)]
+    actual_paths = {
+        str(item.get("path") or "").strip()
+        for item in actual_changes
+        if str(item.get("path") or "").strip()
+    }
+    blockers: list[str] = []
+    undocumented = sorted(path for path in changed_files if path not in actual_paths)
+    if undocumented:
+        blockers.append("diff contract undocumented changed files: " + ", ".join(undocumented))
+    for item in actual_changes:
+        path = str(item.get("path") or "").strip()
+        if not path:
+            blockers.append("diff contract actual_changes entry is missing path")
+            continue
+        reason = str(item.get("reason") or item.get("linked_intent") or "").strip()
+        if not reason:
+            blockers.append(f"diff contract missing change reason: {path}")
+        cross_boundary = bool(item.get("cross_boundary") or item.get("cross_bc"))
+        edge = str(item.get("edge_path") or item.get("boundary_edge") or "").strip()
+        if cross_boundary and not edge:
+            blockers.append(f"diff contract missing boundary edge explanation: {path}")
+    return blockers
 
 
 def _obligation_name(line: str) -> str | None:

--- a/harness_codex/runtime/workflows/materializer.py
+++ b/harness_codex/runtime/workflows/materializer.py
@@ -49,6 +49,7 @@ def materialize_workflow_for_scope(
             "change_set_id": change_set.change_set_id,
             "work_item_id": scope.display_id,
             "work_item_type": scope.work_item_type.value,
+            "work_item_profile": _work_item_profile(scope.work_item_type),
             "replacements": replacements,
             "gate_policy": policy.as_dict(),
             "skipped_gates": skipped_gates,
@@ -80,6 +81,10 @@ def materialization_replacements(
         "<WORK-ITEM-ID>": scope.display_id,
         "<RUN-ID>": run_id,
     }
+
+
+def _work_item_profile(work_item_type: WorkItemType) -> str:
+    return "use_case" if work_item_type == WorkItemType.USE_CASE else "maintenance"
 
 
 def unresolved_placeholders(workflow: Workflow) -> frozenset[str]:

--- a/tests/test_bug_cli.py
+++ b/tests/test_bug_cli.py
@@ -1,6 +1,17 @@
+import json
 from pathlib import Path
+import subprocess
 
 from harness_codex import bug_cli, canonical_cli
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True, capture_output=True)
+    (path / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "초기 커밋"], cwd=path, check=True, capture_output=True)
 
 
 def test_bug_start_creates_lightweight_maintenance_slice(tmp_path: Path) -> None:
@@ -24,13 +35,15 @@ def test_bug_start_creates_lightweight_maintenance_slice(tmp_path: Path) -> None
     bug_dirs = sorted((tmp_path / "docs/maintenance").glob("BUG-*"))
     assert len(bug_dirs) == 1
     bug_dir = bug_dirs[0]
-    assert (bug_dir / "index.md").is_file()
+    assert (bug_dir / "index.xml").is_file()
     assert (bug_dir / "change-intent.md").is_file()
     assert (bug_dir / "verification-goal.md").is_file()
     assert (bug_dir / "triage.md").is_file()
     assert (bug_dir / "technical-decisions.md").is_file()
-    assert "Workflow tier|incident" in (bug_dir / "index.md").read_text(encoding="utf-8")
-    assert "memory/cache/graph 기반 탐색 결과" in (bug_dir / "index.md").read_text(encoding="utf-8")
+    index = (bug_dir / "index.xml").read_text(encoding="utf-8")
+    assert "<workflow-tier>incident</workflow-tier>" in index
+    assert '<document path="triage.md" status="draft">' in index
+    assert "<purpose>memory/cache/graph 기반 탐색 결과</purpose>" in index
 
 
 def test_bug_plan_verify_and_complete(tmp_path: Path) -> None:
@@ -57,13 +70,92 @@ def test_bug_plan_verify_and_complete(tmp_path: Path) -> None:
     plan = tmp_path / "docs/plans/active" / bug_id / "plan.md"
     assert plan.is_file()
     assert "실패 테스트 또는 재현 증거" in plan.read_text(encoding="utf-8")
-    index = tmp_path / "docs/maintenance" / bug_id / "index.md"
-    assert "|상태|completed|" in index.read_text(encoding="utf-8")
+    index = tmp_path / "docs/maintenance" / bug_id / "index.xml"
+    assert "<status>completed</status>" in index.read_text(encoding="utf-8")
 
 
 def test_public_help_includes_bug_workflow() -> None:
     help_text = canonical_cli.help_command("bug")
 
     assert "harness bug start" in help_text
+    assert "harness bug run BUG-ID" in help_text
     assert "memory" in help_text
     assert "graph" in help_text
+
+
+def test_bug_run_completes_with_single_successful_loop(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    assert bug_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "start",
+            "--title",
+            "파일 없음",
+            "--symptom",
+            "missing file",
+        ]
+    ) == 0
+    bug_id = next((tmp_path / "docs/maintenance").glob("BUG-*")).name
+    assert bug_cli.main(["--repo-root", str(tmp_path), "plan", bug_id]) == 0
+
+    result = bug_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "run",
+            bug_id,
+            "--implement-command",
+            "mkdir -p src && printf 'ok\\n' > src/fix.txt",
+            "--verify-command",
+            "test -f src/fix.txt",
+        ]
+    )
+
+    assert result == 0
+    index = (tmp_path / "docs/maintenance" / bug_id / "index.xml").read_text(encoding="utf-8")
+    assert "<status>completed</status>" in index
+    loop_state = json.loads((tmp_path / "docs/maintenance" / bug_id / "loop-state.json").read_text(encoding="utf-8"))
+    assert loop_state["status"] == "completed"
+    worktree_root = Path(loop_state["worktree_root"])
+    assert (worktree_root / "src/fix.txt").is_file()
+    assert not (tmp_path / "src/fix.txt").exists()
+
+
+def test_bug_run_blocks_after_repeated_failure_fingerprint(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    assert bug_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "start",
+            "--title",
+            "반복 실패",
+            "--symptom",
+            "repeat failure",
+        ]
+    ) == 0
+    bug_id = next((tmp_path / "docs/maintenance").glob("BUG-*")).name
+    assert bug_cli.main(["--repo-root", str(tmp_path), "plan", bug_id]) == 0
+
+    result = bug_cli.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "run",
+            bug_id,
+            "--implement-command",
+            "true",
+            "--verify-command",
+            "false",
+            "--max-loops",
+            "2",
+        ]
+    )
+
+    assert result == 2
+    index = (tmp_path / "docs/maintenance" / bug_id / "index.xml").read_text(encoding="utf-8")
+    assert "<status>blocked</status>" in index
+    loop_state = json.loads((tmp_path / "docs/maintenance" / bug_id / "loop-state.json").read_text(encoding="utf-8"))
+    assert loop_state["status"] == "blocked"
+    assert loop_state["worktree_root"]

--- a/tests/test_issue_460_contracts.py
+++ b/tests/test_issue_460_contracts.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_codex.runtime.changes import ChangeSetResolver
+from harness_codex.runtime.materialize_execution_scope import materialize_execution_scope
+from harness_codex.runtime.verify_work_item import verify_work_item
+
+
+def test_maintenance_changeset_runtime_ready_without_global_scope_docs(tmp_path: Path) -> None:
+    change_set = tmp_path / "docs/changes/active/CHG-001.md"
+    change_set.parent.mkdir(parents=True)
+    change_set.write_text(
+        "\n".join(
+            [
+                "# CHG-001",
+                "",
+                "## 1. 메타데이터",
+                "",
+                "|항목|값|",
+                "|---|---|",
+                "|ChangeSet ID|CHG-001|",
+                "",
+                "## 2. 구현 의도",
+                "",
+                "- 요청 요약: maintenance runtime-ready gate 완화",
+                "",
+                "## 6. 영향 작업",
+                "",
+                "|Work Item ID|Type|Name|Impact Type|Slice Path|Status|",
+                "|---|---|---|---|---|---|",
+                "|BUG-001|maintenance|정렬 버그 수정|update|docs/maintenance/BUG-001|ready|",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs/maintenance/BUG-001").mkdir(parents=True)
+
+    resolver = ChangeSetResolver(tmp_path)
+    blocked = resolver.validate_active_change_set(resolver.load(change_set))
+
+    assert blocked is None
+
+
+def test_materialize_execution_scope_includes_issue_460_contract_fields(tmp_path: Path) -> None:
+    change_set = tmp_path / "docs/changes/active/CHG-001.md"
+    plan = tmp_path / "docs/plans/active/BUG-001/plan.md"
+    change_set.parent.mkdir(parents=True)
+    plan.parent.mkdir(parents=True)
+    change_set.write_text(
+        "\n".join(
+            [
+                "# CHG-001",
+                "",
+                "## 1. 메타데이터",
+                "",
+                "|항목|값|",
+                "|---|---|",
+                "|ChangeSet ID|CHG-001|",
+                "",
+                "## 2. 구현 의도",
+                "",
+                "- 요청 요약: frontier 기반 maintenance 계획",
+                "",
+                "## 6. 영향 작업",
+                "",
+                "|Work Item ID|Type|Name|Impact Type|Slice Path|Status|",
+                "|---|---|---|---|---|---|",
+                "|BUG-001|maintenance|정렬 버그 수정|update|docs/maintenance/BUG-001|ready|",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    plan.write_text(
+        "\n".join(
+            [
+                "# BUG-001 계획",
+                "",
+                "## Context Discovery",
+                "",
+                "### Read Frontier",
+                "",
+                "- `app/service.py`: 실패 stacktrace 상위 frame",
+                "",
+                "## Write Intent",
+                "",
+                "- `app/service.py`: 정렬 기준 수정",
+                "- `tests/test_service.py`: 회귀 테스트 추가",
+                "",
+                "## 작업 체크리스트",
+                "",
+                "- [ ] `app/service.py` 정렬 기준 수정",
+                "",
+                "## Focused Regression Plan",
+                "",
+                "- `./venv/bin/python3 -m pytest -q tests/test_service.py`",
+                "",
+                "## 집중 검증",
+                "",
+                "- [ ] VERIFY-001 Tests: `./venv/bin/python3 -m pytest -q tests/test_service.py`",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = materialize_execution_scope(
+        repo_root=tmp_path,
+        change_set_id="CHG-001",
+        work_item_id="BUG-001",
+        plan_path=Path("docs/plans/active/BUG-001/plan.md"),
+        output_path=Path(".harness/runs/run-1/work-items/BUG-001/execution-scope.xml"),
+    )
+
+    assert payload["work_item_profile"] == "maintenance"
+    assert payload["read_frontier"] == [{"path": "app/service.py", "reason": "`app/service.py`: 실패 stacktrace 상위 frame"}]
+    assert payload["write_intent"][0]["path"] == "app/service.py"
+    assert payload["verification_plan"] == ["- `./venv/bin/python3 -m pytest -q tests/test_service.py`"]
+
+
+def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> None:
+    (tmp_path / "docs/plans/active/BUG-001").mkdir(parents=True)
+    (tmp_path / "docs/maintenance/BUG-001").mkdir(parents=True)
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / "docs/plans/active/BUG-001/plan.md").write_text(
+        "\n".join(
+            [
+                "# 계획",
+                "## 집중 검증",
+                "- [ ] VERIFY-001 Tests: `./venv/bin/python3 -m pytest -q tests/test_bug.py`",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs/maintenance/BUG-001/verification-goal.md").write_text("# 검증\n", encoding="utf-8")
+    (tmp_path / ".codex/test-gate.yaml").write_text("required: []\n", encoding="utf-8")
+    evidence_root = tmp_path / ".harness/runs/run-1/work-items/BUG-001/steps/execute-work-item/evidence"
+    evidence_root.mkdir(parents=True)
+    for name in ("build.txt", "tests.txt", "e2e.txt", "test-gate.txt", "runtime.txt", "static-analysis.txt"):
+        (evidence_root / name).write_text("PASS\n", encoding="utf-8")
+    report = tmp_path / ".harness/runs/run-1/work-items/BUG-001/execution-report.json"
+    report.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "change_set_id": "CHG-001",
+                "work_item_id": "BUG-001",
+                "plan_path": "docs/plans/active/BUG-001/plan.md",
+                "plan_fingerprint": "sha256:test",
+                "status": "completed",
+                "completed_tasks": [],
+                "remaining_tasks": [],
+                "changed_files": ["app/service.py", "tests/test_bug.py"],
+                "verification": [
+                    {"label": "Build", "status": "PASS", "evidence_path": str(evidence_root / "build.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "Tests", "status": "PASS", "evidence_path": str(evidence_root / "tests.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "E2E 또는 maintenance verification", "status": "PASS", "evidence_path": str(evidence_root / "e2e.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "Test gate", "status": "PASS", "evidence_path": str(evidence_root / "test-gate.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "Runtime server verification", "status": "PASS", "evidence_path": str(evidence_root / "runtime.txt").replace(str(tmp_path) + "/", "")},
+                    {"label": "Static analysis", "status": "PASS", "evidence_path": str(evidence_root / "static-analysis.txt").replace(str(tmp_path) + "/", "")},
+                ],
+                "blockers": [],
+                "actual_changes": [
+                    {"path": "app/service.py", "action": "modified", "reason": "정렬 기준 수정"}
+                ],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = verify_work_item(
+        tmp_path,
+        change_set_id="CHG-001",
+        work_item_id="BUG-001",
+        run_id="run-1",
+        write_legacy_reports=False,
+    )
+
+    assert not result.passed
+    assert result.blocker is not None
+    assert "diff contract undocumented changed files" in result.blocker

--- a/tests/test_issue_460_contracts.py
+++ b/tests/test_issue_460_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from harness_codex.runtime.changes import ChangeSetResolver
@@ -122,6 +123,9 @@ def test_materialize_execution_scope_includes_issue_460_contract_fields(tmp_path
 
 
 def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True)
     (tmp_path / "docs/plans/active/BUG-001").mkdir(parents=True)
     (tmp_path / "docs/maintenance/BUG-001").mkdir(parents=True)
     (tmp_path / ".codex").mkdir()
@@ -138,6 +142,15 @@ def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> 
     )
     (tmp_path / "docs/maintenance/BUG-001/verification-goal.md").write_text("# 검증\n", encoding="utf-8")
     (tmp_path / ".codex/test-gate.yaml").write_text("required: []\n", encoding="utf-8")
+    tracked = tmp_path / "app/service.py"
+    tracked.parent.mkdir(parents=True, exist_ok=True)
+    tracked.write_text("before\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True)
+    tracked.write_text("after\n", encoding="utf-8")
+    untracked = tmp_path / "tests/test_bug.py"
+    untracked.parent.mkdir(parents=True, exist_ok=True)
+    untracked.write_text("def test_bug():\n    assert True\n", encoding="utf-8")
     evidence_root = tmp_path / ".harness/runs/run-1/work-items/BUG-001/steps/execute-work-item/evidence"
     evidence_root.mkdir(parents=True)
     for name in ("build.txt", "tests.txt", "e2e.txt", "test-gate.txt", "runtime.txt", "static-analysis.txt"):
@@ -154,7 +167,6 @@ def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> 
                 "status": "completed",
                 "completed_tasks": [],
                 "remaining_tasks": [],
-                "changed_files": ["app/service.py", "tests/test_bug.py"],
                 "verification": [
                     {"label": "Build", "status": "PASS", "evidence_path": str(evidence_root / "build.txt").replace(str(tmp_path) + "/", "")},
                     {"label": "Tests", "status": "PASS", "evidence_path": str(evidence_root / "tests.txt").replace(str(tmp_path) + "/", "")},
@@ -164,7 +176,7 @@ def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> 
                     {"label": "Static analysis", "status": "PASS", "evidence_path": str(evidence_root / "static-analysis.txt").replace(str(tmp_path) + "/", "")},
                 ],
                 "blockers": [],
-                "actual_changes": [
+                "declared_changes": [
                     {"path": "app/service.py", "action": "modified", "reason": "정렬 기준 수정"}
                 ],
             },
@@ -185,3 +197,58 @@ def test_verify_work_item_blocks_undocumented_actual_changes(tmp_path: Path) -> 
     assert not result.passed
     assert result.blocker is not None
     assert "diff contract undocumented changed files" in result.blocker
+
+
+def test_materialize_execution_report_keeps_declared_changes_only(tmp_path: Path) -> None:
+    from harness_codex.runtime.materialize_execution_report import materialize_execution_report
+
+    scope = tmp_path / ".harness/runs/run-1/work-items/BUG-001/execution-scope.xml"
+    source = tmp_path / ".harness/runs/run-1/steps/execute-work-item/final-message.md"
+    output = tmp_path / ".harness/runs/run-1/work-items/BUG-001/execution-report.xml"
+    scope.parent.mkdir(parents=True, exist_ok=True)
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("done\n", encoding="utf-8")
+    report_json = output.parent / "execution-report.json"
+    report_json.write_text(
+        json.dumps(
+            {
+                "declared_changes": [
+                    {"path": "app/service.py", "action": "modified", "reason": "정렬 수정"}
+                ],
+                "frontier_expansion": [{"path": "app/service.py", "reason": "stacktrace"}],
+                "test_evidence": [{"command": "pytest -q tests/test_bug.py", "result": "passed"}],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    from harness_codex.runtime.xml_handoff import write_handoff, read_handoff
+
+    write_handoff(
+        scope,
+        "execution-scope",
+        {
+            "schema_version": 2,
+            "change_set_id": "CHG-001",
+            "work_item_id": "BUG-001",
+            "work_item_profile": "maintenance",
+            "active_plan_path": "docs/plans/active/BUG-001/plan.md",
+            "plan_sha256": "abc",
+            "plan_fingerprint": "sha256:abc",
+            "execution_report_path": str(output.relative_to(tmp_path)),
+        },
+    )
+
+    materialize_execution_report(
+        repo_root=tmp_path,
+        scope_path=scope.relative_to(tmp_path),
+        source_path=source.relative_to(tmp_path),
+        output_path=output.relative_to(tmp_path),
+    )
+
+    payload = read_handoff(output, expected_type="execution-report")
+    assert "changed_files" not in payload
+    assert payload["declared_changes"] == [
+        {"path": "app/service.py", "action": "modified", "reason": "정렬 수정"}
+    ]


### PR DESCRIPTION
## 구현 의도
- bug workflow가 source repo를 직접 오염시키지 않고 별도 worktree에서 구현/검증을 돌리게 전환한다.
- bug slice 메타 파일을 markdown 대신 XML로 단순 구조화한다.

## 구현 접근
- `harness bug run`이 전용 git worktree를 준비한 뒤 그 안에서 `implement-command`와 `verify-command`를 실행하도록 변경했다.
- `index.md` 생성/파싱/상태 갱신을 `index.xml` 기반으로 바꿨다.
- loop 상태 파일에 `worktree_root`, `worktree_branch`를 기록하고 테스트를 해당 동작 기준으로 갱신했다.

## 검증 방법
- `PYTHONPATH=. /home/jiwoo/workspace/harness/venv/bin/python3 -m pytest -q tests/test_bug_cli.py`

## 위험 및 롤백
- 위험: worktree 생성 전제상 git repo이면서 최소 1개 commit이 있어야 한다.
- 롤백: PR merge revert 또는 해당 커밋 revert로 기존 source-root 직접 실행 방식으로 복구 가능하다.