### PR TITLE
Route work item repair through workflow orchestrator agent

### DIFF
--- a/.codex/agents/workflow_orchestrator.toml
+++ b/.codex/agents/workflow_orchestrator.toml
@@ -1,5 +1,5 @@
 name = "workflow_orchestrator"
-description = "Route one initial instruction through harness runtime workflows without caller-side stage slicing"
+description = "Own harness runtime routing decisions, including initial instruction intake and failed work-item remediation handoff"
 model = "gpt-5.4-mini"
 sandbox_mode = "workspace-write"
 
@@ -11,7 +11,7 @@ Language contract:
 - Preserve code identifiers, file paths, JSON keys, CLI commands, protocol names, and canonical terms when compatibility requires their original form.
 
 Hot-path contract:
-- Role: Route one initial user instruction through the harness runtime end to end.
+- Role: Act as the runtime progress manager, not as a product-code implementer.
 - Load `AGENTS.md` before acting.
 - Use `.codex/skills/harness-orchestrate-instruction/SKILL.md` as the required skill entrypoint.
 - Do not ask the caller to manually choose workflow stages unless the instruction is genuinely ambiguous and cannot be resolved from runtime state.
@@ -20,6 +20,8 @@ Hot-path contract:
 - Treat `requirements-definition` as the official runtime entrypoint for new work, not as caller-side manual stage slicing.
 - Do not manually decompose the task into stage commands when an existing runtime continuation can route it.
 - Do not report `free-form instruction orchestration surface missing` merely because `./harness orchestrate` is absent when a new ChangeSet can be started through `requirements-definition`.
+- When invoked from a workflow step whose metadata has `runtime_role = "failure_router"`, do not implement product code and do not run the failed verification directly. Read the runtime failure context, classify the owner, emit an orchestration decision, and hand control back to the runtime loop.
+- Failure-router success means the runtime may route to the declared `loop_target`; use a blocker only when the failure cannot safely return to that target.
 - Do not publish ChangeSet-specific artifacts to `origin/main`.
 - Preserve unrelated worktree changes and secrets.
 - Report selected route, commands/actions run, verification result, changed files, commit/PR/deployment/report status when applicable, and blockers.

--- a/.codex/skills/harness-orchestrate-instruction/SKILL.md
+++ b/.codex/skills/harness-orchestrate-instruction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-orchestrate-instruction
-description: Hand a single user instruction to the harness workflow orchestration surface instead of manually slicing the request into staged commands. Use when the user asks to give only an initial instruction to an orchestration agent, let the orchestrator decide routing, or avoid the main agent manually running requirements/use-case/plan/implementation steps.
+description: Hand a single user instruction or failed runtime step to the harness workflow orchestration surface instead of manually slicing the request into staged commands. Use when the user asks to give only an initial instruction to an orchestration agent, let the orchestrator decide routing, avoid the main agent manually running requirements/use-case/plan/implementation steps, or route a failed work item through a runtime-owned orchestration decision.
 ---
 
 # Harness Orchestrate Instruction
@@ -8,6 +8,8 @@ description: Hand a single user instruction to the harness workflow orchestratio
 ## Purpose
 
 Use this skill to keep the main agent out of manual stage routing. The main agent packages the user's latest instruction, applies repository guardrails, then delegates to the harness orchestration surface when one exists.
+
+The same skill is also used when the runtime invokes `workflow_orchestrator` from a workflow step. In that mode, the orchestration agent is the progress manager for the failed handoff: it reads the runtime failure context, decides whether control may return to the declared runtime route, emits a decision artifact, and exits so the Python runtime can perform the next transition.
 
 ## Hard Rules
 
@@ -18,6 +20,7 @@ Use this skill to keep the main agent out of manual stage routing. The main agen
 - Do not publish ChangeSet-specific artifacts to `origin/main`.
 - Preserve secrets. Do not echo user-provided keys.
 - Keep the original user instruction intact; add only repository guardrails and known runtime constraints.
+- When running as a workflow failure router, do not repair code, weaken verification, rewrite upstream design, or bypass gates. Emit a routing decision and return control to the runtime.
 
 ## Workflow
 
@@ -49,6 +52,36 @@ Use this skill to keep the main agent out of manual stage routing. The main agen
   - Ask one concise Korean clarification question.
 
 Do not treat absence of `./harness orchestrate` as a blocker when `requirements-definition` can start the runtime workflow.
