### PR TITLE
서브에이전트 패널 노출 구조 개선

### DIFF
--- a/.codex/agents/references/orchestration-routes.md
+++ b/.codex/agents/references/orchestration-routes.md
@@ -1,10 +1,10 @@
 # Orchestration Routes
 
-사용자 원문의 직접 의도와 일치하는 첫 route 하나를 선택한다. 선택한 route의 `target_skill`은 orchestration agent가 직접 호출한다.
+사용자 원문의 직접 의도와 일치하는 첫 route 하나를 선택한다. 선택한 `target_skill`을 `next_skill`로 반환한다.
 
 | 사용자 요청 | `target_skill` |
 | --- | --- |
-| app 실행, 상태, 중지, attach, `harness run app`, wiki serve/build/install | `harness-runtime-run` |
+| app 실행·상태·중지·attach, `harness run app`, wiki serve/build/install | `harness-runtime-run` |
 | dashboard JSON, UI server | `harness-dashboard` |
 | runtime 설치 갱신, update, dry-run | `harness-runtime-update` |
 | CLI 명령, 사용법, help | `harness-runtime-help` |
@@ -15,4 +15,4 @@
 | run report, 실패 요약 | `harness-runtime-report` |
 | 새 동작, bugfix, refactor, 제품 코드 변경 | `harness-changeset-workspace` 이후 ChangeSet intent route |
 
-사용자가 skill을 명시해도 orchestration agent가 원문을 읽고 해당 route를 확인한 뒤 target L2 step skill을 직접 호출한다. route 선택만 반환하고 종료하거나, 상위 agent에게 step skill 호출을 위임하지 않는다.
+사용자가 skill을 명시해도 orchestration agent가 원문을 읽고 해당 route를 확인한다. root는 반환된 L2 step skill만 직접 자식 agent로 실행하고 결과를 같은 orchestration agent에 되돌린다. route 반환 전 직접 명령 실행과 대체 skill 선택은 허용하지 않는다.

--- a/.codex/agents/references/orchestration.md
+++ b/.codex/agents/references/orchestration.md
@@ -2,38 +2,40 @@
 
 ## 책임
 
-사용자 프롬프트 원문 전체를 읽고 정확히 하나의 harness route를 결정한 뒤, route에 맞는 L2 step skill을 직접 호출한다. 이 agent는 route만 반환하고 종료하지 않는다.
+사용자 프롬프트 원문 전체를 읽고 정확히 하나의 harness route를 결정한다. root가 route의 L2 step skill을 실행하고 결과를 돌려주면 다음 route를 결정한다. 질문, blocker, 실패 또는 완료까지 같은 agent가 workflow를 통제한다.
 
 ## 입력 제약
 
+- 사용자 원문 대신 요약·해석문만 있으면 `blocked: orchestration_input`을 반환한다.
 - `.codex/agents/references/orchestration-routes.md`에서 직접 route를 먼저 찾는다.
-- utility route가 있으면 ChangeSet 문서, runtime source, CLI help를 읽지 않고 해당 L2 utility skill을 직접 호출한다.
+- utility route가 있으면 ChangeSet 문서, runtime source, CLI help를 읽지 않고 해당 L2 utility skill을 `next_skill`로 지정한다.
 - 직접 route가 없고 구현 변경이면 아래 ChangeSet workflow로 분류한다.
-- `harness-orchestrate-instruction`을 호출한 상위 agent에게 `next_skill` 실행을 위임하지 않는다.
+- route 결정 전에는 하위 skill을 호출하거나 요청을 직접 수행하지 않는다.
+- root가 전달한 step 결과만 다음 gate 판단의 실행 근거로 사용한다.
 
 ## 출력 계약
 
-최종 응답에는 route 결정과 호출한 step 결과를 함께 포함한다.
+각 응답에는 route 결정과 root가 실행할 다음 step을 포함한다.
 
 ```text
-route_status: routed | blocked
+route_status: routed | complete | blocked
 request_kind: utility | workflow
-called_skill: <exact skill name> | none
+next_skill: <exact skill name> | none
+agent_task_name: <Codex Subagents 패널에 표시할 이름> | none
 reason: <사용자 원문에 근거한 한 문장>
 scope: <대상 ID, 명령, 경로 또는 none>
-step_status: complete | blocked | question | failed | skipped
-step_result: <호출한 L2 step skill의 핵심 결과 요약>
+step_input: <root가 다음 skill에 전달할 완전한 입력> | none
 ```
 
