### PR TITLE
fix: validate GitHub Issue body templates

### DIFF
--- a/.codex/skills/to-ticket/SKILL.md
+++ b/.codex/skills/to-ticket/SKILL.md
@@ -17,7 +17,7 @@ description: Split approved product and architecture specifications into vertica
 4. Define dependencies between slices.
 5. Present the split plan to the user and wait for approval before any mutation.
 6. After approval, read `.codex/harness.yaml` and use its tracker mode exclusively.
-7. GitHub mode: create one parent Issue for the plan set and one child Issue per split slice, add them to the configured GitHub Project, and set their configured `Workflow Status` to `Planned`. Put the complete split-plan contract in each child Issue body and link the child Issues under the parent. local-markdown mode: create one ticket file and one matching plan document per slice in the configured directory with status `planned`, plus `docs/plans/plans.md` as its backlink index.
+7. GitHub mode: read `references/github-issue-template.md`, render one parent Issue and one child Issue per split slice, validate each rendered body against the template, then create the Issues. Add them to the configured GitHub Project and set their configured `Workflow Status` to `Planned`. Put the complete split-plan contract in each child Issue body and link the child Issues under the parent. local-markdown mode: create one ticket file and one matching plan document per slice in the configured directory with status `planned`, plus `docs/plans/plans.md` as its backlink index.
 8. Store blocking edges in that same selected tracker.
 9. Capture the current session branch and `HEAD` using the rules below, create the new plan-set branch from that fixed base ref, and push it to the remote. Do not assume or switch to `origin/main`.
 10. In GitHub mode, after every split plan has been created, linked, and set to `Planned`, run `gh-open-pr` to create or update a draft plan PR against the captured session base branch. Include the parent Issue, all child Issues, dependencies, Product Spec, Architecture Spec, available diagram links, planning validation, and captured base branch. Diagram links are optional: link only available ticket-scoped SVG artifacts using the captured head branch; an absent diagram or explicit `해당 없음` is valid and must not block splitting or the draft PR. Do not add an Issue-closing trigger. If the pushed branch has no commits beyond the fixed base ref, report that GitHub cannot create the PR and stop before implementation handoff.
@@ -43,7 +43,7 @@ current session branch at captured HEAD
 
 ## Plan Representation
 
-- GitHub Issues mode: each child Issue is one split plan. Its body must contain status, dependencies, implementation purpose, scope, acceptance criteria, and test contract. Add links to relevant ticket-scoped SVG diagrams when they exist, with the head-branch-qualified URL required by `gh-open-pr`; if a diagram is absent, record `해당 없음` and its reason without treating it as a prerequisite. The parent Issue and its child links replace `docs/plans/plans.md`.
+- GitHub Issues mode: use `references/github-issue-template.md` as the only parent/child body format. Validate rendered bodies before any GitHub mutation. Each child Issue is one split plan. Its body must contain status, dependencies, implementation purpose, scope, acceptance criteria, test contract, related specs, and diagram disposition. Add links to relevant ticket-scoped SVG diagrams when they exist, with the head-branch-qualified URL required by `gh-open-pr`; if a diagram is absent, record `해당 없음` and its reason without treating it as a prerequisite. The parent Issue and its child links replace `docs/plans/plans.md`.
 - local-markdown mode: create exactly one plan document per split slice at `docs/plans/<plan-id>.md`. Keep `docs/plans/plans.md` as an index only: it contains backlinks to the current individual plan documents, not full plan bodies. After approval, create or overwrite it for the current ticket set; do not preserve or append prior entries or collapse plan bodies into it.
 - In either mode, record slice-specific classes, relationships, states, and transitions when the slice changes them.
 - Write a Korean implementation-purpose section in every plan representation. Explain clearly what the plan will implement and why, so the intended implementation is understandable without reading the Issue.
@@ -51,6 +51,7 @@ current session branch at captured HEAD
 ## Rules
 
 - Do not mutate GitHub or local plan files before approval.
+- Do not mutate GitHub until every rendered body passes the template's heading, placeholder, link, and status checks.
 - Keep one Issue per split plan.
 - Include policy-based unit tests and `ui ~ entity` e2e tests in every plan slice.
 - Do not split only by layer.

