### PR TITLE
에이전트 모델 계층을 최적화

### DIFF
--- a/.codex/agents/artifact_reviewer.toml
+++ b/.codex/agents/artifact_reviewer.toml
@@ -1,11 +1,6 @@
 name = "artifact_reviewer"
 description = "Independently assess one declared workflow artifact"
-provider = "ollama"
-provider_binary = "ollama"
-model = "qwen3.5:2b"
-fallback_provider = "codex"
-fallback_model = "gpt-5.4-mini"
-fallback_on_retry = true
+model = "gpt-5.6-terra"
 sandbox_mode = "danger-full-access"
 
 developer_instructions = """

--- a/.codex/agents/ddd_architect.toml
+++ b/.codex/agents/ddd_architect.toml
@@ -1,6 +1,6 @@
 name = "ddd_architect"
 description = "이벤트 스토밍으로 UC별 후보 DDD 설계를 만든다"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/ddd_design_integrator.toml
+++ b/.codex/agents/ddd_design_integrator.toml
@@ -1,6 +1,6 @@
 name = "ddd_design_integrator"
 description = "다중 UC 후보 DDD 설계를 ChangeSet DDD architecture로 통합한다"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-sol"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/delivery_coordinator.toml
+++ b/.codex/agents/delivery_coordinator.toml
@@ -1,6 +1,6 @@
 name = "delivery_coordinator"
 description = "다중 저장소 ChangeSet 전달과 GitHub Issue를 조정한다"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "danger-full-access"
 
 developer_instructions = """

--- a/.codex/agents/harness_usecases.toml
+++ b/.codex/agents/harness_usecases.toml
@@ -1,6 +1,6 @@
 name = "harness_usecases"
 description = "Derive external-actor use cases and runtime-ready use-case slice docs from confirmed requirements and context language"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/implementation_executor.toml
+++ b/.codex/agents/implementation_executor.toml
@@ -1,6 +1,6 @@
 name = "implementation_executor"
 description = "ChangeSet 첫 미완료 구현 작업 하나를 실행한다"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "danger-full-access"
 
 developer_instructions = """

--- a/.codex/agents/implementation_planner.toml
+++ b/.codex/agents/implementation_planner.toml
@@ -1,6 +1,6 @@
 name = "implementation_planner"
 description = "ChangeSet 구현 계획을 만든다"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/oracle.toml
+++ b/.codex/agents/oracle.toml
@@ -1,6 +1,6 @@
 name = "oracle"
 description = "유스케이스별 이벤트 스토밍을 확정한다"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/orchestration.toml
+++ b/.codex/agents/orchestration.toml
@@ -1,6 +1,6 @@
 name = "orchestration"
 description = "Route one complete user prompt to exactly one harness skill or workflow gate"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/question_orchestrator.toml
+++ b/.codex/agents/question_orchestrator.toml
@@ -1,6 +1,6 @@
 name = "question_orchestrator"
 description = "Answer harness ChangeSet implementation questions through bounded DDD scope routing"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/requirements_interviewer.toml
+++ b/.codex/agents/requirements_interviewer.toml
@@ -1,6 +1,6 @@
 name = "requirements_interviewer"
 description = "Derive functional and non-functional requirements without full ubiquitous language confirmation"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,6 +1,6 @@
 name = "reviewer"
 description = "완료된 ChangeSet 구현을 gate로 검토한다"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-sol"
 sandbox_mode = "danger-full-access"
 
 developer_instructions = """

--- a/.codex/agents/security_implementation_reviewer.toml
+++ b/.codex/agents/security_implementation_reviewer.toml
@@ -1,11 +1,6 @@
 name = "security_implementation_reviewer"
 description = "Reviews implemented ChangeSet work-item code and evidence for applicable security findings."
-provider = "ollama"
-provider_binary = "ollama"
-model = "qwen3.5:2b"
-fallback_provider = "codex"
-fallback_model = "gpt-5.4-mini"
-fallback_on_retry = true
+model = "gpt-5.6-sol"
 sandbox_mode = "read-only"
 
 developer_instructions = """

--- a/.codex/agents/security_plan_reviewer.toml
+++ b/.codex/agents/security_plan_reviewer.toml
@@ -1,6 +1,6 @@
 name = "security_plan_reviewer"
 description = "Review active implementation plans and add applicable OWASP security tasks"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-terra"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """

--- a/.codex/agents/technical_decisions.toml
+++ b/.codex/agents/technical_decisions.toml
@@ -1,6 +1,6 @@
 name = "technical_decisions"
 description = "구현을 막는 기술 문제의 해결을 확정한다"
-model = "gpt-5.4-mini"
+model = "gpt-5.6-sol"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """


### PR DESCRIPTION
## 변경 사항

- 고위험 판단 에이전트를 `gpt-5.6-sol`로 조정
- 일반 설계·구현·검토 에이전트를 `gpt-5.6-terra`로 조정
- 정형 문서·운영 에이전트는 `gpt-5.4-mini` 유지
- GPT 모델을 사용하는 검토 에이전트의 Ollama provider 설정 제거

## 검증

- agent TOML 설정 25개 파싱
- `tests/test_model_override_policy.py`, `tests/test_agent_tmux.py`: 10개 테스트 통과
- `git diff --check` 통과