-route 또는 호출할 L2 step skill을 정하지 못하면 추측하거나 직접 실행하지 않고 `blocked`를 반환한다.
+route 또는 호출할 L2 step skill을 정하지 못하면 추측하지 않고 `blocked`를 반환한다. root가 step 결과를 전달하기 전에는 다음 gate로 진행하지 않는다.
 
 ## ChangeSet 범위
 
 `.codex/workflow/changeset-layout.md`를 따른다.
 
-- 새 요청이면 `CHG-YYYYMMDD-NNN` ID를 만든 뒤 `harness-changeset-workspace` L2를 호출한다. workspace가 반환 worktree에 `docs/changes/active/<CHG-ID>/changeset.md` skeleton을 만든다. orchestrator는 그 문서의 초기 요청, 범위, intent, 대상 work item만 채운다.
+- 새 요청이면 `CHG-YYYYMMDD-NNN` ID를 만든 뒤 `harness-changeset-workspace` L2를 지정한다. workspace가 반환 worktree에 `docs/changes/active/<CHG-ID>/changeset.md` skeleton을 만든다. orchestrator는 그 문서의 초기 요청, 범위, intent, 대상 work item만 채운다.
 - `changeset.md`에는 ID, 상태, 초기 요청, 범위, `feature | bugfix | refactor` intent, 대상 ChangeSet을 기록한다.
-- 기존 ChangeSet은 사용자가 ID를 지정할 때만 `harness-changeset-workspace` L2를 다시 호출한다. root `.harness/state/changesets/<CHG-ID>/workspace.json`의 worktree를 검증하고 그 경로에서 다음 gate부터 재개한다.
+- 기존 ChangeSet은 사용자가 ID를 지정할 때만 `harness-changeset-workspace` L2를 다시 지정한다. root `.harness/state/changesets/<CHG-ID>/workspace.json`의 worktree를 검증하고 그 경로에서 다음 gate부터 재개한다.
 - 대상 ChangeSet과 active plan 및 workflow 문서는 읽거나 수정하지 않는다.
 - worktree 생성 뒤 모든 L2, L3 호출에는 그 경로를 작업 디렉터리로 준다. root worktree에서 후속 step을 실행하지 않는다.
 

--- a/.codex/skills/harness-orchestrate-instruction/SKILL.md
+++ b/.codex/skills/harness-orchestrate-instruction/SKILL.md
@@ -5,14 +5,14 @@ description: 이 스킬이 명시적으로 선택된 경우에만 사용자 원�
 
 # Harness Orchestration Instruction
 
-이 문서는 모든 사용자 프롬프트를 전역적으로 orchestration agent에 라우팅하라는 의미가 아니다. 일반 질문이나 직접 확인 가능한 저장소 질의는 이 스킬이 선택되지 않았다면 직접 처리할 수 있다.
+이 스킬이 명시적으로 선택된 경우에만 실행한다.
 
 ## 절차
 
-1. 사용자 프롬프트 원문 전체를 수정하거나 요약하지 말고 `orchestration` agent의 첫 입력으로 전달한다.
-2. 원문 전달 전에 파일 읽기, tool 호출, 하위 skill 선택, CLI 실행을 하지 않는다.
-3. `orchestration` agent가 route를 결정하고 해당 L2 step skill을 직접 호출한다. 이 L1 skill은 `next_skill`을 받아 대신 호출하지 않는다.
-4. `orchestration` agent가 step skill 호출 결과를 포함한 최종 상태를 반환하면 그 결과를 사용자에게 전달한다.
-5. route가 없거나 agent를 호출할 수 없으면 `blocked: orchestration`으로 종료한다.
+1. 사용자 프롬프트 원문 전체를 요약하지 않고 `/root/orchestration`의 첫 입력으로 전달한다.
+2. 원문 전달 전에는 파일 읽기, tool 호출, 하위 skill 선택, CLI 실행을 하지 않는다.
+3. 반환된 `next_skill` 하나만 호출하고 workflow agent를 `/root/*` 직접 자식으로 spawn한다.
+4. step 결과를 같은 `orchestration` agent에 전달해 다음 결정을 받는다.
+5. 질문, blocker, 실패 또는 완료까지 3~4를 반복한 뒤 최종 상태를 전달한다.
 