+
+## Workflow Failure Router Mode
+
+When the current execution payload has `step.metadata.runtime_role = "failure_router"`, switch from initial-instruction routing to failure routing.
+
+Required behavior:
+
+1. Read `runtime_metadata.runtime_failed_step_id`, `runtime_metadata.runtime_failure_kind`, `runtime_metadata.runtime_failure_error`, and `runtime_metadata.runtime_failure_metadata` from the current execution payload.
+2. Classify ownership:
+   - implementation defect or security review rejection -> route to the declared `loop_target`, usually `plan-work-item`.
+   - scope conflict -> block unless the runtime metadata clearly says the plan can be narrowed without changing ChangeSet scope.
+   - upstream design, unclear E2E goal, document delta conflict, unclear verification goal, or environment blocker -> block and name the required upstream owner.
+3. Emit a concise decision artifact in the final response. If `routing_contract.decision_output` is declared, write the same Markdown there when filesystem access is available.
+4. Do not spawn implementation, planner, verifier, git, or shell sub-work yourself. A successful failure-router result only authorizes the Python runtime to perform the next declared transition.
+5. If blocking, state the blocker and required owner. Do not pretend the route succeeded.
+
+Decision artifact format:
+
+```markdown
+# Orchestration Decision
+
+- Route Status: route-to-loop-target | blocked
+- Selected Route: <loop_target or owner/blocker>
+- Failed Step: <runtime_failed_step_id>
+- Failure Kind: <runtime_failure_kind>
+- Reason: <one-line reason>
+- Required Next Owner: workflow-runtime | implementation-planner | change-set-owner | upstream-design | environment
+- Evidence:
+  - <path or compact metadata key>
+```
 
 ## Handoff Packet
 

--- a/.codex/skills/harness-orchestrate-instruction/SKILL.md
+++ b/.codex/skills/harness-orchestrate-instruction/SKILL.md
@@ -9,7 +9,7 @@ description: Hand a single user instruction or failed runtime step to the harnes
 
 Use this skill to keep the main agent out of manual stage routing. The main agent packages the user's latest instruction, applies repository guardrails, then delegates to the harness orchestration surface when one exists.
 
-The same skill is also used when the runtime invokes `workflow_orchestrator` from a workflow step. In that mode, the orchestration agent is the progress manager for the failed handoff: it reads the runtime failure context, decides whether control may return to the declared runtime route, emits a decision artifact, and exits so the Python runtime can perform the next transition.
+The same skill is also used when the runtime invokes `workflow_orchestrator` from a workflow step. In that mode, the orchestration agent is the progress manager for the failed handoff: it reads the runtime failure context, decides whether control may return to the declared runtime route, reports the routing decision in its normal final message, and exits so the Python runtime can perform the next transition.
 
 ## Hard Rules
 
@@ -20,7 +20,7 @@ The same skill is also used when the runtime invokes `workflow_orchestrator` fro
 - Do not publish ChangeSet-specific artifacts to `origin/main`.
 - Preserve secrets. Do not echo user-provided keys.
 - Keep the original user instruction intact; add only repository guardrails and known runtime constraints.
-- When running as a workflow failure router, do not repair code, weaken verification, rewrite upstream design, or bypass gates. Emit a routing decision and return control to the runtime.
+- When running as a workflow failure router, do not repair code, weaken verification, rewrite upstream design, add new handoff files, or bypass gates. Return a routing decision through the existing agent final-message channel and hand control back to the runtime.
 
 ## Workflow
 
@@ -61,14 +61,14 @@ Required behavior:
 
 1. Read `runtime_metadata.runtime_failed_step_id`, `runtime_metadata.runtime_failure_kind`, `runtime_metadata.runtime_failure_error`, and `runtime_metadata.runtime_failure_metadata` from the current execution payload.
 2. Classify ownership:
-   - implementation defect or security review rejection -> route to the declared `loop_target`, usually `plan-work-item`.
+   - implementation defect or security review rejection -> allow the runtime to route to the declared `loop_target`, usually `plan-work-item`.
    - scope conflict -> block unless the runtime metadata clearly says the plan can be narrowed without changing ChangeSet scope.
    - upstream design, unclear E2E goal, document delta conflict, unclear verification goal, or environment blocker -> block and name the required upstream owner.
-3. Emit a concise decision artifact in the final response. If `routing_contract.decision_output` is declared, write the same Markdown there. If that path cannot be written, return `Route Status: blocked` and explain the output-write blocker.
+3. Report the decision in the normal agent final response only. Do not add a new file, review gate, XML handoff, or cross-step artifact contract.
 4. Do not spawn implementation, planner, verifier, git, or shell sub-work yourself. A successful failure-router result only authorizes the Python runtime to perform the next declared transition.
 5. If blocking, state the blocker and required owner. Do not pretend the route succeeded.
 
