### PR TITLE
Add advisory frontier and mechanical runtime evidence model

### DIFF
--- a/harness_codex/runtime/step_xml_contracts.py
+++ b/harness_codex/runtime/step_xml_contracts.py
@@ -1,17 +1,17 @@
-"""Structured step contracts for read-frontier and diff-contract verification.
+"""Structured step evidence for frontier hints and diff-contract verification.
 
 These contracts model #460's policy directly:
 
-* readFrontier is advisory context, not a write allowlist.
-* writeIntent is an expectation, not final write authority.
-* actualChanges are the executor's accountable explanation of the git diff.
+* readFrontier is runtime/tool generated starting context, not an executor read gate.
+* editHypothesis is an optional area-level hypothesis, not a file allowlist.
+* actualChanges are derived from git diff first and then enriched with executor explanation.
 * diffContract is verified after execution by comparing git diff, actualChanges,
   intent links, boundary edges, and test evidence.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Iterable
@@ -27,10 +27,11 @@ class DiffContractLevel(str, Enum):
 
 @dataclass(frozen=True)
 class ReadFrontierCandidate:
-    """A file/symbol/module the step should inspect first.
+    """A runtime/tool generated file/symbol/module to inspect first.
 
-    This is deliberately advisory. A candidate here never grants write authority,
-    and absence from this list must not block execution by itself.
+    This is deliberately advisory. It is not a read gate, not a write gate, and
+    absence from this list must not block either file reads or implementation.
+    The executor may inspect any additional file needed to understand the task.
     """
 
     path: Path
@@ -40,21 +41,28 @@ class ReadFrontierCandidate:
     confidence: float | None = None
     edge_path: str = ""
     profile: str = ""
+    source: str = "runtime"
 
 
 @dataclass(frozen=True)
-class WriteIntentCandidate:
-    """A planner expectation for where edits may likely happen."""
+class EditHypothesis:
+    """Optional area-level guess about where the fix may happen.
 
-    path: Path
+    This replaces file-level writeIntent. It is allowed to be vague and must not
+    be interpreted as a required edit list, write allowlist, or verifier gate.
+    """
+
+    area: str
     reason: str
-    linked_intent: str = ""
+    confidence: str = "low"
 
 
 @dataclass(frozen=True)
 class FrontierExpansion:
-    """Executor-discovered read frontier expansion.
+    """Executor-discovered context expansion.
 
+    This records why the executor inspected or changed context outside the initial
+    frontier. It explains discovery, but it is not required for every file read.
     Cross-boundary expansion should include an edge path such as event, API, ACL,
     message, outbox, or contract-test traversal.
     """
@@ -67,7 +75,11 @@ class FrontierExpansion:
 
 @dataclass(frozen=True)
 class ActualChange:
-    """One changed file with executor accountability metadata."""
+    """One changed file with runtime diff data and executor explanation.
+
+    The changed file list should be generated from git diff first. The executor
+    only enriches it with reason, linked intent, and optional boundary edge.
+    """
 
     path: Path
     action: str
@@ -87,13 +99,13 @@ class TestEvidence:
 
 @dataclass(frozen=True)
 class StepXmlContract:
-    """Structured contract exchanged between plan/execute/verify steps."""
+    """Structured evidence exchanged between plan/execute/verify steps."""
 
     work_item_id: str
     work_item_type: str
     intent_summary: str = ""
     read_frontier: tuple[ReadFrontierCandidate, ...] = ()
-    write_intent: tuple[WriteIntentCandidate, ...] = ()
+    edit_hypotheses: tuple[EditHypothesis, ...] = ()
     frontier_expansion: tuple[FrontierExpansion, ...] = ()
     actual_changes: tuple[ActualChange, ...] = ()
     test_evidence: tuple[TestEvidence, ...] = ()
@@ -101,9 +113,6 @@ class StepXmlContract:
 
     def read_frontier_paths(self) -> frozenset[Path]:
         return frozenset(candidate.path for candidate in self.read_frontier)
-
-    def write_intent_paths(self) -> frozenset[Path]:
-        return frozenset(candidate.path for candidate in self.write_intent)
 
     def actual_change_paths(self) -> frozenset[Path]:
         return frozenset(change.path for change in self.actual_changes)
@@ -143,12 +152,13 @@ def evaluate_diff_contract(
     execute_contract: StepXmlContract,
     git_diff_paths: Iterable[Path | str],
 ) -> DiffContractResult:
-    """Evaluate git diff against executor accountability, not a write allowlist.
+    """Evaluate git diff against executor accountability, not frontier gates.
 
