### PR TITLE
Replace maintenance scope scaffold with advisory read-frontier XML

### DIFF
--- a/harness_codex/runtime/changes/work_item_documents.py
+++ b/harness_codex/runtime/changes/work_item_documents.py
@@ -13,6 +13,7 @@ from typing import Iterable, Sequence
 
 from harness_codex.runtime.changes.models import AffectedWorkItem, ChangeSet, WorkItemType
 from harness_codex.runtime.changes.parser import parse_changeset_markdown
+from harness_codex.runtime.xml_handoff import write_handoff
 
 
 _COMMON_DOCUMENTS = (
@@ -25,18 +26,19 @@ _COMMON_DOCUMENTS = (
 _TYPE_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
     WorkItemType.USE_CASE: (),
     WorkItemType.MAINTENANCE: (
-        "scope.md",
+        "read-frontier.xml",
         "change-intent.md",
         "maintenance-spec.md",
     ),
-    WorkItemType.BUG_FIX: ("reproduction.md", "regression-goal.md"),
-    WorkItemType.REFACTORING: ("refactoring-contract.md",),
+    WorkItemType.BUG_FIX: ("read-frontier.xml", "reproduction.md", "regression-goal.md"),
+    WorkItemType.REFACTORING: ("read-frontier.xml", "refactoring-contract.md"),
     WorkItemType.FEATURE_EXTENSION: ("acceptance-delta.md",),
 }
 
-# A maintenance slice is independent of a UC slice. Its required documents make
-# the operational scope, code boundary, architecture assessment, and verification
-# contract explicit, so planner/executor inputs never fall back to UC-only paths.
+# A maintenance slice is independent of a UC slice. It keeps the operational
+# intent and verification goal explicit, while read-frontier.xml remains an
+# advisory list of files to inspect first. It is not a write allowlist and must
+# not be used as an affected-files gate.
 _REQUIRED_DOCUMENTS: dict[WorkItemType, tuple[str, ...]] = {
     WorkItemType.USE_CASE: (
         "use-case.md",
@@ -159,7 +161,7 @@ def scaffold_work_item_documents(
         if absolute_path.exists():
             continue
         absolute_path.parent.mkdir(parents=True, exist_ok=True)
-        absolute_path.write_text(_render_document(work_item, relative_path.name), encoding="utf-8")
+        _write_document(work_item, absolute_path, relative_path.name)
         created.append(relative_path)
     return tuple(created)
 
@@ -196,6 +198,26 @@ def _existing_or_required(
     return tuple(dict.fromkeys(paths))
 
 
+def _write_document(work_item: AffectedWorkItem, path: Path, filename: str) -> None:
+    if filename == "read-frontier.xml":
+        write_handoff(path, "read-frontier", _read_frontier_payload(work_item))
+        return
+    path.write_text(_render_document(work_item, filename), encoding="utf-8")
+
+
+def _read_frontier_payload(work_item: AffectedWorkItem) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "work_item_id": work_item.work_item_id,
+        "advisory_only": True,
+        "entries": [],
+        "notes": [
+            "Read frontier lists files to inspect first; it is not an affected-files contract.",
+            "Do not use read-frontier.xml as a write allowlist or blocking scope gate.",
+        ],
+    }
+
+
 def _render_document(work_item: AffectedWorkItem, filename: str) -> str:
     frontmatter = (
         "---\n"
@@ -209,15 +231,6 @@ def _render_document(work_item: AffectedWorkItem, filename: str) -> str:
         "brief.md": (
             "## Goal\n\n- TODO: describe the intended outcome.\n\n"
             "## Non-goals\n\n- TODO\n\n## Dependencies\n\n- TODO\n"
-        ),
-        "scope.md": (
-            "## Maintenance Scope\n\n"
-            "- Bounded context: TODO\n"
-            "- Aggregate: TODO or `none`\n"
-            "- Application service: TODO or `none`\n"
-            "- Module or package: TODO\n"
-            "- Adapter or port: TODO or `none`\n"
-            "- Why this boundary is the smallest safe change: TODO\n"
         ),
         "architecture-impact.md": (
             "## Architecture Impact\n\n"

--- a/harness_codex/runtime/xml_handoff.py
+++ b/harness_codex/runtime/xml_handoff.py
@@ -53,6 +53,9 @@ _REQUIRED: dict[str, frozenset[str]] = {
     "token-metrics": frozenset({"schema_version", "run_id"}),
     "finalization-report": frozenset({"schema_version", "workflow", "status"}),
     "gate-verdict": frozenset({"schema_version", "gate_id", "status", "source_path"}),
+    "read-frontier": frozenset(
+        {"schema_version", "work_item_id", "advisory_only", "entries", "notes"}
+    ),
 }
 
 
@@ -124,6 +127,22 @@ def _validate_payload(handoff_type: str, payload: Mapping[str, Any]) -> None:
         raise XmlHandoffValidationError("gate-verdict status must be approved or rejected")
     if handoff_type == "security-profile" and not isinstance(payload.get("review_required"), bool):
         raise XmlHandoffValidationError("security-profile review_required must be boolean")
+    if handoff_type == "read-frontier":
+        if payload.get("advisory_only") is not True:
+            raise XmlHandoffValidationError("read-frontier must be advisory_only=true")
+        entries = payload.get("entries")
+        if not isinstance(entries, list):
+            raise XmlHandoffValidationError("read-frontier entries must be a list")
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, Mapping):
+                raise XmlHandoffValidationError(f"read-frontier entry {index} must be a map")
+            for key in ("path", "reason"):
+                if not isinstance(entry.get(key), str) or not str(entry.get(key)).strip():
+                    raise XmlHandoffValidationError(
+                        f"read-frontier entry {index} requires a non-empty {key}"
+                    )
+        if not isinstance(payload.get("notes"), list):
+            raise XmlHandoffValidationError("read-frontier notes must be a list")
 
 
 def _tag(name: str) -> str:

--- a/tests/test_read_frontier_contract.py
+++ b/tests/test_read_frontier_contract.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from harness_codex.runtime.changes.models import AffectedWorkItem, WorkItemType
+from harness_codex.runtime.changes.work_item_documents import scaffold_work_item_documents
+from harness_codex.runtime.xml_handoff import (
+    XmlHandoffValidationError,
+    read_handoff,
+    write_handoff,
+)
+
+
+def _maintenance_item() -> AffectedWorkItem:
+    return AffectedWorkItem(
+        work_item_id="MAINT-001",
+        work_item_type=WorkItemType.MAINTENANCE,
+        name="Runtime cleanup",
+        impact_type="maintenance",
+        slice_path=Path("docs/maintenance/MAINT-001"),
+    )
+
+
+def test_read_frontier_handoff_round_trips_as_advisory_contract(tmp_path: Path) -> None:
+    path = tmp_path / "read-frontier.xml"
+
+    write_handoff(
+        path,
+        "read-frontier",
+        {
+            "schema_version": 1,
+            "work_item_id": "MAINT-001",
+            "advisory_only": True,
+            "entries": [
+                {
+                    "path": "harness_codex/runtime/changes/work_item_documents.py",
+                    "reason": "scaffold behavior starts here",
+                }
+            ],
+            "notes": ["Suggested first reads only; not a write allowlist."],
+        },
+    )
+
+    payload = read_handoff(path, expected_type="read-frontier")
+
+    assert payload["work_item_id"] == "MAINT-001"
+    assert payload["advisory_only"] is True
+    assert payload["entries"][0]["path"] == "harness_codex/runtime/changes/work_item_documents.py"
+
+
+def test_read_frontier_rejects_write_allowlist_semantics(tmp_path: Path) -> None:
+    with pytest.raises(XmlHandoffValidationError, match="advisory_only=true"):
+        write_handoff(
+            tmp_path / "read-frontier.xml",
+            "read-frontier",
+            {
+                "schema_version": 1,
+                "work_item_id": "MAINT-001",
+                "advisory_only": False,
+                "entries": [],
+                "notes": [],
+            },
+        )
+
+
+def test_maintenance_scaffold_creates_read_frontier_xml_without_scope_md(tmp_path: Path) -> None:
+    item = _maintenance_item()
+
+    created = scaffold_work_item_documents(tmp_path, item)
+
+    assert item.slice_path / "read-frontier.xml" in created
+    assert item.slice_path / "scope.md" not in created
+    assert not (tmp_path / item.slice_path / "scope.md").exists()
+
+    payload = read_handoff(tmp_path / item.slice_path / "read-frontier.xml", expected_type="read-frontier")
+    assert payload["advisory_only"] is True
+    assert payload["entries"] == []
+    assert any("not a write allowlist" in note for note in payload["notes"])


### PR DESCRIPTION
## Summary

- Adds a `read-frontier` XML handoff type.
- Enforces `advisory_only=true` so read-frontier cannot be treated as a write allowlist or affected-files gate.
- Replaces non-UC `scope.md` scaffolding with `read-frontier.xml` for maintenance-oriented work items.
- Creates read-frontier files with an empty starting list and explicit notes that they are suggested first reads only.
- Adds tests for read-frontier XML validation and maintenance scaffold behavior.

## Notes

This is a focused first slice of #463. It removes the scope/affected-files style scaffold from maintenance work items and introduces the canonical advisory read-frontier XML contract. Follow-up work can move additional state/design artifacts into structured run artifacts and promote design deltas separately from canonical Markdown.

Refs #463