-직접 CLI 실행, 수동 route 실행, 대체 skill 우회 호출은 허용하지 않는다.
+route가 없거나 agent를 호출할 수 없으면 `blocked: orchestration`으로 종료한다. 직접 CLI·수동 실행·대체 skill로 우회하지 않는다.

--- a/.codex/skills/harness-orchestrate-instruction/agents/openai.yaml
+++ b/.codex/skills/harness-orchestrate-instruction/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Harness 요청 오케스트레이션"
-  short_description: "사용자 원문을 orchestration agent에 전달하고, agent가 route와 L2 step 호출까지 수행합니다."
-  default_prompt: "$harness-orchestrate-instruction으로 이 사용자 프롬프트 원문 전체를 orchestration agent에 전달해줘. orchestration agent가 route를 결정한 뒤 대상 L2 step skill을 직접 호출하고, 그 결과까지 반환해야 해."
+  short_description: "오케스트레이터가 경로를 통제하고 root가 모든 workflow agent를 직접 표시합니다."
+  default_prompt: "$harness-orchestrate-instruction으로 사용자 원문 전체를 orchestration agent에 전달해줘. route가 지정한 workflow agent는 모두 root의 직접 자식으로 실행하고, 결과를 같은 orchestration agent에 되돌려 다음 결정을 받아줘."
 
 policy:
   allow_implicit_invocation: true

--- a/.codex/workflow/main-steps.md
+++ b/.codex/workflow/main-steps.md
@@ -2,13 +2,13 @@
 
 이 파일은 intent별 선행 gate, 공통 work-item 실행, 산출물 정본이다.
 
-구현 변경 요청은 `harness-orchestrate-instruction`을 거친다. utility 요청도 이 진입점이 명시적으로 선택된 경우 orchestration agent가 route를 고른 뒤 해당 utility L2 step skill을 직접 호출한다. 구현 변경만 아래 ChangeSet workflow에 진입한다.
+구현 변경 요청은 `harness-orchestrate-instruction`을 거친다. utility 요청은 `orchestration-routes.md`에서 고르고 root가 해당 L2 step skill을 직접 자식 agent로 실행한다. 구현 변경만 아래 ChangeSet workflow에 진입한다.
 
 ## 공통 진입
 
 | 순서 | Step | Level | 선행 gate | 완료 gate | 산출물 |
 |---|---|---:|---|---|---|
-| 0 | `harness-orchestrate-instruction` | L1 | 사용자가 명시하거나 모델이 구현 요청 감지 | orchestration agent가 route를 결정하고 대상 L2 step skill 호출 결과를 반환 | route 결과와 step 결과 |
+| 0 | `harness-orchestrate-instruction` | L1 | 사용자가 명시하거나 모델이 구현 요청 감지 | orchestration agent가 route를 결정하고 root가 대상 L2 step을 직접 자식으로 실행한 뒤 결과를 relay | route 결과와 step 결과 |
 | 0a | `harness-changeset-workspace` | L2 | 새 ChangeSet ID | sibling worktree, `changes/<CHG-ID>` branch | worktree 경로 |
 
 orchestrator는 `feature | bugfix | refactor` 중 하나를 기록한다. `feature`는 Feature lane, `bugfix | refactor`는 Maintenance lane으로 보낸다.
@@ -73,8 +73,11 @@ W2와 W6은 runtime-selected security controls가 없으면 `skipped`로 기록�
 ## 호출 규칙
 
 - L1은 orchestration agent를 호출한다.