-    The initial read frontier and write intent are not hard gates. A file changed
-    outside both can still pass when the executor records an actualChange with a
-    reason, linked intent, and sufficient test evidence. This function only blocks
-    when the changed file is unexplained or the explanation lacks required proof.
+    The initial read frontier is not a hard gate for reading or editing files.
+    Edit hypotheses are area-level guesses and are also ignored for gating. A
+    changed file passes when the executor records an actualChange with reason,
+    linked intent, and sufficient test evidence. This function only blocks when
+    the changed file is unexplained or the explanation lacks required proof.
     """
 
     findings: list[DiffContractFinding] = []
@@ -205,17 +215,13 @@ def evaluate_diff_contract(
                     message="implementation diff requires test evidence",
                 )
             )
-        if (
-            path not in plan_contract.read_frontier_paths()
-            and path not in plan_contract.write_intent_paths()
-            and path in expansion_paths
-        ):
+        if path not in plan_contract.read_frontier_paths() and path in expansion_paths:
             findings.append(
                 DiffContractFinding(
                     level=DiffContractLevel.WARN,
                     code="FRONTIER_EXPANDED",
                     path=path,
-                    message="file was outside initial frontier but recorded as a frontier expansion",
+                    message="file was outside initial frontier but recorded as discovered context",
                 )
             )
 
@@ -255,4 +261,16 @@ def _evidence_mentions_obligation(evidence: tuple[TestEvidence, ...], obligation
 
 def _looks_cross_boundary(change: ActualChange) -> bool:
     hint = f"{change.path} {change.reason} {change.linked_intent}".lower()
-    return any(token in hint for token in ("cross-bc", "cross bounded", "boundary", "acl", "event", "message", "outbox", "contract"))
+    return any(
+        token in hint
+        for token in (
+            "cross-bc",
+            "cross bounded",
+            "boundary",
+            "acl",
+            "event",
+            "message",
+            "outbox",
+            "contract",
+        )
+    )

--- a/harness_codex/runtime/step_xml_contracts.py
+++ b/harness_codex/runtime/step_xml_contracts.py
@@ -1,0 +1,258 @@
+"""Structured step contracts for read-frontier and diff-contract verification.
+
+These contracts model #460's policy directly:
+
+* readFrontier is advisory context, not a write allowlist.
+* writeIntent is an expectation, not final write authority.
+* actualChanges are the executor's accountable explanation of the git diff.
+* diffContract is verified after execution by comparing git diff, actualChanges,
+  intent links, boundary edges, and test evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Iterable
+
+
+class DiffContractLevel(str, Enum):
+    """Verifier severity for one diff-contract finding."""
+
+    ALLOW = "allow"
+    WARN = "warn"
+    BLOCK = "block"
+
+
+@dataclass(frozen=True)
+class ReadFrontierCandidate:
+    """A file/symbol/module the step should inspect first.
+
+    This is deliberately advisory. A candidate here never grants write authority,
+    and absence from this list must not block execution by itself.
+    """
+
+    path: Path
+    reason: str
+    symbol: str = ""
+    priority: str = "medium"
+    confidence: float | None = None
+    edge_path: str = ""
+    profile: str = ""
+
+
+@dataclass(frozen=True)
+class WriteIntentCandidate:
+    """A planner expectation for where edits may likely happen."""
+
+    path: Path
+    reason: str
+    linked_intent: str = ""
+
+
+@dataclass(frozen=True)
+class FrontierExpansion:
+    """Executor-discovered read frontier expansion.
+
+    Cross-boundary expansion should include an edge path such as event, API, ACL,
+    message, outbox, or contract-test traversal.
+    """
+
+    path: Path
+    reason: str
+    edge_path: str = ""
+    query: str = ""
+
+
+@dataclass(frozen=True)
+class ActualChange:
+    """One changed file with executor accountability metadata."""
+
+    path: Path
+    action: str
+    reason: str
+    linked_intent: str = ""
+    boundary_edge: str = ""
+
+
+@dataclass(frozen=True)
+class TestEvidence:
+    """Command/result evidence collected during execution or verification."""
+
+    command: str
+    result: str
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class StepXmlContract:
+    """Structured contract exchanged between plan/execute/verify steps."""
+
+    work_item_id: str
+    work_item_type: str
+    intent_summary: str = ""
+    read_frontier: tuple[ReadFrontierCandidate, ...] = ()
+    write_intent: tuple[WriteIntentCandidate, ...] = ()
+    frontier_expansion: tuple[FrontierExpansion, ...] = ()
+    actual_changes: tuple[ActualChange, ...] = ()
+    test_evidence: tuple[TestEvidence, ...] = ()
+    test_obligations: tuple[str, ...] = ()
+
+    def read_frontier_paths(self) -> frozenset[Path]:
+        return frozenset(candidate.path for candidate in self.read_frontier)
+
+    def write_intent_paths(self) -> frozenset[Path]:
+        return frozenset(candidate.path for candidate in self.write_intent)
+
+    def actual_change_paths(self) -> frozenset[Path]:
+        return frozenset(change.path for change in self.actual_changes)
+
+    def frontier_expansion_paths(self) -> frozenset[Path]:
+        return frozenset(expansion.path for expansion in self.frontier_expansion)
+
+
+@dataclass(frozen=True)
+class DiffContractFinding:
+    level: DiffContractLevel
+    code: str
+    path: Path | None = None
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class DiffContractResult:
+    findings: tuple[DiffContractFinding, ...] = ()
+
+    @property
+    def blocked(self) -> bool:
+        return any(finding.level is DiffContractLevel.BLOCK for finding in self.findings)
+
+    @property
+    def warnings(self) -> tuple[DiffContractFinding, ...]:
+        return tuple(finding for finding in self.findings if finding.level is DiffContractLevel.WARN)
+
+    @property
+    def blockers(self) -> tuple[DiffContractFinding, ...]:
+        return tuple(finding for finding in self.findings if finding.level is DiffContractLevel.BLOCK)
+
+
+def evaluate_diff_contract(
+    *,
+    plan_contract: StepXmlContract,
+    execute_contract: StepXmlContract,
+    git_diff_paths: Iterable[Path | str],
+) -> DiffContractResult:
+    """Evaluate git diff against executor accountability, not a write allowlist.
+
+    The initial read frontier and write intent are not hard gates. A file changed
+    outside both can still pass when the executor records an actualChange with a
+    reason, linked intent, and sufficient test evidence. This function only blocks
+    when the changed file is unexplained or the explanation lacks required proof.
+    """
+
+    findings: list[DiffContractFinding] = []
+    normalized_diff = frozenset(Path(path) for path in git_diff_paths)
+    actual_by_path = {change.path: change for change in execute_contract.actual_changes}
+    expansion_paths = execute_contract.frontier_expansion_paths()
+    evidence = execute_contract.test_evidence
+
+    for path in sorted(normalized_diff):
+        actual = actual_by_path.get(path)
+        if actual is None:
+            findings.append(
+                DiffContractFinding(
+                    level=DiffContractLevel.BLOCK,
+                    code="MISSING_ACTUAL_CHANGE",
+                    path=path,
+                    message="git diff contains a file not recorded in execute actualChanges",
+                )
+            )
+            continue
+        if not actual.reason.strip():
+            findings.append(
+                DiffContractFinding(
+                    level=DiffContractLevel.BLOCK,
+                    code="MISSING_CHANGE_REASON",
+                    path=path,
+                    message="actualChanges entry must explain why the file changed",
+                )
+            )
+        if not actual.linked_intent.strip():
+            findings.append(
+                DiffContractFinding(
+                    level=DiffContractLevel.BLOCK,
+                    code="MISSING_LINKED_INTENT",
+                    path=path,
+                    message="actualChanges entry must link the change to ChangeSet/work-item intent",
+                )
+            )
+        if _looks_cross_boundary(actual) and not actual.boundary_edge.strip():
+            findings.append(
+                DiffContractFinding(
+                    level=DiffContractLevel.BLOCK,
+                    code="MISSING_BOUNDARY_EDGE",
+                    path=path,
+                    message="cross-boundary change requires event/API/ACL/message/outbox/contract-test edge",
+                )
+            )
+        if not evidence:
+            findings.append(
+                DiffContractFinding(
+                    level=DiffContractLevel.BLOCK,
+                    code="MISSING_TEST_EVIDENCE",
+                    path=path,
+                    message="implementation diff requires test evidence",
+                )
+            )
+        if (
+            path not in plan_contract.read_frontier_paths()
+            and path not in plan_contract.write_intent_paths()
+            and path in expansion_paths
+        ):
+            findings.append(
+                DiffContractFinding(
+                    level=DiffContractLevel.WARN,
+                    code="FRONTIER_EXPANDED",
+                    path=path,
+                    message="file was outside initial frontier but recorded as a frontier expansion",
+                )
+            )
+
+    for change in execute_contract.actual_changes:
+        if change.path not in normalized_diff:
+            findings.append(
+                DiffContractFinding(
+                    level=DiffContractLevel.WARN,
+                    code="ACTUAL_CHANGE_WITHOUT_DIFF",
+                    path=change.path,
+                    message="actualChanges records a file absent from git diff",
+                )
+            )
+
+    for obligation in plan_contract.test_obligations:
+        if not _evidence_mentions_obligation(evidence, obligation):
+            findings.append(
+                DiffContractFinding(
+                    level=DiffContractLevel.BLOCK,
+                    code="MISSING_TEST_OBLIGATION_EVIDENCE",
+                    message=f"missing test evidence for obligation: {obligation}",
+                )
+            )
+
+    return DiffContractResult(tuple(findings))
+
+
+def _evidence_mentions_obligation(evidence: tuple[TestEvidence, ...], obligation: str) -> bool:
+    normalized = obligation.strip().lower()
+    if not normalized:
+        return True
+    return any(
+        normalized in item.reason.lower() or normalized in item.command.lower()
+        for item in evidence
+    )
+
+
+def _looks_cross_boundary(change: ActualChange) -> bool:
+    hint = f"{change.path} {change.reason} {change.linked_intent}".lower()
+    return any(token in hint for token in ("cross-bc", "cross bounded", "boundary", "acl", "event", "message", "outbox", "contract"))

