### PR TITLE
feat: grill-me 및 grilling 스킬 추가

### DIFF
--- a/.codex/skills/grill-me/SKILL.md
+++ b/.codex/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session.

--- a/.codex/skills/grilling/SKILL.md
+++ b/.codex/skills/grilling/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
+
+Do not act on it until I confirm we have reached a shared understanding.

--- a/.harness/docs/skills.md
+++ b/.harness/docs/skills.md
@@ -1,7 +1,8 @@
 # Active Skills
 
-This catalog lists only the skills mapped by the current workflow. It does not
-list every directory under `.codex/skills/`.
+This catalog lists the skills mapped by the current workflow and shared skills
+explicitly invoked by those stages or the runtime. It does not list every
+directory under `.codex/skills/`.
 
 ## Orchestration과 intake
 
@@ -9,6 +10,13 @@ list every directory under `.codex/skills/`.
 | --- | --- | --- |
 | Intent routing | `harness-orchestrate-instruction` | [source](../../.codex/skills/harness-orchestrate-instruction/SKILL.md) |
 | Maintenance definition | `harness-maintenance-bootstrap` | [source](../../.codex/skills/harness-maintenance-bootstrap/SKILL.md) |
+
+## Shared interview skills
+
+| 역할 | Skill | Source |
+| --- | --- | --- |
+| Shared-understanding interview entrypoint | `grill-me` | [source](../../.codex/skills/grill-me/SKILL.md) |
+| One-question-at-a-time grilling protocol | `grilling` | [source](../../.codex/skills/grilling/SKILL.md) |
 
 ## Public stages
 
@@ -37,6 +45,6 @@ list every directory under `.codex/skills/`.
 
 The public-stage IDs come from the stage registry. The implementation IDs come
 from the active work-item workflow. Update this catalog only when those mappings
-change.
+or their shared dependencies change.
 
 See [Active Agents](agents.md) for the corresponding roles.

--- a/tests/test_grill_me_skill_contract.py
+++ b/tests/test_grill_me_skill_contract.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_grill_me_delegates_to_grilling() -> None:
+    skill = (ROOT / ".codex/skills/grill-me/SKILL.md").read_text(encoding="utf-8")
+
+    assert "name: grill-me" in skill
+    assert "disable-model-invocation: true" in skill
+    assert "Run a `/grilling` session." in skill
+
+
+def test_grilling_preserves_single_question_decision_protocol() -> None:
+    skill = (ROOT / ".codex/skills/grilling/SKILL.md").read_text(encoding="utf-8")
+
+    assert "name: grilling" in skill
+    assert "Ask the questions one at a time" in skill
+    assert "If a *fact* can be found by exploring the environment" in skill
+    assert "The *decisions*, though, are mine" in skill
+    assert "Do not act on it until I confirm" in skill


### PR DESCRIPTION
## 변경 사항

- `mattpocock/skills`의 `grill-me` 스킬 추가
- `grill-me`가 호출하는 `grilling` 스킬 추가
- 공유 인터뷰 스킬을 `.harness/docs/skills.md`에 등록
- 두 스킬의 위임 관계와 핵심 질문 규칙을 고정하는 계약 테스트 추가

## 의존 관계

```text
grill-me
└─ grilling
```

`grilling`은 추가 스킬을 호출하지 않습니다.

## 원본

- https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md
- https://github.com/mattpocock/skills/blob/main/skills/productivity/grilling/SKILL.md

## 검증

- `main` 기준 추가/수정 파일 4개 확인
- 원본 스킬 내용과 대상 경로 확인
- 실행 환경이 제공되지 않아 pytest는 이 작업에서 직접 실행하지 못함