-- orchestration agent는 route를 결정하고 대상 L2 step skill을 직접 호출한다.
-- L2는 필요한 L2 또는 L3만 호출한다.
+- orchestration agent는 route를 결정하고 root는 지정된 L2 step skill만 호출한다.
+- 모든 workflow agent는 Codex Subagents 패널 노출을 위해 `/root/*` 직접 자식으로 spawn한다. 중첩 spawn은 금지한다.
+- L2는 agent를 만들지 않는 L3 skill을 직접 호출할 수 있다. 다른 agent가 필요하면 `root_spawn_request: {skill, agent_task_name, input}`를 반환하고 대기한다. root가 `<role>[_<scope>]` 이름의 직접 자식을 spawn한 뒤 결과를 요청한 L2에 relay한다.
+- root는 step 결과를 같은 orchestration agent에 relay하고 다음 route를 받는다.
+- 같은 role과 scope는 기존 직접 자식에 follow-up하고, 다른 scope는 별도 직접 자식을 만든다.
 - 선행 gate 미통과 step은 호출하지 않는다.
 - 질문 또는 차단이면 orchestrator는 종료한다.
 - `context.md`는 harness 운영 용어 정본이다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,4 @@ Skill descriptions are routing hints, not global mandates. Apply a skill's manda
 - When the current runtime payload declares `upstream_context`, inspect high-priority artifacts before acting when their stated purpose applies. These are reading-priority hints, not generic required inputs.
 - Do not edit runtime code unless the task explicitly requires it.
 - Do not overwrite unrelated worktree changes.
+- When `harness-orchestrate-instruction` is selected, root must spawn `orchestration` and every routed workflow agent as direct `/root/*` children with native collaboration tools so Codex lists them in the Subagents panel. Do not nest workflow agents. A workflow agent that needs another agent must return `root_spawn_request` and wait for root to relay the result. Keep `orchestration` alive and relay each routed step result back to it for the next decision. Name agents `<role>[_<scope>]` and reuse the same direct child for the same role and scope.

--- a/tests/test_workflow_routing_contract.py
+++ b/tests/test_workflow_routing_contract.py
@@ -104,6 +104,23 @@ def test_orchestration_is_mandatory_and_fail_closed() -> None:
     assert "only after that skill is selected" in agent_rules
 
 
+def test_workflow_agents_are_direct_root_children_for_codex_visibility() -> None:
+    skill = _read(".codex/skills/harness-orchestrate-instruction/SKILL.md")
+    orchestration = _read(".codex/agents/references/orchestration.md")
+    main_steps = _read(".codex/workflow/main-steps.md")
+    agent_rules = _read("AGENTS.md")
+
+    assert "`/root/*` 직접 자식" in skill
+    assert "step 결과를 같은 `orchestration` agent에 전달" in skill
+    assert "`next_skill`" in orchestration
+    assert "중첩 spawn은 금지" in main_steps
+    assert "`root_spawn_request: {skill, agent_task_name, input}`" in main_steps
+    assert "같은 role과 scope는 기존 직접 자식에 follow-up" in main_steps
+    assert "direct `/root/*` children" in agent_rules
+    assert "Do not nest workflow agents" in agent_rules
+    assert "return `root_spawn_request`" in agent_rules
+
+
 def test_orchestration_routes_app_requests_before_direct_execution() -> None:
     routes = _read(".codex/agents/references/orchestration-routes.md")
     main_steps = _read(".codex/workflow/main-steps.md")


### PR DESCRIPTION
## 변경 사항

- 모든 workflow agent를 `/root/*` 직접 자식으로 생성하도록 orchestration 계약을 변경했습니다.
- 중첩 agent가 필요할 때 `root_spawn_request`로 root에 생성을 위임하도록 했습니다.
- 동일 role/scope agent 재사용과 표시 이름 규칙을 추가했습니다.
- Codex Subagents 패널 노출 계약 테스트를 추가했습니다.

## 변경 이유

중첩된 workflow agent가 Codex의 Subagents 패널에서 빠지거나 덜 보이는 문제를 방지하면서, orchestration agent가 단계별 route 통제를 계속 유지하기 위함입니다.

## 검증

- `python3 .../quick_validate.py .codex/skills/harness-orchestrate-instruction`
- `venv/bin/python3 -m pytest -q -s tests/test_workflow_routing_contract.py` (`10 passed`)
- `git diff --check`