### PR TITLE
메인 푸시 버전 자동 증가 복구

### DIFF
--- a/.github/workflows/bump-runtime-version.yml
+++ b/.github/workflows/bump-runtime-version.yml
@@ -1,8 +1,7 @@
-name: Bump runtime version after merged PR
+name: Bump runtime version after main update
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 
 permissions:
@@ -14,10 +13,11 @@ concurrency:
 
 jobs:
   bump-version:
-    if: github.event.pull_request.merged == true
+    if: >-
+      ${{ !startsWith(github.event.head_commit.message, 'chore: 런타임 패치 버전 자동 증가') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check out merged main branch
+      - name: Check out updated main branch
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.VERSION_BUMP_TOKEN }}

--- a/tests/test_version_bump_workflow.py
+++ b/tests/test_version_bump_workflow.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_runtime_version_bump_runs_for_main_push_without_recursing() -> None:
+    workflow = (
+        ROOT / ".github/workflows/bump-runtime-version.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "  push:\n    branches: [main]" in workflow
+    assert "  pull_request:" not in workflow
+    assert "!startsWith(github.event.head_commit.message" in workflow
+    assert "chore: 런타임 패치 버전 자동 증가" in workflow
+    assert "python3 scripts/bump_runtime_version.py" in workflow
+    assert "git push origin HEAD:main" in workflow


### PR DESCRIPTION
## 변경 사항

- 런타임 버전 범프 workflow를 `pull_request.closed`에서 `main`의 `push` 이벤트로 변경했습니다.
- PR merge와 직접 push를 동일한 경로로 처리합니다.
- 자동 범프 커밋이 PAT을 통해 다시 workflow를 실행해 무한 증가하지 않도록 자기 커밋 제외 조건을 추가했습니다.
- 트리거와 재귀 방지 계약 테스트를 추가했습니다.

## 원인

기존 workflow는 merge된 PR의 close 이벤트만 감시하여 `origin/main` 직접 push에는 실행되지 않았습니다.

## 영향

이 변경이 main에 반영된 뒤부터 merge와 직접 push 모두 런타임 patch version을 한 번 증가시킵니다.

## 검증

- workflow YAML parse 성공
- `venv/bin/python3 -m pytest -q -s tests/test_version_bump_workflow.py` (`1 passed`)
- `git diff --check`