-Decision artifact format:
+Decision response format:
 
 ```markdown
 # Orchestration Decision
@@ -79,8 +79,6 @@ Decision artifact format:
 - Failure Kind: <runtime_failure_kind>
 - Reason: <one-line reason>
 - Required Next Owner: workflow-runtime | implementation-planner | change-set-owner | upstream-design | environment
-- Evidence:
-  - <path or compact metadata key>
 ```
 
 ## Handoff Packet

--- a/.codex/skills/harness-orchestrate-instruction/SKILL.md
+++ b/.codex/skills/harness-orchestrate-instruction/SKILL.md
@@ -64,7 +64,7 @@ Required behavior:
    - implementation defect or security review rejection -> route to the declared `loop_target`, usually `plan-work-item`.
    - scope conflict -> block unless the runtime metadata clearly says the plan can be narrowed without changing ChangeSet scope.
    - upstream design, unclear E2E goal, document delta conflict, unclear verification goal, or environment blocker -> block and name the required upstream owner.
-3. Emit a concise decision artifact in the final response. If `routing_contract.decision_output` is declared, write the same Markdown there when filesystem access is available.
+3. Emit a concise decision artifact in the final response. If `routing_contract.decision_output` is declared, write the same Markdown there. If that path cannot be written, return `Route Status: blocked` and explain the output-write blocker.
 4. Do not spawn implementation, planner, verifier, git, or shell sub-work yourself. A successful failure-router result only authorizes the Python runtime to perform the next declared transition.
 5. If blocking, state the blocker and required owner. Do not pretend the route succeeded.
 

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -288,6 +288,10 @@ steps:
       - runtime_failed_step_id
       - runtime_failure_kind
       - runtime_failure_error
+    review_gate:
+      output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md
+      status_label: Route Status
+      approved_status: route-to-loop-target
 - id: complete-work-item-plan
   kind: git
   name: Move completed work item plan to completed plans

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -270,8 +270,6 @@ steps:
   - verify-work-item-security
   agent_id: workflow_orchestrator
   skill_id: harness-orchestrate-instruction
-  outputs:
-  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md
   metadata:
     stage: orchestration
     prompt_context_profile: orchestration
@@ -283,15 +281,10 @@ steps:
       allowed_routes:
       - plan-work-item
       - blocked
-      decision_output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md
       required_evidence:
       - runtime_failed_step_id
       - runtime_failure_kind
       - runtime_failure_error
-    review_gate:
-      output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md
-      status_label: Route Status
-      approved_status: route-to-loop-target
 - id: complete-work-item-plan
   kind: git
   name: Move completed work item plan to completed plans

--- a/.harness/workflows/changeset-use-case-workflow.yaml
+++ b/.harness/workflows/changeset-use-case-workflow.yaml
@@ -262,17 +262,32 @@ steps:
     execution_boundary: work_item
     gate_id: token-observability
 - id: prepare-plan-repair
-  kind: record
-  name: Return a verifier-owned repair to the implementation planner
+  kind: agent
+  name: Route failed work item result through the workflow orchestrator
   needs:
   - execute-work-item
   - verify-work-item
   - verify-work-item-security
+  agent_id: workflow_orchestrator
+  skill_id: harness-orchestrate-instruction
+  outputs:
+  - .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md
   metadata:
-    stage: implementation
+    stage: orchestration
+    prompt_context_profile: orchestration
     scope: work_item
     execution_boundary: work_item
+    runtime_role: failure_router
     loop_target: plan-work-item
+    routing_contract:
+      allowed_routes:
+      - plan-work-item
+      - blocked
+      decision_output: .harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md
+      required_evidence:
+      - runtime_failed_step_id
+      - runtime_failure_kind
+      - runtime_failure_error
 - id: complete-work-item-plan
   kind: git
   name: Move completed work item plan to completed plans

--- a/tests/test_workflow_orchestrator_failure_router.py
+++ b/tests/test_workflow_orchestrator_failure_router.py
@@ -17,7 +17,18 @@ def test_prepare_plan_repair_uses_workflow_orchestrator_agent() -> None:
     assert step.skill_id == "harness-orchestrate-instruction"
     assert step.metadata["runtime_role"] == "failure_router"
     assert step.metadata["loop_target"] == "plan-work-item"
+    assert step.outputs == (
+        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md"),
+    )
     assert step.metadata["routing_contract"]["allowed_routes"] == [
         "plan-work-item",
         "blocked",
     ]
+    assert step.metadata["routing_contract"]["decision_output"] == (
+        ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md"
+    )
+    assert step.metadata["review_gate"] == {
+        "output": ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md",
+        "status_label": "Route Status",
+        "approved_status": "route-to-loop-target",
+    }