--- a/harness_codex/runtime/step_xml_contracts.py
+++ b/harness_codex/runtime/step_xml_contracts.py
@@ -1,12 +1,11 @@
-"""Structured step evidence for frontier hints and diff-contract verification.
+"""Minimal runtime evidence for frontier hints and mechanical verification.
 
-These contracts model #460's policy directly:
+These contracts keep runtime verification out of content/intent review:
 
-* readFrontier is runtime/tool generated starting context, not an executor read gate.
-* editHypothesis is an optional area-level hypothesis, not a file allowlist.
-* actualChanges are derived from git diff first and then enriched with executor explanation.
-* diffContract is verified after execution by comparing git diff, actualChanges,
-  intent links, boundary edges, and test evidence.
+* readFrontier is a runtime/tool generated starting hint, not an executor read gate.
+* diffSummary is generated from git diff and records what changed, not why.
+* verification only checks mechanical runtime facts such as diff collection and test
+  gate status. Semantic correctness belongs to design, plan, and tests.
 """
 
 from __future__ import annotations
@@ -17,10 +16,10 @@ from pathlib import Path
 from typing import Iterable
 
 
-class DiffContractLevel(str, Enum):
-    """Verifier severity for one diff-contract finding."""
+class VerificationLevel(str, Enum):
+    """Runtime verification severity for mechanical findings."""
 
-    ALLOW = "allow"
+    INFO = "info"
     WARN = "warn"
     BLOCK = "block"
 
@@ -45,232 +44,126 @@ class ReadFrontierCandidate:
 
 
 @dataclass(frozen=True)
-class EditHypothesis:
-    """Optional area-level guess about where the fix may happen.
+class DiffEntry:
+    """One file entry collected from git diff.
 
-    This replaces file-level writeIntent. It is allowed to be vague and must not
-    be interpreted as a required edit list, write allowlist, or verifier gate.
-    """
-
-    area: str
-    reason: str
-    confidence: str = "low"
-
-
-@dataclass(frozen=True)
-class FrontierExpansion:
-    """Executor-discovered context expansion.
-
-    This records why the executor inspected or changed context outside the initial
-    frontier. It explains discovery, but it is not required for every file read.
-    Cross-boundary expansion should include an edge path such as event, API, ACL,
-    message, outbox, or contract-test traversal.
-    """
-
-    path: Path
-    reason: str
-    edge_path: str = ""
-    query: str = ""
-
-
-@dataclass(frozen=True)
-class ActualChange:
-    """One changed file with runtime diff data and executor explanation.
-
-    The changed file list should be generated from git diff first. The executor
-    only enriches it with reason, linked intent, and optional boundary edge.
+    This is factual runtime evidence only. It intentionally does not require an
+    agent-authored reason, linked intent, or semantic justification.
     """
 
     path: Path
     action: str
