### PR TITLE
fix: prevent architecture spec over-fragmentation

### DIFF
--- a/.codex/skills/architecture-spec/SKILL.md
+++ b/.codex/skills/architecture-spec/SKILL.md
@@ -29,10 +29,63 @@ Turn the Product Spec into an implementable architecture contract.
 6. Do not treat current implementation choices as automatically settling the target design when multiple valid architectures remain.
 7. Run the `grill-with-docs` interview with the architecture coverage checklist.
 8. Ask only about material target decisions that remain `PARTIAL` or `UNRESOLVED` after evidence is considered.
-9. For DDD design, resolve and confirm the relevant `bounded context`, `aggregate`, `entity/value object/domain service`, state transition, repository boundary, and business-rule ownership decisions. Do not silently choose among material alternatives.
-10. Resolve program-design and technical-architecture decisions required by `references/template.md`, including responsibilities, call contracts, interfaces, dependency rules, runtime behavior, failure handling, and integration contracts where applicable.
+9. For DDD design, classify domain concepts and capabilities before promoting boundaries. Resolve and confirm the relevant `bounded context`, `aggregate`, `entity/value object/domain service`, state transition, repository boundary, and business-rule ownership decisions. Do not silently choose among material alternatives.
+10. Resolve program-design and technical-architecture decisions required by `references/template.md`, including responsibilities, call contracts, interfaces, dependency rules, runtime behavior, failure handling, integration contracts, and the weakest sufficient code/runtime boundary where applicable.
 11. Add class and state diagrams that reflect the settled design. The diagrams must show relationships, responsibilities, state transitions, and transition conditions rather than repeat the tables.
 12. Write the Architecture Spec only after the `grill-with-docs` completion gate passes.
+
+## Boundary Granularity
+
+Boundary creation is promotion, not decomposition.
+
+A domain concept MUST NOT automatically become a bounded context, code module, or independently deployable service. Treat the following as different levels of architectural strength:
+
+```text
+Domain concept
+→ Entity / Value Object / Domain Service
+→ Aggregate
+→ Internal capability
+→ Bounded Context
+→ Code module
+→ Deployment service
+```
+
+Use the weakest boundary that preserves the required ownership, consistency, dependency isolation, and runtime properties. The default is to keep a capability inside an existing bounded context when that context can own the capability coherently.
+
+Do not promote a concept to a stronger boundary merely because:
+
+- it has a distinct name,
+- it has multiple classes,
+- it participates in event-storming,
+- it contains domain logic,
+- it has its own aggregate or domain service,
+- it could theoretically expose an API,
+- or it may be reusable.
+
+Promote a capability to a new bounded context only when there is material evidence of autonomous domain ownership, such as:
+
+- a distinct ubiquitous language or model whose meaning differs from neighboring contexts,
+- independent business rules and invariants,
+- independent state or data lifecycle,
+- an independent consistency or transaction boundary,
+- meaningful change independence,
+- or a clear upstream/downstream relationship that requires translation.
+
+Strong signals against creating a separate bounded context include:
+
+- the capability exists primarily to support another context's use cases,
+- it has no independently owned state or data lifecycle,
+- most calls would be synchronous and occur inside another context's workflow,
+- correctness requires frequent cross-boundary transactions,
+- it cannot meaningfully operate without the parent context,
+- its vocabulary has the same meaning as the parent context,
+- or the boundary is primarily around a technical operation, algorithm, or named feature.
+
+Promote a bounded context to a separate code module only when compile-time isolation provides concrete architectural value. Promote a module to an independently deployable service only when independent deployment, scaling, failure isolation, ownership, or operational lifecycle is a plausible requirement.
+
+For every proposed new bounded context, module, or service, explicitly explain why the next weaker boundary is insufficient and what cost the stronger boundary introduces.
+
+When the target system starts as a modular monolith and may evolve toward MSA, preserve explicit context ownership and contracts without pre-creating a service for every capability. Extraction readiness means preserving ownership and seams, not mirroring every domain concept as a deployment boundary.
 
 ## Coverage gate
 
@@ -58,6 +111,7 @@ There is no minimum question count. Question count follows unresolved coverage. 
 
 - Every applicable topic in `references/topics.md` is settled.
 - No material architecture decision is based only on model preference or inference.