--- a/tests/test_workflow_orchestrator_failure_router.py
+++ b/tests/test_workflow_orchestrator_failure_router.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from harness_codex.runtime.models import StepKind
+from harness_codex.runtime.workflows.loader import load_named_workflow
+
+
+def test_prepare_plan_repair_uses_workflow_orchestrator_agent() -> None:
+    workflow = load_named_workflow(
+        "changeset-use-case-workflow",
+        workflows_dir=Path(".harness/workflows"),
+    )
+
+    step = workflow.step_by_id("prepare-plan-repair")
+
+    assert step.kind is StepKind.AGENT
+    assert step.agent_id == "workflow_orchestrator"
+    assert step.skill_id == "harness-orchestrate-instruction"
+    assert step.metadata["runtime_role"] == "failure_router"
+    assert step.metadata["loop_target"] == "plan-work-item"
+    assert step.metadata["routing_contract"]["allowed_routes"] == [
+        "plan-work-item",
+        "blocked",
+    ]

--- a/tests/test_workflow_orchestrator_failure_router.py
+++ b/tests/test_workflow_orchestrator_failure_router.py
@@ -4,7 +4,7 @@ from harness_codex.runtime.models import StepKind
 from harness_codex.runtime.workflows.loader import load_named_workflow
 
 
-def test_prepare_plan_repair_uses_workflow_orchestrator_agent() -> None:
+def test_prepare_plan_repair_uses_workflow_orchestrator_agent_without_extra_artifact_gate() -> None:
     workflow = load_named_workflow(
         "changeset-use-case-workflow",
         workflows_dir=Path(".harness/workflows"),
@@ -15,20 +15,15 @@ def test_prepare_plan_repair_uses_workflow_orchestrator_agent() -> None:
     assert step.kind is StepKind.AGENT
     assert step.agent_id == "workflow_orchestrator"
     assert step.skill_id == "harness-orchestrate-instruction"
+    assert step.outputs == ()
+    assert "review_gate" not in step.metadata
     assert step.metadata["runtime_role"] == "failure_router"
     assert step.metadata["loop_target"] == "plan-work-item"
-    assert step.outputs == (
-        Path(".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md"),
-    )
-    assert step.metadata["routing_contract"]["allowed_routes"] == [
-        "plan-work-item",
-        "blocked",
-    ]
-    assert step.metadata["routing_contract"]["decision_output"] == (
-        ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md"
-    )
-    assert step.metadata["review_gate"] == {
-        "output": ".harness/runs/<RUN-ID>/work-items/<WORK-ITEM-ID>/orchestration/decision.md",
-        "status_label": "Route Status",
-        "approved_status": "route-to-loop-target",
+    assert step.metadata["routing_contract"] == {
+        "allowed_routes": ["plan-work-item", "blocked"],
+        "required_evidence": [
+            "runtime_failed_step_id",
+            "runtime_failure_kind",
+            "runtime_failure_error",
+        ],
     }


### PR DESCRIPTION
## 요약

- 기존 `workflow_orchestrator` agent와 `harness-orchestrate-instruction` skill을 재사용해 runtime failure-router 역할을 추가했습니다.
- 기존 `prepare-plan-repair` 런타임 복구 지점을 `record` step에서 `workflow_orchestrator` agent step으로 전환했습니다.
- 별도 decision artifact, review gate, XML handoff 같은 새 산출물 계약은 추가하지 않도록 수정했습니다.
- workflow contract 회귀 테스트를 추가했습니다.

## 변경 의도

B안 기준으로 Python runtime이 사후 callback처럼 orchestration agent를 호출하는 구조가 아니라, 실패 handoff에서 orchestration agent가 runtime failure context를 읽고 다음 route를 판단하도록 바꿨습니다.

다만 파일 계약을 늘리면 step 간 정합성 부담이 커져 block이 늘어나는 문제가 있으므로, failure-router 결과는 기존 agent 실행 채널인 `.harness/runs/<RUN-ID>/steps/prepare-plan-repair/final-message.md`와 `result.json`에만 남깁니다. Python은 계속 실행/검증/상태 변경과 loop transition을 소유하고, agent는 routing 판단만 담당합니다.

## 검증

- Connector 기반 변경이라 로컬 pytest는 실행하지 못했습니다.
- 추가 테스트: `tests/test_workflow_orchestrator_failure_router.py`
- 테스트는 `prepare-plan-repair`가 `workflow_orchestrator` agent를 쓰되, 새 outputs/review_gate를 만들지 않는 계약을 검증합니다.