--- a/.codex/skills/to-ticket/references/github-issue-template.md
+++ b/.codex/skills/to-ticket/references/github-issue-template.md
@@ -1,0 +1,84 @@
+# GitHub Issue 본문 템플릿
+
+`to-ticket`이 GitHub mode에서 생성하는 Issue는 아래 두 형식만 사용한다. 대괄호 placeholder는 실제 값으로 치환한다.
+
+## Parent Issue
+
+```markdown
+## Plan Set
+
+- Product/Architecture Spec: [#SPEC]
+- Child plans: [#CHILD-ISSUES]
+
+## 목적
+
+[이 계획 세트가 해결하는 문제와 기대 결과]
+
+## 실행 순서
+
+1. [#CHILD] — [요약]
+
+## 의존성
+
+[child Issue 간 blocking 관계. 없으면 `없음`]
+
+## 검증
+
+- Product Spec: [경로]
+- Architecture Spec: [경로]
+- 각 child Issue의 테스트 계약을 실행한다.
+
+구현·검증 완료 전에는 이 Issue를 닫지 않는다.
+```
+
+필수: `Plan Set`, `목적`, `실행 순서`, `의존성`, `검증`, parent/child Issue 링크.
+
+## Child Issue
+
+```markdown
+## 상태
+
+Planned
+
+## 의존성
+
+[blocking Issue 링크 또는 `없음`]
+
+## 구현 목적
+
+[무엇을 구현하고 왜 필요한지]
+
+## 범위
+
+- [vertical slice 범위]
+
+## 수용 기준
+
+- [관찰 가능한 완료 조건]
+
+## 테스트 계약
+
+- 단위/정책: [검증 대상]
+- `ui ~ entity` E2E: [시나리오 또는 현재 환경 제약]
+
+## 관련 명세
+
+- Product Spec: [경로]
+- Architecture Spec: [경로]
+
+## 다이어그램
+
+[사용 가능한 ticket-scoped SVG 링크 또는 `해당 없음 — 이유`]
+```
+
+필수: `상태`, `의존성`, `구현 목적`, `범위`, `수용 기준`, `테스트 계약`, `관련 명세`, `다이어그램`.
+
+## 생성 전 검증
+
+- parent와 child 본문을 서로 바꾸지 않는다.
+- placeholder(`[... ]`)를 남기지 않는다.
+- 모든 child Issue는 하나의 split plan만 표현한다.
+- 상태는 `Planned`로 고정한다. tracker 상태가 아닌 임의 상태/label을 쓰지 않는다.
+- 의존성은 실제 Issue 번호만 사용한다. 추측한 번호·경로를 만들지 않는다.
+- 다이어그램이 없으면 링크를 생략하고 `해당 없음 — <reason>`을 기록한다.
+- 본문이 비어 있거나 필수 heading이 빠지거나 위 규칙을 위반하면 GitHub mutation을 중단한다.

--- a/tests/test_github_issue_template_contract.py
+++ b/tests/test_github_issue_template_contract.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / ".codex" / "skills" / "to-ticket" / "references" / "github-issue-template.md"
+TO_TICKET = ROOT / ".codex" / "skills" / "to-ticket" / "SKILL.md"
+
+
+class GithubIssueTemplateContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.template = TEMPLATE.read_text(encoding="utf-8")
+        cls.skill = TO_TICKET.read_text(encoding="utf-8")
+
+    def test_template_defines_distinct_parent_and_child_formats(self):
+        self.assertIn("## Parent Issue", self.template)
+        self.assertIn("## Child Issue", self.template)
+        self.assertIn("필수: `Plan Set`, `목적`, `실행 순서`, `의존성`, `검증`", self.template)
+        for heading in ("상태", "의존성", "구현 목적", "범위", "수용 기준", "테스트 계약", "관련 명세", "다이어그램"):
+            self.assertIn(f"`{heading}`", self.template)
+
+    def test_template_forbids_unvalidated_mutation(self):
+        self.assertIn("생성 전 검증", self.template)
+        self.assertIn("placeholder", self.template)
+        self.assertIn("GitHub mutation을 중단", self.template)
+        self.assertIn("validate each rendered body against the template", self.skill)
+        self.assertIn("Validate rendered bodies before any GitHub mutation", self.skill)
+
+    def test_child_contract_keeps_diagram_absence_non_blocking(self):
+        self.assertIn("해당 없음 — 이유", self.template)
+        self.assertRegex(self.template, r"다이어그램이 없으면.*링크를 생략")
+        self.assertIn("다이어그램이 없으면 링크를 생략", self.skill)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 한눈에 보기

이슈 본문을 같은 모양으로 만들고, 이상한 본문은 GitHub에 쓰기 전에 막습니다.

1. Before: 규칙이 흩어짐 → After: Parent/Child 템플릿 하나로 통일
2. Before: 필수 항목 누락 가능 → After: heading·placeholder·상태·링크 검증
3. Before: 잘못된 본문 생성 → After: mutation 중단 및 테스트로 회귀 방지

## 변경

- GitHub Parent/Child Issue 본문 canonical template 추가
- `to-ticket`에 mutation 전 template validation 게이트 추가
- 필수 섹션, placeholder, 상태, 다이어그램 부재 처리 contract test 추가

## 검증

- `python3 -m unittest discover -s tests`
- 54 tests passed

## 영향

- 기존 사용자 변경사항은 포함하지 않음
- 기존 Issue 본문은 수정하지 않음