+- Every new bounded context, module, or service has passed the boundary-promotion test and documents why a weaker boundary is insufficient.
 - No blocking design decision, contradiction, risk requiring a decision, or open question remains.
 - Do not hide mismatches between the code and requirements.
 - Do not ask again about facts already settled in the Product Spec or authoritative evidence.

--- a/.codex/skills/architecture-spec/references/template.md
+++ b/.codex/skills/architecture-spec/references/template.md
@@ -115,6 +115,16 @@ stop
 | --------------- | ------------------ | ------------------- | -------------- | ---------- |
 | `<context>`     | `<responsibility>` | `<terms>`           | `<aggregates>` | `<data>`   |
 
+Bounded Context는 기능 이름이나 Aggregate 수에 맞춰 생성하지 않는다. 먼저 capability를 기존 context에 배치하고, 기존 context의 언어·비즈니스 규칙·데이터 lifecycle·일관성 경계로 소유할 수 없을 때만 새로운 Bounded Context로 승격한다.
+
+## 3.1.1 Boundary Decisions
+
+| Capability     | Owner Context | Candidate Boundary                                                        | Chosen Boundary | Why Not Weaker?          | Why Not Stronger?          |
+| -------------- | ------------- | ------------------------------------------------------------------------- | --------------- | ------------------------ | -------------------------- |
+| `<capability>` | `<context>`   | Domain Type / Aggregate / Internal Capability / Bounded Context / External | `<boundary>`    | `<insufficient reason>`  | `<unnecessary cost/reason>` |
+
+새로운 Bounded Context가 선택되면 `Why Not Weaker?`에 기존 context 내부 capability로 둘 수 없는 이유를 적는다. 이름이 분명하거나 도메인 로직이 존재한다는 사실만으로는 승격 근거가 되지 않는다.
+
 ## 3.2 Context Map
 
 ```plantuml
@@ -140,6 +150,8 @@ external --> downstream : <ACL / Adapter>
 | Aggregate     | Root     | Responsibility     | Commands     | Events     | Invariants     |
 | ------------- | -------- | ------------------ | ------------ | ---------- | -------------- |
 | `<aggregate>` | `<root>` | `<responsibility>` | `<commands>` | `<events>` | `<invariants>` |
+
+Aggregate 경계는 Bounded Context 경계를 자동으로 의미하지 않는다.
 
 ## 3.4 Entities
 
@@ -409,17 +421,21 @@ stop
 
 # 5. Technical Architecture
 
-## 5.1 Service and Module Mapping
+## 5.1 Boundary Mapping
 
-| Bounded Context | Program Component | Service     | Module     | Runtime     |
-| --------------- | ----------------- | ----------- | ---------- | ----------- |
-| `<context>`     | `<component>`     | `<service>` | `<module>` | `<runtime>` |
+Bounded Context, internal capability, code module, deployment service를 1:1로 매핑하지 않는다. 각 capability에는 필요한 격리를 만족하는 가장 약한 경계를 선택한다.
 
-## 5.2 Service and Module Boundaries
+| Bounded Context | Internal Capability | Code Boundary                 | Deployment Unit | Boundary Rationale     |
+| --------------- | ------------------- | ----------------------------- | --------------- | ---------------------- |
+| `<context>`     | `<capability>`      | Package / Module / Process    | `<runtime>`     | `<why this strength>`  |
 
-| Service / Module     | Responsibility     | Public Contract | Internal Components | Dependencies     |
-| -------------------- | ------------------ | --------------- | ------------------- | ---------------- |
-| `<service / module>` | `<responsibility>` | `<contract>`    | `<components>`      | `<dependencies>` |
+## 5.2 Boundary Promotion Decisions
+
+| Candidate     | Owner Context | Chosen Boundary                                  | Why Not Weaker?         | Why Not Stronger?        | Introduced Cost                    |
+| ------------- | ------------- | ------------------------------------------------ | ----------------------- | ------------------------ | ---------------------------------- |
+| `<candidate>` | `<context>`   | Package / Module / Bounded Context / Service     | `<insufficient reason>` | `<unnecessary reason>`   | `<contract/build/runtime overhead>` |
+
+새 module 또는 service는 기능 이름을 물리적 경계로 옮기기 위해 만들지 않는다. Package보다 module이 필요한 이유, module보다 service가 필요한 이유를 각각 증명한다. 미래 MSA 추출 가능성은 소유권과 seam을 보존하는 근거이지 모든 capability를 service 형태로 미리 만드는 근거가 아니다.
 
 ## 5.3 System Interaction Flow
 
@@ -429,12 +445,12 @@ title System Interaction Flow
 
 start
 
-:<Caller Service>;
-:<Provider Service>;
+:<Caller Component / Deployment Unit>;
+:<Provider Component / Deployment Unit>;
 
 if (<Synchronous interaction?>) then (yes)
-    :<API Request>;
-    :<API Response>;
+    :<API / Internal Call Request>;
+    :<Response>;
 else (no)
     :<Publish Message>;
     :<Consume Message>;
@@ -832,7 +848,7 @@ stop
 
 | Condition                                             | Execution Model | Expected Result |
 | ----------------------------------------------------- | --------------- | --------------- |
-| `<concurrency / transaction / idempotency condition>` | `<execution>`   | `<result>`      |
+| `<concurrency / transaction / idempotency condition>` | `<execution>`   | `<result>`       |
 
 ## 11.5 Recovery Verification
 
@@ -844,6 +860,8 @@ stop
 
 ### Domain
 
+* [ ] Capability와 Bounded Context가 구분되어 있음
+* [ ] 새 Bounded Context가 weaker boundary로 충분하지 않은 근거를 가짐
 * [ ] Bounded Context 책임 준수
 * [ ] Aggregate 경계 준수
 * [ ] 비즈니스 규칙 소유권 준수
@@ -859,7 +877,8 @@ stop
 
 ### Technical Architecture
 
-* [ ] 서비스와 모듈 배치 일치
+* [ ] Bounded Context / capability / code boundary / deployment unit 매핑 일치
+* [ ] 새 module 또는 service 경계가 weaker boundary로 충분하지 않은 근거를 가짐
 * [ ] API와 메시지 계약 준수
 * [ ] 데이터 소유권 준수
 * [ ] 외부 의존성 격리

--- a/.codex/skills/architecture-spec/references/topics.md
+++ b/.codex/skills/architecture-spec/references/topics.md
@@ -8,11 +8,11 @@ Use these topics as the coverage checklist for the architecture interview. The c
 2. **Domain Flow and Hotspots**
    Resolve commands, events, policies, read models, external interactions, and any domain-flow uncertainty that materially changes the design.
 
-3. **Bounded Contexts and Context Map**
-   Resolve context responsibilities, ownership boundaries, upstream/downstream relationships, translations, and integration contracts.
+3. **Domain Boundaries and Bounded Context Promotion**
+   Classify domain concepts and capabilities before deciding bounded contexts. Resolve which capabilities belong to an existing bounded context, which boundaries are aggregate or internal-capability boundaries only, whether any capability genuinely requires a new bounded context, and why a weaker boundary would be insufficient. Do not equate a domain concept, aggregate, feature, domain service, technical operation, or event-storming cluster with a bounded context.
 
-4. **Aggregates and Business Rule Ownership**
-   Resolve aggregate boundaries, aggregate roots, invariants, consistency boundaries, and where each business rule is enforced.
+4. **Context Map and Business Rule Ownership**
+   For the bounded contexts that remain after promotion, resolve responsibilities, ownership boundaries, upstream/downstream relationships, translations, integration contracts, aggregate boundaries, aggregate roots, invariants, consistency boundaries, and where each business rule is enforced.
 
 5. **Entities, Value Objects, and Domain Services**
    Resolve identities, state ownership, value semantics, validations, domain behaviors, and domain-service responsibilities when they materially affect implementation.
@@ -23,8 +23,8 @@ Use these topics as the coverage checklist for the architecture interview. The c
 7. **Program Design**
    Resolve major components, responsibilities, application flow, call contracts, major types, interfaces, function signatures, error propagation, and dependency rules.
 
-8. **Technical Architecture and Contracts**
-   Resolve service/module boundaries, synchronous and asynchronous communication, API/message contracts, data ownership, schema changes, consistency model, infrastructure dependencies, external dependency isolation, and target file/module structure.
+8. **Technical Architecture and Boundary Mapping**
+   Map domain boundaries to code and runtime boundaries without assuming one-to-one mapping. Explicitly distinguish bounded contexts, internal capabilities, code modules, and deployment services. Prefer the weakest boundary that preserves the required isolation. For every new module or service boundary, resolve why the weaker boundary is insufficient, what dependency or ownership problem the boundary solves, what coupling or operational cost it introduces, and whether independent deployment, scaling, failure isolation, ownership, or operational lifecycle is a plausible requirement. Also resolve synchronous and asynchronous communication, API/message contracts, data ownership, schema changes, consistency model, infrastructure dependencies, external dependency isolation, and target file/module structure.
 
 9. **Runtime Design**
    Resolve concurrency, ordering, transaction boundaries, idempotency, duplicate handling, and partial-failure behavior.
@@ -36,13 +36,40 @@ Use these topics as the coverage checklist for the architecture interview. The c
     Resolve authentication/authorization impact, input validation, sensitive data handling, secrets, logs, metrics, tracing, and alerts when relevant to the change.
 
 12. **Change and Verification Boundaries**
-    Resolve allowed, forbidden, and conditional changes plus the verification evidence required for domain, program, technical, runtime, and recovery contracts.
+    Resolve allowed, forbidden, and conditional changes plus the verification evidence required for domain, program, technical, runtime, recovery, and boundary-promotion contracts.
 
 13. **Alternatives, Trade-offs, Risks, and Open Questions**
-    Resolve material alternatives, expensive-to-reverse decisions, risks, and every blocking open question.
+    Resolve material alternatives, expensive-to-reverse decisions, risks, and every blocking open question. Include the trade-off between the chosen boundary strength and the next weaker viable boundary for every newly introduced bounded context, module, or service.
+
+## Boundary evidence rule
+
+Boundary creation is promotion, not decomposition. A named capability is not evidence by itself that a new bounded context, module, or service is required.
+
+The default is to place a capability inside an existing bounded context when its language, business rules, state/data lifecycle, consistency requirements, and change pattern fit that context.
+
+Strong evidence for promotion may include:
+
+- a distinct ubiquitous language or model,
+- independent business rules or invariants,
+- independent state or data lifecycle,
+- independent consistency or transaction boundaries,
+- meaningful change independence,
+- required model translation across an upstream/downstream relationship,
+- or, for deployment boundaries, a plausible need for independent deployment, scaling, failure isolation, ownership, or operational lifecycle.
+
+Strong evidence against promotion includes:
+
+- the capability primarily supports another context's workflow,
+- it has no independent state or data lifecycle,
+- most interactions would be synchronous inside a parent workflow,
+- correctness requires frequent cross-boundary transactions,
+- it shares the same vocabulary and model meaning as the parent context,
+- or the proposed boundary is mainly around an algorithm, technical operation, or named feature.
+
+For every proposed stronger boundary, explain why the next weaker boundary is insufficient.
 
 ## Evidence rule
 
 Current code, tests, Product Spec, ADRs, and project documents may settle descriptive facts about the existing system. They do not by themselves settle a target architecture decision when multiple valid futures remain.
 
-Ask the user only when a material target decision, trade-off, product interpretation, or irreversible architecture choice remains unresolved after the available evidence is read.
+Ask the user only when a material target decision, trade-off, product interpretation, irreversible architecture choice, or unresolved boundary-promotion decision remains unresolved after the available evidence is read.

--- a/.codex/skills/codebase-design/SKILL.md
+++ b/.codex/skills/codebase-design/SKILL.md
@@ -9,6 +9,8 @@ description: Translate DDD decisions into concrete packages, seams, adapters, fi
 
 `codebase-design` turns DDD decisions into an implementation contract covering packages, seams, adapters, tests, and files.
 
+It maps settled domain boundaries into code boundaries without assuming that every bounded context, aggregate, feature, or capability requires a separate code module.
+
 ## Inputs
 
 - Architecture Spec
@@ -33,6 +35,37 @@ infra
 - `domain` holds entities, value objects, domain methods, domain services, aggregates, and domain policies.
 - `infra` holds adapters that implement ports.
 
+## Module Granularity
+
+Prefer the weakest code boundary that preserves the required ownership and dependency isolation.
+
+Do not create a code module merely to mirror:
+
+- an aggregate,
+- a domain service,
+- a feature,
+- a use case,
+- an event-storming cluster,
+- a technical operation or algorithm,
+- or an internal capability.
+
+Prefer package-level boundaries inside the owning module unless compile-time isolation provides concrete architectural value.
+
+A new code module must have an explicit owner boundary and a meaningful public contract. For every proposed new module, answer:
+
+1. Which bounded context owns this module?
+2. Is the module itself the bounded-context boundary, or is it only an internal capability?
+3. Why is a package inside the owning module insufficient?
+4. Which dependency or ownership problem must compile-time isolation prevent?
+5. Could this boundary plausibly support independent ownership or future deployment, if that is a project goal?
+6. What contract, adapter, build, testing, and coordination cost does the new boundary introduce?
+
+If these questions do not reveal meaningful isolation value, do not introduce a new module.
+
+A bounded context does not require a one-to-one code module when another code boundary can preserve its required isolation. Likewise, a code module does not imply an independently deployable service.
+
+For modular-monolith systems designed for possible future MSA extraction, optimize for clear ownership, explicit seams, and dependency direction. Do not pre-create microservice-shaped modules for internal capabilities solely to make hypothetical extraction easier.
+
 ## Process
 
 1. Translate the `event-storming` policy output into unit-testable behavior.
@@ -40,8 +73,10 @@ infra
 3. Model aggregate relationships through entity IDs, not through broad object graphs.
 4. Put orchestration-only application services in `app`.
 5. Put port implementations and external-system adapters in `infra`.
-6. Map the minimum set of files, modules, interfaces, seams, and tests needed to realize the design.
-7. Consult `effective-java-notes.md` before writing Java code.
+6. Map capabilities into packages first, then promote to modules only when the Module Granularity gate demonstrates meaningful compile-time isolation value.
+7. Map the minimum set of files, modules, interfaces, seams, and tests needed to realize the design.
+8. For every new module, record why the next weaker package-level boundary is insufficient and what cost the module introduces.
+9. Consult `effective-java-notes.md` before writing Java code.
 
 ## Completion
 
@@ -49,4 +84,6 @@ infra
 - Domain decisions are not re-litigated here.
 - The package shape stays `ui / app / domain / infra`.
 - The transaction boundary stays in `app`.
+- New modules have passed the Module Granularity gate.
+- No module exists solely because a feature, aggregate, domain service, or named capability exists.
 - Policy behavior is covered by unit tests.

--- a/.codex/skills/ddd-design/SKILL.md
+++ b/.codex/skills/ddd-design/SKILL.md
@@ -7,7 +7,7 @@ description: Derive aggregate, consistency, transaction, and integration boundar
 
 ## What it does
 
-`ddd-design` narrows `/event-storming` output into aggregates, boundaries, consistency, transaction, and integration decisions.
+`ddd-design` narrows `/event-storming` output into aggregates, domain capabilities, bounded-context candidates, consistency, transaction, and integration decisions.
 
 It does not choose packages, modules, persistence, or framework wiring; those choices belong to `codebase-design`.
 
@@ -18,29 +18,49 @@ It does not choose packages, modules, persistence, or framework wiring; those ch
 - related ADRs
 - event-storming output
 
+## Boundary rule
+
+Aggregate boundaries, domain-service boundaries, feature boundaries, and event-storming clusters do not imply bounded-context boundaries.
+
+Treat creation of a new bounded context as a promotion decision. Prefer assigning a capability to an existing bounded context when the language, business-rule ownership, state/data lifecycle, consistency requirements, and change pattern fit that context.
+
+A capability should become a new bounded-context candidate only when there is material evidence that the existing context cannot own it coherently. Evidence may include a distinct ubiquitous language or model, independent business rules or invariants, independent state/data lifecycle, a separate consistency boundary, meaningful change independence, or a required upstream/downstream translation boundary.
+
+Do not create a bounded-context candidate merely because a capability has a distinct name, contains domain logic, owns an aggregate, could expose an API, may be reusable, or is implemented by a technical algorithm.
+
+For every proposed bounded-context candidate, document why modeling it as an internal capability of an existing context would be incorrect or materially harmful.
+
 ## Process
 
 1. Read the Product Spec and domain guidance.
 2. Review the event-storming result: actors, commands, events, policies, and external systems.
-3. Group the flow into aggregate candidates and boundary candidates.
-4. Decide consistency, transaction, and integration boundaries only as far as the design needs them.
-5. Ask one question at a time if a stakeholder perspective is still missing.
-6. Hand off structure-level decisions to `codebase-design`.
+3. Group the flow into aggregate candidates and domain-capability candidates.
+4. Assign each capability to an existing bounded context whenever its language, business rules, lifecycle, and consistency requirements fit that context.
+5. Treat a new bounded context as an exceptional promotion decision and compare semantic/model independence, business-rule ownership, data/state ownership, consistency and transaction boundaries, change independence, and translation needs before proposing one.
+6. Do not infer a bounded context from an aggregate, domain service, event-storming cluster, technical subsystem, algorithm, or named feature alone.
+7. Decide consistency, transaction, and integration boundaries only as far as the design needs them.
+8. For every proposed bounded context, record why an internal capability boundary in an existing context is insufficient.
+9. Ask one question at a time if a stakeholder perspective or material boundary decision is still missing.
+10. Hand off structure-level decisions to `codebase-design` without assuming a one-to-one mapping between bounded contexts, code modules, and deployment services.
 
 ## Connection
 
 - `event-storming` exposes the business flow and domain shape.
-- `ddd-design` turns that flow into DDD boundaries and invariants.
-- `codebase-design` turns the DDD shape into module and seam decisions.
+- `ddd-design` classifies aggregates and capabilities, then promotes only sufficiently independent capabilities into bounded-context candidates.
+- `codebase-design` turns the settled DDD shape into package, module, and seam decisions using the weakest sufficient code boundary.
 
 ## Output shape
 
+- Domain capabilities are classified as part of an existing bounded context, a justified new bounded-context candidate, or an external system.
 - Aggregate boundaries are described through entity identity relationships.
+- Aggregate boundaries MUST NOT imply bounded-context boundaries.
 - Domain behavior is expressed as domain methods or domain services.
 - Policies remain design facts that later become unit-testable behavior.
+- Every new bounded-context candidate includes the evidence for promotion and why the weaker internal-capability boundary is insufficient.
 
 ## Completion
 
 - The design is concrete enough to implement.
 - The established vocabulary is not destabilized.
+- Bounded-context candidates are supported by ownership and lifecycle evidence rather than feature naming or implementation structure alone.
 - Remaining structural questions are deferred to `codebase-design`.


### PR DESCRIPTION
## Summary

Prevent `architecture-spec` / `ddd-design` / `codebase-design` from promoting every named capability into a bounded context, Gradle module, or deployable service.

## Problem

The current workflow resolves bounded contexts and service/module boundaries, but it does not require proof that a stronger boundary is necessary. This can turn a cohesive internal capability such as dice rolling into a standalone service-shaped module simply because it has a distinct name and domain logic.

## Changes

- add a boundary-granularity hierarchy and `boundary creation is promotion, not decomposition` rule to `architecture-spec`
- make the weakest sufficient boundary the default
- require every new bounded context/module/service to explain why the next weaker boundary is insufficient
- add positive and negative evidence for bounded-context promotion
- make `ddd-design` explicitly separate aggregate/capability boundaries from bounded-context boundaries
- add a package-to-module promotion gate to `codebase-design`
- update architecture interview topics to classify capabilities before creating bounded contexts
- replace the template's implicit `Bounded Context -> Service -> Module` mapping with explicit capability/code/deployment boundary mapping and promotion decisions
- add verifier criteria for unnecessary boundary promotion

## Modular monolith -> MSA

The rules preserve the existing strategy of starting as a modular monolith while keeping future MSA extraction possible. Extraction readiness is treated as clear ownership, seams, and dependency direction rather than pre-creating a microservice-shaped module for every capability.

## Verification

- diff limited to five architecture/DDD/codebase-design prompt and template files
- no runtime code changed
- branch is 5 commits ahead of `main` and 0 behind