-    reason: str
-    linked_intent: str = ""
-    boundary_edge: str = ""
 
 
 @dataclass(frozen=True)
-class TestEvidence:
-    """Command/result evidence collected during execution or verification."""
+class TestGateResult:
+    """Result of the test gate selected by the plan/workflow profile."""
 
     command: str
-    result: str
-    reason: str = ""
+    status: str
+    output_path: Path | None = None
 
 
 @dataclass(frozen=True)
-class StepXmlContract:
-    """Structured evidence exchanged between plan/execute/verify steps."""
+class RuntimeEvidence:
+    """Evidence exchanged between execute and verify steps."""
 
     work_item_id: str
     work_item_type: str
-    intent_summary: str = ""
     read_frontier: tuple[ReadFrontierCandidate, ...] = ()
-    edit_hypotheses: tuple[EditHypothesis, ...] = ()
-    frontier_expansion: tuple[FrontierExpansion, ...] = ()
-    actual_changes: tuple[ActualChange, ...] = ()
-    test_evidence: tuple[TestEvidence, ...] = ()
-    test_obligations: tuple[str, ...] = ()
+    diff_summary: tuple[DiffEntry, ...] = ()
+    test_results: tuple[TestGateResult, ...] = ()
 
-    def read_frontier_paths(self) -> frozenset[Path]:
-        return frozenset(candidate.path for candidate in self.read_frontier)
-
-    def actual_change_paths(self) -> frozenset[Path]:
-        return frozenset(change.path for change in self.actual_changes)
-
-    def frontier_expansion_paths(self) -> frozenset[Path]:
-        return frozenset(expansion.path for expansion in self.frontier_expansion)
+    def diff_paths(self) -> frozenset[Path]:
+        return frozenset(entry.path for entry in self.diff_summary)
 
 
 @dataclass(frozen=True)
-class DiffContractFinding:
-    level: DiffContractLevel
+class VerificationFinding:
+    level: VerificationLevel
     code: str
     path: Path | None = None
     message: str = ""
 
 
 @dataclass(frozen=True)
-class DiffContractResult:
-    findings: tuple[DiffContractFinding, ...] = ()
+class RuntimeVerificationResult:
+    """Mechanical verifier output consumed by the orchestrator."""
+
+    findings: tuple[VerificationFinding, ...] = ()
 
     @property
     def blocked(self) -> bool:
-        return any(finding.level is DiffContractLevel.BLOCK for finding in self.findings)
+        return any(finding.level is VerificationLevel.BLOCK for finding in self.findings)
 
     @property
-    def warnings(self) -> tuple[DiffContractFinding, ...]:
-        return tuple(finding for finding in self.findings if finding.level is DiffContractLevel.WARN)
+    def warnings(self) -> tuple[VerificationFinding, ...]:
+        return tuple(finding for finding in self.findings if finding.level is VerificationLevel.WARN)
 
     @property
-    def blockers(self) -> tuple[DiffContractFinding, ...]:
-        return tuple(finding for finding in self.findings if finding.level is DiffContractLevel.BLOCK)
+    def blockers(self) -> tuple[VerificationFinding, ...]:
+        return tuple(finding for finding in self.findings if finding.level is VerificationLevel.BLOCK)
 
 
-def evaluate_diff_contract(
+def collect_diff_summary(git_diff_entries: Iterable[tuple[Path | str, str]]) -> tuple[DiffEntry, ...]:
+    """Normalize git diff name-status output into factual runtime evidence."""
+
+    return tuple(DiffEntry(path=Path(path), action=action) for path, action in git_diff_entries)
+
+
+def verify_runtime_evidence(
     *,
-    plan_contract: StepXmlContract,
-    execute_contract: StepXmlContract,
+    evidence: RuntimeEvidence,
     git_diff_paths: Iterable[Path | str],
-) -> DiffContractResult:
-    """Evaluate git diff against executor accountability, not frontier gates.
+    require_tests: bool = True,
+) -> RuntimeVerificationResult:
+    """Verify mechanical runtime facts without semantic content judgment.
 
-    The initial read frontier is not a hard gate for reading or editing files.
-    Edit hypotheses are area-level guesses and are also ignored for gating. A
-    changed file passes when the executor records an actualChange with reason,
-    linked intent, and sufficient test evidence. This function only blocks when
-    the changed file is unexplained or the explanation lacks required proof.
+    This verifier does not ask why files changed and does not decide whether the
+    implementation is conceptually correct. That belongs to design/plan/test
+    obligations. Here we only ensure the runtime captured the diff and that the
+    selected test gate passed when required.
     """
 
-    findings: list[DiffContractFinding] = []
-    normalized_diff = frozenset(Path(path) for path in git_diff_paths)
-    actual_by_path = {change.path: change for change in execute_contract.actual_changes}
-    expansion_paths = execute_contract.frontier_expansion_paths()
-    evidence = execute_contract.test_evidence
+    findings: list[VerificationFinding] = []
+    actual_paths = frozenset(Path(path) for path in git_diff_paths)
+    summary_paths = evidence.diff_paths()
 
-    for path in sorted(normalized_diff):
-        actual = actual_by_path.get(path)
-        if actual is None:
-            findings.append(
-                DiffContractFinding(
-                    level=DiffContractLevel.BLOCK,
-                    code="MISSING_ACTUAL_CHANGE",
-                    path=path,
-                    message="git diff contains a file not recorded in execute actualChanges",
-                )
+    for path in sorted(actual_paths - summary_paths):
+        findings.append(
+            VerificationFinding(
+                level=VerificationLevel.BLOCK,
+                code="DIFF_SUMMARY_MISSING_FILE",
+                path=path,
+                message="git diff contains a file absent from diffSummary",
             )
-            continue
-        if not actual.reason.strip():
-            findings.append(
-                DiffContractFinding(
-                    level=DiffContractLevel.BLOCK,
-                    code="MISSING_CHANGE_REASON",
-                    path=path,
-                    message="actualChanges entry must explain why the file changed",
-                )
-            )
-        if not actual.linked_intent.strip():
-            findings.append(
-                DiffContractFinding(
-                    level=DiffContractLevel.BLOCK,
-                    code="MISSING_LINKED_INTENT",
-                    path=path,
-                    message="actualChanges entry must link the change to ChangeSet/work-item intent",
-                )
-            )
-        if _looks_cross_boundary(actual) and not actual.boundary_edge.strip():
-            findings.append(
-                DiffContractFinding(
-                    level=DiffContractLevel.BLOCK,
-                    code="MISSING_BOUNDARY_EDGE",
-                    path=path,
-                    message="cross-boundary change requires event/API/ACL/message/outbox/contract-test edge",
-                )
-            )
-        if not evidence:
-            findings.append(
-                DiffContractFinding(
-                    level=DiffContractLevel.BLOCK,
-                    code="MISSING_TEST_EVIDENCE",
-                    path=path,
-                    message="implementation diff requires test evidence",
-                )
-            )
-        if path not in plan_contract.read_frontier_paths() and path in expansion_paths:
-            findings.append(
-                DiffContractFinding(
-                    level=DiffContractLevel.WARN,
-                    code="FRONTIER_EXPANDED",
-                    path=path,
-                    message="file was outside initial frontier but recorded as discovered context",
-                )
-            )
-
-    for change in execute_contract.actual_changes:
-        if change.path not in normalized_diff:
-            findings.append(
-                DiffContractFinding(
-                    level=DiffContractLevel.WARN,
-                    code="ACTUAL_CHANGE_WITHOUT_DIFF",
-                    path=change.path,
-                    message="actualChanges records a file absent from git diff",
-                )
-            )
-
-    for obligation in plan_contract.test_obligations:
-        if not _evidence_mentions_obligation(evidence, obligation):
-            findings.append(
-                DiffContractFinding(
-                    level=DiffContractLevel.BLOCK,
-                    code="MISSING_TEST_OBLIGATION_EVIDENCE",
-                    message=f"missing test evidence for obligation: {obligation}",
-                )
-            )
-
-    return DiffContractResult(tuple(findings))
-
-
-def _evidence_mentions_obligation(evidence: tuple[TestEvidence, ...], obligation: str) -> bool:
-    normalized = obligation.strip().lower()
-    if not normalized:
-        return True
-    return any(
-        normalized in item.reason.lower() or normalized in item.command.lower()
-        for item in evidence
-    )
-
-
-def _looks_cross_boundary(change: ActualChange) -> bool:
-    hint = f"{change.path} {change.reason} {change.linked_intent}".lower()
-    return any(
-        token in hint
-        for token in (
-            "cross-bc",
-            "cross bounded",
-            "boundary",
-            "acl",
-            "event",
-            "message",
-            "outbox",
-            "contract",
         )
-    )
+    for path in sorted(summary_paths - actual_paths):
+        findings.append(
+            VerificationFinding(
+                level=VerificationLevel.WARN,
+                code="DIFF_SUMMARY_STALE_FILE",
+                path=path,
+                message="diffSummary contains a file absent from current git diff",
+            )
+        )
+
+    if require_tests and not evidence.test_results:
+        findings.append(
+            VerificationFinding(
+                level=VerificationLevel.BLOCK,
+                code="TEST_GATE_NOT_RUN",
+                message="required test gate did not produce a result",
+            )
+        )
+    for result in evidence.test_results:
+        if result.status.lower() not in {"passed", "skipped"}:
+            findings.append(
+                VerificationFinding(
+                    level=VerificationLevel.BLOCK,
+                    code="TEST_GATE_FAILED",
+                    message=f"test gate failed: {result.command}",
+                )
+            )
+
+    return RuntimeVerificationResult(tuple(findings))

--- a/tests/test_step_xml_contracts.py
+++ b/tests/test_step_xml_contracts.py
@@ -3,19 +3,18 @@ from __future__ import annotations
 from pathlib import Path
 
 from harness_codex.runtime.step_xml_contracts import (
-    ActualChange,
-    DiffContractLevel,
-    EditHypothesis,
-    FrontierExpansion,
+    DiffEntry,
     ReadFrontierCandidate,
-    StepXmlContract,
-    TestEvidence,
-    evaluate_diff_contract,
+    RuntimeEvidence,
+    TestGateResult,
+    VerificationLevel,
+    collect_diff_summary,
+    verify_runtime_evidence,
 )
 
 
 def test_read_frontier_is_not_an_executor_read_or_write_gate() -> None:
-    plan = StepXmlContract(
+    evidence = RuntimeEvidence(
         work_item_id="MAINT-001",
         work_item_type="maintenance",
         read_frontier=(
@@ -25,159 +24,86 @@ def test_read_frontier_is_not_an_executor_read_or_write_gate() -> None:
                 profile="maintenance",
             ),
         ),
-        edit_hypotheses=(
-            EditHypothesis(
-                area="runtime adapter behavior",
-                reason="entry delegates to adapter",
-                confidence="low",
-            ),
-        ),
-    )
-    execute = StepXmlContract(
-        work_item_id="MAINT-001",
-        work_item_type="maintenance",
-        frontier_expansion=(
-            FrontierExpansion(
-                path=Path("src/adapter.py"),
-                reason="entry delegates to adapter",
-                edge_path="entry -> direct-call -> adapter",
-            ),
-        ),
-        actual_changes=(
-            ActualChange(
-                path=Path("src/adapter.py"),
-                action="modified",
-                reason="adapter contained the failing behavior",
-                linked_intent="fix runtime routing",
-            ),
-        ),
-        test_evidence=(
-            TestEvidence(
-                command="pytest tests/test_entry.py",
-                result="passed",
-                reason="focused regression for fix runtime routing",
-            ),
-        ),
+        diff_summary=(DiffEntry(path=Path("src/adapter.py"), action="modified"),),
+        test_results=(TestGateResult(command="pytest tests/test_entry.py", status="passed"),),
     )
 
-    result = evaluate_diff_contract(
-        plan_contract=plan,
-        execute_contract=execute,
+    result = verify_runtime_evidence(
+        evidence=evidence,
         git_diff_paths=["src/adapter.py"],
     )
 
     assert not result.blocked
-    assert result.warnings[0].code == "FRONTIER_EXPANDED"
+    assert result.findings == ()
 
 
-def test_unrecorded_git_diff_is_blocked() -> None:
-    plan = StepXmlContract(work_item_id="MAINT-001", work_item_type="maintenance")
-    execute = StepXmlContract(
+def test_missing_diff_summary_entry_is_blocked() -> None:
+    evidence = RuntimeEvidence(
         work_item_id="MAINT-001",
         work_item_type="maintenance",
-        test_evidence=(TestEvidence(command="pytest", result="passed"),),
+        test_results=(TestGateResult(command="pytest", status="passed"),),
     )
 
-    result = evaluate_diff_contract(
-        plan_contract=plan,
-        execute_contract=execute,
-        git_diff_paths=["src/unexplained.py"],
+    result = verify_runtime_evidence(
+        evidence=evidence,
+        git_diff_paths=["src/untracked-in-summary.py"],
     )
 
     assert result.blocked
-    assert result.blockers[0].code == "MISSING_ACTUAL_CHANGE"
+    assert result.blockers[0].code == "DIFF_SUMMARY_MISSING_FILE"
 
 
-def test_actual_change_requires_linked_intent_and_test_evidence() -> None:
-    plan = StepXmlContract(work_item_id="MAINT-001", work_item_type="maintenance")
-    execute = StepXmlContract(
+def test_stale_diff_summary_entry_warns_only() -> None:
+    evidence = RuntimeEvidence(
         work_item_id="MAINT-001",
         work_item_type="maintenance",
-        actual_changes=(
-            ActualChange(
-                path=Path("src/fix.py"),
-                action="modified",
-                reason="fix bug",
-            ),
-        ),
+        diff_summary=(DiffEntry(path=Path("src/stale.py"), action="modified"),),
+        test_results=(TestGateResult(command="pytest", status="passed"),),
     )
 
-    result = evaluate_diff_contract(
-        plan_contract=plan,
-        execute_contract=execute,
+    result = verify_runtime_evidence(evidence=evidence, git_diff_paths=[])
+
+    assert not result.blocked
+    assert result.warnings[0].code == "DIFF_SUMMARY_STALE_FILE"
+
+
+def test_required_test_gate_must_run_and_pass() -> None:
+    evidence = RuntimeEvidence(
+        work_item_id="MAINT-001",
+        work_item_type="maintenance",
+        diff_summary=(DiffEntry(path=Path("src/fix.py"), action="modified"),),
+    )
+
+    missing = verify_runtime_evidence(evidence=evidence, git_diff_paths=["src/fix.py"])
+
+    assert missing.blocked
+    assert missing.blockers[0].code == "TEST_GATE_NOT_RUN"
+
+    failed = verify_runtime_evidence(
+        evidence=RuntimeEvidence(
+            work_item_id="MAINT-001",
+            work_item_type="maintenance",
+            diff_summary=(DiffEntry(path=Path("src/fix.py"), action="modified"),),
+            test_results=(TestGateResult(command="pytest", status="failed"),),
+        ),
         git_diff_paths=["src/fix.py"],
     )
 
-    assert result.blocked
-    assert {finding.code for finding in result.blockers} == {
-        "MISSING_LINKED_INTENT",
-        "MISSING_TEST_EVIDENCE",
-    }
+    assert failed.blocked
+    assert failed.blockers[0].code == "TEST_GATE_FAILED"
 
 
-def test_cross_boundary_change_requires_boundary_edge() -> None:
-    plan = StepXmlContract(work_item_id="UC-001", work_item_type="use_case")
-    execute = StepXmlContract(
-        work_item_id="UC-001",
-        work_item_type="use_case",
-        actual_changes=(
-            ActualChange(
-                path=Path("purchase/events/PaymentCompletedHandler.py"),
-                action="modified",
-                reason="cross-bc event handler update",
-                linked_intent="confirm purchase after payment",
-            ),
-        ),
-        test_evidence=(
-            TestEvidence(
-                command="pytest tests/purchase/test_payment_completed.py",
-                result="passed",
-                reason="payment completed event contract",
-            ),
-        ),
+def test_collect_diff_summary_normalizes_name_status_entries() -> None:
+    summary = collect_diff_summary(
+        [
+            ("src/fix.py", "modified"),
+            (Path("tests/test_fix.py"), "created"),
+        ]
     )
 
-    result = evaluate_diff_contract(
-        plan_contract=plan,
-        execute_contract=execute,
-        git_diff_paths=["purchase/events/PaymentCompletedHandler.py"],
+    assert summary == (
+        DiffEntry(path=Path("src/fix.py"), action="modified"),
+        DiffEntry(path=Path("tests/test_fix.py"), action="created"),
     )
-
-    assert result.blocked
-    assert any(finding.code == "MISSING_BOUNDARY_EDGE" for finding in result.blockers)
-
-
-def test_use_case_test_obligations_are_explicit_plan_contracts() -> None:
-    plan = StepXmlContract(
-        work_item_id="UC-001",
-        work_item_type="use_case",
-        test_obligations=("reserveSeat rejects already reserved seat",),
-    )
-    execute = StepXmlContract(
-        work_item_id="UC-001",
-        work_item_type="use_case",
-        actual_changes=(
-            ActualChange(
-                path=Path("reservation/domain/reservation.py"),
-                action="modified",
-                reason="enforce seat invariant",
-                linked_intent="reserve seat use case",
-            ),
-        ),
-        test_evidence=(
-            TestEvidence(
-                command="pytest tests/domain/test_reservation.py",
-                result="passed",
-                reason="reserveSeat rejects already reserved seat",
-            ),
-        ),
-    )
-
-    result = evaluate_diff_contract(
-        plan_contract=plan,
-        execute_contract=execute,
-        git_diff_paths=["reservation/domain/reservation.py"],
-    )
-
-    assert not result.blocked
-    assert all(finding.level is not DiffContractLevel.BLOCK for finding in result.findings)
+    assert all(isinstance(entry.path, Path) for entry in summary)
+    assert all(level.value for level in VerificationLevel)

--- a/tests/test_step_xml_contracts.py
+++ b/tests/test_step_xml_contracts.py
@@ -5,16 +5,16 @@ from pathlib import Path
 from harness_codex.runtime.step_xml_contracts import (
     ActualChange,
     DiffContractLevel,
+    EditHypothesis,
     FrontierExpansion,
     ReadFrontierCandidate,
     StepXmlContract,
     TestEvidence,
-    WriteIntentCandidate,
     evaluate_diff_contract,
 )
 
 
-def test_read_frontier_is_not_a_write_allowlist() -> None:
+def test_read_frontier_is_not_an_executor_read_or_write_gate() -> None:
     plan = StepXmlContract(
         work_item_id="MAINT-001",
         work_item_type="maintenance",
@@ -25,11 +25,11 @@ def test_read_frontier_is_not_a_write_allowlist() -> None:
                 profile="maintenance",
             ),
         ),
-        write_intent=(
-            WriteIntentCandidate(
-                path=Path("tests/test_entry.py"),
-                reason="focused regression test",
-                linked_intent="fix runtime routing",
+        edit_hypotheses=(
+            EditHypothesis(
+                area="runtime adapter behavior",
+                reason="entry delegates to adapter",
+                confidence="low",
             ),
         ),
     )

--- a/tests/test_step_xml_contracts.py
+++ b/tests/test_step_xml_contracts.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_codex.runtime.step_xml_contracts import (
+    ActualChange,
+    DiffContractLevel,
+    FrontierExpansion,
+    ReadFrontierCandidate,
+    StepXmlContract,
+    TestEvidence,
+    WriteIntentCandidate,
+    evaluate_diff_contract,
+)
+
+
+def test_read_frontier_is_not_a_write_allowlist() -> None:
+    plan = StepXmlContract(
+        work_item_id="MAINT-001",
+        work_item_type="maintenance",
+        read_frontier=(
+            ReadFrontierCandidate(
+                path=Path("src/entry.py"),
+                reason="failure starts here",
+                profile="maintenance",
+            ),
+        ),
+        write_intent=(
+            WriteIntentCandidate(
+                path=Path("tests/test_entry.py"),
+                reason="focused regression test",
+                linked_intent="fix runtime routing",
+            ),
+        ),
+    )
+    execute = StepXmlContract(
+        work_item_id="MAINT-001",
+        work_item_type="maintenance",
+        frontier_expansion=(
+            FrontierExpansion(
+                path=Path("src/adapter.py"),
+                reason="entry delegates to adapter",
+                edge_path="entry -> direct-call -> adapter",
+            ),
+        ),
+        actual_changes=(
+            ActualChange(
+                path=Path("src/adapter.py"),
+                action="modified",
+                reason="adapter contained the failing behavior",
+                linked_intent="fix runtime routing",
+            ),
+        ),
+        test_evidence=(
+            TestEvidence(
+                command="pytest tests/test_entry.py",
+                result="passed",
+                reason="focused regression for fix runtime routing",
+            ),
+        ),
+    )
+
+    result = evaluate_diff_contract(
+        plan_contract=plan,
+        execute_contract=execute,
+        git_diff_paths=["src/adapter.py"],
+    )
+
+    assert not result.blocked
+    assert result.warnings[0].code == "FRONTIER_EXPANDED"
+
+
+def test_unrecorded_git_diff_is_blocked() -> None:
+    plan = StepXmlContract(work_item_id="MAINT-001", work_item_type="maintenance")
+    execute = StepXmlContract(
+        work_item_id="MAINT-001",
+        work_item_type="maintenance",
+        test_evidence=(TestEvidence(command="pytest", result="passed"),),
+    )
+
+    result = evaluate_diff_contract(
+        plan_contract=plan,
+        execute_contract=execute,
+        git_diff_paths=["src/unexplained.py"],
+    )
+
+    assert result.blocked
+    assert result.blockers[0].code == "MISSING_ACTUAL_CHANGE"
+
+
+def test_actual_change_requires_linked_intent_and_test_evidence() -> None:
+    plan = StepXmlContract(work_item_id="MAINT-001", work_item_type="maintenance")
+    execute = StepXmlContract(
+        work_item_id="MAINT-001",
+        work_item_type="maintenance",
+        actual_changes=(
+            ActualChange(
+                path=Path("src/fix.py"),
+                action="modified",
+                reason="fix bug",
+            ),
+        ),
+    )
+
+    result = evaluate_diff_contract(
+        plan_contract=plan,
+        execute_contract=execute,
+        git_diff_paths=["src/fix.py"],
+    )
+
+    assert result.blocked
+    assert {finding.code for finding in result.blockers} == {
+        "MISSING_LINKED_INTENT",
+        "MISSING_TEST_EVIDENCE",
+    }
+
+
+def test_cross_boundary_change_requires_boundary_edge() -> None:
+    plan = StepXmlContract(work_item_id="UC-001", work_item_type="use_case")
+    execute = StepXmlContract(
+        work_item_id="UC-001",
+        work_item_type="use_case",
+        actual_changes=(
+            ActualChange(
+                path=Path("purchase/events/PaymentCompletedHandler.py"),
+                action="modified",
+                reason="cross-bc event handler update",
+                linked_intent="confirm purchase after payment",
+            ),
+        ),
+        test_evidence=(
+            TestEvidence(
+                command="pytest tests/purchase/test_payment_completed.py",
+                result="passed",
+                reason="payment completed event contract",
+            ),
+        ),
+    )
+
+    result = evaluate_diff_contract(
+        plan_contract=plan,
+        execute_contract=execute,
+        git_diff_paths=["purchase/events/PaymentCompletedHandler.py"],
+    )
+
+    assert result.blocked
+    assert any(finding.code == "MISSING_BOUNDARY_EDGE" for finding in result.blockers)
+
+
+def test_use_case_test_obligations_are_explicit_plan_contracts() -> None:
+    plan = StepXmlContract(
+        work_item_id="UC-001",
+        work_item_type="use_case",
+        test_obligations=("reserveSeat rejects already reserved seat",),
+    )
+    execute = StepXmlContract(
+        work_item_id="UC-001",
+        work_item_type="use_case",
+        actual_changes=(
+            ActualChange(
+                path=Path("reservation/domain/reservation.py"),
+                action="modified",
+                reason="enforce seat invariant",
+                linked_intent="reserve seat use case",
+            ),
+        ),
+        test_evidence=(
+            TestEvidence(
+                command="pytest tests/domain/test_reservation.py",
+                result="passed",
+                reason="reserveSeat rejects already reserved seat",
+            ),
+        ),
+    )
+
+    result = evaluate_diff_contract(
+        plan_contract=plan,
+        execute_contract=execute,
+        git_diff_paths=["reservation/domain/reservation.py"],
+    )
+
+    assert not result.blocked
+    assert all(finding.level is not DiffContractLevel.BLOCK for finding in result.findings)


### PR DESCRIPTION
## Summary

- Adds minimal runtime evidence primitives for advisory `readFrontier`, factual `diffSummary`, and `testGate` results.
- Defines `readFrontier` as a runtime/tool generated starting hint, not an executor read gate and not a write allowlist.
- Removes `editHypothesis`, agent-authored change reasons, linked intent, boundary semantic checks, and content-level diff verification.
- Adds mechanical runtime verification only:
  - current git diff must be captured in `diffSummary`;
  - stale diff summary entries warn;
  - required test gates must run and pass.
- Adds tests proving readFrontier is not a read/write gate and that verification is limited to diff collection and test-gate status.

## Notes

This is a focused slice of #460 after reducing the scope: runtime verifier does **not** judge why a file changed or whether the content is semantically correct. That belongs to the design process, plan, and tests.

Runtime verification should only confirm that execution evidence was collected and that the selected test gate passed. Follow-up work can wire this evidence into `verify-work-item` and RunReport/RunState without adding content-level review back into the executor path.

Refs #460